### PR TITLE
Fix adjustDate to use long for microseconds

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/date/testAdjustDate.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/date/testAdjustDate.pure
@@ -115,6 +115,24 @@ function <<test.Test>> meta::pure::functions::date::tests::testAdjustBySeconds()
     assertEquals(%2015-04-15T12:11:10, %2015-04-15T13:11:11->adjust(-3601, DurationUnit.SECONDS));
 }
 
+function <<test.Test>> meta::pure::functions::date::tests::testAdjustByMicroseconds():Boolean[1]
+{
+  assertEquals(%2015-04-15T13:11:11.338001, %2015-04-15T13:11:11.338000->adjust(1, DurationUnit.MICROSECONDS));
+  assertEquals(%2015-04-15T13:11:11.337999, %2015-04-15T13:11:11.338000->adjust(-1, DurationUnit.MICROSECONDS));
+
+  assertEquals(%2015-04-15T13:11:11.338061, %2015-04-15T13:11:11.338000->adjust(61, DurationUnit.MICROSECONDS));
+  assertEquals(%2015-04-15T13:11:11.337939, %2015-04-15T13:11:11.338000->adjust(-61, DurationUnit.MICROSECONDS));
+
+  assertEquals(%2015-04-15T13:11:11.341601, %2015-04-15T13:11:11.338000->adjust(3601, DurationUnit.MICROSECONDS));
+  assertEquals(%2015-04-15T13:11:11.334399, %2015-04-15T13:11:11.338000->adjust(-3601, DurationUnit.MICROSECONDS));
+  
+  // Test epoch calculation
+  assertEquals(%2021-06-21T09:37:37.4990000+0000, 
+               %1970-01-01T00:00:00.0000000->adjust(1624268257499000, DurationUnit.MICROSECONDS));
+  assertEquals(%2021-06-21T09:37:37.4990000+0000, 
+               %1970-01-01T00:00:00.0000000->adjust(floor(1624268257499000000/1000), DurationUnit.MICROSECONDS));
+}
+
 function <<test.Test>> meta::pure::functions::date::tests::testAdjustByMilliseconds():Boolean[1]
 {
     assertEquals(%2015-04-15T13:11:11.339, %2015-04-15T13:11:11.338->adjust(1, DurationUnit.MILLISECONDS));

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/simpleObject.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/tests/legend/simpleObject.pure
@@ -665,6 +665,31 @@ meta::pure::mapping::modelToModel::test::alloy::simple::simpleM2MMappingUsingImp
    assert(jsonEquivalent('{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"s\\":\\"test string data\\"}"},"value":{"s":"test string data"}},"value":{"name":"ok"}}'->parseJSON(), $result.values->toOne()->parseJSON()));
 }
 
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly, feature.M2MBasics>>
+{
+    serverVersion.start='v1_20_0'
+}
+meta::pure::mapping::modelToModel::test::alloy::simple::simpleM2MMappingEpochDateInMicrosecondsToDate() : Boolean[1]
+{
+  let tree = #{meta::pure::mapping::modelToModel::test::alloy::simple::objects::dest::FromEpochDate{d}}#;
+  
+   let result = execute(
+      | meta::pure::mapping::modelToModel::test::alloy::simple::objects::dest::FromEpochDate.all()->graphFetchChecked($tree)->serialize($tree),
+      meta::pure::mapping::modelToModel::test::alloy::simple::simpleEpochToDate,
+      ^Runtime(connections = ^JsonModelConnection(
+                              element=^ModelStore(),
+                              class = meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::EpochDate,
+                              url = 'data:application/json,{"epochDate":1624268257499000000}'
+                             )
+         ),
+      []
+   );
+
+  let expected = '{"defects":[],"source":{"defects":[],"source":{"number":1,"record":"{\\"epochDate\\":1624268257499000000}"},"value":{"epochDate":1624268257499000000}},"value":{"d":"2021-06-21T09:37:37.4990000"}}';
+
+  assert(jsonEquivalent($expected->parseJSON(), $result.values->toOne()->parseJSON()));
+  
+}
 
 ###Pure
 import meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::*;
@@ -778,6 +803,32 @@ Class meta::pure::mapping::modelToModel::test::alloy::simple::objects::dest::Fri
    friendA    : meta::pure::mapping::modelToModel::test::shared::dest::Person[1];
    friendB    : meta::pure::mapping::modelToModel::test::shared::dest::Person[1];
 }
+
+Class meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::EpochDate
+{
+  epochDate : Integer[1];
+}
+
+Class meta::pure::mapping::modelToModel::test::alloy::simple::objects::dest::FromEpochDate
+{
+  epochDate: Integer[1];
+  d : Date[1];
+}
+
+###Mapping 
+import meta::pure::mapping::modelToModel::test::alloy::simple::objects::src::*;
+import meta::pure::mapping::modelToModel::test::alloy::simple::objects::dest::*;
+
+Mapping meta::pure::mapping::modelToModel::test::alloy::simple::simpleEpochToDate
+(
+  FromEpochDate : Pure
+  {
+    ~src EpochDate
+    epochDate : $src.epochDate,
+    d: %1970-01-01T00:00:00.0000000->adjust(floor($src.epochDate/1000), DurationUnit.MICROSECONDS)
+  }
+)
+
 
 ###Mapping
 import meta::pure::mapping::modelToModel::test::shared::src::*;

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractDateWithDay.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractDateWithDay.java
@@ -79,7 +79,7 @@ abstract class AbstractDateWithDay extends AbstractDateWithMonth
     @Override
     public abstract AbstractDateWithDay clone();
 
