### PR TITLE
Fix match clause in addSubTrees

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/graphExtension.pure
@@ -59,10 +59,10 @@ function <<access.private>> meta::pure::graphFetch::addSubTrees(onto:GraphFetchT
 function <<access.private>> meta::pure::graphFetch::addSubTree(onto:GraphFetchTree[1], subTree:PropertyGraphFetchTree[1]): GraphFetchTree[1]
 {
    let existingSubTrees = $onto.subTrees->filter(st|$st->cast(@PropertyGraphFetchTree).property == $subTree.property && $st->cast(@PropertyGraphFetchTree).subType == $subTree.subType);
-   let r = $existingSubTrees->match([
-      stree0: PropertyGraphFetchTree[0] | ^$onto(subTrees=$onto.subTrees->concatenate($subTree)),
-      stree : PropertyGraphFetchTree[1] | ^$onto(subTrees=$onto.subTrees->cast(@PropertyGraphFetchTree)->filter(st|!$st->forSameProperty($stree))->concatenate($stree->addSubTrees($subTree.subTrees->cast(@PropertyGraphFetchTree))))
-   ]);
+   if($existingSubTrees->isEmpty(),
+    | ^$onto(subTrees=$onto.subTrees->concatenate($subTree)),
+    | $existingSubTrees->fold({stree, newTree | ^$newTree(subTrees=$onto.subTrees->cast(@PropertyGraphFetchTree)->filter(st | !$st->forSameProperty($stree->cast(@PropertyGraphFetchTree)))->concatenate($stree->addSubTrees($subTree.subTrees))->removeDuplicates())}, $onto)
+   );
 }
 
 function <<access.private>> meta::pure::graphFetch::forSameProperty(t1:PropertyGraphFetchTree[1], t2:PropertyGraphFetchTree[1]): Boolean[1]

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/testSourceTreeCalc.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/graphFetch/tests/testSourceTreeCalc.pure
@@ -1254,6 +1254,44 @@ function <<test.Test>> meta::pure::graphFetch::tests::sourceTreeCalc::testNested
   
 }
 
+function <<test.Test>> meta::pure::graphFetch::tests::sourceTreeCalc::testNestedSubTypeAndSuperTypeAccesses2():Boolean[1]
+{
+  let tree = #{
+      TargetForSubTypeAndSuperTypeAccesses {
+         id
+      }
+   }#;
+
+  let expectedString = 'Source [requires: accessClassBProperties]\n' +
+                        '(\n' +
+                        '  a\n' +
+                        '  (\n' +
+                        '    b\n' +
+                        '    (\n' +
+                        '      id\n' +
+                        '      id2\n' +
+                        '    )\n' +
+                        '  )\n' +
+                        ')';
+
+   let sourceTree = meta::pure::graphFetch::calculateSourceTree($tree, 
+                                                                meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::SourceToTargetMappingWithSubtypeAndSuperTypeAccesses2,
+                                                                meta::pure::router::extension::defaultExtensions())->meta::pure::graphFetch::sortTree();
+   assertEquals($expectedString, $sourceTree->meta::pure::graphFetch::sortTree()->meta::pure::graphFetch::treeToString());
+   
+  
+}
+
+function meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::f(a:A[1]):Boolean[1]
+{
+  $a.b.id->isNotEmpty() && $a.b->meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::g();
+}
+
+function meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::g(c:meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::C[*]):Boolean[1]
+{
+  $c.cid->isNotEmpty();
+}
+
 ###Mapping
 Mapping meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::SourceToTargetMappingWithSubtypeAndSuperTypeAccesses
 (
@@ -1263,6 +1301,16 @@ Mapping meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::SourceToTarg
     id : if($src.a->size() == 1, | $src.accessClassBProperties, | $src.accessClassBAndCSuperTypeProperties)
   }
 )
+
+Mapping meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::SourceToTargetMappingWithSubtypeAndSuperTypeAccesses2
+(
+  meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::TargetForSubTypeAndSuperTypeAccesses : Pure
+  {
+    ~src meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::Source
+    id : if($src.a->size()==1, | $src.a->filter(a|$a.b.id->isNotEmpty() && $a->meta::pure::graphFetch::tests::sourceTreeCalc::withSubType::f()).b.id, | $src.accessClassBProperties())
+  }
+)
+
 
 
 


### PR DESCRIPTION
Fixes addSubTree (which was missed in https://github.com/finos/legend-pure/pull/337) to handle more than one subtree