### PR TITLE
Add support for reading subsection of service response

### DIFF
--- a/legend-pure-code-compiled-core-external-format-flatdata/src/main/resources/core_external_format_flatdata/executionPlan/executionPlan.pure
+++ b/legend-pure-code-compiled-core-external-format-flatdata/src/main/resources/core_external_format_flatdata/executionPlan/executionPlan.pure
@@ -43,7 +43,7 @@ Class meta::external::format::flatdata::executionPlan::FlatDataSerializeExecutio
 {
 }
 
-Class meta::external::format::flatdata::executionPlan::FlatDataDeserializeExecutionNode extends ExecutionNode
+Class meta::external::format::flatdata::executionPlan::FlatDataDeserializeExecutionNode extends ExternalFormatDeserializeExecutionNode
 {
    binding : Binding[1];
    tree    : RootGraphFetchTree<Any>[0..1]; 

--- a/legend-pure-code-compiled-core-external-format-json/src/main/resources/core_external_format_json/executionPlan/executionPlan.pure
+++ b/legend-pure-code-compiled-core-external-format-json/src/main/resources/core_external_format_json/executionPlan/executionPlan.pure
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import meta::external::shared::format::binding::*;
+import meta::pure::metamodel::path::*;
 import meta::external::shared::format::executionPlan::*;
 
 import meta::external::format::json::executionPlan::*;
@@ -30,10 +31,15 @@ Class meta::external::format::json::executionPlan::JsonSerializeExecutionNode ex
 {
 }
 
-Class meta::external::format::json::executionPlan::JsonDeserializeExecutionNode extends ExecutionNode
+Class meta::external::format::json::executionPlan::JsonDeserializeExecutionNode extends ExternalFormatDeserializeExecutionNode
 {
    binding : Binding[1];
    tree    : RootGraphFetchTree<Any>[0..1]; 
+}
+
+Class meta::external::format::json::executionPlan::JsonPathReference extends meta::external::shared::format::executionPlan::PathReference
+{
+   path    : String[1];
 }
 
 function meta::external::format::json::executionPlan::generateSerializeNode(checked:Boolean[1], binding:Binding[1], children:ExecutionNode[*]): ExternalFormatSerializeExecutionNode[1]
@@ -60,9 +66,18 @@ function meta::external::format::json::executionPlan::generateDeserializeNode(co
                             propertiesWithParameters = $tree.subTrees->cast(@PropertyGraphFetchTree)->map(x | $x->map(x | ^PropertyWithParameters(property = $x.property, parameters = $x.parameters)))
                          ),
       resultSizeRange = ZeroMany,
+      pathOffset      = $connection->cast(@ExternalFormatConnection).pathOffset->cast(@JsonPathReference),
       binding         = $connection->cast(@ExternalFormatConnection).element->cast(@Binding),
       tree            = $tree,
       executionNodes  = $children
+   );
+}
+
+function meta::external::format::json::executionPlan::generatePathReference(path:Path<Nil,Any|*>[1]): PathReference[1]
+{
+   let pathString = $path.path->filter(ele | $ele->instanceOf(PropertyPathElement))->cast(@PropertyPathElement).property.name->joinStrings('/', '/', '');
+   ^JsonPathReference(
+      path = $pathString
    );
 }
 
