### PR TITLE
fix routing for multiple class mappings

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/testRouting.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/testRouting.pure
@@ -39,3 +39,17 @@ function <<test.Test>> meta::pure::graphFetch::tests::routing::testSimpleM2MTree
    let f = routeFunction(|meta::pure::mapping::modelToModel::test::shared::dest::Firm.all()->graphFetch($m2mTree)->serialize($m2mTree), meta::pure::mapping::modelToModel::test::simple::simpleModelMappingWithAssociation, ^Runtime(), ^ExecutionContext(), meta::pure::router::extension::defaultExtensions(), noDebug());
    assertEquals(' | {Platform> {MODEL> [1 meta_pure_mapping_modelToModel_test_shared_dest_Firm/[1 meta_pure_mapping_modelToModel_test_shared_dest_Firm/[1 meta_pure_mapping_modelToModel_test_shared_dest_Firm/Class Firm].all()] -> graphFetch({MODEL> [meta_pure_mapping_modelToModel_test_shared_dest_Firm / meta::pure::mapping::modelToModel::test::shared::dest::Firm] {@(meta_pure_mapping_modelToModel_test_shared_dest_Firm->)@ [meta_pure_mapping_modelToModel_test_shared_dest_Firm / legalName], @(meta_pure_mapping_modelToModel_test_shared_dest_Firm->meta_pure_mapping_modelToModel_test_shared_dest_Person)@ [meta_pure_mapping_modelToModel_test_shared_dest_Person / employees] {@(meta_pure_mapping_modelToModel_test_shared_dest_Person->)@ [meta_pure_mapping_modelToModel_test_shared_dest_Person / firstName]}}})]} -> serialize(meta::pure::mapping::modelToModel::test::shared::dest::Firm {legalName, employees {firstName}})};', $f.functions->at(0)->meta::pure::router::printer::asString());
 }
+
+function <<test.Test>> meta::pure::graphFetch::tests::routing::testSimpleM2MTreeRoutingUsingNonRootSet():Boolean[1]
+{
+   let m2mTree = #{
+      meta::pure::mapping::modelToModel::test::shared::dest::Firm {
+         legalName,
+         employees {
+            firstName
+         }
+      }
+   }#;
+   let f = routeFunction(|meta::pure::mapping::modelToModel::test::shared::dest::Firm.all()->graphFetch($m2mTree)->serialize($m2mTree), meta::pure::mapping::modelToModel::test::simple::simpleModelMappingWithMultipleClassMappings, ^Runtime(), ^ExecutionContext(), meta::pure::router::extension::defaultExtensions(), noDebug());
+   assertEquals(' | {Platform> {MODEL> [1 meta_pure_mapping_modelToModel_test_shared_dest_Firm/[1 meta_pure_mapping_modelToModel_test_shared_dest_Firm/[1 meta_pure_mapping_modelToModel_test_shared_dest_Firm/Class Firm].all()] -> graphFetch({MODEL> [meta_pure_mapping_modelToModel_test_shared_dest_Firm / meta::pure::mapping::modelToModel::test::shared::dest::Firm] {@(meta_pure_mapping_modelToModel_test_shared_dest_Firm->)@ [meta_pure_mapping_modelToModel_test_shared_dest_Firm / legalName], @(meta_pure_mapping_modelToModel_test_shared_dest_Firm->p1)@ [p1 / employees] {@(meta_pure_mapping_modelToModel_test_shared_dest_Person->)@ [p1 / firstName]}}})]} -> serialize(meta::pure::mapping::modelToModel::test::shared::dest::Firm {legalName, employees {firstName}})};', $f.functions->at(0)->meta::pure::router::printer::asString());
+}

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/simple.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/simple.pure
@@ -316,6 +316,31 @@ Mapping meta::pure::mapping::modelToModel::test::simple::simpleModelMappingWithA
 
 )
 
+Mapping meta::pure::mapping::modelToModel::test::simple::simpleModelMappingWithMultipleClassMappings
+(
+   *Person : Pure
+            {
+               ~src _Person
+               firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')),
+               lastName : $src.fullName->substring($src.fullName->indexOf(' ')+1, $src.fullName->length())
+            }
+
+   Person[p1] : Pure
+   {
+       ~src _Person
+       firstName : $src.fullName->substring(0, $src.fullName->indexOf(' ')),
+       lastName : $src.fullName->substring($src.fullName->indexOf(' ')+1, $src.fullName->length())
+   }
+
+   Firm : Pure
+   {
+      ~src _Firm
+      legalName : $src.name,
+      employees[p1] : $src.employees
+   }
+
+)
+
 ###Mapping
 import meta::pure::mapping::modelToModel::test::shared::src::*;
 import meta::pure::mapping::modelToModel::test::shared::dest::*;

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/mappingExtension.pure
@@ -237,9 +237,9 @@ function meta::pure::router::routing::findMappingsFromProperty(p:AbstractPropert
                                           | let embeddedMappings = $sourceMappings->resolveOperation($mapping)->cast(@PropertyMappingsImplementation)->map(s|$s.propertyMappingsByPropertyName($p.name->toOne())->map(pm | $pm->reprocessAggregationAwarePropertyMapping())->filter(p|$p->instanceOf(EmbeddedSetImplementation)))->cast(@EmbeddedSetImplementation);
                                             let containers = $embeddedMappings->map(e | ^SetImplementationContainer(id=$e.id, setImplementation=$e));
                                             ^OperationSetImplementation(id='embedded_operation', root=true, class=$c->cast(@Class<Any>), parent=$mapping, parameters=$containers, operation=$sourceMappings->at(0)->cast(@OperationSetImplementation).operation);,
-                                          | let embeddedRelationalIds = $extensions.mapping_extractRelationalPropertyMappingFromEmbedded->map(f|$f->eval($p, $sourceMappings, $mapping));
-                                            if(!$embeddedRelationalIds->isEmpty(),
-                                               | let classMappingsById = $mapping._classMappingByIdRecursive($embeddedRelationalIds)->map(x | $mapping.classMappingById($x.id));
+                                          | let targetSetIds = $sourceMappings->resolveOperation($mapping)->cast(@PropertyMappingsImplementation)->map(s|$s.propertyMappingsByPropertyName($p.name->toOne())).targetSetImplementationId;
+                                            if(!$targetSetIds->isEmpty(),
+                                               | let classMappingsById = $targetSetIds->map(id | $mapping.classMappingById($id));
                                                  if($classMappingsById->isEmpty(),
                                                     |$mapping.rootClassMappingByClass($c->cast(@Class<Any>))->potentiallyResolveOperation($mapping),
                                                     |$classMappingsById


### PR DESCRIPTION
A bug was identified in routing flow. It impacts non-relational store use cases when there are multiple class mappings for same class