### PR TITLE
fix java code gen explosion bug

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/shared/mappingAdaptor.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/shared/mappingAdaptor.pure
@@ -48,8 +48,7 @@ function <<access.private>> meta::alloy::runtime::java::generateMappingClasses(t
 {
    print(if($debug.debug,|$debug.space+'generateMappingClasses\n', |''));
 
-   let mappers     = $tree.sets->cast(@InstanceSetImplementation)
-                                                                        ->map(pisi| $pisi->generateMapperClass($context, $extensions, $debug->indent()));
+   let mappers     = $tree.sets->cast(@InstanceSetImplementation)->map(pisi| $pisi->generateMapperClass($context, $extensions, $debug->indent()));
    let adaptors    = $tree->map(s|$s->generateMappingAdaptor($context, $createConstraintChecking, $extensions, $debug->indent()));
    let forSubTrees = $tree.subTrees
        ->cast(@RoutedPropertyGraphFetchTree)
@@ -85,7 +84,7 @@ function <<access.private>> meta::alloy::runtime::java::generateMapperClass(setI
       ->imports($adaptorClass);
 
    if(containsExplodeProperty($setImplementation),
-      | generateExplodeMapperClass($setImplementation, $assocProperties, $class, $conventions, $adaptorClass, $targetOne, $targetMany, $sourceOne, $sourceMany, $debug),
+      | generateExplodeMapperClass($setImplementation, $assocProperties, $class, $conventions, $adaptorClass, $targetOne, $targetMany, $sourceOne, $sourceMany, $extensions, $debug),
       | generateMapperClass($setImplementation, $assocProperties, $class, $conventions, $adaptorClass, $targetOne, $targetMany, $sourceOne, $sourceMany, $extensions, $debug)
    );
 }
@@ -477,8 +476,11 @@ function <<access.private>> meta::alloy::runtime::java::generatePropertyMapping(
             
                if(isJavaList($transformed.type),
                   | $mapperClass->j_invoke('mapMany', $mapperArgs, $resultMany),
+                  |
+               if(containsExplodeProperty($pisi),
+                  | j_conditional($transformed->j_eq(j_null()), javaCollections()->j_invoke($resultOne, 'emptyList', [], $resultMany), $mapperClass->j_invoke('mapOne', $mapperArgs, $resultMany)),
                   | j_conditional($transformed->j_eq(j_null()), j_null(), $mapperClass->j_invoke('mapOne', $mapperArgs, $resultOne))
-               );
+               ));
             }
          );
       }
@@ -586,33 +588,40 @@ function <<access.private>> meta::alloy::runtime::java::generateExplodeMapperCla
                                                                                    targetMany:meta::java::metamodel::Type[1],
                                                                                    sourceOne:meta::java::metamodel::Class[1],
                                                                                    sourceMany:meta::java::metamodel::Type[1],
