### PR TITLE
Fix typo in subType test

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/simpleObject.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/simpleObject.pure
@@ -465,7 +465,7 @@ meta::pure::mapping::modelToModel::test::alloy::simple::testM2MQueryWithMappingU
       []
    );
    let json = $result.values->toOne();
-   let expected= '{"streetNames":["Oxford"],"zipCodes":["123456"]';
+   let expected= '{"streetNames":["Oxford"],"zipCodes":["123456"]}';
 
    assert(jsonEquivalent($expected->parseJSON(), $json->parseJSON()));
 }


### PR DESCRIPTION
There was a typo in the subType test for m2m 