### PR TITLE
revert dropwizard and jetty upgrade and improve IDE execution perceived performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,16 @@
+# IDE
+.vscode
+.settings
+.classpath
+.project
 .idea/**
+.factorypath
 **/*.iml
+
+# Build
 **/target
 **/lib
 **/surefire-reports-aggregate
 **/dependency-reduced-pom.xml
 **/node_modules/
-
-.factorypath
-
-# VS Code ignores
-.vscode
-.settings
-.classpath
-.project
+package-lock.json

--- a/legend-pure-ide-light/src/main/web/README.md
+++ b/legend-pure-ide-light/src/main/web/README.md
@@ -1,0 +1,69 @@
+# Pure IDE (Light) UI
+
+This is the code for the web application of the Pure IDE (Light). Notice that if you just need to boot the IDE, you can do so by doing a `mvn install` on the root project and start the Pure IDE with dropwizard. Hence, starting the IDE here is mainly for development purpose.
+
+## Getting started
+
+```bash
+  yarn install
+  yarn start
+```
+
+Note that we derive the backend address/port from `ideLightConfig.json`.
+
+## Developer setups
+
+If you use [VSCode](https://code.visualstudio.com/) you should install their `Prettier` and `ESLint` plugins, then configuallore your workspace settings in `./.vscode/settings.json` like this:
+
+```jsonc
+{
+  "editor.tabSize": 2,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "eslint.options": {
+    // NOTE: we disable advanced linting rules during development to make faster incremental build
+    // but we can still get the full benefit by enabling it for the IDE
+    "configFile": "./.eslintrc-advanced.js"
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/package-lock.json": true
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "vscode.html-language-features"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  },
+  "prettier.singleQuote": true,
+  "prettier.trailingComma": "es5",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "javascript.preferences.importModuleSpecifier": "non-relative",
+  "typescript.preferences.importModuleSpecifier": "non-relative"
+}
+```

--- a/legend-pure-ide-light/src/main/web/package-lock.json
+++ b/legend-pure-ide-light/src/main/web/package-lock.json
@@ -5234,9 +5234,9 @@
       }
     },
     "html-webpack-plugin": {
-      "version": "5.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.0.0-alpha.6.tgz",
-      "integrity": "sha512-duuDbc+3/GZtTmxP7N4jsTyF83QpjOlM2llL0AjCg22wSreSmbzD6r2ZjnAgLjHvNAmSrMQgPxL9PrE0pTaBmQ==",
+      "version": "5.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.0.0-alpha.7.tgz",
+      "integrity": "sha512-3sdfEqSjuJ41YpIzweFkTDepTVIuIflvfOh8MhACNk92gE2MsOXL/7MYTVvIHEAeXp+9yTx0DTkYlInCUmtP/g==",
       "dev": true,
       "requires": {
         "@types/html-minifier-terser": "^5.0.0",

--- a/legend-pure-ide-light/src/main/web/package.json
+++ b/legend-pure-ide-light/src/main/web/package.json
@@ -11,8 +11,8 @@
     "start:advanced": "node ./dev/scripts/start.js --advanced",
     "start:minimal": "webpack serve --mode development --hot",
     "serve:static": "npx http-server ../../../target/classes/ -p 3000 -a localhost -g --cors -o /ide",
-    "lint": "eslint --config ./.eslintrc-advanced.js --rulesdir ./dev/eslint_rules .",
-    "lint:fix": "eslint --config ./.eslintrc-advanced.js --rulesdir ./dev/eslint_rules --fix .",
+    "lint": "eslint --config ./.eslintrc-advanced.js .",
+    "lint:fix": "eslint --config ./.eslintrc-advanced.js --fix .",
     "update": "yarn upgrade-interactive --latest"
   },
   "dependencies": {

--- a/legend-pure-ide-light/src/main/web/src/components/editor/edit-panel/FileEditor.tsx
+++ b/legend-pure-ide-light/src/main/web/src/components/editor/edit-panel/FileEditor.tsx
@@ -44,7 +44,15 @@ export const FileEditor = observer((props: {
         ...baseTextEditorSettings,
         language: EDITOR_LANGUAGE.PURE,
         theme: EDITOR_THEME.NATIVE,
+        // NOTE: These following font options are needed (and CSS font-size option `.monaco-editor * { font-size: 1.2rem }` as well)
+        // in order to make the editor appear properly on multiple platform, the ligatures option is needed for Mac to display properly
+        // otherwise the cursor position relatively to text would be off
+        // Another potential cause for this misaligment is that the fonts are being lazy-loaded and made available after `monaco-editor`
+        // calculated the font-width, for this, we can use `remeasureFonts`, but our case here, `fontLigatures: true` seems
+        // to do the trick
+        // See https://github.com/microsoft/monaco-editor/issues/392
         fontSize: 12,
+        fontLigatures: true,
       });
       editor.onDidChangeModelContent(() => {
         const currentVal = editor.getValue();

--- a/legend-pure-ide-light/src/main/web/src/stores/ConceptTreeState.ts
+++ b/legend-pure-ide-light/src/main/web/src/stores/ConceptTreeState.ts
@@ -102,7 +102,7 @@ export class ConceptTreeState extends TreeState<ConceptTreeNode, ConceptNode> {
   }
 
   async pullConceptsActivity(): Promise<void> {
-    const result = await this.editorStore.applicationStore.client.getConceptActivity() as ConceptActivity;
+    const result = await this.editorStore.applicationStore.client.getConceptActivity() as unknown as ConceptActivity;
     if (result.text) {
       this.setStatusText(`Preparing - ${result.text}`);
     }

--- a/legend-pure-ide-light/src/main/web/src/stores/TestRunnerState.ts
+++ b/legend-pure-ide-light/src/main/web/src/stores/TestRunnerState.ts
@@ -235,7 +235,7 @@ export class TestRunnerState {
   }
 
   async pullTestRunnerResult(testResultInfo: TestResultInfo): Promise<void> {
-    const result = deserializeTestRunnerCheckResult(await this.editorStore.applicationStore.client.checkTestRunner(this.testExecutionResult.runnerId) as Record<PropertyKey, undefined>);
+    const result = deserializeTestRunnerCheckResult(await this.editorStore.applicationStore.client.checkTestRunner(this.testExecutionResult.runnerId));
     if (result instanceof TestRunnerCheckResult) {
       await Promise.all(result.tests.map(test => promisify(() => testResultInfo.addResult(test, getFullTestId(test, this.testExecutionResult)))));
       if (!result.finished) {
@@ -247,7 +247,7 @@ export class TestRunnerState {
               this.editorStore.applicationStore.notifyWarning(`Failed to run test${e.message ? `: ${e.message}` : ''}`);
               reject(e);
             }
-            // NOTE: this call might take some time so we need to tune this depending on the performance of the app
+            // NOTE: this call might take a while so we need to tune this depending on the performance of the app
           }, 1000)
         );
       }

--- a/legend-pure-ide-light/src/main/web/src/utils/GeneralUtil.ts
+++ b/legend-pure-ide-light/src/main/web/src/utils/GeneralUtil.ts
@@ -332,4 +332,4 @@ export const downloadFile = (fileName: string, content: string, contentType: Con
 export const getNullableFirstElement = <T>(array: T[]): T | undefined => array.length ? array[0] : undefined;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type PlainObject<T> = unknown;
+export type PlainObject<T> = Record<PropertyKey, unknown>;

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <log4j.version>1.2.17</log4j.version>
         <jersey.version>2.25.1</jersey.version>
         <jackson.version>2.10.3</jackson.version>
-        <jetty.version>9.4.33.v20201020</jetty.version>
+        <jetty.version>9.4.18.v20190429</jetty.version>
         <bouncycastle.version>1.64</bouncycastle.version>
         <eclipsecollections.version>10.2.0</eclipsecollections.version>
         <json-simple.version>1.1.1</json-simple.version>
@@ -97,7 +97,7 @@
         <junit.version>4.13.1</junit.version>
         <jacoco.maven.plugin.version>0.8.5</jacoco.maven.plugin.version>
         <maven.javadoc.plugin.version>3.2.0</maven.javadoc.plugin.version>
-        <dropwizard.version>1.3.26</dropwizard.version>
+        <dropwizard.version>1.3.24</dropwizard.version>
         <dropwizard-swagger.version>1.3.17-1</dropwizard-swagger.version>
         <joda.time.version>2.10.6</joda.time.version>
         <jaxrs.version>2.0.1</jaxrs.version>
@@ -731,43 +731,6 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlets</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <!-- The following Jetty dependencies are added to address security issues, this can be removed once we upgrade dropwizard -->
-            <!-- See https://nvd.nist.gov/vuln/detail/CVE-2020-27216 -->
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-continuation</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-http</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-io</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlet</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-util</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-webapp</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <!-- Jetty -->


### PR DESCRIPTION
@aziemchawdhary-gs @kevin-m-knight-gs @pierredebelen it seems like the `dropwizard` and `jetty` upgrade in #36 breaks execution in the IDE. I tried to execute something that takes a long time like `[1:10000]->map(i|print($i);` and the IDE returns me an error. Could you confirm that @aziemchawdhary-gs?

This will certainly make `whitesource` scream, but we might need to workaround that somehow, `dropwizard` is still taking sometimes to port their fix in https://github.com/dropwizard/dropwizard/pull/3522 (and https://github.com/dropwizard/dropwizard/pull/3527) to v1.3.x so we might not be able to wait. I reckon that the best way is to revert this for now. What do you guys think?