-    void incrementDay(int delta)
+    void incrementDay(long delta)
     {
         if (delta < 0)
         {

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractDateWithHour.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractDateWithHour.java
@@ -58,7 +58,7 @@ abstract class AbstractDateWithHour extends AbstractDateWithDay implements DateT
     @Override
     public abstract AbstractDateWithHour clone();
 
-    void incrementHour(int delta)
+    void incrementHour(long delta)
     {
         incrementDay(delta / 24);
         this.hour += (delta % 24);

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractDateWithMinute.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractDateWithMinute.java
@@ -54,7 +54,7 @@ abstract class AbstractDateWithMinute extends AbstractDateWithHour
     @Override
     public abstract AbstractDateWithMinute clone();
 
-    void incrementMinute(int delta)
+    void incrementMinute(long delta)
     {
         incrementHour(delta / 60);
         this.minute += (delta % 60);

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractDateWithSecond.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractDateWithSecond.java
@@ -52,7 +52,7 @@ abstract class AbstractDateWithSecond extends AbstractDateWithMinute
     @Override
     public abstract AbstractDateWithSecond clone();
 
-    void incrementSecond(int delta)
+    void incrementSecond(long delta)
     {
         incrementMinute(delta / 60);
         this.second += (delta % 60);

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractDateWithSubsecond.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractDateWithSubsecond.java
@@ -81,7 +81,7 @@ abstract class AbstractDateWithSubsecond extends AbstractDateWithSecond
     }
 
     @Override
-    public PureDate addMicroseconds(int microseconds)
+    public PureDate addMicroseconds(long microseconds)
     {
         if (microseconds == 0)
         {
@@ -95,7 +95,7 @@ abstract class AbstractDateWithSubsecond extends AbstractDateWithSecond
         }
 
         AbstractDateWithSubsecond copy = clone();
-        int seconds = microseconds / 1_000_000;
+        long seconds = microseconds / 1_000_000;
         if (seconds != 0)
         {
             copy.incrementSecond(seconds);

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithHour.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithHour.java
@@ -79,7 +79,7 @@ public final class DateWithHour extends AbstractDateWithHour
     }
 
     @Override
-    public PureDate addMicroseconds(int microseconds)
+    public PureDate addMicroseconds(long microseconds)
     {
         throw new UnsupportedOperationException();
     }

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithMinute.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithMinute.java
@@ -61,7 +61,7 @@ public final class DateWithMinute extends AbstractDateWithMinute
     }
 
     @Override
-    public PureDate addMicroseconds(int microseconds)
+    public PureDate addMicroseconds(long microseconds)
     {
         throw new UnsupportedOperationException();
     }

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithSecond.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithSecond.java
@@ -40,7 +40,7 @@ public class DateWithSecond extends AbstractDateWithSecond
     }
 
     @Override
-    public PureDate addMicroseconds(int microseconds)
+    public PureDate addMicroseconds(long microseconds)
     {
         throw new UnsupportedOperationException();
     }

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/LatestDate.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/LatestDate.java
@@ -164,7 +164,7 @@ public class LatestDate implements PureDate
     }
 
     @Override
-    public PureDate addMicroseconds(int microseconds)
+    public PureDate addMicroseconds(long microseconds)
     {
         throw new UnsupportedOperationException("Invalid operation for LatestDate");
     }

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/PureDate.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/PureDate.java
@@ -65,7 +65,7 @@ public interface PureDate extends Comparable<PureDate>
 
     PureDate addMilliseconds(int milliseconds);
 
-    PureDate addMicroseconds(int microseconds);
+    PureDate addMicroseconds(long microseconds);
 
     PureDate addNanoseconds(long nanoseconds);
 

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/StrictDate.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/StrictDate.java
@@ -97,7 +97,7 @@ public final class StrictDate extends AbstractDateWithDay
     }
 
     @Override
-    public PureDate addMicroseconds(int microseconds)
+    public PureDate addMicroseconds(long microseconds)
     {
         throw new UnsupportedOperationException();
     }

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/Year.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/Year.java
@@ -130,7 +130,7 @@ public final class Year extends AbstractDateWithYear
     }
 
     @Override
-    public PureDate addMicroseconds(int microseconds)
+    public PureDate addMicroseconds(long microseconds)
     {
         throw new UnsupportedOperationException();
     }

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/YearMonth.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/YearMonth.java
@@ -112,7 +112,7 @@ public final class YearMonth extends AbstractDateWithMonth
     }
 
     @Override
-    public PureDate addMicroseconds(int microseconds)
+    public PureDate addMicroseconds(long microseconds)
     {
         throw new UnsupportedOperationException();
     }

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/CompiledSupport.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/CompiledSupport.java
@@ -2729,7 +2729,7 @@ public class CompiledSupport
             }
             case "MICROSECONDS":
             {
-                return date.addMicroseconds((int)number);
+                return date.addMicroseconds(number);
             }
             case "NANOSECONDS":
             {

--- a/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/core/date/AdjustDate.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/core/date/AdjustDate.java
@@ -98,7 +98,7 @@ public class AdjustDate extends NativeFunction
             }
             case "MICROSECONDS":
             {
-                result = date.addMicroseconds(number.intValue());
+                result = date.addMicroseconds(number.longValue());
                 break;
             }
             case "NANOSECONDS":


### PR DESCRIPTION
Change adjustDate to use long for computations with microseconds.

Tests added at legend-pure language level and for mapping execution against legend-engine