@@ -82,6 +97,7 @@ function meta::external::format::json::executionPlan::printPlanNodeToString(spac
          'JSON_Deserialize\n' + 
          $space + '(' + header($node, $space, $extensions) + '\n' +
          $space + '  binding = ' + $node.binding->elementToPath() + '\n' +
+         if($node.pathOffset->isEmpty(), | '', | $space + '  pathOffset = ' + $node.pathOffset->cast(@JsonPathReference).path->toOne() + '\n')  +
          $node->childrenToString($space+'  ', $extensions) + '\n' +
          $node.implementation->printImplementation('implementation', $space+'  ', $extensions) +
          $space + ')\n'

--- a/legend-pure-code-compiled-core-external-format-json/src/main/resources/core_external_format_json/executionPlan/javaRuntime/executionPlanNodes/jsonDeserialize/jsonDeserialize.pure
+++ b/legend-pure-code-compiled-core-external-format-json/src/main/resources/core_external_format_json/executionPlan/javaRuntime/executionPlanNodes/jsonDeserialize/jsonDeserialize.pure
@@ -84,7 +84,7 @@ function meta::external::format::json::executionPlan::engine::java::jsonDeserial
    let readableEnums      = $context.typeInfos->enumDependenciesViaProperties($pureClass);
    let dataClassesProject = $readableClasses->map(rc | $rc->createStreamReadingDataClass($path, $context, true, $debug->indent()));
 
-   let storeReaderProject = createJsonReading($pureClass, $conventions->className($pureClass), $path, $readableClasses, $readableEnums, $context, $debug->indent());
+   let storeReaderProject = createJsonReading($pureClass, $conventions->className($pureClass), $path, $node.pathOffset->cast(@JsonPathReference).path, $readableClasses, $readableEnums, $context, $debug->indent());
 
    let sourceStreamParam       = j_parameter(javaInputStream(), 'sourceStream');
    let streamReaderMethodCodes = $conventions->jsonReaderClass($path, $pureClass)

--- a/legend-pure-code-compiled-core-external-format-json/src/main/resources/core_external_format_json/extension.pure
+++ b/legend-pure-code-compiled-core-external-format-json/src/main/resources/core_external_format_json/extension.pure
@@ -24,6 +24,7 @@ function meta::external::format::json::jsonFormatExtension(): meta::external::sh
       externalFormat            = 'JSON',
       generateSerializeNode     = generateSerializeNode_Boolean_1__Binding_1__ExecutionNode_MANY__ExternalFormatSerializeExecutionNode_1_,
       generateDeserializeNode   = generateDeserializeNode_Connection_1__ExecutionNode_1__RootGraphFetchTree_$0_1$__ExecutionNode_1_,
+      generatePathReference     = generatePathReference_Path_1__PathReference_1_,
       printPlanNodeToString     = printPlanNodeToString_String_1__RouterExtension_MANY__Function_MANY_,
       
       planJavaPrepare           = planJavaPrepare_String_1__GenerationContext_1__RouterExtension_MANY__DebugContext_1__Function_MANY_,

--- a/legend-pure-code-compiled-core-external-format-json/src/main/resources/core_external_format_json/protocols/pure/vX_X_X/models/executionPlan_external_format_json.pure
+++ b/legend-pure-code-compiled-core-external-format-json/src/main/resources/core_external_format_json/protocols/pure/vX_X_X/models/executionPlan_external_format_json.pure
@@ -13,13 +13,19 @@
 // limitations under the License.
 
 import meta::protocols::pure::vX_X_X::metamodel::executionPlan::*;
+import meta::protocols::pure::vX_X_X::metamodel::external::shared::format::executionPlan::*;
 
-Class meta::protocols::pure::vX_X_X::metamodel::external::format::json::executionPlan::JsonSerializeExecutionNode extends meta::protocols::pure::vX_X_X::metamodel::external::shared::format::executionPlan::ExternalFormatSerializeExecutionNode
+Class meta::protocols::pure::vX_X_X::metamodel::external::format::json::executionPlan::JsonSerializeExecutionNode extends ExternalFormatSerializeExecutionNode
 {   
 }
 
-Class meta::protocols::pure::vX_X_X::metamodel::external::format::json::executionPlan::JsonDeserializeExecutionNode extends ExecutionNode
+Class meta::protocols::pure::vX_X_X::metamodel::external::format::json::executionPlan::JsonDeserializeExecutionNode extends ExternalFormatDeserializeExecutionNode
 {
    binding : String[1];
    tree    : meta::protocols::pure::vX_X_X::metamodel::valueSpecification::raw::RootGraphFetchTree[0..1];
+}
+
+Class meta::protocols::pure::vX_X_X::metamodel::external::format::json::executionPlan::JsonPathReference extends PathReference
+{
+   path : String[1];
 }

--- a/legend-pure-code-compiled-core-external-format-json/src/main/resources/core_external_format_json/protocols/pure/vX_X_X/transfers/executionPlan_external_format_json.pure
+++ b/legend-pure-code-compiled-core-external-format-json/src/main/resources/core_external_format_json/protocols/pure/vX_X_X/transfers/executionPlan_external_format_json.pure
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import meta::protocols::pure::vX_X_X::metamodel::executionPlan::*;
+import meta::protocols::pure::vX_X_X::metamodel::external::format::json::executionPlan::*;
 
 function meta::protocols::pure::vX_X_X::transformation::fromPureGraph::external::format::json::transformSerializeNode(node:meta::external::format::json::executionPlan::JsonSerializeExecutionNode[1], mapping:meta::pure::mapping::Mapping[1], extensions:meta::pure::router::extension::RouterExtension[*]): ExecutionNode[1]
 {
@@ -33,5 +34,13 @@ function meta::protocols::pure::vX_X_X::transformation::fromPureGraph::external:
       resultSizeRange = $node.resultSizeRange->map(s| $s->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::domain::transformMultiplicity()),
       binding         = $node.binding->elementToPath(),
       tree            = $node.tree->map(t| $t->meta::protocols::pure::vX_X_X::transformation::fromPureGraph::valueSpecification::transformGraphFetchTree([], ^Map<String,List<Any>>(), $extensions))->cast(@meta::protocols::pure::vX_X_X::metamodel::valueSpecification::raw::RootGraphFetchTree)
+   );
+}
+
+function meta::protocols::pure::vX_X_X::transformation::fromPureGraph::external::format::json::transformPathReference(pathRef:meta::external::format::json::executionPlan::JsonPathReference[1]): JsonPathReference[1]
+{
+   ^JsonPathReference(
+      _type = 'json',
+      path  = $pathRef.path
    );
 }

