### PR TITLE
M2M: Refine computation of prohibited classes for new operator

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/main.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/main.pure
@@ -103,6 +103,7 @@ Class meta::alloy::runtime::java::typeInfo::ClassTypeInfo extends TypeInfo
    supertypes          : Class<Any>[*];
    qualifiedProperties : QualifiedProperty<Any>[*];
    constraints         : ConstraintInfo[*];
+   isFromConstraint    : Boolean[1];
    
    class() { $this.type->cast(@Class<Any>) }: Class<Any>[1];
 }
@@ -201,10 +202,9 @@ function meta::alloy::runtime::java::prepare(node:ExecutionNode[1], path:String[
 
 function <<access.private>> meta::alloy::runtime::java::fillNewFunctionProhibitedList(context:GenerationContext[1]):GenerationContext[1]
 {
-   let cls = $context.typeInfos.typeInfos->filter(t|$t->instanceOf(ClassTypeInfo))->cast(@ClassTypeInfo)->map(c|$c.class());
+   let cls = $context.typeInfos.typeInfos->filter(t|$t->instanceOf(ClassTypeInfo))->cast(@ClassTypeInfo)->filter(c| !$c.isFromConstraint);
    let oldConventions = $context.conventions; 
-  
-   ^$context(conventions = ^$oldConventions(newFunctionProhibitedList = $cls));
+   ^$context(conventions = ^$oldConventions(newFunctionProhibitedList = $cls->map(c|$c.class())));
 }
 
 function <<access.private>> meta::alloy::runtime::java::prepareChildNodes(nodes:ExecutionNode[*], childNo:Integer[1], parentPath:String[1], context:GenerationContext[1], extensions:meta::pure::router::extension::RouterExtension[*], debug:DebugContext[1]):GenerationContext[1]

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/shared/typeInfo.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/shared/typeInfo.pure
@@ -126,7 +126,7 @@ function meta::alloy::runtime::java::typeInfo::containsProperty(info:TypeInfoSet
                                                p:Property<Nil,Any|*>[1]    | $c.properties->contains($p),
                                                q:QualifiedProperty<Any>[1] | $c.qualifiedProperties->contains($q)
                                             ]) ,
-           a: Any[*]           | true; // If we don't have Type info the property is coming from a newed object which will support all properties
+           a: Any[*]           | false;
         ]);
 }
 
@@ -266,8 +266,8 @@ function <<access.private>> meta::alloy::runtime::java::typeInfo::addConstraint(
 
    let newTypeInfos = $missingProperties->fold(
                            {prop, infos | if($prop->instanceOf(QualifiedProperty), 
-                                             | $infos->addQualifiedPropertyForTypeIfMissing($prop->cast(@QualifiedProperty<Any>)), 
-                                             | $infos->addPropertyForTypeIfMissing($prop->cast(@Property<Nil,Any|*>)))}
+                                             | $infos->addQualifiedPropertyForTypeIfMissing($prop->cast(@QualifiedProperty<Any>), true), 
+                                             | $infos->addPropertyForTypeIfMissing($prop->cast(@Property<Nil,Any|*>), true))}
                            , $typeInfos);
    
    let withConstraint    = $newTypeInfos->forClass($class)->addSupportedConstraint($constraint);
@@ -312,10 +312,15 @@ function <<access.private>> meta::alloy::runtime::java::typeInfo::typeInfoFromIn
 
 function <<access.private>> meta::alloy::runtime::java::typeInfo::addPropertyForTypeIfMissing(info:TypeInfoSet[1], property:Property<Nil,Any|*>[1]): TypeInfoSet[1]
 {
+  addPropertyForTypeIfMissing($info, $property, false);
+}
+
+function <<access.private>> meta::alloy::runtime::java::typeInfo::addPropertyForTypeIfMissing(info:TypeInfoSet[1], property:Property<Nil,Any|*>[1], isFromConstraint:Boolean[1]): TypeInfoSet[1]
+{
     
    $property.owner->match([
       {c: Class<Any>[1] |
-         $info->addPropertyForClassIfMissing($c, $property);
+         $info->addPropertyForClassIfMissing($c, $property, $isFromConstraint);
       },
       {a: Association[1] |
          let p1 = $a.properties->at(0);
@@ -323,16 +328,21 @@ function <<access.private>> meta::alloy::runtime::java::typeInfo::addPropertyFor
          let p2 = $a.properties->at(1);
          let c2 = $a.properties->at(0).genericType.rawType->cast(@Class<Any>)->toOne();
          
-         $info->addPropertyForClassIfMissing($c1, $p1)->addPropertyForClassIfMissing($c2, $p2);
+         $info->addPropertyForClassIfMissing($c1, $p1)->addPropertyForClassIfMissing($c2, $p2, $isFromConstraint);
       }
    ]);
 }
 
 function <<access.private>> meta::alloy::runtime::java::typeInfo::addPropertyForClassIfMissing(info:TypeInfoSet[1], class:Class<Any>[1], property:Property<Nil,Any|*>[1]): TypeInfoSet[1]
