### PR TITLE
Add missing asserts to Java-gen to avoid translating their definition

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/assertLibrary.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/assertLibrary.pure
@@ -26,7 +26,9 @@ function meta::pure::executionPlan::engine::java::registerAssertLibrary(conventi
    let lib = newConventionsLibrary()
       ->addFunctionCoders([
          fc2(assert_Boolean_1__Function_1__Boolean_1_,         {ctx,test,message     | $library->j_invoke('pureAssert', [$test, $message], javaBoolean())}),
-         fc3(assert_Boolean_1__String_1__Any_MANY__Boolean_1_, {ctx,test,format,args | $library->j_invoke('pureAssert', [$test, j_lambda($noParams, $library->j_invoke('format', [$format, $args->j_listOf(javaList(javaObject()))], javaString()))], javaBoolean())})
+         fc1(assert_Boolean_1__Boolean_1_,                     {ctx,test             | $library->j_invoke('pureAssert', [$test, j_lambda($noParams, j_string('Assert failed'))], javaBoolean())}),
+         fc3(assert_Boolean_1__String_1__Any_MANY__Boolean_1_, {ctx,test,format,args | $library->j_invoke('pureAssert', [$test, j_lambda($noParams, $library->j_invoke('format', [$format, $args->j_listOf(javaList(javaObject()))], javaString()))], javaBoolean())}),
+         fc2(assert_Boolean_1__String_1__Boolean_1_,           {ctx,test,message     | $library->j_invoke('pureAssert', [$test, j_lambda($noParams, $message)], javaBoolean())})
       ]);
 
    $conventions->registerLibrary($lib);

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/simpleObject.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/simpleObject.pure
@@ -596,6 +596,49 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleSerializeOfOneObje
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"friendA\\":{\\"fullName\\":\\"Robert T\\",\\"aName\\":\\"A\\",\\"@type\\":\\"meta::pure::mapping::modelToModel::test::shared::src::_S_PersonA\\"},\\"friendB\\":{\\"fullName\\":\\"John T\\",\\"aName\\":\\"A\\",\\"@type\\":\\"meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::_S_PersonA\\"}}"},"value":{"friendA":{"aName":"A","fullName":"Robert T"},"friendB":{"aName":"A","fullName":"John T"}}},"value":{"friendA":{"firstName":"RobertA"},"friendB":{"firstName":"JohnA"}}}'->parseJSON(), $result.values->toOne()->parseJSON()));
 }
 
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly, feature.M2MBasics>>
+meta::pure::mapping::modelToModel::test::alloy::simple::simpleM2MMappingUsingExplicitAssert() : Boolean[1]
+{
+   let tree = #{Name {name}}#;
+   
+   let result = execute(
+      | Name.all()->graphFetchChecked($tree)->serialize($tree),
+      meta::pure::mapping::modelToModel::test::alloy::simple::simpleModelMappingWithExplicitAssert,
+      ^Runtime(connections = ^JsonModelConnection(
+                              element=^ModelStore(),
+                              class = meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::_AString,
+                              url = 'data:application/json,{"s":"test string data"}'
+                             )
+         ),
+      []
+   );
+
+   println($result.values);
+   assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"s\\":\\"test string data\\"}"},"value":{"s":"test string data"}},"value":{"name":"ok"}}'->parseJSON(), $result.values->toOne()->parseJSON()));
+}
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly, feature.M2MBasics>>
+meta::pure::mapping::modelToModel::test::alloy::simple::simpleM2MMappingUsingImplicitAssert() : Boolean[1]
+{
+   let tree = #{Name {name}}#;
+   
+   let result = execute(
+      | Name.all()->graphFetchChecked($tree)->serialize($tree),
+      meta::pure::mapping::modelToModel::test::alloy::simple::simpleModelMappingWithImplicitAssert,
+      ^Runtime(connections = ^JsonModelConnection(
+                              element=^ModelStore(),
+                              class = meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::_AString,
+                              url = 'data:application/json,{"s":"test string data"}'
+                             )
+         ),
+      []
+   );
+
+   println($result.values);
+   assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"s\\":\\"test string data\\"}"},"value":{"s":"test string data"}},"value":{"name":"ok"}}'->parseJSON(), $result.values->toOne()->parseJSON()));
+}
+
+
 ###Pure
 import meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::*;
 import meta::pure::mapping::modelToModel::test::alloy::simple::objects::dest::*;
@@ -848,5 +891,25 @@ Mapping meta::pure::mapping::modelToModel::test::alloy::simpleModelMappingWithMu
   }   
 )
 
+
+Mapping meta::pure::mapping::modelToModel::test::alloy::simple::simpleModelMappingWithExplicitAssert
+(
+   meta::pure::mapping::modelToModel::test::alloy::simple::objects::dest::Name : Pure
+   {
+      ~src _AString
+      name: if($src.s->isNoShorterThan(10), | assert($src.s->length() >= 0);'ok';, | 'not ok')
+   }
+)
+
+// isNoShorterThan uses an assert in its definition: this is testing out translation of the isNoShorterThan body 
+// and translation of the assert to make sure we pick up the right defintion
+Mapping meta::pure::mapping::modelToModel::test::alloy::simple::simpleModelMappingWithImplicitAssert
+(
+   meta::pure::mapping::modelToModel::test::alloy::simple::objects::dest::Name : Pure
+   {
+      ~src _AString
+      name: if($src.s->isNoShorterThan(10), | 'ok', | 'not ok')
+   }
+)
 
 


### PR DESCRIPTION
**Functional change:**
Add missing assert functions to Java code generator: this avoids having to translate the definitions of these assert functions and instead relies on the hard-coded translation defined in the assertLibrary. 
There is a bug in Pure, where the Java code generator picks up the wrong body when translating some assert functions - this means that we generate Java code which does not compile.

**Tests**
Two tests added in this change to ensure that we compile asserts correctly in execution plans 