--- a/legend-pure-code-compiled-core-external-format-xml/src/main/resources/core_external_format_xml/executionPlan/executionPlan.pure
+++ b/legend-pure-code-compiled-core-external-format-xml/src/main/resources/core_external_format_xml/executionPlan/executionPlan.pure
@@ -40,7 +40,7 @@ Class meta::external::format::xml::executionPlan::XmlSerializeExecutionNode exte
 {
 }
 
-Class meta::external::format::xml::executionPlan::XmlDeserializeExecutionNode extends ExecutionNode
+Class meta::external::format::xml::executionPlan::XmlDeserializeExecutionNode extends ExternalFormatDeserializeExecutionNode
 {
    binding : Binding[1];
    tree    : RootGraphFetchTree<Any>[0..1]; 

--- a/legend-pure-code-compiled-core-external-shared/src/main/resources/core_external_shared/executionPlan/executionPlan.pure
+++ b/legend-pure-code-compiled-core-external-shared/src/main/resources/core_external_shared/executionPlan/executionPlan.pure
@@ -69,12 +69,18 @@ function meta::external::shared::format::executionPlan::planPrepareDataQuality(p
    };
 }
 
-function meta::external::shared::format::executionPlan::generateUrlStreamExecutionNode(connection:ExternalFormatConnection[1]): ExecutionNode[1]
+function meta::external::shared::format::executionPlan::getSourceNodeFromExternalSource(externalSource:ExternalSource[1]): ExecutionNode[1]
 {
-   assert($connection.externalSource->instanceOf(UrlStreamExternalSource), | 'Only UrlStreamExternalSource is supported !!');
+   $externalSource->match([
+      u:UrlStreamExternalSource[1]     | generateUrlStreamExecutionNode($u),
+      e:ExternalSource[1]              | fail('External source format not supported !!'); @ExecutionNode;
+   ]);
+}
 
