### PR TITLE
handle `ClassNotFoundException` in `subTypeOf()`

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -117,7 +117,7 @@ function <<access.private>> meta::pure::graphFetch::xstoreProperties(nodes:Graph
       ->cast(@meta::pure::mapping::xStore::XStorePropertyMapping)
       ->map({xpm |
          let allProperties = $xpm.crossExpression.expressionSequence->evaluateAndDeactivate()->toOne()->findPropertiesInValueSpecification();
-         let srcProperties = $allProperties->filter(x | $x.owner->cast(@Class<Any>)->subTypeOf($srcClass) || $srcClass->subTypeOf($x.owner->cast(@Class<Any>)));
+         let srcProperties = $allProperties->filter(x | $x.owner->cast(@Class<Any>)->_subTypeOf($srcClass) || $srcClass->_subTypeOf($x.owner->cast(@Class<Any>)));
          $srcProperties->filter(x | !$currentSubTreeProperties->contains($x));
       });
 }

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -117,7 +117,7 @@ function <<access.private>> meta::pure::graphFetch::xstoreProperties(nodes:Graph
       ->cast(@meta::pure::mapping::xStore::XStorePropertyMapping)
       ->map({xpm |
          let allProperties = $xpm.crossExpression.expressionSequence->evaluateAndDeactivate()->toOne()->findPropertiesInValueSpecification();
-         let srcProperties = $allProperties->filter(x | $x.owner->cast(@Class<Any>)->_subTypeOf($srcClass) || $srcClass->_subTypeOf($x.owner->cast(@Class<Any>)));
+         let srcProperties = $allProperties->filter(x | $x.owner->cast(@Class<Any>)->subTypeOf($srcClass) || $srcClass->subTypeOf($x.owner->cast(@Class<Any>)));
          $srcProperties->filter(x | !$currentSubTreeProperties->contains($x));
       });
 }

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -489,7 +489,7 @@ function <<access.private>> meta::pure::graphFetch::propertyTreeToGraphFetchTree
        let childrenGroupedByDerivedClasses = $pTree.children->groupBy(c|$c.value->cast(@PropertyPathNode).class);
        $childrenGroupedByDerivedClasses->keyValues()->map(k|let propertyPathOwner = $k.first;
                                                             let children = $k.second.values;
-                                                            if($propertyPathOwner != $nodeClass && $propertyPathOwner->_subTypeOf($nodeClass->toOne()),
+                                                            if($propertyPathOwner != $nodeClass && $propertyPathOwner->subTypeOf($nodeClass->toOne()),
                                                                 |^PropertyGraphFetchTree(property = $node.property, subType = $propertyPathOwner, subTrees = $children->map(c| $c->propertyTreeToGraphFetchTree($propertyPathOwner))),
                                                                 |^PropertyGraphFetchTree(property = $node.property, subTrees = $children->map(c| $c->propertyTreeToGraphFetchTree($node.property->functionReturnType().rawType->cast(@Class<Any>)->toOne()))));
                                                          );

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -489,7 +489,7 @@ function <<access.private>> meta::pure::graphFetch::propertyTreeToGraphFetchTree
        let childrenGroupedByDerivedClasses = $pTree.children->groupBy(c|$c.value->cast(@PropertyPathNode).class);
        $childrenGroupedByDerivedClasses->keyValues()->map(k|let propertyPathOwner = $k.first;
                                                             let children = $k.second.values;
-                                                            if($propertyPathOwner != $nodeClass && $propertyPathOwner->subTypeOf($nodeClass->toOne()),
+                                                            if($propertyPathOwner != $nodeClass && $propertyPathOwner->_subTypeOf($nodeClass->toOne()),
                                                                 |^PropertyGraphFetchTree(property = $node.property, subType = $propertyPathOwner, subTrees = $children->map(c| $c->propertyTreeToGraphFetchTree($propertyPathOwner))),
                                                                 |^PropertyGraphFetchTree(property = $node.property, subTrees = $children->map(c| $c->propertyTreeToGraphFetchTree($node.property->functionReturnType().rawType->cast(@Class<Any>)->toOne()))));
                                                          );

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
@@ -72,6 +72,8 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecificat
 import org.finos.legend.pure.m3.coreinstance.meta.pure.router.RoutedValueSpecification;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
+import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m3.tools.ListHelper;
@@ -858,7 +860,18 @@ public class Pure
             return (obj instanceof Enum) && type.equals(((CompiledExecutionSupport) es).getMetadataAccessor().getEnumeration(((Enum) obj).getFullSystemPath()));
         }
 
-        Class<?> javaClass = pureTypeToJavaClass(type, es);
+        Class<?> javaClass;
+        try
+        {
+            javaClass = pureTypeToJavaClass(type, es);
+        }
+        catch (Exception e)
+        {
+            if (obj instanceof CoreInstance) {
+                return Instance.instanceOf((CoreInstance) obj, type, ((CompiledExecutionSupport) es).getProcessorSupport());
+            }
+            throw e;
+        }
         if (javaClass == Any.class)
         {
             return true;

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
@@ -123,8 +123,8 @@ public class Pure
     private static final ExecutorService traceAsyncExecutor = Executors.newCachedThreadPool(new ThreadFactory()
     {
         private final ThreadGroup group = System.getSecurityManager() == null
-                ? Thread.currentThread().getThreadGroup()
-                : System.getSecurityManager().getThreadGroup();
+            ? Thread.currentThread().getThreadGroup()
+            : System.getSecurityManager().getThreadGroup();
         private final AtomicInteger threadNumber = new AtomicInteger(1);
 
         @Override
@@ -191,11 +191,11 @@ public class Pure
         {
             if (port == -1)
             {
-                throw new PureExecutionException("The system variable 'legend.test.server.host' is set to '"+host+"' however 'legend.test.server.port' has not been set!");
+                throw new PureExecutionException("The system variable 'legend.test.server.host' is set to '" + host + "' however 'legend.test.server.port' has not been set!");
             }
             if (serializationKind == null || !(serializationKind.equals("text") || serializationKind.equals("json")))
             {
-                serializationKind="json";
+                serializationKind = "json";
             }
             if (clientVersion == null)
             {
@@ -329,10 +329,12 @@ public class Pure
         try
         {
             return value.getClass().getField("_" + property._name()).get(value);
-        } catch (NoSuchFieldException e)
+        }
+        catch (NoSuchFieldException e)
         {
             throw new PureExecutionException(sourceInformation, "Can't find the property '" + property._name() + "' in the class " + CompiledSupport.getPureClassName(value));
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             throw new RuntimeException(e);
         }
@@ -466,7 +468,8 @@ public class Pure
         {
             Class myClass = ((CompiledExecutionSupport) es).getClassLoader().loadClass(JavaPackageAndImportBuilder.rootPackage() + "." + IdBuilder.sourceToId(func.getSourceInformation()));
             functions = (MutableMap<String, SharedPureFunction>) myClass.getDeclaredField("__functions").get(null);
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             throw new RuntimeException(e);
         }
@@ -541,7 +544,8 @@ public class Pure
             {
                 Object o = ((RichIterable) paramInputs.getFirst()).getFirst();
                 return o.getClass().getMethod("_" + func.getName()).invoke(o);
-            } catch (Exception e)
+            }
+            catch (Exception e)
             {
                 throw new RuntimeException(e);
             }
@@ -568,7 +572,7 @@ public class Pure
             {
                 Object o = ((RichIterable) paramInputs.getFirst()).getFirst();
                 return CompiledSupport.executeMethod(o.getClass(), func._functionName(), func, Arrays.copyOfRange(paramClasses, 1, paramClasses.length),
-                        o, Arrays.copyOfRange(paramInstances, 1, paramInstances.length), es);
+                    o, Arrays.copyOfRange(paramInstances, 1, paramInstances.length), es);
             }
             if (func instanceof ConcreteFunctionDefinition)
             {
@@ -584,10 +588,12 @@ public class Pure
                 return foundFunc.execute(Lists.mutable.with(paramInstances), es);
             }
             throw new PureExecutionException("Unknown function type:" + func.getClass().getName());
-        } catch (RuntimeException e)
+        }
+        catch (RuntimeException e)
         {
             throw e;
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             throw new RuntimeException(e);
         }
@@ -605,7 +611,8 @@ public class Pure
                     Class myClass = ((CompiledExecutionSupport) es).getClassLoader().loadClass(JavaPackageAndImportBuilder.rootPackage() + "." + IdBuilder.sourceToId(func.getSourceInformation()));
                     MutableMap<String, SharedPureFunction> functions = (MutableMap<String, SharedPureFunction>) myClass.getDeclaredField("__functions").get(null);
                     return functions.get(func.getName());
-                } catch (Exception e)
+                }
+                catch (Exception e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -619,7 +626,8 @@ public class Pure
         {
             SharedPureFunction spf = getNativeOrLambdaFunction(es, func);
             return spf != null;
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             return false;
         }
@@ -773,7 +781,8 @@ public class Pure
             });
 
             return result;
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             throw new RuntimeException(e);
         }
