### PR TITLE
Allow for injection of alternate SourceCoordinateMapProvider implementation

### DIFF
--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/serialization/binary/SourceCoordinateMapProvider.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/serialization/binary/SourceCoordinateMapProvider.java
@@ -1,0 +1,7 @@
+package org.finos.legend.pure.runtime.java.compiled.serialization.binary;
+
+import org.eclipse.collections.api.map.MutableMap;
+
+public interface SourceCoordinateMapProvider {
+    MutableMap<String, DistributedBinaryGraphDeserializer.SourceCoordinates> getMap(int instanceCount, String classifier);
+}


### PR DESCRIPTION
Update to allow injection of alternate MutableMap implementations into binary deserialzer to store source-coordinates.  The default in-memory impl is preserved.