-   let sourceUrl = $connection.externalSource->cast(@UrlStreamExternalSource).url;
-
+function meta::external::shared::format::executionPlan::generateUrlStreamExecutionNode(externalSource:UrlStreamExternalSource[1]): ExecutionNode[1]
+{
+   let sourceUrl = $externalSource->cast(@UrlStreamExternalSource).url;
+   
    ^UrlStreamExecutionNode(
       resultType = ^DataTypeResultType(type = String),
       url        = $sourceUrl

--- a/legend-pure-code-compiled-core-external-shared/src/main/resources/core_external_shared/executionPlan/model.pure
+++ b/legend-pure-code-compiled-core-external-shared/src/main/resources/core_external_shared/executionPlan/model.pure
@@ -31,6 +31,11 @@ Class meta::external::shared::format::executionPlan::ExternalFormatSerializeExec
    binding : Binding[1];
 }
 
+Class meta::external::shared::format::executionPlan::ExternalFormatDeserializeExecutionNode extends ExecutionNode
+{
+   pathOffset : PathReference[0..1];
+}
+
 Class meta::external::shared::format::executionPlan::UrlStreamExecutionNode extends ExecutionNode
 {
    url : String[1];
@@ -42,13 +47,18 @@ Class meta::external::shared::format::executionPlan::ExternalFormatConnection ex
 ]
 {
    externalSource : ExternalSource[1];
+   pathOffset : PathReference[0..1];
+}
+
+Class <<typemodifiers.abstract>> meta::external::shared::format::executionPlan::PathReference
+{
 }
 
 Class <<typemodifiers.abstract>> meta::external::shared::format::executionPlan::ExternalSource
 {
 }
 
-Class <<typemodifiers.abstract>> meta::external::shared::format::executionPlan::UrlStreamExternalSource extends ExternalSource
+Class meta::external::shared::format::executionPlan::UrlStreamExternalSource extends ExternalSource
 {
    url : String[1];
 }

--- a/legend-pure-code-compiled-core-external-shared/src/main/resources/core_external_shared/extension.pure
+++ b/legend-pure-code-compiled-core-external-shared/src/main/resources/core_external_shared/extension.pure
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 import meta::pure::executionPlan::engine::java::*;
+import meta::pure::metamodel::path::*;
 import meta::external::language::java::factory::*;
 import meta::external::language::java::transform::*;
 import meta::external::shared::format::*;
 import meta::external::shared::format::binding::*;
 import meta::external::shared::format::executionPlan::*;
+import meta::external::shared::format::router::extension::*;
 import meta::external::shared::runtime::*;
 import meta::pure::executionPlan::*;
 import meta::pure::graphFetch::*;
@@ -47,7 +49,7 @@ function meta::external::shared::format::routerExtensions(type:String[1], extern
                {x:ExternalFormatConnection[1] | 
                   let binding         = $x.element->cast(@Binding);
                   let formatExtension = $externalFormatExtensions->getExtensionForContentType($binding.contentType);
-                  let sourceNode      = generateUrlStreamExecutionNode($x);
+                  let sourceNode      = getSourceNodeFromExternalSource($x.externalSource);
                   let deserializeNode = $formatExtension.generateDeserializeNode->eval($x, $sourceNode, $tree);
                   generateDataQualityNode($deserializeNode, $enableConstraints, $checked);
                }
@@ -92,7 +94,18 @@ function meta::external::shared::format::routerExtensions(type:String[1], extern
       plan_javaRuntime_main_generatePlatformCode1 = 
          {path:String[1], context:GenerationContext[1], extensions:RouterExtension[*], debug:DebugContext[1] |
             $externalFormatExtensions.planJavaGenerate->map(x|$x->eval($path, $context, $extensions, $debug));
-         }
+         },
+      moduleExtensions = [
+         ^ExternalFormatModuleExtension(
+            module                = 'externalFormat',
+            generatePathReference = {binding:Binding[1], path:Path<Nil,Any|*>[1] |
+                                       let formatExtension = $externalFormatExtensions->getExtensionForContentType($binding.contentType);
+                                       assert($formatExtension.generatePathReference->isNotEmpty(), | 'Path Offset not supported by : ' + $formatExtension.externalFormat + ' external format');
+               
+                                       $formatExtension.generatePathReference->toOne()->eval($path);
+                                    }
+         )
+      ]
    );
 
    let perFormat = $externalFormatExtensions->map(formatExt| ^RouterExtension(type                                                    = $type+':'+$formatExt.externalFormat, 
@@ -129,6 +142,7 @@ Class meta::external::shared::format::ExternalFormatExtension
    
    generateSerializeNode   : Function<{Boolean[1], Binding[1], ExecutionNode[*] -> ExecutionNode[1]}>[1];  
    generateDeserializeNode : Function<{Connection[1], ExecutionNode[1], RootGraphFetchTree<Any>[0..1] -> ExecutionNode[1]}>[1];
+   generatePathReference   : Function<{Path<Nil,Any|*>[1] -> PathReference[1]}>[0..1];
    printPlanNodeToString   : Function<{String[1], RouterExtension[*] -> Function<{Nil[1] -> String[1]}>[*]}>[1];
    
    planJavaPrepare         : Function<{String[1], GenerationContext[1], RouterExtension[*], DebugContext[1] -> Function<{Nil[1]->GenerationContext[1]}>[*]}>[1];

--- a/legend-pure-code-compiled-core-external-shared/src/main/resources/core_external_shared/extensions/extension.pure
+++ b/legend-pure-code-compiled-core-external-shared/src/main/resources/core_external_shared/extensions/extension.pure
@@ -1,0 +1,23 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::external::shared::format::binding::*;
+import meta::external::shared::format::executionPlan::*;
+import meta::pure::metamodel::path::*;
+import meta::pure::router::extension::*;
+
+Class meta::external::shared::format::router::extension::ExternalFormatModuleExtension extends ModuleExtension
+{
+   generatePathReference   : Function<{Binding[1], Path<Nil,Any|*>[1] -> PathReference[1]}>[0..1];
+}

--- a/legend-pure-code-compiled-core-external-shared/src/main/resources/core_external_shared/protocol_vX_X_X.pure
+++ b/legend-pure-code-compiled-core-external-shared/src/main/resources/core_external_shared/protocol_vX_X_X.pure
@@ -103,3 +103,12 @@ Class meta::protocols::pure::vX_X_X::metamodel::external::shared::format::execut
    binding : String[1];   
 }
 
+Class meta::protocols::pure::vX_X_X::metamodel::external::shared::format::executionPlan::ExternalFormatDeserializeExecutionNode extends ExecutionNode
+{
+   pathOffset : meta::protocols::pure::vX_X_X::metamodel::external::shared::format::executionPlan::PathReference[0..1];
+}
+
+Class meta::protocols::pure::vX_X_X::metamodel::external::shared::format::executionPlan::PathReference
+{
+   _type: String[1];
+}

--- a/legend-pure-code-compiled-core-servicestore/src/main/resources/core_servicestore/executionPlan/executionPlan_generation.pure
+++ b/legend-pure-code-compiled-core-servicestore/src/main/resources/core_servicestore/executionPlan/executionPlan_generation.pure
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import meta::external::shared::format::executionPlan::*;
+import meta::external::shared::format::router::extension::*;
 
 import meta::pure::executionPlan::*;
 
@@ -224,8 +225,13 @@ function meta::external::store::service::executionPlan::generation::nodeFromServ
                                     | ^SequenceExecutionNode(executionNodes = $allNodes, resultType = $serviceStoreNode.resultType), 
                                     | $allNodes)->toOne();
       
+                  let pathOffset               = if($serviceMapping.path->isNotEmpty(),
+                                                    |$extensions.moduleExtension('externalFormat')->cast(@ExternalFormatModuleExtension).generatePathReference->toOne()->eval($serviceMapping.service.response.binding, $serviceMapping.path->toOne()),
+                                                    |[]);
+             
                   let externalFormatConnection = ^ExternalFormatConnection(element        = $serviceMapping.service.response.binding,
-                                                                           externalSource = ^UrlStreamExternalSource(url = 'dummy Url For Service Store Processing'));
+                                                                           externalSource = ^UrlStreamExternalSource(url = 'dummy url'),
+                                                                           pathOffset     = $pathOffset);
       
                   $externalFormatConnection->meta::pure::executionPlan::nodeFromConnection($tree, $node, $enableConstraints, $checked, $extensions);,
       c: Connection[1]            | fail('Expected ServiceStoreConnection for Service Store execution. Found : ' + $c->meta::pure::executionPlan::toString::connectionToString($extensions)); @ExecutionNode;

