### PR TITLE
Check function expressions in constraints

### DIFF
--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/validator/ElementWithConstraintsValidator.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/validator/ElementWithConstraintsValidator.java
@@ -48,10 +48,10 @@ public class ElementWithConstraintsValidator implements MatchRunner<ElementWithC
     @Override
     public void run(ElementWithConstraints instance, MatcherState state, Matcher matcher, ModelRepository modelRepository, Context context) throws PureCompilationException
     {
-        validateConstraints((ModelElement)instance, instance._constraints(), state);
+        validateConstraints((ModelElement)instance, instance._constraints(), state,matcher, modelRepository, context);
     }
 
-    static void validateConstraints(ModelElement instance, RichIterable<? extends Constraint> constraints, MatcherState state) throws PureCompilationException
+    static void validateConstraints(ModelElement instance, RichIterable<? extends Constraint> constraints, MatcherState state, Matcher matcher, ModelRepository modelRepository, Context context) throws PureCompilationException
     {
         ValidatorState validatorState = (ValidatorState)state;
         ProcessorSupport processorSupport = validatorState.getProcessorSupport();
@@ -71,6 +71,11 @@ public class ElementWithConstraintsValidator implements MatchRunner<ElementWithC
                 ruleNames.add(ruleName);
 
                 ValueSpecification definition = constraint._functionDefinition()._expressionSequence().getFirst();
+                if(definition instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.FunctionExpression)
+                {
+                    FunctionExpressionValidator.validateFunctionExpression(matcher, validatorState, (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.FunctionExpression) definition, modelRepository, processorSupport);
+                }
+
                 Type type = (Type)ImportStub.withImportStubByPass(definition._genericType()._rawTypeCoreInstance(), processorSupport);
                 if (type != booleanType || !Multiplicity.isToOne(definition._multiplicity(), true))
                 {
@@ -82,6 +87,11 @@ public class ElementWithConstraintsValidator implements MatchRunner<ElementWithC
                     if(constraint._messageFunction() != null)
                     {
                         ValueSpecification message = constraint._messageFunction()._expressionSequence().getFirst();
+                        if(message instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.FunctionExpression)
+                        {
+                            FunctionExpressionValidator.validateFunctionExpression(matcher, validatorState, (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.FunctionExpression) message, modelRepository, processorSupport);
+                        }
+
                         Type messageType = (Type)ImportStub.withImportStubByPass(message._genericType()._rawTypeCoreInstance(), processorSupport);
                         if (messageType != stringType || !Multiplicity.isToOne(message._multiplicity(), true))
                         {

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/validator/FunctionDefinitionValidator.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/validator/FunctionDefinitionValidator.java
@@ -91,8 +91,8 @@ public class FunctionDefinitionValidator implements MatchRunner<FunctionDefiniti
         validateEqualityFunctions(functionDefinition);
         validateFunctionDefinitionReturnType(functionDefinition, functionType, processorSupport);
         VisibilityValidation.validateFunctionDefinition(functionDefinition, context, validatorState, processorSupport);
-        ElementWithConstraintsValidator.validateConstraints(functionDefinition, functionDefinition._preConstraints(), state);
-        ElementWithConstraintsValidator.validateConstraints(functionDefinition, functionDefinition._postConstraints(), state);
+        ElementWithConstraintsValidator.validateConstraints(functionDefinition, functionDefinition._preConstraints(), state, matcher , modelRepository , context);
+        ElementWithConstraintsValidator.validateConstraints(functionDefinition, functionDefinition._postConstraints(), state, matcher, modelRepository, context);
 
     }
 

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/constraints/AbstractTestConstraints.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/constraints/AbstractTestConstraints.java
@@ -16,6 +16,7 @@ package org.finos.legend.pure.m3.tests.constraints;
 
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
+import org.finos.legend.pure.m3.exception.PureUnmatchedFunctionException;
 import org.finos.legend.pure.m4.serialization.grammar.antlr.PureParserException;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.junit.After;
@@ -668,6 +669,71 @@ public abstract class AbstractTestConstraints extends AbstractPureTestWithCoreCo
                 "   startDate: Date[1];\n" +
                 "   endDate: Date[1];\n" +
                 "}");
+    }
+
+    @Test
+    public void testExtendedConstraintGrammarCompilationFailure()
+    {
+        try {
+            this.compileTestSource("fromString.pure", "Class Position\n" +
+                    "[\n" +
+                    "   c1\n" +
+                    "   (\n" +
+                    "      ~owner            : Finance\n" +
+                    "      ~externalId       : 'My_Ext_Id'\n" +
+                    "      ~function         : $this.contractId->startsWith('A')\n" +
+                    "      ~enforcementLevel : Error\n" +
+                    "      ~message          : 'Contract ID: ' + $this.contractId\n" +
+                    "   )\n" +
+                    "]\n" +
+                    "{\n" +
+                    "   contractId: String[0..1];\n" +
+                    "   positionType: String[1];\n" +
+                    "   startDate: Date[1];\n" +
+                    "   endDate: Date[1];\n" +
+                    "}");
+            Assert.fail();
+        }
+        catch(Exception e)
+        {
+            String expectedError = "The system can't find a match for the function: startsWith(_:String[0..1],_:String[1])\n" +
+                                    "\n" +
+                                    "No functions, in packages already imported, match the function name.\n" +
+                                    "\n" +
+                                    "These functions, in packages not imported, match the function name. Add the package to imports so that the function is in scope.\n" +
+                                    "\tmeta::pure::functions::string::startsWith(String[1], String[1]):Boolean[1]\n";
+
+            this.assertOriginatingPureException(PureUnmatchedFunctionException.class, expectedError,7,45,e);
+        }
+    }
+
+    @Test
+    public void testExtendedConstraintGrammarMessageCompilationFailure()
+    {
+        try {
+            this.compileTestSource("fromString.pure", "Class Position\n" +
+                    "[\n" +
+                    "   c1\n" +
+                    "   (\n" +
+                    "      ~owner            : Finance\n" +
+                    "      ~externalId       : 'My_Ext_Id'\n" +
+                    "      ~function         : $this.contractId->toOne()->startsWith('A')\n" +
+                    "      ~enforcementLevel : Error\n" +
+                    "      ~message          : 'Contract ID: ' + $this.contractId\n" +
+                    "   )\n" +
+                    "]\n" +
+                    "{\n" +
+                    "   contractId: String[0..1];\n" +
+                    "   positionType: String[1];\n" +
+                    "   startDate: Date[1];\n" +
+                    "   endDate: Date[1];\n" +
+                    "}");
+            Assert.fail();
+        }
+        catch(Exception e)
+        {
+            this.assertOriginatingPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1",9,51,e);
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes the Pure compiler to type check lambdas in constraint definitions (both function and message lambdas). 