+                                                                                   extensions : meta::pure::router::extension::RouterExtension[*],
                                                                                    debug:DebugContext[1]):Project[1]
 {
    let cc = $conventions->forClass($class);
+   let srcOneVar  = javaParam($sourceOne, $setImplementation->variableName($extensions));
+   let srcManyVar = javaParam($sourceMany, 'in');
 
    newProject()->addClass($class
                           ->addMethods(
                              [
-                                javaMethod(['public', 'static'], $targetMany, 'mapOne', [ javaParam($sourceOne, 'src') ],
-                                           generateExplodeMapOne($setImplementation, $cc->codeType($adaptorClass)->codeToString($conventions), false, $conventions, $debug)),
-
-                                javaMethod(['public', 'static'], $targetMany, 'mapMany', [ javaParam($sourceMany, 'in') ],
-                                           'return in == null ? ' + $cc->codeType(javaType('java.util.Collections'))->codeToString($cc) + '.<' + $cc->codeType($targetOne)->codeToString($conventions) + '>emptyList() : in.stream().map(' + $class.simpleName + '::mapOne).flatMap(Collection::stream).collect(Collectors.toList());')
+                                javaMethod(['public', 'static'], $targetMany, 'mapOne', [ $srcOneVar ],
+                                           generateExplodeMapOne($setImplementation, $adaptorClass, $srcOneVar, [], $conventions, $class, $debug)->codesToString($class)),
+                                javaMethod(['public', 'static'], $targetMany, 'mapMany', [ $srcManyVar ],
+                                           j_conditional(j_parameter($srcManyVar)->j_eq(j_null()),
+                                                        javaCollections()->j_invoke($targetOne, 'emptyList', [], $targetMany),
+                                                        j_parameter($srcManyVar)->j_streamOf()->js_map($class->j_methodReference('mapOne', javaFunctionType($sourceOne, $targetMany)))
+                                                                                 ->j_invoke('collect', j_invoke(javaCollectors(), 'toList', [], javaCollector()), $targetMany))->j_return()->codeToString($class))
                              ]
                           )
                           ->addMethods(
                              $assocProperties->map(
                                 {p|
-                                   let pJavaType = $conventions->className($p->functionReturnType().rawType->toOne());
+                                   let parentJavaVar = javaParam($conventions->className($p->functionReturnType().rawType->toOne()), 'parent');
+                                   let lambdaParam = j_parameter(javaParam($sourceOne, 'x'));
                                    [
-                                      javaMethod(['public', 'static'], $targetOne, 'mapOne', [ javaParam($sourceOne, 'src'), javaParam($pJavaType, 'parent') ],
-                                                 generateExplodeMapOne($setImplementation, $cc->codeType($adaptorClass)->codeToString($conventions), true, $conventions, $debug)
-           ),
-                                      javaMethod(['public', 'static'], $targetMany, 'mapMany', [ javaParam($sourceMany, 'in'), javaParam($pJavaType, 'parent') ],
-                                                 'return in == null ? ' + $cc->codeType(javaType('java.util.Collections'))->codeToString($cc) + '.<' + $cc->codeType($targetOne)->codeToString($conventions) + '>emptyList() : in.stream().map(x -> '+$class.simpleName+'.mapOne(x, parent)).flatMap(Collection::stream).collect(Collectors.toList());'
-           )
+                                      javaMethod(['public', 'static'], $targetOne, 'mapOne', [ $srcOneVar, $parentJavaVar ],
+                                                 generateExplodeMapOne($setImplementation, $adaptorClass, $srcOneVar, $parentJavaVar, $conventions, $class, $debug)->codesToString($class)),
+                                      javaMethod(['public', 'static'], $targetMany, 'mapMany', [ $srcManyVar, $parentJavaVar ],
+                                                 j_conditional(j_parameter($srcManyVar)->j_eq(j_null()),
+                                                        javaCollections()->j_invoke($targetOne, 'emptyList', [], $targetMany),
+                                                        j_parameter($srcManyVar)->j_streamOf()->js_map(j_lambda($lambdaParam, $class->j_invoke('mapOne', [$lambdaParam, j_parameter($parentJavaVar)], $targetMany)))
+                                                                                 ->j_invoke('collect', j_invoke(javaCollectors(), 'toList', [], javaCollector()), $targetMany))->j_return()->codeToString($class))
                                    ];
-   }
+                                }
                              )
                           )
    );
@@ -690,19 +699,35 @@ function <<access.private>> meta::alloy::runtime::java::generateExplodeMappingAd
    );
 }
 