--- a/legend-pure-code-compiled-core-servicestore/src/main/resources/core_servicestore/metamodel/serviceStoreMapping.pure
+++ b/legend-pure-code-compiled-core-servicestore/src/main/resources/core_servicestore/metamodel/serviceStoreMapping.pure
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import meta::pure::mapping::*;
+import meta::pure::metamodel::path::*;
 import meta::external::shared::format::metamodel::*;
 import meta::external::store::service::metamodel::*;
 import meta::external::store::service::metamodel::mapping::*;
@@ -32,6 +33,7 @@ Class meta::external::store::service::metamodel::mapping::ServiceMapping
    owner             : RootServiceInstanceSetImplementation[1];
    
    service           : Service[1];
+   path              : Path<Nil,Any|*>[0..1];
    parameterMappings : ServiceParameterMapping[*];
 }
 

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/executionNode/graphFetch/inMemory/graphFetchJson.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/executionNode/graphFetch/inMemory/graphFetchJson.pure
@@ -37,8 +37,13 @@ function meta::pure::executionPlan::engine::java::graphFetch::json::jsonReaderCl
 
 function meta::pure::executionPlan::engine::java::graphFetch::json::createJsonReading(pureClass:meta::pure::metamodel::type::Class<Any>[1], javaInterface:meta::external::language::java::metamodel::Class[1], path:String[1], readableClasses:meta::pure::metamodel::type::Class<Any>[*], readableEnums:meta::pure::metamodel::type::Enumeration<Any>[*], context:GenerationContext[1], debug:DebugContext[1]): Project[1]
 {
+   createJsonReading($pureClass, $javaInterface, $path, [], $readableClasses, $readableEnums, $context, $debug);
+}
+
+function meta::pure::executionPlan::engine::java::graphFetch::json::createJsonReading(pureClass:meta::pure::metamodel::type::Class<Any>[1], javaInterface:meta::external::language::java::metamodel::Class[1], path:String[1], pathOffset:String[0..1], readableClasses:meta::pure::metamodel::type::Class<Any>[*], readableEnums:meta::pure::metamodel::type::Enumeration<Any>[*], context:GenerationContext[1], debug:DebugContext[1]): Project[1]
+{
    newProject()
-      ->addClasses(createJsonReadingClass($pureClass, $javaInterface, $path, $readableClasses, $readableEnums, $context, $debug))
+      ->addClasses(createJsonReadingClass($pureClass, $javaInterface, $path, $pathOffset, $readableClasses, $readableEnums, $context, $debug))
       ->addMavenDependency('com.fasterxml.jackson.core', 'jackson-core', '2.10.3');
 }
 
