### PR TITLE
Initial compiled state integrity test for core

### DIFF
--- a/legend-pure-code-compiled-core/pom.xml
+++ b/legend-pure-code-compiled-core/pom.xml
@@ -54,4 +54,62 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-dsl-path</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-dsl-graph</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-mapping</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-dsl-diagram</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-external-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-testutils</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/legend-pure-code-compiled-core/src/test/java/org/finos/legend/pure/code/core/TestCoreCompiledStateIntegrity.java
+++ b/legend-pure-code-compiled-core/src/test/java/org/finos/legend/pure/code/core/TestCoreCompiledStateIntegrity.java
@@ -20,6 +20,7 @@ public class TestCoreCompiledStateIntegrity extends AbstractCompiledStateIntegri
 
     @Test
     @Ignore
+    @Override
     public void testPackageHasChildrenWithDuplicateNames()
     {
         // TODO fix this test
@@ -28,6 +29,7 @@ public class TestCoreCompiledStateIntegrity extends AbstractCompiledStateIntegri
 
     @Test
     @Ignore
+    @Override
     public void testReferenceUsages()
     {
         // TODO fix this test

--- a/legend-pure-code-compiled-core/src/test/java/org/finos/legend/pure/code/core/TestCoreCompiledStateIntegrity.java
+++ b/legend-pure-code-compiled-core/src/test/java/org/finos/legend/pure/code/core/TestCoreCompiledStateIntegrity.java
@@ -1,0 +1,36 @@
+package org.finos.legend.pure.code.core;
+
+import org.finos.legend.pure.m3.AbstractCompiledStateIntegrityTest;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestCoreCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        MutableCodeStorage codeStorage = new PureCodeStorage(null, new ClassLoaderCodeStorage(CodeRepository.newPlatformCodeRepository(), CodeRepository.newCoreCodeRepository()));
+        initialize(codeStorage);
+    }
+
+    @Test
+    @Ignore
+    public void testPackageHasChildrenWithDuplicateNames()
+    {
+        // TODO fix this test
+        super.testPackageHasChildrenWithDuplicateNames();
+    }
+
+    @Test
+    @Ignore
+    public void testReferenceUsages()
+    {
+        // TODO fix this test
+        super.testReferenceUsages();
+    }
+}

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/functionmatch/FunctionExpressionMatcher.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/functionmatch/FunctionExpressionMatcher.java
@@ -15,51 +15,50 @@
 package org.finos.legend.pure.m3.compiler.postprocessing.functionmatch;
 
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.SetIterable;
-import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Multimaps;
-import org.eclipse.collections.impl.factory.Sets;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.finos.legend.pure.m3.navigation.M3Paths;
-import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
-import org.finos.legend.pure.m3.navigation._package._Package;
-import org.finos.legend.pure.m3.navigation.imports.Imports;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.FunctionExpression;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation._package._Package;
+import org.finos.legend.pure.m3.navigation.imports.Imports;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+import org.finos.legend.pure.m4.exception.PureCompilationException;
 
 public class FunctionExpressionMatcher
 {
-    public static ListIterable<? extends CoreInstance> findMatchingFunctionsInTheRepository(FunctionExpression functionExpression, boolean lenient, ProcessorSupport processorSupport) throws PureCompilationException
+    public static ListIterable<Function<?>> findMatchingFunctionsInTheRepository(FunctionExpression functionExpression, boolean lenient, ProcessorSupport processorSupport) throws PureCompilationException
     {
         RichIterable<? extends ValueSpecification> parametersValues = functionExpression._parametersValues();
 
         ListIterable<String> splitFunctionPath = PackageableElement.splitUserPath(functionExpression._functionName());
         int lastIndex = splitFunctionPath.size() - 1;
         String functionToFindName = splitFunctionPath.get(lastIndex);
-        ListIterable<String> functionPkg = (lastIndex == 0) ? Lists.immutable.<String>with() : splitFunctionPath.take(lastIndex);
+        ListIterable<String> functionPkg = (lastIndex == 0) ? Lists.immutable.with() : splitFunctionPath.take(lastIndex);
 
-        RichIterable<Function> functionsToSearch = getFunctionsWithMatchingName(functionToFindName, functionPkg, functionExpression, processorSupport);
+        RichIterable<Function<?>> functionsToSearch = getFunctionsWithMatchingName(functionToFindName, functionPkg, functionExpression, processorSupport);
 
         SourceInformation sourceInformation = functionExpression.getSourceInformation();
 
         return getFunctionMatches(functionsToSearch, parametersValues, functionToFindName, sourceInformation, lenient, processorSupport);
     }
 
-    public static ListIterable<? extends CoreInstance> getFunctionMatches(RichIterable<Function> functionsToSearch, RichIterable<? extends ValueSpecification> parametersValues, String functionToFindName, SourceInformation sourceInformation, boolean lenient, ProcessorSupport processorSupport) throws PureCompilationException
+    public static <T extends Function<?>> ListIterable<T> getFunctionMatches(RichIterable<T> functionsToSearch, RichIterable<? extends ValueSpecification> parametersValues, String functionToFindName, SourceInformation sourceInformation, boolean lenient, ProcessorSupport processorSupport) throws PureCompilationException
     {
-        MutableListMultimap<FunctionMatch, CoreInstance> functionsByMatch = Multimaps.mutable.list.empty();
+        MutableListMultimap<FunctionMatch, T> functionsByMatch = Multimaps.mutable.list.empty();
         try
         {
-            for (Function function : functionsToSearch)
+            for (T function : functionsToSearch)
             {
                 FunctionMatch match = FunctionMatch.newFunctionMatch(function, functionToFindName, parametersValues.toList(), lenient, processorSupport);
                 if (match != null)
@@ -70,18 +69,16 @@ public class FunctionExpressionMatcher
         }
         catch (RuntimeException e)
         {
-            StringBuilder message = new StringBuilder("Error finding match for function '");
-            message.append(functionToFindName);
-            message.append('\'');
-            if (e.getMessage() != null)
+            StringBuilder message = new StringBuilder("Error finding match for function '").append(functionToFindName).append('\'');
+            String eMessage = e.getMessage();
+            if (eMessage != null)
             {
-                message.append(": ");
-                message.append(e.getMessage());
+                message.append(": ").append(eMessage);
             }
             throw new PureCompilationException(sourceInformation, message.toString(), e);
         }
 
-        MutableList<CoreInstance> functionMatches = FastList.newList(functionsByMatch.sizeDistinct());
+        MutableList<T> functionMatches = Lists.mutable.ofInitialCapacity(functionsByMatch.sizeDistinct());
         for (FunctionMatch match : functionsByMatch.keysView().toSortedList())
         {
             functionMatches.addAllIterable(functionsByMatch.get(match));
@@ -89,14 +86,14 @@ public class FunctionExpressionMatcher
         return functionMatches;
     }
 
-    public static CoreInstance getBestFunctionMatch(RichIterable<? extends Function> functionsToSearch, ListIterable<? extends ValueSpecification> parametersValues, String functionToFindName, SourceInformation sourceInformation, boolean lenient, ProcessorSupport processorSupport) throws PureCompilationException
+    public static <T extends Function<?>> T getBestFunctionMatch(RichIterable<T> functionsToSearch, ListIterable<? extends ValueSpecification> parametersValues, String functionToFindName, SourceInformation sourceInformation, boolean lenient, ProcessorSupport processorSupport) throws PureCompilationException
     {
         FunctionMatch bestMatch = null;
-        MutableList<Function> bestFunctions = null;
+        MutableList<T> bestFunctions = Lists.mutable.empty();
 
         try
         {
-            for (Function function : functionsToSearch)
+            for (T function : functionsToSearch)
             {
                 FunctionMatch match = FunctionMatch.newFunctionMatch(function, functionToFindName, parametersValues, lenient, processorSupport);
                 if (match != null)
@@ -104,7 +101,7 @@ public class FunctionExpressionMatcher
                     if (bestMatch == null)
                     {
                         bestMatch = match;
-                        bestFunctions = Lists.mutable.with(function);
+                        bestFunctions.add(function);
                     }
                     else
                     {
@@ -125,18 +122,16 @@ public class FunctionExpressionMatcher
         }
         catch (RuntimeException e)
         {
-            StringBuilder message = new StringBuilder("Error finding match for function '");
-            message.append(functionToFindName);
-            message.append('\'');
-            if (e.getMessage() != null)
+            StringBuilder message = new StringBuilder("Error finding match for function '").append(functionToFindName).append('\'');
+            String eMessage = e.getMessage();
+            if (eMessage != null)
             {
-                message.append(": ");
-                message.append(e.getMessage());
+                message.append(": ").append(eMessage);
             }
             throw new PureCompilationException(sourceInformation, message.toString(), e);
         }
 
-        if (bestFunctions == null)
+        if (bestMatch == null)
         {
             return null;
         }
@@ -145,7 +140,7 @@ public class FunctionExpressionMatcher
         {
             StringBuilder message = new StringBuilder("Too many matches for ");
             org.finos.legend.pure.m3.navigation.functionexpression.FunctionExpression.printFunctionSignatureFromExpression(message, functionToFindName, parametersValues, processorSupport);
-            MutableList<String> functionDescriptors = FastList.newList(bestFunctions.size());
+            MutableList<String> functionDescriptors = Lists.mutable.ofInitialCapacity(bestFunctions.size());
             for (CoreInstance func : bestFunctions)
             {
                 functionDescriptors.add(org.finos.legend.pure.m3.navigation.function.Function.print(func, processorSupport));
@@ -157,15 +152,15 @@ public class FunctionExpressionMatcher
         return bestFunctions.getFirst();
     }
 
-    private static RichIterable<Function> getFunctionsWithMatchingName(String functionName, ListIterable<String> functionPackage, FunctionExpression functionExpression, ProcessorSupport processorSupport)
+    private static RichIterable<Function<?>> getFunctionsWithMatchingName(String functionName, ListIterable<String> functionPackage, FunctionExpression functionExpression, ProcessorSupport processorSupport)
     {
         SetIterable<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement> packages = getValidPackages(functionPackage, functionExpression, processorSupport);
-        MutableList<Function> functions = Lists.mutable.empty();
+        MutableList<Function<?>> functions = Lists.mutable.empty();
         for (CoreInstance function : processorSupport.function_getFunctionsForName(functionName))
         {
-            if (packages.contains(((Function)function)._package()))
+            if (packages.contains(((Function<?>) function)._package()))
             {
-                functions.add((Function)function);
+                functions.add((Function<?>) function);
             }
         }
         return functions;
@@ -175,12 +170,12 @@ public class FunctionExpressionMatcher
     {
         if (functionPackage.notEmpty())
         {
-            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement pkg = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement)_Package.getByUserPath(functionPackage, processorSupport);
-            return (pkg == null) ? Sets.immutable.<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement>empty() : Sets.immutable.with(pkg);
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement pkg = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) _Package.getByUserPath(functionPackage, processorSupport);
+            return (pkg == null) ? Sets.immutable.empty() : Sets.immutable.with(pkg);
         }
 
         MutableSet<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement> packages = Imports.getImportGroupPackages(functionExpression._importGroup(), processorSupport).toSet();
-        packages.add((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement)processorSupport.repository_getTopLevel(M3Paths.Root));
+        packages.add((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) processorSupport.repository_getTopLevel(M3Paths.Root));
         return packages;
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/lineinfo/TestLineInfo.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/lineinfo/TestLineInfo.java
@@ -41,12 +41,14 @@ import org.junit.Test;
 public class TestLineInfo extends AbstractPureTestWithCoreCompiledPlatform
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getExtra());
     }
 
     @After
-    public void clearRuntime() {
+    public void clearRuntime()
+    {
         runtime.delete("fromString.pure");
     }
 

--- a/legend-pure-m3-dsl-graph/src/main/java/org/finos/legend/pure/m3/inlinedsl/graph/processor/RootGraphFetchTreeProcessor.java
+++ b/legend-pure-m3-dsl-graph/src/main/java/org/finos/legend/pure/m3/inlinedsl/graph/processor/RootGraphFetchTreeProcessor.java
@@ -17,28 +17,20 @@ package org.finos.legend.pure.m3.inlinedsl.graph.processor;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
-import org.finos.legend.pure.m3.inlinedsl.graph.M3GraphPaths;
-import org.finos.legend.pure.m3.inlinedsl.graph.M3GraphProperties;
-import org.finos.legend.pure.m3.navigation.M3Paths;
-import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.compiler.Context;
-import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.compiler.postprocessing.PostProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState;
 import org.finos.legend.pure.m3.compiler.postprocessing.functionmatch.FunctionExpressionMatcher;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.Processor;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.milestoning.MilestoningFunctions;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.valuespecification.InstanceValueProcessor;
-import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
-import org.finos.legend.pure.m3.navigation._class._Class;
-import org.finos.legend.pure.m3.navigation.functionexpression.FunctionExpression;
-import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.graphFetch.GraphFetchTree;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.graphFetch.PropertyGraphFetchTree;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.graphFetch.RootGraphFetchTree;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.EnumStub;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.PropertyStub;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.AbstractProperty;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.ClassInstance;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration;
@@ -49,14 +41,23 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.G
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
+import org.finos.legend.pure.m3.inlinedsl.graph.M3GraphPaths;
+import org.finos.legend.pure.m3.inlinedsl.graph.M3GraphProperties;
+import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation._class._Class;
+import org.finos.legend.pure.m3.navigation.functionexpression.FunctionExpression;
+import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
 import org.finos.legend.pure.m3.tools.matcher.Matcher;
-import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.ModelRepository;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+import org.finos.legend.pure.m4.exception.PureCompilationException;
 
-public class RootGraphFetchTreeProcessor extends Processor<RootGraphFetchTree>
+public class RootGraphFetchTreeProcessor extends Processor<RootGraphFetchTree<?>>
 {
     @Override
     public String getClassName()
@@ -65,7 +66,7 @@ public class RootGraphFetchTreeProcessor extends Processor<RootGraphFetchTree>
     }
 
     @Override
-    public void process(RootGraphFetchTree instance, ProcessorState state, Matcher matcher, ModelRepository repository, Context context, ProcessorSupport processorSupport)
+    public void process(RootGraphFetchTree<?> instance, ProcessorState state, Matcher matcher, ModelRepository repository, Context context, ProcessorSupport processorSupport)
     {
         CoreInstance _class = ImportStub.withImportStubByPass(instance._classCoreInstance(), processorSupport);
         PostProcessor.processElement(matcher, _class, state, processorSupport);
@@ -78,13 +79,13 @@ public class RootGraphFetchTreeProcessor extends Processor<RootGraphFetchTree>
         classifierGT._typeArgumentsAdd(typeArg);
         instance._classifierGenericType(classifierGT);
 
-        for(GraphFetchTree subTree : instance._subTrees())
+        for (GraphFetchTree subTree : instance._subTrees())
         {
             this.processPropertyGraphFetchTree((PropertyGraphFetchTree) subTree, _class, state, matcher, repository, processorSupport);
         }
     }
 
-    private void processPropertyGraphFetchTree(PropertyGraphFetchTree propertyGraphFetchTree, CoreInstance _class, ProcessorState state, Matcher matcher, ModelRepository repository,ProcessorSupport processorSupport)
+    private void processPropertyGraphFetchTree(PropertyGraphFetchTree propertyGraphFetchTree, CoreInstance _class, ProcessorState state, Matcher matcher, ModelRepository repository, ProcessorSupport processorSupport)
     {
         ClassInstance type = (ClassInstance) processorSupport.package_getByUserPath(M3GraphPaths.PropertyGraphFetchTree);
         GenericType classifierGT = GenericTypeInstance.createPersistent(repository);
@@ -105,7 +106,7 @@ public class RootGraphFetchTreeProcessor extends Processor<RootGraphFetchTree>
                     if (value instanceof EnumStub)
                     {
                         EnumStub enumStub = (EnumStub) value;
-                        Enumeration enumerationCoreInstance = (Enumeration) ImportStub.withImportStubByPass(enumStub._enumerationCoreInstance(), processorSupport);
+                        Enumeration<?> enumerationCoreInstance = (Enumeration<?>) ImportStub.withImportStubByPass(enumStub._enumerationCoreInstance(), processorSupport);
                         org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum enumValue = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum) org.finos.legend.pure.m3.navigation.enumeration.Enumeration.findEnum(enumerationCoreInstance, enumStub._enumName());
 
                         if (enumValue == null)
@@ -118,14 +119,14 @@ public class RootGraphFetchTreeProcessor extends Processor<RootGraphFetchTree>
             InstanceValueProcessor.updateInstanceValue(vs, processorSupport);
         }
 
-        AbstractProperty property = null;
+        AbstractProperty<?> property = null;
 
         if (propertyGraphFetchTree._parameters().isEmpty())
         {
             CoreInstance resolvedProperty = processorSupport.class_findPropertyUsingGeneralization(_class, propertyName);
             if (resolvedProperty != null)
             {
-                property = (AbstractProperty) resolvedProperty;
+                property = (AbstractProperty<?>) resolvedProperty;
                 Instance.addValueToProperty(propertyStubNonResolved, M3Properties.resolvedProperty, property, processorSupport);
             }
         }
@@ -134,8 +135,8 @@ public class RootGraphFetchTreeProcessor extends Processor<RootGraphFetchTree>
         {
             // Qualified
             VariableExpression firstParam = (VariableExpression) processorSupport.newAnonymousCoreInstance(null, M3Paths.VariableExpression);
-            firstParam._genericType((GenericType)org.finos.legend.pure.m3.navigation.type.Type.wrapGenericType(_class, processorSupport));
-            firstParam._multiplicity((Multiplicity)processorSupport.package_getByUserPath(M3Paths.PureOne));
+            firstParam._genericType((GenericType) org.finos.legend.pure.m3.navigation.type.Type.wrapGenericType(_class, processorSupport));
+            firstParam._multiplicity((Multiplicity) processorSupport.package_getByUserPath(M3Paths.PureOne));
             MutableList<ValueSpecification> params = FastList.newList();
             params.add(firstParam);
             for (ValueSpecification vs : propertyGraphFetchTree._parameters())
@@ -143,8 +144,8 @@ public class RootGraphFetchTreeProcessor extends Processor<RootGraphFetchTree>
                 params.add(vs);
             }
 
-            ListIterable<CoreInstance> qualifiedProperties = _Class.findQualifiedPropertiesUsingGeneralization(_class, propertyName, processorSupport);
-            ListIterable<CoreInstance> foundQualifiedProperties = FunctionExpressionMatcher.getFunctionMatches((ListIterable) qualifiedProperties, params, propertyName, propertyStubNonResolved.getSourceInformation(), true, processorSupport);
+            ListIterable<QualifiedProperty<?>> qualifiedProperties = _Class.findQualifiedPropertiesUsingGeneralization(_class, propertyName, processorSupport);
+            ListIterable<QualifiedProperty<?>> foundQualifiedProperties = FunctionExpressionMatcher.getFunctionMatches(qualifiedProperties, params, propertyName, propertyStubNonResolved.getSourceInformation(), true, processorSupport);
 
             if (foundQualifiedProperties.isEmpty())
             {
@@ -154,19 +155,19 @@ public class RootGraphFetchTreeProcessor extends Processor<RootGraphFetchTree>
                 {
                     if (MilestoningFunctions.isGeneratedQualifiedProperty(qualifiedProperties.getFirst(), processorSupport))
                     {
-                        CoreInstance noArgPropertyReturnType = ImportStub.withImportStubByPass(((AbstractProperty) qualifiedProperties.getFirst())._genericType()._rawTypeCoreInstance(), processorSupport);
+                        CoreInstance noArgPropertyReturnType = ImportStub.withImportStubByPass(qualifiedProperties.getFirst()._genericType()._rawTypeCoreInstance(), processorSupport);
                         ListIterable<String> temporalPropertyNames = MilestoningFunctions.getTemporalStereoTypePropertyNamesFromTopMostNonTopTypeGeneralizations(noArgPropertyReturnType, processorSupport);
-                        message.append(". No-Arg milestoned property: '" + propertyName + "' is not supported yet in graph fetch flow! It needs to be supplied with " + temporalPropertyNames.makeString("[", ",", "]") + " parameters");
+                        message.append(". No-Arg milestoned property: '").append(propertyName).append("' is not supported yet in graph fetch flow! It needs to be supplied with ").append(temporalPropertyNames.makeString("[", ",", "]")).append(" parameters");
                     }
                 }
                 throw new PureCompilationException(propertyStubNonResolved.getSourceInformation(), message.toString());
             }
 
-            property = (AbstractProperty) foundQualifiedProperties.getFirst();
+            property = foundQualifiedProperties.getFirst();
             Instance.addValueToProperty(propertyStubNonResolved, M3Properties.resolvedProperty, property, processorSupport);
         }
 
-        FunctionType functionType = (FunctionType)processorSupport.function_getFunctionType(property);
+        FunctionType functionType = (FunctionType) processorSupport.function_getFunctionType(property);
         CoreInstance returnType = ImportStub.withImportStubByPass(functionType._returnType()._rawTypeCoreInstance(), processorSupport);
         PostProcessor.processElement(matcher, returnType, state, processorSupport);
 
@@ -195,7 +196,7 @@ public class RootGraphFetchTreeProcessor extends Processor<RootGraphFetchTree>
         }
     }
 
-    private void throwMilestoningPropertyPathValidationException(AbstractProperty property, SourceInformation souceInformation, ProcessorSupport processorSupport)
+    private void throwMilestoningPropertyPathValidationException(AbstractProperty<?> property, SourceInformation souceInformation, ProcessorSupport processorSupport)
     {
         String noArgPropertyName = property._functionName();
         CoreInstance noArgPropertyReturnType = ImportStub.withImportStubByPass(property._genericType()._rawTypeCoreInstance(), processorSupport);
@@ -204,23 +205,25 @@ public class RootGraphFetchTreeProcessor extends Processor<RootGraphFetchTree>
     }
 
     @Override
-    public void populateReferenceUsages(RootGraphFetchTree instance, ModelRepository repository, ProcessorSupport processorSupport)
+    public void populateReferenceUsages(RootGraphFetchTree<?> instance, ModelRepository repository, ProcessorSupport processorSupport)
     {
         this.addReferenceUsageForToOneProperty(instance, instance._classCoreInstance(), M3GraphProperties._class, repository, processorSupport, instance._classCoreInstance().getSourceInformation());
-        for(GraphFetchTree subTree : instance._subTrees())
+        for (GraphFetchTree subTree : instance._subTrees())
         {
             this.populateReferenceUsagesForPropertyGraphFetchTrees((PropertyGraphFetchTree) subTree, instance, repository, processorSupport);
         }
     }
 
-    private void populateReferenceUsagesForPropertyGraphFetchTrees(PropertyGraphFetchTree propertyGraphFetchTree, RootGraphFetchTree mainTree, ModelRepository repository, ProcessorSupport processorSupport)
+    private void populateReferenceUsagesForPropertyGraphFetchTrees(PropertyGraphFetchTree propertyGraphFetchTree, RootGraphFetchTree<?> mainTree, ModelRepository repository, ProcessorSupport processorSupport)
     {
+        // TODO fix this reference usage: the reference should be to propertyGraphFetchTree, not mainTree
         this.addReferenceUsageForToOneProperty(mainTree, propertyGraphFetchTree._propertyCoreInstance(), M3GraphProperties.property, repository, processorSupport, propertyGraphFetchTree._propertyCoreInstance().getSourceInformation());
         if (propertyGraphFetchTree._subTypeCoreInstance() != null)
         {
+            // TODO fix this reference usage: the reference should be to propertyGraphFetchTree, not mainTree
             this.addReferenceUsageForToOneProperty(mainTree, propertyGraphFetchTree._subTypeCoreInstance(), M3GraphProperties.subType, repository, processorSupport, propertyGraphFetchTree._subTypeCoreInstance().getSourceInformation());
         }
-        for(GraphFetchTree subTree : propertyGraphFetchTree._subTrees())
+        for (GraphFetchTree subTree : propertyGraphFetchTree._subTrees())
         {
             this.populateReferenceUsagesForPropertyGraphFetchTrees((PropertyGraphFetchTree) subTree, mainTree, repository, processorSupport);
         }


### PR DESCRIPTION
Two of the integrity tests are currently failing and so are ignored. They need to be fixed. But the rest of the tests still have value, so I think it's worthwhile to merge the test in. And the ignored tests can be used as a guide for what needs to be fixed (the single biggest one being the reference usages for graph fetch trees).