### PR TITLE
Allow unmapped properties to be used in constraints

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/executionNode/graphFetch/graphFetchCommon.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/executionNode/graphFetch/graphFetchCommon.pure
@@ -25,6 +25,7 @@ import meta::java::metamodel::project::*;
 import meta::java::serialization::*;
 import meta::pure::executionPlan::*;
 import meta::pure::mapping::*;
+import meta::pure::mapping::modelToModel::inMemory::*;
 import meta::pure::milestoning::*;
 import meta::pure::graphFetch::*;
 import meta::pure::graphFetch::routing::*;
@@ -132,7 +133,7 @@ function <<access.private>> meta::alloy::runtime::java::graphFetch::common::upda
       let getterName  = $conventions->getterName($p);
       let fieldType   = $conventions->pureTypeToJavaType($p);
 
-      let noMappingDefaultToEmpty = $p.owner->instanceOf(Class) && ($fetchTree.sets->size() == 1) && $fetchTree.sets->toOne()->defaultToEmptyProperty($p);
+      let noMappingDefaultToEmpty = ($fetchTree.sets->size() == 1) && $fetchTree.sets->toOne()->isNoMappingDefaultToEmpty($p);
       let noMappingPassThru = $p.owner->instanceOf(Class) && ($fetchTree.sets->size() == 1) && $fetchTree.sets->toOne()->passThruProperty($p);
 
       if ($p.owner->instanceOf(Class) && ($fetchTree.sets->size() == 1) && $fetchTree.sets->toOne()->cast(@InstanceSetImplementation).propertyMappingsByPropertyName($p.name->toOne())->isEmpty() && !($p->hasGeneratedMilestoningDatePropertyStereotype()) && !($noMappingDefaultToEmpty || $noMappingPassThru),
@@ -243,12 +244,6 @@ function <<access.private>> meta::alloy::runtime::java::graphFetch::common::upda
    );
 
    newProject()->addClasses($implClass->addMethods([$classSizeMethod, $instanceSizeMethod]));
-}
-
-
-function <<access.private>> meta::alloy::runtime::java::graphFetch::common::defaultToEmptyProperty(setImpl:SetImplementation[1], property:AbstractProperty<Any>[1]):Boolean[1]
-{
-   !$property.multiplicity->hasLowerBound() && $property->functionReturnType().rawType->toOne()->instanceOf(DataType)
 }
 
 function <<access.private>> meta::alloy::runtime::java::graphFetch::common::passThruProperty(setImpl:SetImplementation[1], property:AbstractProperty<Any>[1]):Boolean[1]

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/executionNode/graphFetch/inMemory/graphFetchInMemory.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/executionNode/graphFetch/inMemory/graphFetchInMemory.pure
@@ -224,7 +224,10 @@ function <<access.private>> meta::alloy::runtime::java::graphFetch::inMemory::ge
    let transformPropertyMethodCodes = $propertyMappings->map({pm |
       $streamVarGenerator->eval($pm)->j_declare($singlePropMappingStreamGenerator->eval($pm));
    })->concatenate(
-      javaStream()->j_invoke('of', $propertyMappings->map(p | $streamVarGenerator->eval($p)), $graphInstanceStream)->js_flatMap(j_identity($graphInstanceStream))->j_return()
+      if($propertyMappings->isEmpty(),
+         | javaStream()->j_invoke('empty', [], $graphInstanceStream),
+         | javaStream()->j_invoke('of', $propertyMappings->map(p | $streamVarGenerator->eval($p)), $graphInstanceStream)->js_flatMap(j_identity($graphInstanceStream))
+      )->j_return()
    );
 
    let transformPropertyMethod = javaMethod(['public'], javaStream($conventions->className(GraphInstance)), 'transformProperty', [$graphObjects], $transformPropertyMethodCodes->codesToString($executeClassWithFields));

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -365,14 +365,17 @@ function <<access.private>> meta::pure::graphFetch::enrichSourceTreeNodeForPrope
                   assert($o.parameters.setImplementation->forAll(s|$s->instanceOf(PureInstanceSetImplementation)), |'Unsupported types: ' + $o.parameters.setImplementation->filter(i|!$i->instanceOf(PureInstanceSetImplementation))->type()->elementToPath());
                   $o->meta::pure::router::clustering::resolveInstanceSetImplementations($extensions);
                },
-               {i:InstanceSetImplementation[1] | 
+               {e:EmbeddedSetImplementation[1] |
+                  [];
+               },
+               {i:InstanceSetImplementation[1] |
                   assert($i->instanceOf(PureInstanceSetImplementation), 'Unsupported type: ' + $childSI->type()->elementToPath());
                   $i;
                }
             ])->cast(@PureInstanceSetImplementation)
          );
                