@@ -47,7 +52,7 @@ function meta::pure::executionPlan::engine::java::graphFetch::json::hasDecimal(t
   $typeInfos.typeInfos->filter(ti | $ti->instanceOf(ClassTypeInfo))->cast(@ClassTypeInfo)->exists(cti| $cti.properties->exists(p | $p.genericType.rawType == Decimal));
 }
 
-function meta::pure::executionPlan::engine::java::graphFetch::json::createJsonReadingClass(pureClass:meta::pure::metamodel::type::Class<Any>[1], javaInterface:meta::external::language::java::metamodel::Class[1], path:String[1], readableClasses:meta::pure::metamodel::type::Class<Any>[*], readableEnums:meta::pure::metamodel::type::Enumeration<Any>[*], context:GenerationContext[1], debug:DebugContext[1]): meta::external::language::java::metamodel::Class[1]
+function meta::pure::executionPlan::engine::java::graphFetch::json::createJsonReadingClass(pureClass:meta::pure::metamodel::type::Class<Any>[1], javaInterface:meta::external::language::java::metamodel::Class[1], path:String[1], pathOffset:String[0..1], readableClasses:meta::pure::metamodel::type::Class<Any>[*], readableEnums:meta::pure::metamodel::type::Enumeration<Any>[*], context:GenerationContext[1], debug:DebugContext[1]): meta::external::language::java::metamodel::Class[1]
 {
    let proto = $context.conventions->jsonReaderClass($path, $pureClass)
       ->implements($context.conventions->className(StoreStreamReader))
@@ -85,7 +90,7 @@ function meta::pure::executionPlan::engine::java::graphFetch::json::createJsonRe
       ->addField(javaField('private', javaLong(), 'recordCount', '0'))
       ->addField(javaField('private', javaInputStream(), 'in'))
       ->addConstructor()
-      ->addInitReading($context.typeInfos->hasDecimal())
+      ->addInitReading($context.typeInfos->hasDecimal(), $pathOffset)
       ->addMethodExist()
       ->addMethodInvoke()
       ->addMethod(
@@ -533,7 +538,7 @@ function <<access.private>> meta::pure::executionPlan::engine::java::graphFetch:
    );
 }
 