-function <<access.private>> meta::alloy::runtime::java::generateExplodeMapOne(setImplementation:InstanceSetImplementation[1], adaptorClassName:String[1], fromAssociation:Boolean[1], conventions:Conventions[1], debug:DebugContext[1]): String[1]
+function <<access.private>> meta::alloy::runtime::java::generateExplodeMapOne(setImplementation:InstanceSetImplementation[1], adaptorClass:meta::java::metamodel::Class[1], srcVar:meta::java::metamodel::Parameter[1], parentVar:meta::java::metamodel::Parameter[0..1], conventions:Conventions[1], srcClass:meta::java::metamodel::Class[1], debug:DebugContext[1]): Code[*]
 {
-   let mappings = $setImplementation.propertyMappings->filter(pm|$pm->instanceOf(PurePropertyMapping))->cast(@PurePropertyMapping)->filter(pm| $pm.explodeProperty->isTrue());
-   let listsString = $mappings->map(m|let property = $m.property;
-                                'List<' + $property.genericType.rawType.name->toOne() + '> ' + $property.name->toOne() + 'List = '
-                                                                      + $m.transform.expressionSequence->at(0)->evaluateAndDeactivate()->generateJava($conventions, $debug->indent())->codeToString() + ';';)->joinStrings('\n');
-   let lengthString = 'int length = ' + $mappings->at(0).property.name->toOne() + 'List.size();';
-   let errorHandlingString = $mappings->tail()->map(m|'if(' + $m.property.name->toOne() + 'List.size() != length)\n' +
-                                                          '{\n' +
-                                                          'throw new IllegalArgumentException("Explode properties do not have the same size.");\n' +
-                                                          '};')->joinStrings('\n');
-   let inputString = 'IntStream indexStream =  IntStream.range(0, length);';
+   let explosionPropertyMappings = $setImplementation.propertyMappings->filter(pm|$pm->instanceOf(PurePropertyMapping))->cast(@PurePropertyMapping)->filter(pm| $pm.explodeProperty->isTrue());
+   let explosionPropertyVarDeclaration = $explosionPropertyMappings->map(pm|
+                                let property = $pm.property;
+                                let propertyVariable = j_variable(javaList($conventions->pureTypeToJavaType($property)), $property.name->toOne() + '_list');
+                                $propertyVariable->j_declare($pm.transform.expressionSequence->at(0)->evaluateAndDeactivate()->generateJava($conventions, $debug->indent())););
 
-   let returnStatementString = 'return indexStream.mapToObj(index -> new ' + $adaptorClassName + '(src, ' + if($fromAssociation, |'parent, ',|'') + $mappings->map(m|$m.property.name->toOne() + 'List')->joinStrings(',') + ',index)).collect(Collectors.toList());';
-   [$listsString, $lengthString, $errorHandlingString, $inputString, $returnStatementString]->joinStrings('\n');
+   let lengthVariable = j_variable(javaInt(), 'length');
+   let lengthVarDeclaration = $lengthVariable->j_declare(j_variable(javaList($conventions->pureTypeToJavaType($explosionPropertyMappings->at(0).property)), $explosionPropertyMappings->at(0).property.name->toOne() + '_list')->j_invoke('size',[],javaInt()));
+
+   let errorHandlingCodeBlock = $explosionPropertyMappings->tail()->map(pm|
+                                                        j_if(j_variable(javaList($conventions->pureTypeToJavaType($pm.property)), $pm.property.name->toOne() + '_list')->j_invoke('size',[],javaInt())->j_ne($lengthVariable),
+                                                        javaIllegalArgumentException()->j_new(j_string('Explode properties do not have the same size. Failure in class ' + $srcClass.simpleName + '. Mismatch between properties - ' + $pm.property.name->toOne() + ' and ' + $explosionPropertyMappings->at(0).property.name->toOne()))->j_throw()
+                                                      ));
+
+   let indexStreamVar = j_variable(javaClass('java.util.stream.IntStream'), 'indexStream');
+   let indexStreamDeclaration = $indexStreamVar->j_declare(javaClass('java.util.stream.IntStream')->j_invoke('range', [j_int(0), $lengthVariable], javaClass('java.util.stream.IntStream')));
+
+   let lambdaParam = j_parameter(javaInt(), 'index');
+   let returnStatement = $indexStreamVar->j_invoke('mapToObj', j_lambda($lambdaParam, $adaptorClass->j_new(j_parameter($srcVar)
+                                                                                                          ->concatenate($parentVar->map(p | j_parameter($p)))
+                                                                                                          ->concatenate($explosionPropertyMappings->map(pm|j_variable(javaList($conventions->pureTypeToJavaType($pm.property)), $pm.property.name->toOne() + '_list')))
+                                                                                                          ->concatenate($lambdaParam))), javaStream($adaptorClass))
+                                        ->j_invoke('collect', j_invoke(javaCollectors(), 'toList', [], javaCollector()), javaList($adaptorClass))
+                                        ->j_return();
+
+   $explosionPropertyVarDeclaration->concatenate($lengthVarDeclaration)
+                                   ->concatenate($errorHandlingCodeBlock)
+                                   ->concatenate($indexStreamDeclaration)
+                                   ->concatenate($returnStatement);
 }

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/testExplosion.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/testExplosion.pure
@@ -107,12 +107,42 @@ meta::pure::mapping::modelToModel::test::alloy::explosion::testMappingWithSetsUs
    assert(jsonEquivalent('{"firstName":"Pierre","lastName":"Doe"}'->parseJSON(), $result.values->toOne()->parseJSON()));
 }
 
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly, meta::alloy::runtime::java::roadmap::feature.M2MBasics>>
+{  meta::pure::executionPlan::profiles::serverVersion.start='v1_13_0',
+   doc.doc='Given: a single JSON object that matches a source definition, and an M2M mapping',
+   doc.doc='When:  the mapping is executed using graphFetch and serialize. GraphFetch tree demonstrates usage of explosion at a property level.',
+   doc.doc='Then:  the mapping is applied and the result of the mapping is serialized.'
+}
+meta::pure::mapping::modelToModel::test::alloy::explosion::testExplosionAtPropertyLevel(): Boolean[1]
+{
+   let tree = #{TargetFirm {name,firmEmployees{firmName, fullName, streetAddress, dateOfBirth}} }#;
+
+   let result = execute(
+      |TargetFirm.all()->graphFetch($tree)->serialize($tree),
+      mappingWithSetsUsingAndNotUsingExplosion,
+      ^Runtime(connections = ^JsonModelConnection(
+                                element=^ModelStore(),
+                                class=_SimpleFirm,
+                                url='data:application/json,{"name":"Dunder Mifflin","simpleEmployees":[{"fullName":"Jim","dateOfBirth":"2020-11-09","address":{"street":"first"}},{"fullName":"Pam","dateOfBirth":"2020-11-10","address":{"street":"second"}}]}'
+                             )
+      ),
+      []
+   );
+   assert(jsonEquivalent('{"name": "Dunder Mifflin","firmEmployees": [{"firmName": "Dunder Mifflin","fullName": "Jim","streetAddress": "first","dateOfBirth": "2020-11-09"},{"firmName": "Dunder Mifflin","fullName": "Pam","streetAddress": "second","dateOfBirth": "2020-11-10"}]}'->parseJSON(), $result.values->toOne()->parseJSON()));
+}
+
 Class meta::pure::mapping::modelToModel::test::alloy::explosion::FirmEmployeeWithConstraint
 [  hasLongName: $this.fullName->size() > 4 ]
 {
    firmName : String[1];
    fullName : String[1];
    streetAddress: String[0..1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::explosion::TargetFirm
+{
+    name: String[1];
+    firmEmployees: meta::pure::mapping::modelToModel::test::shared::dest::FirmEmployee[*];
 }
 
 ###Mapping
@@ -162,10 +192,26 @@ Mapping meta::pure::mapping::modelToModel::test::alloy::explosion::mappingWithSe
                type      : $src.type
             }
 
+  TargetFirm : Pure
+  {
+    ~src _SimpleFirm
+    name : $src.name,
+    firmEmployees : $src
+  }
+
   FirmEmployeeWithConstraint : Pure
             {
                ~src _SimpleFirm
                firmName : $src.name,
                fullName* : $src.simpleEmployees.fullName
+            }
+
+  FirmEmployee : Pure
+            {
+               ~src _SimpleFirm
+               firmName : $src.name,
+               fullName* : $src.simpleEmployees.fullName,
+               streetAddress* : $src.simpleEmployees.address.street,
+               dateOfBirth* : $src.simpleEmployees.dateOfBirth
             }
 )

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/shared.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/shared.pure
@@ -52,15 +52,11 @@ Class meta::pure::mapping::modelToModel::test::shared::dest::PersonWithConstrain
 
 Class meta::pure::mapping::modelToModel::test::shared::dest::FirmEmployee
 {
-   
    firmName : String[1];
    fullName : String[1];
+   dateOfBirth : StrictDate[0..1];
    streetAddress: String[0..1];
-   
 }
-
-
-
 
 Class meta::pure::mapping::modelToModel::test::shared::dest::Address
 {
@@ -70,7 +66,7 @@ Class meta::pure::mapping::modelToModel::test::shared::dest::Address
 
 Class meta::pure::mapping::modelToModel::test::shared::dest::AddressExtension
 {
-    stuff : String[1];  
+    stuff : String[1];
 }
 
 Class meta::pure::mapping::modelToModel::test::shared::dest::Vehicle
@@ -114,6 +110,7 @@ Class meta::pure::mapping::modelToModel::test::shared::src::_Person
 Class meta::pure::mapping::modelToModel::test::shared::src::_SimplePerson
 {
    fullName : String[1];
+   dateOfBirth : StrictDate[0..1];
    address : Address[1];
 }
 


### PR DESCRIPTION
Encountered a bug in java code gen flow. Bug impacts graphfetch queries where explosion mapping is used at a property level or explosion mapping is used on date properties