### PR TITLE
Allow multiple aggregates in query

### DIFF
--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/aggregationAware/test/mapping.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/aggregationAware/test/mapping.pure
@@ -148,7 +148,7 @@ Mapping meta::relational::tests::aggregationAware::mapping::simpleMapping
    }
 )
 
-Mapping meta::relational::tests::aggregationAware::mapping::mappingWithMonthCannotbeAggregated
+Mapping meta::relational::tests::aggregationAware::mapping::mappingWithMonthCannotBeAggregated
 (
    include meta::relational::tests::aggregationAware::mapping::baseMapping
    

--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/aggregationAware/test/rewrite/objectGroupBy.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/aggregationAware/test/rewrite/objectGroupBy.pure
@@ -7,7 +7,7 @@ import meta::relational::tests::aggregationAware::domain::*;
 import meta::relational::tests::aggregationAware::*;
 
 
-function <<test.Test>> meta::relational::tests::aggregationAware::testRewrite::objectGroupBy::testRewriteCanAggrgeateGroupByOnLiteralWithSumAgg():Boolean[1]
+function <<test.Test>> meta::relational::tests::aggregationAware::testRewrite::objectGroupBy::testRewriteCanAggregateGroupByOnLiteralWithSumAgg():Boolean[1]
 {
    let query = {|
       Wholesales.all()->groupBy(
@@ -16,12 +16,30 @@ function <<test.Test>> meta::relational::tests::aggregationAware::testRewrite::o
          ['Name', 'Total Price Sum']
       )
    };
-   let mapping = mappingWithMonthCannotbeAggregated;
+   let mapping = mappingWithMonthCannotBeAggregated;
    let runtime = runtime();
    
    let result = execute($query, $mapping, $runtime, defaultRelationalExtensions());
    
    assertSameSQL('select 1 as "Name", sum("root".revenue) as "Total Price Sum" from user_view_agg.SalesTable_Day as "root" group by "Name"', $result);
+}
+
+function <<test.Test>> meta::relational::tests::aggregationAware::testRewrite::objectGroupBy::testRewriteCanAggregateGroupByOnLiteralWithMultipleAgg():Boolean[1]
+{
+   let query = {|
+      Wholesales.all()->groupBy(
+         [x|1],
+         [agg(x|$x.revenue.price, y|$y->sum()),
+         agg(x|$x.revenue.price, y|$y->max())],
+         ['Name', 'Total Price Sum', 'Total Price Max']
+      )
+   };
+   let mapping = mappingWithMonthCannotBeAggregated;
+   let runtime = runtime();
+
+   let result = execute($query, $mapping, $runtime, defaultRelationalExtensions());
+
+   assertSameSQL('select 1 as "Name", sum("root".revenue) as "Total Price Sum", max("root".revenue) as "Total Price Max" from user_view_agg.SalesTable_Day as "root" group by "Name"', $result);
 }
 
 function <<test.Test>> meta::relational::tests::aggregationAware::testRewrite::objectGroupBy::testRewriteSwitchToSalesTable():Boolean[1]

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/aggregationAware/aggregationAware.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/aggregationAware/aggregationAware.pure
@@ -160,12 +160,12 @@ function meta::pure::mapping::aggregationAware::potentiallyRewriteObjectGroupBy(
                    | let aggSpecGroupByFunctionPaths = $aggSpec.aggregateSpecification.groupByFunctions->map(g | $g.groupByFn.expressionSequence->evaluateAndDeactivate()->toOne()->generateProjectPath(newMap(pair('this', ^ProjectPath(thisLevel=$c->elementToPath()))), ^Map<String, List<Any>>()));
                      let functions = $params->at(1)->cast(@InstanceValue).values->evaluateAndDeactivate()->cast(@meta::pure::metamodel::function::Function<Any>);
                      let aggs = $params->at(2)->match([
-                        i: InstanceValue[1] | $i.values->match([
+                        i: InstanceValue[1] | $i.values->map(x | $x->match([
                                                                a:meta::pure::functions::collection::AggregateValue<Any,Any,Any>[1]| pair($a.mapFn->cast(@meta::pure::metamodel::function::FunctionDefinition<Any>), $a.aggregateFn->cast(@meta::pure::metamodel::function::FunctionDefinition<Any>));,
 
                                                                v: Any[*]| $v->evaluateAndDeactivate()->map(agg | pair($agg->cast(@SimpleFunctionExpression).parametersValues->at(0)->evaluateAndDeactivate()->cast(@InstanceValue).values->at(0)->cast(@meta::pure::metamodel::function::FunctionDefinition<Any>),
                                                                                                  $agg->cast(@SimpleFunctionExpression).parametersValues->at(1)->evaluateAndDeactivate()->cast(@InstanceValue).values->at(0)->cast(@meta::pure::metamodel::function::FunctionDefinition<Any>)))
-                                                               ]),
+                                                               ])),
                         s: SimpleFunctionExpression[1] | pair($s.parametersValues->at(0)->evaluateAndDeactivate()->cast(@InstanceValue).values->at(0)->cast(@meta::pure::metamodel::function::FunctionDefinition<Any>),
                                                               $s.parametersValues->at(1)->evaluateAndDeactivate()->cast(@InstanceValue).values->at(0)->cast(@meta::pure::metamodel::function::FunctionDefinition<Any>))
                      ]);


### PR DESCRIPTION
This is fix for an error that originally was spotted during plan generation when we use more than one agg() function in the query