### PR TITLE
Support at(0)/indexOf on properties with [1] or [0..1] in execution plan

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/collections/testAt.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/collections/testAt.pure
@@ -20,6 +20,9 @@ function <<test.Test>> meta::pure::functions::collection::tests::at::testAt():Bo
     assertEq('a', $collection->at(0));
     assertEq('b', $collection->at(1));
     assertEq('c', $collection->at(2));
+   
+   let singleItem = 'a';
+   assertEq('a', $singleItem->at(0));
 }
 
 function <<test.Test>> meta::pure::functions::collection::tests::at::testAtOtherScenario():Boolean[1]

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/collections/testIndexOf.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/collections/testIndexOf.pure
@@ -18,3 +18,9 @@ function <<test.Test>> meta::pure::functions::collection::tests::indexof::testIn
 {
    assertEquals(2, ['a', 'b', 'c', 'd']->indexOf('c'));
 }
+
+function <<test.Test>> meta::pure::functions::collection::tests::indexof::testIndexOfOneElement():Boolean[1]
+{
+   assertEquals(0, 'c'->indexOf('c'));
+   assertEquals(-1, 'c'->indexOf('b'));
+}

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/collectionsLibrary.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/collectionsLibrary.pure
@@ -44,8 +44,8 @@ function meta::java::generation::functions::collection::register(conventions: Co
          {b:Boolean[1] | j_boolean($b)}
       )
       ->addFunctionCoders([
-         fc2(at_T_MANY__Integer_1__T_1_,                                         {ctx,collection,index         | $collection->j_invoke('get', $index->j_cast(javaInt()))}),
-         fc2(indexOf_T_MANY__T_1__Integer_1_,                                    {ctx,collection,obj           | $collection->j_invoke('indexOf', $obj)}),
+         fc2(at_T_MANY__Integer_1__T_1_,                                         {ctx,collection,index         | $library->j_invoke('at', [$collection, $index], if($collection.type->isJavaList(), |$collection.type->elementTypeOfJavaList(), |$collection.type))}),
+         fc2(indexOf_T_MANY__T_1__Integer_1_,                                    {ctx,collection,obj           | $library->j_invoke('indexOf', [$collection, $obj], if($collection.type->isJavaList(), |$collection.type->elementTypeOfJavaList(), |$collection.type))}),
          fc1(first_T_MANY__T_$0_1$_,                                             {ctx,collection               | $library->j_invoke('first', $collection, if($collection.type->isJavaList(), |$collection.type->elementTypeOfJavaList(), |$collection.type))}),
 
          fc1(range_Integer_1__Integer_MANY_,                                     {ctx,stop                     | javaLongStream()->j_invoke('range', [j_long(0), $stop])->j_invoke('boxed', [])}), 

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/test/collectionsLibraryTests.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/test/collectionsLibraryTests.pure
@@ -183,8 +183,10 @@ meta::java::generation::tests::functions::collection::testPartsOfCollections() :
    let conventions = alloyConventions([]);
    
    javaExpressionTests($conventions)
-      ->addTest('at from many', {|[1,2]->at(1)}, 'java.util.Arrays.asList(1L, 2L).get((int) 1L).longValue()', javaLong())
+      ->addTest('at from many', {|[1,2]->at(1)}, 'org.finos.legend.engine.plan.dependencies.util.Library.at(java.util.Arrays.asList(1L, 2L), 1L).longValue()', javaLong())
          ->assert('%s == 2L')
+      ->addTest('at from single', {|8->at(0)}, 'org.finos.legend.engine.plan.dependencies.util.Library.at(8L, 0L)', javaLong())
+         ->assert('%s == 8L')
       ->addTest('find first', {|[1,2,3]->first()}, 'org.finos.legend.engine.plan.dependencies.util.Library.first(java.util.Arrays.asList(1L, 2L, 3L))', javaLong()->toBoxed())
          ->assert('%s == 1L')
       ->addTest('find first', {|1->first()}, 'org.finos.legend.engine.plan.dependencies.util.Library.first(1L)', javaLong()->toBoxed())
@@ -265,6 +267,7 @@ meta::java::generation::tests::functions::collection::testPureTests() : Boolean[
       ->addTestsWithin(meta::pure::functions::collection::tests::init)
       ->addTestsWithin(meta::pure::functions::collection::tests::tail)
       ->addTestsWithin(meta::pure::functions::collection::tests::last)
+      ->addTestsWithin(meta::pure::functions::collection::tests::at)
       ->addTestsWithin(meta::pure::functions::collection::tests::sort)
       ->addTestsWithin(meta::pure::functions::collection::tests::indexof)
       ->addTestsWithin(meta::pure::functions::collection::tests::range)   


### PR DESCRIPTION
Support at(0)/indexOf on properties with [1] or [0..1] in execution plan.
Need to be released with this commit together.  https://github.com/finos/legend-engine/pull/350