### PR TITLE
Fix metadata id for lambda functions

### DIFF
--- a/legend-pure-code-java-compiled-core/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/TestIdBuilderCore.java
+++ b/legend-pure-code-java-compiled-core/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/TestIdBuilderCore.java
@@ -1,0 +1,84 @@
+package org.finos.legend.pure.runtime.java.compiled.generation.processors;
+
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.primitive.MutableObjectIntMap;
+import org.eclipse.collections.api.map.primitive.ObjectIntMap;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.primitive.ObjectIntMaps;
+import org.finos.legend.pure.code.core.CoreCodeRepositoryProvider;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableCodeStorage;
+import org.finos.legend.pure.m3.serialization.runtime.PureRuntime;
+import org.finos.legend.pure.m3.serialization.runtime.PureRuntimeBuilder;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.tools.GraphNodeIterable;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestIdBuilderCore
+{
+    private static PureRuntime runtime;
+    private static ProcessorSupport processorSupport;
+
+    @BeforeClass
+    public static void setUp()
+    {
+        MutableCodeStorage codeStorage = PureCodeStorage.createCodeStorage(null, Lists.immutable.with(CodeRepository.newPlatformCodeRepository(), new CoreCodeRepositoryProvider().repository()));
+        runtime = new PureRuntimeBuilder(codeStorage).setTransactionalByDefault(false).buildAndInitialize();
+        processorSupport = runtime.getProcessorSupport();
+    }
+
+    @Test
+    public void testIdUniqueness()
+    {
+        testIdUniqueness(IdBuilder.newIdBuilder(processorSupport));
+    }
+
+    @Test
+    public void testIdUniquenessWithPrefix()
+    {
+        testIdUniqueness(IdBuilder.newIdBuilder("$core$", processorSupport));
+    }
+
+    private void testIdUniqueness(IdBuilder idBuilder)
+    {
+        // ImportGroup is excluded because of a known issue with conflicts with ImportGroup ids independent of IdBuilder
+        MutableSet<CoreInstance> excludedClassifiers = PrimitiveUtilities.getPrimitiveTypes(processorSupport).toSet().with(processorSupport.package_getByUserPath(M3Paths.ImportGroup));
+        MutableMap<CoreInstance, MutableSet<String>> classifierIds = Maps.mutable.empty();
+        MutableMap<CoreInstance, MutableObjectIntMap<String>> idConflicts = Maps.mutable.empty();
+        GraphNodeIterable.fromModelRepository(runtime.getModelRepository())
+                .forEach(instance ->
+                {
+                    CoreInstance classifier = instance.getClassifier();
+                    if (!excludedClassifiers.contains(classifier))
+                    {
+                        String id = idBuilder.buildId(instance);
+                        if (!classifierIds.getIfAbsentPut(classifier, Sets.mutable::empty).add(id))
+                        {
+                            idConflicts.getIfAbsentPut(classifier, ObjectIntMaps.mutable::empty).updateValue(id, 1, n -> n + 1);
+                        }
+                    }
+                });
+        if (idConflicts.notEmpty())
+        {
+            MutableMap<CoreInstance, String> classifierPaths = idConflicts.keysView().toMap(c -> c, PackageableElement::getUserPathForPackageableElement);
+            StringBuilder builder = new StringBuilder("The following ids have conflicts:");
+            idConflicts.keysView().toSortedListBy(classifierPaths::get).forEach(classifier ->
+            {
+                builder.append("\n\t").append(classifierPaths.get(classifier));
+                ObjectIntMap<String> classifierIdConflicts = idConflicts.get(classifier);
+                classifierIdConflicts.forEachKeyValue((id, count) -> builder.append("\n\t\t").append(id).append(": ").append(count).append(" instances"));
+            });
+            Assert.fail(builder.toString());
+        }
+    }
+}

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestIncrementalCompiler.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestIncrementalCompiler.java
@@ -14,8 +14,8 @@
 
 package org.finos.legend.pure.m3.serialization.runtime;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -25,7 +25,8 @@ import org.junit.Test;
 public class TestIncrementalCompiler extends AbstractPureTestWithCoreCompiledPlatform
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getExtra());
     }
 
