### PR TITLE
Fix bug impacting use-cases where union is defined on same table with different keys

### DIFF
--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/lineage/scanRelations/scanRelations.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/lineage/scanRelations/scanRelations.pure
@@ -418,7 +418,7 @@ function meta::pure::lineage::scanRelations::generateRelationTreeFromRelationalO
 
                                           let result         = if($sel.data->isEmpty(),
                                                                   | [],
-                                                                  | $sel.data->toOne()->generateRelationTreeFromRelationalTreeNode([], [], $allColumns, $debug->indent(), $extensions));
+                                                                  | $sel.data->toOne()->generateRelationTreeFromRelationalTreeNode([], [], [], $allColumns, $debug->indent(), $extensions));
 
                                           if($debug.debug, | print($debug.space + 'Generated Relation Trees - \n\n' + $result->map(tree | relationTreeAsString($tree, $debug->indent().space))->joinStrings($debug.space + '[\n','\n', '\n' +$debug.space+ ']')  + '\n\n'), |[]);
                                           $result;,
@@ -437,7 +437,7 @@ function meta::pure::lineage::scanRelations::generateRelationTreeFromRelationalO
    ]);
 }
 
-function <<access.private>> meta::pure::lineage::scanRelations::generateRelationTreeFromRelationalTreeNode(r: RelationalTreeNode[1], parentOperation:TableAlias[0..1], parentRelations:NamedRelation[*], columns:TableAliasColumn[*], debug: meta::pure::tools::DebugContext[1], extensions:RouterExtension[*]):RelationTree[*]
+function <<access.private>> meta::pure::lineage::scanRelations::generateRelationTreeFromRelationalTreeNode(r: RelationalTreeNode[1], parentOperation:TableAlias[0..1], parentRelations:NamedRelation[*], parentTree:RelationTree[0..1], columns:TableAliasColumn[*], debug: meta::pure::tools::DebugContext[1], extensions:RouterExtension[*]):RelationTree[*]
 {
    if($debug.debug, | print($debug.space + 'Generate RelationTree from Relational Tree Node\n'), | []);
 
@@ -455,11 +455,11 @@ function <<access.private>> meta::pure::lineage::scanRelations::generateRelation
              
                             if($debug.debug, | print($debug.space + 'Generated Base Trees - \n\n' + $baseTreesWithColumns->map(tree | relationTreeAsString($tree, $debug->indent().space))->joinStrings($debug.space + '[\n','\n', '\n' +$debug.space+ ']')  + '\n\n'), |[]);
 
-                            let treesWithJoin        = $baseTreesWithColumns->map(tree | let processedJoin = processJoinFromTreeNode($j, $parentOperation->toOne(), $parentRelations, $tree.relation->toOne(), $debug, $extensions);
+                            let treesWithJoin        = $baseTreesWithColumns->map(tree | let processedJoin = processJoinFromTreeNode($j, $parentOperation->toOne(), $parentRelations, $tree.relation->toOne(), $tree, $parentTree->toOne(), $debug, $extensions);
                                                                                          if($processedJoin->isEmpty(), | [], | ^$tree(join = $processedJoin->toOne())););
 
                             let childTreeCols        = $allColumns->filter(c | $c.alias.name != $j.alias.name);
-                            let result               = $treesWithJoin->map(tree | let childTrees = $j.children->map(child | $child->generateRelationTreeFromRelationalTreeNode($j.alias, $tree->flattenRelationTree().relation, $childTreeCols, $debug->indent(), $extensions););
+                            let result               = $treesWithJoin->map(tree | let childTrees = $j.children->map(child | $child->generateRelationTreeFromRelationalTreeNode($j.alias, $tree->flattenRelationTree().relation, $tree, $childTreeCols, $debug->indent(), $extensions););
                                                                                   $tree->addChildTrees($childTrees););
 
                             if($debug.debug, | print($debug.space + 'Generated Trees - \n\n' + $result->map(tree | relationTreeAsString($tree, $debug->indent().space))->joinStrings($debug.space + '[\n','\n', '\n' +$debug.space+ ']')  + '\n\n'), |[]);
@@ -479,7 +479,7 @@ function <<access.private>> meta::pure::lineage::scanRelations::generateRelation
                                 if($debug.debug, | print($debug.space + 'Generated Base Trees - \n\n' + $baseTreesWithColumns->map(tree | relationTreeAsString($tree, $debug->indent().space))->joinStrings($debug.space + '[\n','\n', '\n' +$debug.space+ ']')  + '\n\n'), |[]);
                                 
                                 let childTreeCols = $allColumns->filter(c | $c.alias.name != $r.alias.name);
-                                let result        = $baseTreesWithColumns->map(tree | let childTrees = $r.children->map(child | $child->generateRelationTreeFromRelationalTreeNode($r.alias, $tree->flattenRelationTree().relation, $childTreeCols, $debug->indent(), $extensions););
+                                let result        = $baseTreesWithColumns->map(tree | let childTrees = $r.children->map(child | $child->generateRelationTreeFromRelationalTreeNode($r.alias, $tree->flattenRelationTree().relation, $tree, $childTreeCols, $debug->indent(), $extensions););
                                                                                       $tree->addChildTrees($childTrees););
 
                                 if($debug.debug, | print($debug.space + 'Generated Trees - \n\n' + $result->map(tree | relationTreeAsString($tree, $debug->indent().space))->joinStrings($debug.space + '[\n','\n', '\n' +$debug.space+ ']')  + '\n\n'), |[]);
@@ -530,7 +530,7 @@ function meta::pure::lineage::scanRelations::addColumnToRelationTree(tree:Relati
    );
 }
 
-function <<access.private>> meta::pure::lineage::scanRelations::processJoinFromTreeNode(j:JoinTreeNode[1], sourceOperation:TableAlias[1], sourceRelations:NamedRelation[*], targetRelation:NamedRelation[1], debug:meta::pure::tools::DebugContext[1], extensions:RouterExtension[*]):Join[0..1]
+function <<access.private>> meta::pure::lineage::scanRelations::processJoinFromTreeNode(j:JoinTreeNode[1], sourceOperation:TableAlias[1], sourceRelations:NamedRelation[*], targetRelation:NamedRelation[1], targetTree:RelationTree[1], sourceTree:RelationTree[1], debug:meta::pure::tools::DebugContext[1], extensions:RouterExtension[*]):Join[0..1]
 {
    let relationIndentifiers     = $sourceRelations->concatenate($targetRelation)->map(rel | $rel->getRelationName());
    
@@ -545,7 +545,8 @@ function <<access.private>> meta::pure::lineage::scanRelations::processJoinFromT
                                                                 assert($tac.alias.name->in([$targetAliasName, $sourceAliasName]), | 'Columns in join should refer either source alias or target alias');
                                                           
                                                                 let alias         = if($tac.alias.name == $sourceAliasName, | $sourceOperation, |$targetOperation);
-                                                                let sourceColumn  = $tac->extractSourceColumn($alias, $relationIndentifiers);
+                                                                let tree          = if($tac.alias.name == $sourceAliasName, | $sourceTree, |$targetTree);
+                                                                let sourceColumn  = $tac->extractSourceColumn($alias, $relationIndentifiers, $tree);
                                                                 
                                                                 if($sourceColumn->isEmpty(),
                                                                    |pair($tac, ^SQLNull()),
@@ -635,21 +636,21 @@ function <<access.private>> meta::pure::lineage::scanRelations::isNull(d:DynaFun
       |false);
 }
 
-function <<access.private>> meta::pure::lineage::scanRelations::extractSourceColumn(tableAliasColumn:TableAliasColumn[1], sourceOperation:RelationalOperationElement[1], relationIdentifiers:String[*]):Column[0..1]
+function <<access.private>> meta::pure::lineage::scanRelations::extractSourceColumn(tableAliasColumn:TableAliasColumn[1], sourceOperation:RelationalOperationElement[1], relationIdentifiers:String[*], sourceTree:RelationTree[1]):Column[0..1]
 {
    $sourceOperation->match([
                               v:ViewSelectSQLQuery[1]| if(getRelationName($v.view)->in($relationIdentifiers), |$tableAliasColumn.column, |[]),
                               t:Table[1]             | if(getRelationName($t)->in($relationIdentifiers), |$tableAliasColumn.column, |[]),
                               v:View[1]              | if(getRelationName($v)->in($relationIdentifiers), |$tableAliasColumn.column, |[]),
-                              ta:TableAlias[1]       | if($tableAliasColumn.alias.name == $ta.name,| $tableAliasColumn->extractSourceColumn($ta.relation, $relationIdentifiers), | []);,
-                              s:SelectSQLQuery[1]    | $s->extractSourceColumnFromSelectSQLQuery($tableAliasColumn, $relationIdentifiers);,
-                              u:Union[1]             | let colNames = $u.queries->map(query | $query->extractSourceColumnFromSelectSQLQuery($tableAliasColumn, $relationIdentifiers))->removeDuplicates();
+                              ta:TableAlias[1]       | if($tableAliasColumn.alias.name == $ta.name,| $tableAliasColumn->extractSourceColumn($ta.relation, $relationIdentifiers, $sourceTree), | []);,
+                              s:SelectSQLQuery[1]    | $s->extractSourceColumnFromSelectSQLQuery($tableAliasColumn, $relationIdentifiers, $sourceTree);,
+                              u:Union[1]             | let colNames = $u.queries->map(query | $query->extractSourceColumnFromSelectSQLQuery($tableAliasColumn, $relationIdentifiers, $sourceTree))->removeDuplicates()->filter(c | $c.name->in($sourceTree.columns.name));
                                                        assert($colNames->size() <=1 ,|'Expected max 1 column. Found : ' + $colNames->size()->toString());
                                                        if($colNames->isEmpty(), | [], | $colNames->toOne());
                            ]);
 }
 
-function <<access.private>> meta::pure::lineage::scanRelations::extractSourceColumnFromSelectSQLQuery(select : SelectSQLQuery[1], tableAliasColumn:TableAliasColumn[1], relationIdentifiers:String[*]):Column[0..1]
+function <<access.private>> meta::pure::lineage::scanRelations::extractSourceColumnFromSelectSQLQuery(select : SelectSQLQuery[1], tableAliasColumn:TableAliasColumn[1], relationIdentifiers:String[*], sourceTree:RelationTree[1]):Column[0..1]
 {
    let reqTableAliasColumn = $select.columns->filter(col | let colName = $col->match([a:Alias[1] | $a.name, 
                                                                                       tac:TableAliasColumn[1] | $tac.column.name]);
@@ -662,7 +663,7 @@ function <<access.private>> meta::pure::lineage::scanRelations::extractSourceCol
       |let rootTree        = $select.data->toOne();
        let childTrees      = $rootTree.children->map(child | $child->extractLine());
        let sourceOperation = $rootTree->concatenate($childTrees)->filter(tree | $tree.alias.name == $reqTableAliasColumn.alias.name).alias->toOne();
-       $reqTableAliasColumn->toOne()->extractSourceColumn($sourceOperation, $relationIdentifiers);
+       $reqTableAliasColumn->toOne()->extractSourceColumn($sourceOperation, $relationIdentifiers, $sourceTree);
    );
 }
 

--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/lineage/scanRelations/scanRelationsTests.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/lineage/scanRelations/scanRelationsTests.pure
@@ -407,6 +407,19 @@ function <<meta::pure::profiles::test.Test>> meta::pure::lineage::scanRelations:
    assertEquals($expected1, $relationTreeFromPureToSQL-> relationTreeAsString(false));
 }
 
+function <<meta::pure::profiles::test.Test>> meta::pure::lineage::scanRelations::test::testUnionToSameTableWithDiffKeys():Boolean[1]
+{
+   let query = {|Firm.all()-> project([f|$f.legalName, f|$f.employees.firstName], ['legalName','employee_firstname'])};
+   let mapping = meta::relational::tests::mapping::union::unionToUnionMappingWithJoinToSameTableWithDiffKeys;
+
+   let relationTreeFromPureToSQL = meta::pure::lineage::scanRelations::scanRelations($query, $mapping, meta::relational::tests::testRuntime(), defaultRelationalExtensions());
+   let expected1 ='root\n' +
+                  '  ------> (t) Firm [ID, name]\n' +
+                  '    ------> (t) PersonSet4(equal_s(PersonSet4FirmID_1_PersonSet4firstName_s1,PersonSet4,)s(PersonSet4FirmID_2_PersonSet4firstName_s1,PersonSet4,)firmId_FirmID) [FirmID_1, firstName_s1]\n' +
+                  '    ------> (t) PersonSet4(equal_s(PersonSet4FirmID_1_PersonSet4firstName_s1,PersonSet4,)s(PersonSet4FirmID_2_PersonSet4firstName_s1,PersonSet4,)firmId_FirmID) [FirmID_2, firstName_s1]\n';
+   assertEquals($expected1, $relationTreeFromPureToSQL-> relationTreeAsString(true));
+}
+
 
 function <<meta::pure::profiles::test.Test>> meta::pure::lineage::scanRelations::test::testSimpleViewRoot():Boolean[1]
 {

--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/tests/mapping/union/testUnion.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/tests/mapping/union/testUnion.pure
@@ -587,6 +587,15 @@ Database meta::relational::tests::mapping::union::myDB
         FirmID INT
     )
    
+    Table PersonSet4
+    (
+        ID INT PRIMARY KEY,
+        firstName_s1 VARCHAR(200),
+        lastName_s1 VARCHAR(200),
+        FirmID_1 INT,
+        FirmID_2 INT
+    )
+   
     Table Firm
     (
         ID INT PRIMARY KEY,
@@ -726,6 +735,8 @@ Database meta::relational::tests::mapping::union::myDB
    Join PersonSet1Firm(PersonSet1.FirmID = Firm.ID)
    Join PersonSet2Firm(PersonSet2.FirmID = Firm.ID)
    Join PersonSet3Firm(PersonSet3.FirmID = Firm.ID)
+   Join PersonSet4Firm1(PersonSet4.FirmID_1 = Firm.ID)
+   Join PersonSet4Firm2(PersonSet4.FirmID_2 = Firm.ID)
    
    Join PersonSet1AddressSet1(PersonSet1.FirmID = AddressSet1.ID)
    Join PersonSet1AddressSet2(PersonSet1.FirmID = AddressSet2.ID)
@@ -1683,4 +1694,35 @@ Mapping meta::relational::tests::mapping::union::unionToUnionMapping3
           {
              legalName : [myDB]FirmSet2.name
           }
+)
+
+###Mapping
+import meta::relational::tests::mapping::union::*;
+import meta::relational::tests::model::simple::*;
+
+Mapping meta::relational::tests::mapping::union::unionToUnionMappingWithJoinToSameTableWithDiffKeys
+(
+   Firm[firm_set1] : Relational
+          {
+             legalName : [myDB]Firm.name,
+             employees[set1]:[myDB]@PersonSet4Firm1,
+             employees[set2]:[myDB]@PersonSet4Firm2
+          }
+   
+   *Person : Operation
+            {
+               meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_(set1, set2)   
+            }
+   
+   Person[set1] : Relational
+            {
+               +firmId:String[1] : [myDB]PersonSet4.FirmID_1,
+               firstName : [myDB]PersonSet4.firstName_s1
+            }   
+   
+   Person[set2] : Relational
+            {
+               +firmId:String[1] : [myDB]PersonSet4.FirmID_2,
+               firstName : [myDB]PersonSet4.firstName_s1
+            }   
 )


### PR DESCRIPTION
Impact
- Users are not able to generate test data easily for use-case where union is defined on same table with different keys
- Pure/Engine cannot generate relation tree lineage for above use-case