### PR TITLE
Fix datePart sql gen for H2

### DIFF
--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/functions/tests/projection/testFunction.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/functions/tests/projection/testFunction.pure
@@ -89,7 +89,7 @@ function <<test.Test, test.ExcludeAlloy>> meta::relational::tests::projection::f
    let result = execute(|Trade.all()->filter(f| $f.id->in([9,10]))->project([t| datePart($t.settlementDateTime)], ['settlementDateTime']), simpleRelationalMapping, testRuntime(), meta::pure::router::extension::defaultRelationalExtensions());
    assertSize($result.values.rows, 2);
    assertEquals([%2014-12-05, ^TDSNull()], $result.values.rows.values);
-   assertEquals('select truncate("root".settlementDateTime) as "settlementDateTime" from tradeTable as "root" where "root".ID in (9, 10)', $result->sqlRemoveFormatting());
+   assertEquals('select cast(truncate("root".settlementDateTime) as date) as "settlementDateTime" from tradeTable as "root" where "root".ID in (9, 10)', $result->sqlRemoveFormatting());
 }
 
 function <<test.Test>> meta::relational::tests::projection::function::date::testWeekOfYearWithZeroToOne():Boolean[1]

--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
@@ -1114,7 +1114,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::getDy
       forDynafunction('datePart',              [ choice(DatabaseType.SybaseIQ,     $allStates,            ^ToSql(format='date(%s)')),
                                                  choice(DatabaseType.Sybase,       $allStates,            ^ToSql(format='cast(%s as date)')),
                                                  choice(DatabaseType.DB2,          $allStates,            ^ToSql(format='date(%s)')),
-                                                 choice(DatabaseType.H2,           $allStates,            ^ToSql(format='truncate(%s)')),
+                                                 choice(DatabaseType.H2,           $allStates,            ^ToSql(format='cast(truncate(%s) as date)')),
                                                  choice(DatabaseType.Postgres,     $allStates,            ^ToSql(format='Date(%s)')),
                                                  choice(DatabaseType.MemSQL,       $allStates,            ^ToSql(format='date(%s)')),
                                                  choice(DatabaseType.Snowflake,    $allStates,            ^ToSql(format='Date(%s)')),

--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/transform/fromPure/tests/testToSQLString.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/transform/fromPure/tests/testToSQLString.pure
@@ -1075,6 +1075,16 @@ function <<test.Test>> meta::relational::tests::functions::sqlstring::testSqlGen
    assertEquals('select cast("root"."DATE" as date) as "a" from locationTable as "root"', $result);
 }
 
+function <<test.Test>> meta::relational::tests::functions::sqlstring::testSqlGenerationForDatePartForH2():Boolean[1]
+{
+   let result = toSQLString(|Location.all()->project([
+                                                      a | $a.censusdate->toOne()->datePart()
+                                                   ],
+                                                   ['a']),
+                              simpleRelationalMappingInc, DatabaseType.H2, meta::pure::router::extension::defaultRelationalExtensions());
+   assertEquals('select cast(truncate("root".date) as date) as "a" from locationTable as "root"', $result);
+}
+
 function <<test.Test>> meta::relational::tests::functions::sqlstring::testSqlGenerationForPreviousDayOfWeekForPresto():Boolean[1]
 {
    let result = toSQLString(|Trade.all()->filter(d | $d.date == previousDayOfWeek(DayOfWeek.Friday))->project(x | $x.date, 'date'),


### PR DESCRIPTION
Fix datePart sql gen for H2.
Current sql translation - truncate(%s) does not provide correct metadata information for the column.
Returned metadata indicates column is timestamp even though time is stripped from value.
Applying cast helps us work with correct metadata information

**Note: Please merge it close to release**