@@ -37,37 +38,37 @@ public class TestIncrementalCompiler extends AbstractPureTestWithCoreCompiledPla
     public void testInstanceDefinedBeforeClassWillCompile()
     {
 
-        MutableList<Source> sources = new FastList<>();
+        MutableList<Source> sources = Lists.mutable.empty();
         sources.add(new Source("1", false, false, "^my::Table instance\n" +
-                                            "(\n" +
-                                            "    name = 'Hello'\n" +
-                                            ")"));
+                "(\n" +
+                "    name = 'Hello'\n" +
+                ")"));
         sources.add(new Source("2", false, false, "Class my::Table\n" +
-                                "{\n" +
-                                "    name : String[1];\n" +
-                                "}\n"));
-        this.runtime.getIncrementalCompiler().compile(sources);
+                "{\n" +
+                "    name : String[1];\n" +
+                "}\n"));
+        runtime.getIncrementalCompiler().compile(sources);
 
         Assert.assertEquals("instance instance Table\n" +
                 "    name(Property):\n" +
-                "        Hello instance String", this.runtime.getCoreInstance("instance").printWithoutDebug(""));
+                "        Hello instance String", runtime.getCoreInstance("instance").printWithoutDebug(""));
     }
 
     @Test
     public void testClassInstanceUsedBeforeClassWillCompile()
     {
 
-        MutableList<Source> sources = new FastList<>();
+        MutableList<Source> sources = Lists.mutable.empty();
         sources.add(new Source("1.pure", false, false, "function my::tableName():String[1]\n" +
-                                            "{\n" +
-                                            "    let t = ^my::Table(name = 'Hello');\n" +
-                                            "    $t.name;\n" +
-                                            "}\n"));
+                "{\n" +
+                "    let t = ^my::Table(name = 'Hello');\n" +
+                "    $t.name;\n" +
+                "}\n"));
         sources.add(new Source("2.pure", false, false, "Class my::Table\n" +
-                                "{\n" +
-                                "    name : String[1];\n" +
-                                "}\n"));
-        this.runtime.getIncrementalCompiler().compile(sources);
+                "{\n" +
+                "    name : String[1];\n" +
+                "}\n"));
+        runtime.getIncrementalCompiler().compile(sources);
 
         Assert.assertEquals("tableName__String_1_ instance ConcreteFunctionDefinition\n" +
                 "    classifierGenericType(Property):\n" +
@@ -113,7 +114,7 @@ public class TestIncrementalCompiler extends AbstractPureTestWithCoreCompiledPla
                 "                Anonymous_StripedId instance VariableExpression\n" +
                 "                    [... >1]\n" +
                 "            propertyName(Property):\n" +
-                "                my_tableName1$0 instance InstanceValue\n" +
+                "                my$tableName$1$system$imports$import_1_pure_1$0 instance InstanceValue\n" +
                 "                    [... >1]\n" +
                 "            usageContext(Property):\n" +
                 "                Anonymous_StripedId instance ExpressionSequenceValueSpecificationContext\n" +
@@ -123,27 +124,27 @@ public class TestIncrementalCompiler extends AbstractPureTestWithCoreCompiledPla
                 "    name(Property):\n" +
                 "        tableName__String_1_ instance String\n" +
                 "    package(Property):\n" +
-                "        my instance Package", this.runtime.getFunction("my::tableName():String[1]").printWithoutDebug("",1));
+                "        my instance Package", runtime.getFunction("my::tableName():String[1]").printWithoutDebug("", 1));
     }
 
     @Test
     public void testInstanceWithPropertyReferencingEnumBeforeEnumDefinedWillCompile()
     {
 
-        MutableList<Source> sources = new FastList<>();
+        MutableList<Source> sources = Lists.mutable.empty();
         sources.add(new Source("1.pure", false, false, "Class my::myClass\n" +
-                                        "{\n" +
-                                        "    value : my::myEnum[1];\n" +
-                                        "}\n" +
-                                        "^my::myClass instance\n" +
-                                            "(\n" +
-                                            "    value = my::myEnum.VAL1\n" +
-                                            ")"));
+                "{\n" +
+                "    value : my::myEnum[1];\n" +
+                "}\n" +
+                "^my::myClass instance\n" +
+                "(\n" +
+                "    value = my::myEnum.VAL1\n" +
+                ")"));
         sources.add(new Source("2.pure", false, false, "Enum my::myEnum\n" +
-                                "{\n" +
-                                "    VAL1, VAL2\n" +
-                                "}\n"));
-        this.runtime.getIncrementalCompiler().compile(sources);
+                "{\n" +
+                "    VAL1, VAL2\n" +
+                "}\n"));
+        runtime.getIncrementalCompiler().compile(sources);
 
         Assert.assertEquals("instance instance myClass\n" +
                 "    value(Property):\n" +
@@ -155,6 +156,6 @@ public class TestIncrementalCompiler extends AbstractPureTestWithCoreCompiledPla
                 "                    idOrPath(Property):\n" +
                 "                        my::myEnum instance String\n" +
                 "                    importGroup(Property):\n" +
-                "                        import_1_pure_1 instance ImportGroup", this.runtime.getCoreInstance("instance").printWithoutDebug("",1));
+                "                        import_1_pure_1 instance ImportGroup", runtime.getCoreInstance("instance").printWithoutDebug("", 1));
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/function/TestFunction.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/function/TestFunction.java
@@ -205,7 +205,7 @@ public class TestFunction extends AbstractPureTestWithCoreCompiledPlatform
                         "}");
         runtime.compile();
 