-function <<access.private>> meta::pure::executionPlan::engine::java::graphFetch::json::addInitReading(class:meta::external::language::java::metamodel::Class[1], useBigDecimalForFloats:Boolean[0..1]): meta::external::language::java::metamodel::Class[1]
+function <<access.private>> meta::pure::executionPlan::engine::java::graphFetch::json::addInitReading(class:meta::external::language::java::metamodel::Class[1], useBigDecimalForFloats:Boolean[0..1], pathOffset:String[0..1]): meta::external::language::java::metamodel::Class[1]
 {
    let jThis  = j_this($class);
    let parser = $jThis->j_field('parser');
@@ -543,12 +548,22 @@ function <<access.private>> meta::pure::executionPlan::engine::java::graphFetch:
                                       | $objectMapper->j_assign(objectMapper()->j_new([]))
                                     );
 
-   $class->addMethod(javaMethod('public', javaVoid(), 'initReading', [],
-      [
-         $parser->j_assign(jsonFactory()->j_new([])->j_invoke('createParser', $jThis->j_field('in'), jsonParser())),
-         $objectMapperInstantiation
-      ]->j_ioExTryCatch()
-   ));
+   $class->imports(javaClass('com.fasterxml.jackson.core.filter.FilteringParserDelegate'))
+         ->imports(javaClass('com.fasterxml.jackson.core.filter.JsonPointerBasedFilter'))
+         ->addMethod(javaMethod('public', javaVoid(), 'initReading', [],
+                     if($pathOffset->isEmpty(),
+                       |[
+                           $parser->j_assign(jsonFactory()->j_new([])->j_invoke('createParser', $jThis->j_field('in'), jsonParser())),
+                           $objectMapperInstantiation
+                        ],
+                       |let baseParserVar = j_variable(jsonParser(), 'baseParser');
+                        [
+                           $baseParserVar->j_declare(jsonFactory()->j_new([])->j_invoke('createParser', $jThis->j_field('in'), jsonParser())),
+                           $parser->j_assign(jsonFilteringParserDelegate()->j_new([$baseParserVar, jsonPointerBasedFilter()->j_new(j_string($pathOffset->toOne())), j_boolean(false), j_boolean(false)])),
+                           $objectMapperInstantiation
+                        ];
+                     )->j_ioExTryCatch()
+           ));
 }
 
 function <<access.private>> meta::pure::executionPlan::engine::java::graphFetch::json::addMethodExist(class:meta::external::language::java::metamodel::Class[1]): meta::external::language::java::metamodel::Class[1]

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/jacksonSupport.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/jacksonSupport.pure
@@ -347,6 +347,8 @@ function meta::pure::executionPlan::engine::java::jsonGenerator(): meta::externa
 
 function meta::pure::executionPlan::engine::java::jsonFactory():                               meta::external::language::java::metamodel::Class[1] { javaClass('com.fasterxml.jackson.core.JsonFactory'); }
 function meta::pure::executionPlan::engine::java::jsonParser():                                meta::external::language::java::metamodel::Class[1] { javaClass('com.fasterxml.jackson.core.JsonParser'); }
+function meta::pure::executionPlan::engine::java::jsonPointerBasedFilter():                    meta::external::language::java::metamodel::Class[1] { javaClass('com.fasterxml.jackson.core.filter.JsonPointerBasedFilter'); }
+function meta::pure::executionPlan::engine::java::jsonFilteringParserDelegate():               meta::external::language::java::metamodel::Class[1] { javaClass('com.fasterxml.jackson.core.filter.FilteringParserDelegate'); }
 function meta::pure::executionPlan::engine::java::jsonToken():                                 meta::external::language::java::metamodel::Class[1] { javaClass('com.fasterxml.jackson.core.JsonToken'); }
 function meta::pure::executionPlan::engine::java::objectMapper():                              meta::external::language::java::metamodel::Class[1] { javaClass('com.fasterxml.jackson.databind.ObjectMapper'); }
 function meta::pure::executionPlan::engine::java::jsonNode():                                  meta::external::language::java::metamodel::Class[1] { javaClass('com.fasterxml.jackson.databind.JsonNode'); }


### PR DESCRIPTION
There have been use-cases reported where users have their required data wrapped around with some metadata.
In such scenario's people have had to model wrapped structure & then flatten out the response in mapping. This has following disadvantages - 
1. For Json we read input stream node by node but since in this scenario users data had been wrapped we ended up realizing entire data at once.
2. Flattening of wrapped models to required models is not easy (requires effort) and has lot of restrictions (currently explosion operator is used for flattening)

This PR changes help users define the subsection path/offset from where we should start deserializing the contents of the stream. This helps resolve above 2 disadvantages