@@ -1043,13 +1052,29 @@ public class Pure
             return true;
         }
 
-        Class<?> theSubTypeClass = pureTypeToJavaClass(subType, es);
+        Class<?> theSubTypeClass;
+        try
+        {
+            theSubTypeClass = pureTypeToJavaClass(subType, es);
+        }
+        catch (Exception e)
+        {
+            return ((CompiledExecutionSupport) es).getProcessorSupport().type_subTypeOf(subType, superType);
+        }
         if (theSubTypeClass == Nil.class)
         {
             return true;
         }
 
-        Class<?> theSuperTypeClass = pureTypeToJavaClass(superType, es);
+        Class<?> theSuperTypeClass;
+        try
+        {
+            theSuperTypeClass = pureTypeToJavaClass(superType, es);
+        }
+        catch (Exception e)
+        {
+            return ((CompiledExecutionSupport) es).getProcessorSupport().type_subTypeOf(subType, superType);
+        }
         return (theSuperTypeClass == Any.class) || theSuperTypeClass.isAssignableFrom(theSubTypeClass);
     }
 
@@ -1380,7 +1405,8 @@ public class Pure
             try
             {
                 return Reactivator.reactivateWithoutJavaCompilation(bridge, valueSpecification, lambdaOpenVariablesMap, es);
-            } catch (PureDynamicReactivateException e)
+            }
+            catch (PureDynamicReactivateException e)
             {
                 throw new RuntimeException("Out of sync state between can reactivate and actual reactive without Java source code", e);
             }