-        CoreInstance func = this.runtime.getFunction("test():Nil[0]");
+        CoreInstance func = runtime.getFunction("test():Nil[0]");
         Assert.assertEquals("test__Nil_0_ instance ConcreteFunctionDefinition\n" +
                 "    classifierGenericType(Property):\n" +
                 "        Anonymous_StripedId instance GenericType\n" +
@@ -570,7 +570,7 @@ public class TestFunction extends AbstractPureTestWithCoreCompiledPlatform
                 "                            offset(Property):\n" +
                 "                                1 instance Integer\n" +
                 "                    values(Property):\n" +
-                "                        getValue1$1 instance LambdaFunction\n" +
+                "                        getValue$1$system$imports$import_fromString_pure_1$1 instance LambdaFunction\n" +
                 "                            classifierGenericType(Property):\n" +
                 "                                Anonymous_StripedId instance GenericType\n" +
                 "                                    rawType(Property):\n" +
@@ -580,7 +580,7 @@ public class TestFunction extends AbstractPureTestWithCoreCompiledPlatform
                 "                                            rawType(Property):\n" +
                 "                                                Anonymous_StripedId instance FunctionType\n" +
                 "                                                    function(Property):\n" +
-                "                                                        getValue1$1 instance LambdaFunction\n" +
+                "                                                        getValue$1$system$imports$import_fromString_pure_1$1 instance LambdaFunction\n" +
                 "                                                    parameters(Property):\n" +
                 "                                                        Anonymous_StripedId instance VariableExpression\n" +
                 "                                                            functionTypeOwner(Property):\n" +
@@ -729,7 +729,7 @@ public class TestFunction extends AbstractPureTestWithCoreCompiledPlatform
                 "                                                            offset(Property):\n" +
                 "                                                                0 instance Integer\n" +
                 "                                            propertyName(Property):\n" +
-                "                                                getValue1$0 instance InstanceValue\n" +
+                "                                                getValue$1$system$imports$import_fromString_pure_1$0 instance InstanceValue\n" +
                 "                                                    genericType(Property):\n" +
                 "                                                        Anonymous_StripedId instance GenericType\n" +
                 "                                                            rawType(Property):\n" +
@@ -762,7 +762,7 @@ public class TestFunction extends AbstractPureTestWithCoreCompiledPlatform
                 "                                    usageContext(Property):\n" +
                 "                                        Anonymous_StripedId instance ExpressionSequenceValueSpecificationContext\n" +
                 "                                            functionDefinition(Property):\n" +
-                "                                                getValue1$1 instance LambdaFunction\n" +
+                "                                                getValue$1$system$imports$import_fromString_pure_1$1 instance LambdaFunction\n" +
                 "                                            offset(Property):\n" +
                 "                                                0 instance Integer\n" +
                 "                            referenceUsages(Property):\n" +
@@ -784,7 +784,7 @@ public class TestFunction extends AbstractPureTestWithCoreCompiledPlatform
                 "    name(Property):\n" +
                 "        getValue_Any_1__String_1__Any_MANY_ instance String\n" +
                 "    package(Property):\n" +
-                "        Root instance Package", this.runtime.getCoreInstance("getValue_Any_1__String_1__Any_MANY_").printWithoutDebug("", 10));
+                "        Root instance Package", runtime.getCoreInstance("getValue_Any_1__String_1__Any_MANY_").printWithoutDebug("", 10));
 
     }
 

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tools/TestGraphPath.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tools/TestGraphPath.java
@@ -19,12 +19,15 @@ import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class TestGraphPath extends AbstractPureTestWithCoreCompiledPlatform
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getExtra());
         compileTestSource("/test/testModel.pure",
                 "import test::domain::*;\n" +
@@ -113,26 +116,26 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiledPlatform
     public void testResolve()
     {
         Assert.assertSame(
-                this.runtime.getCoreInstance("test::domain::ClassA"),
-                GraphPath.buildPath("test::domain::ClassA").resolve(this.processorSupport));
+                runtime.getCoreInstance("test::domain::ClassA"),
+                GraphPath.buildPath("test::domain::ClassA").resolve(processorSupport));
         Assert.assertSame(
-                this.runtime.getCoreInstance("test::domain::ClassA").getValueForMetaPropertyToOne("classifierGenericType"),
-                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType").resolve(this.processorSupport));
+                runtime.getCoreInstance("test::domain::ClassA").getValueForMetaPropertyToOne("classifierGenericType"),
+                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType").resolve(processorSupport));
         Assert.assertSame(
-                this.runtime.getCoreInstance(M3Paths.Class),
-                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType", "rawType").resolve(this.processorSupport));
+                runtime.getCoreInstance(M3Paths.Class),
+                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType", "rawType").resolve(processorSupport));
         Assert.assertSame(
-                this.runtime.getCoreInstance(M3Paths.String),
-                GraphPath.newPathBuilder("test::domain::ClassA").addToManyPropertyValueAtIndex("properties", 0).addToOneProperties("genericType", "rawType").build().resolve(this.processorSupport));
+                runtime.getCoreInstance(M3Paths.String),
+                GraphPath.newPathBuilder("test::domain::ClassA").addToManyPropertyValueAtIndex("properties", 0).addToOneProperties("genericType", "rawType").build().resolve(processorSupport));
         Assert.assertSame(
-                this.runtime.getCoreInstance("test::domain::ClassA").getValueInValueForMetaPropertyToMany("properties", "prop2").getValueForMetaPropertyToOne("genericType").getValueForMetaPropertyToOne("rawType"),
-                GraphPath.newPathBuilder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolve(this.processorSupport));
+                runtime.getCoreInstance("test::domain::ClassA").getValueInValueForMetaPropertyToMany("properties", "prop2").getValueForMetaPropertyToOne("genericType").getValueForMetaPropertyToOne("rawType"),
+                GraphPath.newPathBuilder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolve(processorSupport));
         Assert.assertSame(
-                this.runtime.getCoreInstance("test::domain::ClassB"),
-                ImportStub.withImportStubByPass(GraphPath.newPathBuilder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType").build().resolve(this.processorSupport), this.processorSupport));
+                runtime.getCoreInstance("test::domain::ClassB"),
+                ImportStub.withImportStubByPass(GraphPath.newPathBuilder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType").build().resolve(processorSupport), processorSupport));
         Assert.assertSame(
-                this.runtime.getCoreInstance("test::domain::ClassB"),
-                GraphPath.newPathBuilder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType", "resolvedNode").build().resolve(this.processorSupport));
+                runtime.getCoreInstance("test::domain::ClassB"),
+                GraphPath.newPathBuilder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType", "resolvedNode").build().resolve(processorSupport));
     }
 
     @Test
@@ -140,22 +143,22 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiledPlatform
     {
         Assert.assertEquals(
                 GraphPath.buildPath("test::domain::ClassA"),
-                GraphPath.buildPath("test::domain::ClassA").reduce(this.processorSupport));
+                GraphPath.buildPath("test::domain::ClassA").reduce(processorSupport));
         Assert.assertEquals(
                 GraphPath.buildPath("test::domain::ClassA", "classifierGenericType"),
-                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType").reduce(this.processorSupport));
+                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType").reduce(processorSupport));
         Assert.assertEquals(
                 GraphPath.buildPath(M3Paths.Class),
-                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType", "rawType").reduce(this.processorSupport));
+                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType", "rawType").reduce(processorSupport));
         Assert.assertEquals(
                 GraphPath.buildPath(M3Paths.Class, "name"),
-                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType", "rawType", "name").reduce(this.processorSupport));
+                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType", "rawType", "name").reduce(processorSupport));
         Assert.assertEquals(
                 GraphPath.newPathBuilder("test::domain::ClassB").addToManyPropertyValueWithKey("properties", "name", "prop3").build(),
-                GraphPath.newPathBuilder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType", "resolvedNode").addToManyPropertyValueWithKey("properties", "name", "prop3").build().reduce(this.processorSupport));
+                GraphPath.newPathBuilder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType", "resolvedNode").addToManyPropertyValueWithKey("properties", "name", "prop3").build().reduce(processorSupport));
         Assert.assertEquals(
                 GraphPath.buildPath(M3Paths.Class, "name"),
-                GraphPath.newPathBuilder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType", "resolvedNode", "classifierGenericType", "rawType", "name").build().reduce(this.processorSupport));
+                GraphPath.newPathBuilder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType", "resolvedNode", "classifierGenericType", "rawType", "name").build().reduce(processorSupport));
     }
 
     @Test

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
@@ -475,13 +475,15 @@ public final class JavaSourceCodeGenerator
         return
                 "public class " + name + "\n" +
                         "{\n" +
-                        "    public static MutableMap<String, SharedPureFunction> __functions = UnifiedMap.newMap();\n" +
+                        ((lambdaFunctions != null || nativeFunctions != null) ?
+                        "    public static MutableMap<String, SharedPureFunction<?>> __functions = Maps.mutable.empty();\n" +
                         "    static\n" +
                         "    {\n" +
-                        (lambdaFunctions == null ? "" : lambdaFunctions.keyValuesView().collect(keyValuePair -> "    __functions.put(\"" + keyValuePair.getOne() + "\", " + keyValuePair.getTwo() + ");\n").makeString("")) +
-                        (nativeFunctions == null ? "" : nativeFunctions.keyValuesView().collect(keyValuePair -> "    __functions.put(\"" + keyValuePair.getOne() + "\", " + keyValuePair.getTwo() + ");\n").makeString("")) +
-                        "    }\n" +
-                        "\n" +
+                        (lambdaFunctions == null ? "" : lambdaFunctions.keyValuesView().collect(keyValuePair -> "        __functions.put(\"" + keyValuePair.getOne() + "\", " + keyValuePair.getTwo() + ");\n").makeString("")) +
+                        (nativeFunctions == null ? "" : nativeFunctions.keyValuesView().collect(keyValuePair -> "        __functions.put(\"" + keyValuePair.getOne() + "\", " + keyValuePair.getTwo() + ");\n").makeString("")) +
+                        "    }\n" :
+                        "    public static MutableMap<String, SharedPureFunction<?>> __functions = Maps.fixedSize.empty();\n"
+                        ) +
                         (functionDefinitions == null || functionDefinitions.isEmpty() ? "" : functionDefinitions.makeString("\n", "\n\n", "\n")) +
                         "}";
     }

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/ProcessorContext.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/ProcessorContext.java
@@ -15,6 +15,9 @@
 package org.finos.legend.pure.runtime.java.compiled.generation;
 
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
@@ -23,12 +26,8 @@ import org.eclipse.collections.api.map.primitive.IntObjectMap;
 import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.block.factory.Functions0;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Maps;
 import org.eclipse.collections.impl.factory.Multimaps;
 import org.eclipse.collections.impl.factory.primitive.IntObjectMaps;
-import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.finos.legend.pure.m3.bootstrap.generator.M3CoreInstanceGenerator;
 import org.finos.legend.pure.m3.bootstrap.generator.M3ToJavaGenerator;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
@@ -59,7 +58,7 @@ public class ProcessorContext
     private final IdBuilder idBuilder;
 
     private int id = 0;
-    private final MutableMap<String, Object> objects = UnifiedMap.newMap();
+    private final MutableMap<String, Object> objects = Maps.mutable.empty();
 
     public ProcessorContext(ProcessorSupport support, Iterable<? extends CompiledExtension> compiledExtensions, IdBuilder idBuilder, boolean includePureStackTrace)
     {
@@ -113,17 +112,17 @@ public class ProcessorContext
 
     public MutableSet<CoreInstance> getProcessedClasses(Class<?> processorClass)
     {
-        return this.processedClasses.getIfAbsentPut(processorClass, Functions0.newUnifiedSet());
+        return this.processedClasses.getIfAbsentPut(processorClass, Sets.mutable::empty);
     }
 
     public MutableSet<CoreInstance> getProcessedMeasures(Class<?> processorClass)
     {
-        return this.processedMeasures.getIfAbsentPut(processorClass, Functions0.newUnifiedSet());
+        return this.processedMeasures.getIfAbsentPut(processorClass, Sets.mutable::empty);
     }
 
     public MutableSet<CoreInstance> getProcessedUnits(Class<?> processorClass)
     {
-        return this.processedUnits.getIfAbsentPut(processorClass, Functions0.newUnifiedSet());
+        return this.processedUnits.getIfAbsentPut(processorClass, Sets.mutable::empty);
     }
 
     public void registerFunctionDefinition(CoreInstance function, String javaCode)
@@ -149,7 +148,7 @@ public class ProcessorContext
 
     public void registerLambdaFunction(String sourceId, String lambdaId, String javaCode)
     {
-        String oldJavaCode = this.lambdaFunctionsByIdBySource.getIfAbsentPut(sourceId, Functions0.newUnifiedMap()).put(lambdaId, javaCode);
+        String oldJavaCode = this.lambdaFunctionsByIdBySource.getIfAbsentPut(sourceId, Maps.mutable::empty).put(lambdaId, javaCode);
         if ((oldJavaCode != null) && !oldJavaCode.equals(javaCode))
         {
             throw new RuntimeException("Lambda " + lambdaId + " defined more than once with different Java code in " + sourceId + ".\n\nCODE 1:\n" + oldJavaCode + "\n\n\n==================\nCODE 2:\n" + javaCode);
@@ -169,7 +168,7 @@ public class ProcessorContext
 
     public void registerNativeLambdaFunction(CoreInstance nativeFunction, Native nat)
     {
-        this.nativeLambdaFunctionsByNameBySource.getIfAbsentPut(IdBuilder.sourceToId(nativeFunction.getSourceInformation()), Functions0.newUnifiedMap()).put(nativeFunction.getName(), nat.buildBody());
+        this.nativeLambdaFunctionsByNameBySource.getIfAbsentPut(IdBuilder.sourceToId(nativeFunction.getSourceInformation()), Maps.mutable::empty).put(nativeFunction.getName(), nat.buildBody());
     }
 
     public RichIterable<String> getSourcesWithNativeLambdaFunctions()

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
@@ -53,6 +53,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.proper
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.path.Path;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.path.PathElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.path.PropertyPathElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Generalization;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Any;
@@ -370,7 +371,10 @@ public class Pure
                 @Override
                 public Object value(Object o, ExecutionSupport es)
                 {
-                    RichIterable<?> result = ((Path<?, ?>) func)._path().injectInto(CompiledSupport.toPureCollection(o), (mutableList, path) ->
+                    // We specify the parameter types in the lambda below to work around a bug in the Java compiler:
+                    // https://bugs.openjdk.java.net/browse/JDK-8210495
+                    // This bug was fixed in 11.0.13, but the workaround ensures compatibility with 11.0.12 and earlier.
+                    RichIterable<?> result = ((Path<?, ?>) func)._path().injectInto(CompiledSupport.toPureCollection(o), (RichIterable<?> mutableList, PathElement path) ->
                     {
                         if (!(path instanceof PropertyPathElement))
                         {

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
@@ -183,7 +183,7 @@ public class MetadataLazy implements Metadata
         }
 
         MutableMap<ObjRef, CoreInstance> objectByRef = Maps.mutable.withInitialCapacity(objRefCounter.getCount());
-        objRefsByClassifier.forEach((classifier, objRefs) ->
+        objRefsByClassifier.forEachKeyValue((classifier, objRefs) ->
         {
             MutableList<String> idsToDeserialize = Lists.mutable.withInitialCapacity(objRefs.size());
             ConcurrentMutableMap<String, CoreInstance> classifierCache = getClassifierInstanceCache(classifier);

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/TestMeasureCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/TestMeasureCompiled.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.runtime.java.compiled;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.measure.AbstractTestMeasure;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -24,15 +23,19 @@ import org.junit.BeforeClass;
 public class TestMeasureCompiled extends AbstractTestMeasure
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getFunctionExecution());
     }
+
     @After
-    public void clearRuntime() {
+    public void clearRuntime()
+    {
         runtime.delete("testModel.pure");
         runtime.delete("testFunc.pure");
     }
-     protected static FunctionExecution getFunctionExecution()
+
+    protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();
     }

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/constraints/TestConstraintHandlerCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/constraints/TestConstraintHandlerCompiled.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.runtime.java.compiled.constraints;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.constraints.AbstractTestConstraintsHandler;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -24,7 +23,8 @@ import org.junit.BeforeClass;
 public class TestConstraintHandlerCompiled extends AbstractTestConstraintsHandler
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getFunctionExecution());
     }
 
@@ -38,6 +38,4 @@ public class TestConstraintHandlerCompiled extends AbstractTestConstraintsHandle
     {
         return new FunctionExecutionCompiledBuilder().build();
     }
-
-
 }

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/constraints/TestConstraints.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/constraints/TestConstraints.java
@@ -76,7 +76,7 @@ public class TestConstraints extends AbstractTestConstraints
                 "  ^test::SubClass(name='')\n" +
                 "}\n";
         // The two sources must be compiled together to test the issue
-        this.runtime.createInMemoryAndCompile(Tuples.pair(source1Name, source1Code), Tuples.pair(source2Name, source2Code));
+        runtime.createInMemoryAndCompile(Tuples.pair(source1Name, source1Code), Tuples.pair(source2Name, source2Code));
         try
         {
             this.execute("test::testNew():Any[*]");

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/TestIdBuilder.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/TestIdBuilder.java
@@ -1,0 +1,81 @@
+package org.finos.legend.pure.runtime.java.compiled.generation.processors;
+
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.primitive.MutableObjectIntMap;
+import org.eclipse.collections.api.map.primitive.ObjectIntMap;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.primitive.ObjectIntMaps;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableCodeStorage;
+import org.finos.legend.pure.m3.serialization.runtime.PureRuntime;
+import org.finos.legend.pure.m3.serialization.runtime.PureRuntimeBuilder;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.tools.GraphNodeIterable;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestIdBuilder
+{
+    private static PureRuntime runtime;
+    private static ProcessorSupport processorSupport;
+
+    @BeforeClass
+    public static void setUp()
+    {
+        MutableCodeStorage codeStorage = PureCodeStorage.createCodeStorage(null, Lists.immutable.with(CodeRepository.newPlatformCodeRepository()));
+        runtime = new PureRuntimeBuilder(codeStorage).setTransactionalByDefault(false).buildAndInitialize();
+        processorSupport = runtime.getProcessorSupport();
+    }
+
+    @Test
+    public void testIdUniqueness()
+    {
+        testIdUniqueness(IdBuilder.newIdBuilder(processorSupport));
+    }
+
+    @Test
+    public void testIdUniquenessWithPrefix()
+    {
+        testIdUniqueness(IdBuilder.newIdBuilder("$core$", processorSupport));
+    }
+
+    private void testIdUniqueness(IdBuilder idBuilder)
+    {
+        MutableSet<CoreInstance> excludedClassifiers = PrimitiveUtilities.getPrimitiveTypes(processorSupport).toSet();
+        MutableMap<CoreInstance, MutableSet<String>> classifierIds = Maps.mutable.empty();
+        MutableMap<CoreInstance, MutableObjectIntMap<String>> idConflicts = Maps.mutable.empty();
+        GraphNodeIterable.fromModelRepository(runtime.getModelRepository())
+                .forEach(instance ->
+                {
+                    CoreInstance classifier = instance.getClassifier();
+                    if (!excludedClassifiers.contains(classifier))
+                    {
+                        String id = idBuilder.buildId(instance);
+                        if (!classifierIds.getIfAbsentPut(classifier, Sets.mutable::empty).add(id))
+                        {
+                            idConflicts.getIfAbsentPut(classifier, ObjectIntMaps.mutable::empty).updateValue(id, 1, n -> n + 1);
+                        }
+                    }
+                });
+        if (idConflicts.notEmpty())
+        {
+            MutableMap<CoreInstance, String> classifierPaths = idConflicts.keysView().toMap(c -> c, PackageableElement::getUserPathForPackageableElement);
+            StringBuilder builder = new StringBuilder("The following ids have conflicts:");
+            idConflicts.keysView().toSortedListBy(classifierPaths::get).forEach(classifier ->
+            {
+                builder.append("\n\t").append(classifierPaths.get(classifier));
+                ObjectIntMap<String> classifierIdConflicts = idConflicts.get(classifier);
+                classifierIdConflicts.forEachKeyValue((id, count) -> builder.append("\n\t\t").append(id).append(": ").append(count).append(" instances"));
+            });
+            Assert.fail(builder.toString());
+        }
+    }
+}

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/asserts/TestAssert.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/asserts/TestAssert.java
@@ -22,7 +22,8 @@ import org.junit.BeforeClass;
 public class TestAssert extends AbstractTestAssert
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getFunctionExecution());
     }
 
@@ -30,5 +31,4 @@ public class TestAssert extends AbstractTestAssert
     {
         return new FunctionExecutionCompiledBuilder().build();
     }
-
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/incremental/TestSyntheticNodeCut.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/incremental/TestSyntheticNodeCut.java
@@ -27,7 +27,8 @@ import org.junit.Test;
 public class TestSyntheticNodeCut extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getFunctionExecution());
     }
 
@@ -40,7 +41,7 @@ public class TestSyntheticNodeCut extends AbstractPureTestWithCoreCompiled
     @Test
     public void testEnsurePropertySourceTypeIsNotResolved()
     {
-        compileTestSource("testSource.pure","Class A{name:String[1];}\n" +
+        compileTestSource("testSource.pure", "Class A{name:String[1];}\n" +
                 "function\n" +
                 "   {doc.doc = 'Get the property with the given name from the given class. Note that this searches only properties defined directly on the class, not those inherited from super-classes or those which come from associations.'}\n" +
                 "   meta::pure::functions::meta::classPropertyByName(class:Class<Any>[1], name:String[1]):Property<Nil,Any|*>[0..1]\n" +
@@ -51,7 +52,7 @@ public class TestSyntheticNodeCut extends AbstractPureTestWithCoreCompiled
                 "{\n" +
                 "    print(A->classPropertyByName('name'),10);\n" +
                 "}\n");
-        this.execute("test():Nil[0]");
+        execute("test():Nil[0]");
         Assert.assertEquals("name instance Property\n" +
                 "    aggregation(Property):\n" +
                 "        None instance AggregationKind\n" +
@@ -103,7 +104,7 @@ public class TestSyntheticNodeCut extends AbstractPureTestWithCoreCompiled
                 "    name(Property):\n" +
                 "        name instance String\n" +
                 "    owner(Property):\n" +
-                "        [X] A instance Class", this.functionExecution.getConsole().getLine(0));
+                "        [X] A instance Class", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -115,7 +116,7 @@ public class TestSyntheticNodeCut extends AbstractPureTestWithCoreCompiled
                         "{\n" +
                         "    |^A();\n" +
                         "}\n");
-        CoreInstance func = this.runtime.getFunction("testMany():FunctionDefinition[1]");
+        CoreInstance func = runtime.getFunction("testMany():FunctionDefinition[1]");
         Assert.assertEquals("Anonymous_StripedId instance InstanceValue\n" +
                         "    genericType(Property):\n" +
                         "        Anonymous_StripedId instance GenericType\n" +
@@ -146,7 +147,7 @@ public class TestSyntheticNodeCut extends AbstractPureTestWithCoreCompiled
                         "            offset(Property):\n" +
                         "                0 instance Integer\n" +
                         "    values(Property):\n" +
-                        "        testMany1$0 instance LambdaFunction\n" +
+                        "        testMany$1$system$imports$import_testSource_pure_1$0 instance LambdaFunction\n" +
                         "            classifierGenericType(Property):\n" +
                         "                Anonymous_StripedId instance GenericType\n" +
                         "                    rawType(Property):\n" +
@@ -156,7 +157,7 @@ public class TestSyntheticNodeCut extends AbstractPureTestWithCoreCompiled
                         "                            rawType(Property):\n" +
                         "                                Anonymous_StripedId instance FunctionType\n" +
                         "                                    function(Property):\n" +
-                        "                                        testMany1$0 instance LambdaFunction\n" +
+                        "                                        testMany$1$system$imports$import_testSource_pure_1$0 instance LambdaFunction\n" +
                         "                                    returnMultiplicity(Property):\n" +
                         "                                        PureOne instance PackageableMultiplicity\n" +
                         "                                    returnType(Property):\n" +
@@ -256,7 +257,7 @@ public class TestSyntheticNodeCut extends AbstractPureTestWithCoreCompiled
                         "                    usageContext(Property):\n" +
                         "                        Anonymous_StripedId instance ExpressionSequenceValueSpecificationContext\n" +
                         "                            functionDefinition(Property):\n" +
-                        "                                testMany1$0 instance LambdaFunction\n" +
+                        "                                testMany$1$system$imports$import_testSource_pure_1$0 instance LambdaFunction\n" +
                         "                            offset(Property):\n" +
                         "                                0 instance Integer\n" +
                         "            referenceUsages(Property):\n" +


### PR DESCRIPTION
Fix the compiled mode metadata id for lambda functions to ensure that it is unique. Previously, the same id could be generated for different lambdas under certain circumstances.

For example, the lambda at:

https://github.com/finos/legend-pure/blob/82e3cadb2934122537e0c24d307b76b5676aac45/legend-pure-m3-platform/src/main/resources/platform/pure/corefunctions/test.pure#L22

would have previously been given the same id as the lambda at:

https://github.com/finos/legend-pure/blob/82e3cadb2934122537e0c24d307b76b5676aac45/legend-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/testExtension.pure#L26

This is no longer the case.