+{
+  addPropertyForClassIfMissing($info, $class, $property, false);  
+}
+
+function <<access.private>> meta::alloy::runtime::java::typeInfo::addPropertyForClassIfMissing(info:TypeInfoSet[1], class:Class<Any>[1], property:Property<Nil,Any|*>[1], isFromConstraint:Boolean[1]): TypeInfoSet[1]
 {   
-   let enriched = $info->addBasicTypeInfoIfMissing($class);
+   let enriched = $info->addBasicTypeInfoIfMissing($class, $isFromConstraint);
    let ti       = $enriched->forClass($class);
-   let enriched2 = if($property->functionReturnType().rawType->toOne()->instanceOf(Class), | $enriched->addBasicTypeInfoIfMissing($property->functionReturnType().rawType->toOne()->cast(@Class<Any>)), | $enriched);
+   let enriched2 = if($property->functionReturnType().rawType->toOne()->instanceOf(Class), | $enriched->addBasicTypeInfoIfMissing($property->functionReturnType().rawType->toOne()->cast(@Class<Any>), $isFromConstraint), | $enriched);
 
    if($ti.properties->exists(p| $p.name == $property.name), 
       | $enriched2, 
@@ -342,26 +352,36 @@ function <<access.private>> meta::alloy::runtime::java::typeInfo::addPropertyFor
 
 function <<access.private>> meta::alloy::runtime::java::typeInfo::addQualifiedPropertyForTypeIfMissing(info:TypeInfoSet[1], qualifiedProperty:QualifiedProperty<Any>[1]): TypeInfoSet[1]
 {
+  addQualifiedPropertyForTypeIfMissing($info, $qualifiedProperty, false);  
+}
+
+function <<access.private>> meta::alloy::runtime::java::typeInfo::addQualifiedPropertyForTypeIfMissing(info:TypeInfoSet[1], qualifiedProperty:QualifiedProperty<Any>[1], isFromConstraint:Boolean[1]): TypeInfoSet[1]
+{
    let owningClass = $qualifiedProperty->functionType().parameters->evaluateAndDeactivate()->at(0).genericType.rawType->toOne()->cast(@Class<Any>);
-   $info->addQualifiedPropertyForClassIfMissing($owningClass, $qualifiedProperty);
+   $info->addQualifiedPropertyForClassIfMissing($owningClass, $qualifiedProperty, $isFromConstraint);
 }
 
 function <<access.private>> meta::alloy::runtime::java::typeInfo::addQualifiedPropertyForClassIfMissing(info:TypeInfoSet[1], class:Class<Any>[1], qualifiedProperty:QualifiedProperty<Any>[1]): TypeInfoSet[1]
 {
-   let enriched = $info->addBasicTypeInfoIfMissing($class);
+  addQualifiedPropertyForClassIfMissing($info, $class, $qualifiedProperty, false);
+}
+
+function <<access.private>> meta::alloy::runtime::java::typeInfo::addQualifiedPropertyForClassIfMissing(info:TypeInfoSet[1], class:Class<Any>[1], qualifiedProperty:QualifiedProperty<Any>[1], isFromConstraint:Boolean[1]): TypeInfoSet[1]
+{
+   let enriched = $info->addBasicTypeInfoIfMissing($class, $isFromConstraint);
    let ti       = $enriched->forClass($class);
    if($qualifiedProperty->printFunctionSignature()->in($ti.qualifiedProperties->map(q| $q->printFunctionSignature())),
       | $enriched,
       {|
          let withQualifier  = $enriched->addOrReplace(^$ti(qualifiedProperties=$ti.qualifiedProperties->concatenate($qualifiedProperty)));
-         let withParameters = $qualifiedProperty->functionType().parameters->evaluateAndDeactivate()->tail()->fold({p, agg | $agg->addBasicTypeInfoIfMissing($p.genericType.rawType->toOne())}, $withQualifier);
+         let withParameters = $qualifiedProperty->functionType().parameters->evaluateAndDeactivate()->tail()->fold({p, agg | $agg->addBasicTypeInfoIfMissing($p.genericType.rawType->toOne(), $isFromConstraint)}, $withQualifier);
 
          let paths = $qualifiedProperty.expressionSequence->map(es| $es->evaluateAndDeactivate()->scanProperties().result);
          $paths.values.property->removeDuplicates()->fold(
             {prop, info|
                $prop->match([
-                  p :Property<Nil,Any|*>[1]    | $info->addPropertyForTypeIfMissing($p),
-                  qp:QualifiedProperty<Any>[1] | $info->addQualifiedPropertyForTypeIfMissing($qp)
+                  p :Property<Nil,Any|*>[1]    | $info->addPropertyForTypeIfMissing($p, $isFromConstraint),
+                  qp:QualifiedProperty<Any>[1] | $info->addQualifiedPropertyForTypeIfMissing($qp, $isFromConstraint)
                ]);
             },
             $withParameters
@@ -379,11 +399,21 @@ function <<access.private>> meta::alloy::runtime::java::typeInfo::addOrReplace(i
 
 function<<access.private>> meta::alloy::runtime::java::typeInfo::addBasicTypeInfoIfMissing(info:TypeInfoSet[1], type:Type[1]):TypeInfoSet[1]
 {
+  addBasicTypeInfoIfMissing($info, $type, false);
+}
+
+function<<access.private>> meta::alloy::runtime::java::typeInfo::addBasicTypeInfoIfMissing(info:TypeInfoSet[1], type:Type[1], isFromConstraint:Boolean[1]):TypeInfoSet[1]
+{
    
-   addBasicTypeInfoIfMissing($info,[],$type);
+   addBasicTypeInfoIfMissing($info,[],$type, $isFromConstraint);
+}
+
+function <<access.private>> meta::alloy::runtime::java::typeInfo::addBasicTypeInfoIfMissing(info:TypeInfoSet[1], seenClasses:Class<Any>[*], type:Type[1]): TypeInfoSet[1]
+{
+  addBasicTypeInfoIfMissing($info, $seenClasses, $type, false);
 }
    
-function <<access.private>> meta::alloy::runtime::java::typeInfo::addBasicTypeInfoIfMissing(info:TypeInfoSet[1], seenClasses:Class<Any>[*], type:Type[1]): TypeInfoSet[1]
+function <<access.private>> meta::alloy::runtime::java::typeInfo::addBasicTypeInfoIfMissing(info:TypeInfoSet[1], seenClasses:Class<Any>[*], type:Type[1], isFromConstraint:Boolean[1]): TypeInfoSet[1]
 {
    if($info.typeInfos.type->contains($type),
       {| 
@@ -392,7 +422,7 @@ function <<access.private>> meta::alloy::runtime::java::typeInfo::addBasicTypeIn
       {| 
          $type->match([
             e : Enumeration<Any>[1] | $info->addEnumerationTypeInfo($e),
-            c : Class<Any>[1]       | $info->addBasicClassTypeInfo($c, $seenClasses),
+            c : Class<Any>[1]       | $info->addBasicClassTypeInfo($c, $seenClasses, $isFromConstraint),
             u : Unit[1]             | $info->addUnitTypeInfo($u),
             a : Any[1]              | $info
          ])
@@ -407,6 +437,11 @@ function <<access.private>> meta::alloy::runtime::java::typeInfo::addEnumeration
 }
 
 function <<access.private>> meta::alloy::runtime::java::typeInfo::addBasicClassTypeInfo(info:TypeInfoSet[1], class:Class<Any>[1], seenClasses:Class<Any>[*]): TypeInfoSet[1]
+{
+  addBasicClassTypeInfo($info, $class, $seenClasses, false);
+}
+
+function <<access.private>> meta::alloy::runtime::java::typeInfo::addBasicClassTypeInfo(info:TypeInfoSet[1], class:Class<Any>[1], seenClasses:Class<Any>[*], isFromConstraint:Boolean[1]): TypeInfoSet[1]
 {
    let supertypes = $class->getGeneralizations();
 
@@ -423,7 +458,8 @@ function <<access.private>> meta::alloy::runtime::java::typeInfo::addBasicClassT
    let classInfo = ^ClassTypeInfo(
       type       = $class, 
       supertypes = $supertypes,
-      properties = $byDefaultProperties
+      properties = $byDefaultProperties,
+      isFromConstraint = $isFromConstraint
    );
 
    $withSupertypes->addOrReplace($classInfo);

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/constraints.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/constraints.pure
@@ -272,7 +272,23 @@ meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnUnmappe
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"n\\":5}"},"value":{"n":5}},"value":{"i":5}}'->parseJSON(), $result.values->toOne()->parseJSON()));
 }
 
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
+{ serverVersion.start='vX_X_X' }
+meta::pure::mapping::modelToModel::test::alloy::constraints::constraintOnUnmappedRequiredComplextTypeViaQualifiedPropertyCanCompile():Boolean[1]
+{
+  let result = execute(|meta::pure::mapping::modelToModel::test::alloy::constraints::Loan.all()->graphFetchChecked(#{meta::pure::mapping::modelToModel::test::alloy::constraints::Loan {id}}#)->serialize(#{meta::pure::mapping::modelToModel::test::alloy::constraints::Loan {id}}#),
+                      meta::pure::mapping::modelToModel::test::alloy::constraints::LoanMapping,
+                      ^Runtime(connections = ^JsonModelConnection(
+                        element = ^ModelStore(),
+                        class = meta::pure::mapping::modelToModel::test::alloy::constraints::From,
+                        url='data:application/json,{"id":20}'
+                      )),
+                      []
+  );
 
+  assert(jsonEquivalent('{"defects":[{"path":[],"enforcementLevel":"Error","ruleType":"ClassConstraint","externalId":null,"id":"0","ruleDefinerPath":"meta::pure::mapping::modelToModel::test::alloy::constraints::Loan","message":"Constraint :[0] violated in the Class Loan"}],"source":{"defects":[],"source":{"number":1,"record":"{\\"id\\":20}"},"value":{"id":20}},"value":{"id":20}}'->parseJSON(),
+                        $result.values->toOne()->parseJSON()));
+}
 
 Class meta::pure::mapping::modelToModel::test::alloy::constraints::TaxonomyValue
 {
@@ -457,6 +473,37 @@ Class meta::pure::mapping::modelToModel::test::alloy::constraints::_Num
    n: Integer[1];
 }
 
+
+Class meta::pure::mapping::modelToModel::test::alloy::constraints::Loan
+[
+  $this.collateral(today()).collateralAddress.country.countryName == 'US6'
+]
+{
+  id:Integer[1];
+  collateral : meta::pure::mapping::modelToModel::test::alloy::constraints::Collateral[*];
+}
+
+Class <<temporal.businesstemporal>> meta::pure::mapping::modelToModel::test::alloy::constraints::Collateral
+{
+  collateralAddress : meta::pure::mapping::modelToModel::test::alloy::constraints::Address[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::constraints::Address
+{
+  county : String[1];
+  country : meta::pure::mapping::modelToModel::test::alloy::constraints::Country[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::constraints::Country
+{
+  countryName : String[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::constraints::From
+{
+  id:Integer[1];
+} 
+
 ###Mapping
 Mapping meta::pure::mapping::modelToModel::test::alloy::constraints::isEqualTest
 (
@@ -565,3 +612,12 @@ Mapping meta::pure::mapping::modelToModel::test::alloy::constraints::m2mconstrai
 )
 
 
+###Mapping
+Mapping meta::pure::mapping::modelToModel::test::alloy::constraints::LoanMapping
+(
+  meta::pure::mapping::modelToModel::test::alloy::constraints::Loan : Pure
+  {
+    ~src meta::pure::mapping::modelToModel::test::alloy::constraints::From
+    id : $src.id
+  }
+)


### PR DESCRIPTION
Refine computation of classes that are prohibited from having new instances created explicitly via the new operator.

This changeset refines the computation of which classes should be prohibited from having new instances created explicitly via the new operator (in constraints for example) to be more self-contained within typeInfo computation and not rely on incorrect assumptions on how class type information is computed in the M2M generation. 
This also fixes a bug where classes were not being generated for property chains starting at a qualified property and resulting in compilation failures during plan generation.