### PR TITLE
Fix tree merging to handle fetchtrees with more than one subtree

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -150,10 +150,12 @@ function <<access.private>> meta::pure::graphFetch::addSubTrees(onto:GraphFetchT
 function <<access.private>> meta::pure::graphFetch::addSubTree(onto:GraphFetchTree[1], subTree:GraphFetchTree[1]): GraphFetchTree[1]
 {
    let existingSubTree = $onto.subTrees->filter(st|$st->cast(@PropertyGraphFetchTree).property == $subTree->cast(@PropertyGraphFetchTree).property);
-   $existingSubTree->match([
-      stree0: PropertyGraphFetchTree[0] | ^$onto(subTrees=$onto.subTrees->concatenate($subTree)),
-      stree : PropertyGraphFetchTree[1] | ^$onto(subTrees=$onto.subTrees->filter(st|$st != $existingSubTree)->concatenate($stree->addSubTrees($subTree.subTrees)))
-   ]);
+
+   if($existingSubTree->isEmpty(),
+     | ^$onto(subTrees=$onto.subTrees->concatenate($subTree)),
+     | $existingSubTree->fold({stree, newTree | ^$newTree(subTrees=$newTree.subTrees->filter(st|$st != $existingSubTree)->concatenate($stree->addSubTrees($subTree.subTrees)))},
+                              $onto)
+   );
 }
 
 function meta::pure::graphFetch::printTree(root:GraphFetchTree[1]): Any[*]

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/testSourceTreeCalc.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/testSourceTreeCalc.pure
@@ -1191,3 +1191,79 @@ Mapping meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::testMappingW
    }
 )
 
+###Pure
+import meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::*;
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::A
+{
+  b:meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::B[*];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::C
+{
+  cid:String[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::B extends meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::C
+{
+  id:String[1];
+  id2:String[1];
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::Source
+{
+  a : meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::A[*];
+  accessClassBProperties() { $this.a->filter(a | $a.b.id->isEmpty()).b.id2} : String[*];
+  accessClassBAndCSuperTypeProperties() { $this.a->filter(a | $a.b.id->isNotEmpty() && $a.b->accessCid()).b.id} : String[*];
+}
+
+function meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::accessCid(c : C[*]) : Boolean[1]
+{
+  $c.cid->isNotEmpty();
+}
+
+Class meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::TargetForSubTypeAndSuperTypeAccesses
+{
+  id : String[*];
+}
+
+function <<test.Test>> meta::pure::graphFetch::tests::sourceTreeCalc::testNestedSubTypeAndSuperTypeAccesses():Boolean[1]
+{
+  let tree = #{
+      TargetForSubTypeAndSuperTypeAccesses {
+         id
+      }
+   }#;
+
+  let expectedString = 'Source [requires: accessClassBProperties,accessClassBAndCSuperTypeProperties]\n' +
+                        '(\n' +
+                        '  a\n' +
+                        '  (\n' +
+                        '    b\n' +
+                        '    (\n' +
+                        '      id\n' +
+                        '      id2\n' +
+                        '    )\n' +
+                        '  )\n' +
+                        ')';
+
+   let sourceTree = meta::pure::graphFetch::calculateSourceTree($tree, 
+                                                                meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::SourceToTargetMappingWithSubtypeAndSuperTypeAccesses,
+                                                                meta::pure::router::extension::defaultExtensions())->meta::pure::graphFetch::sortTree();
+   assertEquals($expectedString, $sourceTree->meta::pure::graphFetch::sortTree()->meta::pure::graphFetch::treeToString());
+   
+  
+}
+
+###Mapping
+Mapping meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::SourceToTargetMappingWithSubtypeAndSuperTypeAccesses
+(
+  meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::TargetForSubTypeAndSuperTypeAccesses : Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::Source
+    id : if($src.a->size() == 1, | $src.accessClassBProperties, | $src.accessClassBAndCSuperTypeProperties)
+  }
+)
+
+
+
+


### PR DESCRIPTION

If a class has property accesses to both its own properties and properties of a supertype then the fetch tree generated has distinct subtrees to represent the subtype and supertype accesses. This is so that we can disambiguate which class the property access is on when performing code generation.

However, the tree merging code assumes that there is a single subTree for each property and will fail if there is more than one subtree.

This fix changes the merging to handle multiple subtrees for the same property.