### PR TITLE
Graphfetch: validate property owners when computing sourceTree

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -299,7 +299,7 @@ function meta::pure::graphFetch::ensureFunctionRequirements(node:GraphFetchTree[
    let constraintResult       = pathsForConstraintFunctions($class, $f->eval($class));
    let qualifiedPropertyPaths = $constraintResult->filter(path| $path.values->exists(x| $x.property->instanceOf(QualifiedProperty)));
    let inlinedPropertyTree    = $constraintResult->buildPropertyTree()->inlineQualifiedPropertyNodes();
-   let inlinedGraphTree       = $inlinedPropertyTree->propertyTreeToGraphFetchTree();
+   let inlinedGraphTree       = $inlinedPropertyTree->propertyTreeToGraphFetchTree($class);
    let withFoundProperties    = $node->addSubTrees($inlinedGraphTree);
    let updatedForClass        = $qualifiedPropertyPaths->fold({path, gt| $gt->recordQualifiedProperties($path)}, $withFoundProperties);
       
@@ -388,7 +388,7 @@ function <<access.private>> meta::pure::graphFetch::enrichSourceTreeNodeForPrope
 
    let setClasses = $childSetImpls->map(s | $s.srcClass);
 
-   let inlinedGraphTree    = $inlinedPropertyTree->propertyTreeToGraphFetchTree();
+   let inlinedGraphTree    = $inlinedPropertyTree->propertyTreeToGraphFetchTree($owner);
 
    let withSubTypes        = $inlinedGraphTree->concatenate($inlinedGraphTree->map(pgft | $setClasses->map(sc | if($sc->getAllTypeGeneralisationsExcluded()->contains($pgft.property.genericType.rawType->toOne()), | ^$pgft(subType=$sc->cast(@Class<Any>)), | []))));
 
@@ -440,11 +440,14 @@ function <<access.private>> meta::pure::graphFetch::enrichSourceTreeNodeAtPath(s
    );
 }
 
-function <<access.private>> meta::pure::graphFetch::propertyTreeToGraphFetchTree(pTree:PropertyPathTree[1]): PropertyGraphFetchTree[*]
+function <<access.private>> meta::pure::graphFetch::propertyTreeToGraphFetchTree(pTree:PropertyPathTree[1], ownerClass:Class<Any>[1]): PropertyGraphFetchTree[*]
 {
    $pTree.value->match([
-      node:PropertyPathNode[1] | ^PropertyGraphFetchTree(property=$node.property, subTrees=$pTree.children->map(c| $c->propertyTreeToGraphFetchTree())),
-      any :Any[1]              | $pTree.children->map(c| $c->propertyTreeToGraphFetchTree())
+      node:PropertyPathNode[1] | if($ownerClass == $node.class, 
+                                      |  ^PropertyGraphFetchTree(property=$node.property, subTrees=$pTree.children->map(c| $c->propertyTreeToGraphFetchTree($node.property->functionReturnType().rawType->cast(@Class<Any>)->toOne())));,
+                                      | []),
+      clz:Class<Any>[1]        | $pTree.children->map(c| $c->propertyTreeToGraphFetchTree($clz)),
+      any :Any[1]              | $pTree.children->map(c| $c->propertyTreeToGraphFetchTree($ownerClass))
    ]);
 }
 
@@ -470,7 +473,7 @@ function <<access.private>> meta::pure::graphFetch::replaceQualifiedPropertiesWi
          {qp:QualifiedProperty<Any>[1]|
             let propertyPaths       = $qp.expressionSequence->evaluateAndDeactivate()->map(e| $e->scanProperties());
             let inlinedPropertyTree = $propertyPaths.result->buildPropertyTree()->inlineQualifiedPropertyNodes();
-            $inlinedPropertyTree->propertyTreeToGraphFetchTree();
+            $inlinedPropertyTree->propertyTreeToGraphFetchTree($class);
          }
       ]);
    );

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/testSourceTreeCalc.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/testSourceTreeCalc.pure
@@ -977,10 +977,11 @@ Class meta::pure::graphFetch::tests::sourceTreeCalc::withUnrelatedConstraintProp
 
 Class meta::pure::graphFetch::tests::sourceTreeCalc::withUnrelatedConstraintProperty::_A
 [
-   constraint: $this.a1 == ^_B(b1='x').b1
+   constraint: $this.a1 == ^_B(b1='x').b1 || $this.qp1()
 ]
 {
    a1: String[1];
+   qp1() { $this.a1 == ^_B(b1='y').b1} : Boolean[1];
 }
 
 Class meta::pure::graphFetch::tests::sourceTreeCalc::withUnrelatedConstraintProperty::_B


### PR DESCRIPTION
When computing properties to include in the source tree we need to make sure that we only include properties that are part of the current class being processed. 
This fix adds validation and filters to ensure that we only include the relevant properties based on the current class being processed. 