### PR TITLE
Allow for injection of custom source coordinate mapping providers

### DIFF
--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/serialization/binary/SourceCoordinateMapProvider.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/serialization/binary/SourceCoordinateMapProvider.java
@@ -1,0 +1,7 @@
+package org.finos.legend.pure.runtime.java.compiled.serialization.binary;
+
+import org.eclipse.collections.api.map.MutableMap;
+
+public interface SourceCoordinateMapProvider {
+    MutableMap<String, DistributedBinaryGraphDeserializer.SourceCoordinates> getMap(int instanceCount, String classifier);
+}


### PR DESCRIPTION
Allow for injection of custom source coordinate mapping providers that (for example) don't use on-heap memory.