@@ -1392,19 +1418,19 @@ public class Pure
     }
 
     public static boolean canReactivateWithoutJavaCompilation(
-            final ValueSpecification valueSpecification,
-            final ExecutionSupport es,
-            Bridge bridge
+        final ValueSpecification valueSpecification,
+        final ExecutionSupport es,
+        Bridge bridge
     )
     {
         return canReactivateWithoutJavaCompilation(valueSpecification, es, new PureMap(UnifiedMap.newMap()), bridge);
     }
 
     public static boolean canReactivateWithoutJavaCompilation(
-            final ValueSpecification valueSpecification,
-            final ExecutionSupport es,
-            final PureMap lambdaOpenVariablesMap,
-            Bridge bridge
+        final ValueSpecification valueSpecification,
+        final ExecutionSupport es,
+        final PureMap lambdaOpenVariablesMap,
+        Bridge bridge
     )
     {
         return Reactivator.canReactivateWithoutJavaCompilation(valueSpecification, es, lambdaOpenVariablesMap, bridge);
@@ -1448,7 +1474,8 @@ public class Pure
                     try
                     {
                         return classLoader.loadClass(TypeProcessor.fullyQualifiedJavaInterfaceNameForType(type));
-                    } catch (ClassNotFoundException e)
+                    }
+                    catch (ClassNotFoundException e)
                     {
                         // Type specified is incorrect or problem with metadata. Return default.
                         return typeFromClassMetaData;
@@ -1515,7 +1542,8 @@ public class Pure
                         }
                     });
                     future.get(60, TimeUnit.SECONDS);
-                } catch (TimeoutException e)
+                }
+                catch (TimeoutException e)
                 {
                     if (span != null)
                     {
@@ -1539,7 +1567,8 @@ public class Pure
                 }
             }
             return evaluate(es, function, bridge, Lists.mutable.empty());
-        } finally
+        }
+        finally
         {
             if (span != null)
             {

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
@@ -1065,6 +1065,12 @@ public class Pure
             return true;
         }
 
+        // NOTE: ClassNotFoundException can occur when we use subTypeOf() in engine where some
+        // Java classes are not available during plan generation. There is a potentially
+        // less performant alternative which is to use type_subTypeOf() as this will use the
+        // metamodel graph instead of Java classes to test subtype; but this alternative is more reliable.
+        // As such, to be defensive, we should fallback to the latter when the former fails with ClassNotFoundException
+        // See https://github.com/finos/legend-pure/issues/324
         Class<?> theSubTypeClass;
         try
         {


### PR DESCRIPTION
### Context

`ClassNotFoundException` can occur when we use `subTypeOf()` in `engine` where some Java classes are not available during plan generation. There is a _potentially_ less performant alternative which is to use `type_subTypeOf()` as this will use the metamodel graph instead of Java classes to test subtype; but this alternative is more reliable. As such, to be defensive, we should fallback to the latter when the former fails with `ClassNotFoundException`

Full context could be found in https://github.com/finos/legend-pure/issues/324

---

### Other Consideration
- [ ] ~~Do we need to take care of any other cases where the method `pureTypeToJavaClass` is being used?~~
- [ ] Bring the test case in https://github.com/finos/legend-pure/issues/324 to `finos/legend-engine` - check with @aziemchawdhary-gs about this

---

Closes https://github.com/finos/legend-pure/issues/324

- [x] Also took care of `instanceOf()` check
 
@kevin-m-knight-gs Could you kindly take a look at this?