-         assert($childSIsResolved->isNotEmpty(), |'Mapping ' + $setImplementation.parent->elementToPath() + ' does not map class from tree: ' + $c->elementToPath());
+         assert($propertyMappings->isEmpty() || $childSIsResolved->isNotEmpty(), |'Mapping ' + $setImplementation.parent->elementToPath() + ' does not map class from tree: ' + $c->elementToPath());
          $childSIsResolved;
       },
       {a:Any[1]| []}

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/constraints.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/constraints.pure
@@ -163,6 +163,78 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::testIsDistinctConst
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"b\\":true}"},"value":{"b":true}},"value":{"b":true}}'->parseJSON(), $result.values->toOne()->parseJSON()));
 }
 
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
+{ serverVersion.start='vX_X_X' }
+meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnOptionalFieldCanSucceed():Boolean[1]
+{
+   let result = execute(|D.all()->graphFetchChecked(#{D { maybe, i }}#)->serialize(#{D { maybe, i }}#),
+                        meta::pure::mapping::modelToModel::test::alloy::constraints::n2dMaybeNotMapped,
+                         ^Runtime(connections = ^JsonModelConnection(
+                                element=^ModelStore(),
+                                class=_Num,
+                             url='data:application/json,{"n":5}'
+                             )
+                         ),
+                        []
+                );
+
+   assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"n\\":5}"},"value":{"n":5}},"value":{"maybe":null,"i":5}}'->parseJSON(), $result.values->toOne()->parseJSON()));
+}
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
+{ serverVersion.start='vX_X_X' }
+meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnOptionalFieldCanFail():Boolean[1]
+{
+   let result = execute(|D.all()->graphFetchChecked(#{D { maybe, i }}#)->serialize(#{D { maybe, i }}#),
+                        meta::pure::mapping::modelToModel::test::alloy::constraints::n2dMaybeNotMapped,
+                         ^Runtime(connections = ^JsonModelConnection(
+                                element=^ModelStore(),
+                                class=_Num,
+                             url='data:application/json,{"n":20}'
+                             )
+                         ),
+                        []
+                );
+
+   assert(jsonEquivalent('{"defects":[{"path":[],"enforcementLevel":"Error","ruleType":"ClassConstraint","externalId":null,"id":"0","ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::constraints::D","message":"Constraint :[0] violated in the Class D"}],"source":{"defects":[],"source":{"number":1,"record":"{\\"n\\":20}"},"value":{"n":20}},"value":{"maybe":null,"i":20}}'->parseJSON(), $result.values->toOne()->parseJSON()));
+}
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
+{ serverVersion.start='vX_X_X' }
+meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnUnmappedRequiredFieldCanSucceed():Boolean[1]
+{
+   let result = execute(|E.all()->graphFetchChecked(#{E { i }}#)->serialize(#{E { i }}#),
+                        meta::pure::mapping::modelToModel::test::alloy::constraints::n2eExpectedNotMapped,
+                         ^Runtime(connections = ^JsonModelConnection(
+                                element=^ModelStore(),
+                                class=_Num,
+                             url='data:application/json,{"n":5}'
+                             )
+                         ),
+                        []
+                );
+
+   assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"n\\":5}"},"value":{"n":5}},"value":{"i":5}}'->parseJSON(), $result.values->toOne()->parseJSON()));
+}
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
+{ serverVersion.start='vX_X_X' }
+meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnUnmappedRequiredFieldCanFail():Boolean[1]
+{
+   let result = execute(|E.all()->graphFetchChecked(#{E { i }}#)->serialize(#{E { i }}#),
+                        meta::pure::mapping::modelToModel::test::alloy::constraints::n2eExpectedNotMapped,
+                         ^Runtime(connections = ^JsonModelConnection(
+                                element=^ModelStore(),
+                                class=_Num,
+                             url='data:application/json,{"n":20}'
+                             )
+                         ),
+                        []
+                );
+
+   assert(jsonEquivalent('{"defects":[{"path":[],"enforcementLevel":"Error","ruleType":"ClassConstraint","externalId":null,"id":"0","ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::constraints::E","message":"Unable to evaluate constraint [0]: No mapping for property \'expected\'"}],"source":{"defects":[],"source":{"number":1,"record":"{\\"n\\":20}"},"value":{"n":20}},"value":{"i":20}}'->parseJSON(), $result.values->toOne()->parseJSON()));
+}
+
 
 Class meta::pure::mapping::modelToModel::test::alloy::constraints::TaxonomyValue
 {
@@ -310,6 +382,29 @@ Class meta::pure::mapping::modelToModel::test::alloy::constraints::_C
    b:Boolean[1];
 }
 
+Class meta::pure::mapping::modelToModel::test::alloy::constraints::D
+[
+   if($this.i < 10, |$this.maybe->isEmpty(), |$this.maybe->isNotEmpty())
+]
+{
+   maybe: String[0..1];
+   i: Integer[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::constraints::E
+[
+   $this.i < 10 || $this.expected == 'Hello'
+]
+{
+   expected: String[1];
+   i: Integer[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::constraints::_Num
+{
+   n: Integer[1];
+}
+
 ###Mapping
 Mapping meta::pure::mapping::modelToModel::test::alloy::constraints::isEqualTest
 (
@@ -327,6 +422,26 @@ Mapping meta::pure::mapping::modelToModel::test::alloy::constraints::isDistinctT
    {
       ~src meta::pure::mapping::modelToModel::test::alloy::constraints::_C
       b: $src.b
+   }
+)
+
+###Mapping
+Mapping meta::pure::mapping::modelToModel::test::alloy::constraints::n2dMaybeNotMapped
+(
+   meta::pure::mapping::modelToModel::test::alloy::constraints::D : Pure
+   {
+      ~src meta::pure::mapping::modelToModel::test::alloy::constraints::_Num
+      i: $src.n
+   }
+)
+
+###Mapping
+Mapping meta::pure::mapping::modelToModel::test::alloy::constraints::n2eExpectedNotMapped
+(
+   meta::pure::mapping::modelToModel::test::alloy::constraints::E : Pure
+   {
+      ~src meta::pure::mapping::modelToModel::test::alloy::constraints::_Num
+      i: $src.n
    }
 )
 

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/simpleObject.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/simpleObject.pure
@@ -360,7 +360,7 @@ function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly
 }
 meta::pure::mapping::modelToModel::test::alloy::simple::unmappedOptionalPropertiesAreEmpty() : Boolean[1]
 {
-   let tree = #{SomeOptionalData {s1, s2, i, f, d, sd, dt, b, c} }#;
+   let tree = #{SomeOptionalData {s1, s2, i, f, d, sd, dt, b, c, nm} }#;
 
    let result = execute(
       |SomeOptionalData.all()->graphFetch($tree)->serialize($tree),
@@ -374,7 +374,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::unmappedOptionalProperti
       []
    );
 
-   let expected = '{"s1":"Hello", "s2":[], "i":null, "f":null, "d":[], "sd":[], "dt":[], "b":null, "c":null}';
+   let expected = '{"s1":"Hello", "s2":[], "i":null, "f":null, "d":[], "sd":[], "dt":[], "b":null, "c":null, "nm":null}';
 
    assert(jsonEquivalent($expected->parseJSON(), $result.values->toOne()->parseJSON()));
 }
@@ -492,6 +492,7 @@ Class meta::pure::mapping::modelToModel::test::alloy::simple::objects::dest::Som
    dt : DateTime[*];
    b  : Boolean[0..1];
    c  : Colour[0..1];
+   nm : Name[0..1];
 }
 
 Class meta::pure::mapping::modelToModel::test::alloy::simple::objects::dest::Name

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/modelToModel.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/modelToModel.pure
@@ -118,9 +118,9 @@ function meta::pure::mapping::modelToModel::inMemory::isNoMappingPassThru(setImp
 function meta::pure::mapping::modelToModel::inMemory::isNoMappingDefaultToEmpty(setImpl:SetImplementation[1], property:AbstractProperty<Any>[1]):Boolean[1]
 {
    $setImpl->match([
-      pisi:PureInstanceSetImplementation[1] | !$property.multiplicity->hasLowerBound() && $property->functionReturnType().rawType->toOne()->instanceOf(DataType),
-      si: SetImplementation[1]              | false;
-   ])
+      pisi:PureInstanceSetImplementation[1] | !$property.multiplicity->hasLowerBound() && $property.owner->instanceOf(Class),
+      si: SetImplementation[1]              | false
+   ]);
 }
 
 function meta::pure::mapping::modelToModel::inMemory::noMappingPassThruSourceProperty(setImpl:PureInstanceSetImplementation[1], property:AbstractProperty<Any>[1]):AbstractProperty<Any>[0..1]


### PR DESCRIPTION
Allow unmapped properties to be used in constraints and not cause defects if the expression does not access the property (for example in an if).