### PR TITLE
Add execution plan diagrams

### DIFF
--- a/legend-pure-code-compiled-core-external-shared/src/main/resources/core_external_shared/executionPlan/executionPlan_diagram.pure
+++ b/legend-pure-code-compiled-core-external-shared/src/main/resources/core_external_shared/executionPlan/executionPlan_diagram.pure
@@ -1,0 +1,113 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Diagram
+Diagram meta::external::shared::format::executionPlan::diagram::ExternalSharedExecutionNodeDiagram(width=0.0, height=0.0)
+{
+    TypeView cview_3(
+        type=meta::external::shared::format::executionPlan::ExternalFormatSerializeExecutionNode,
+        position=(721.00000, 825.00000),
+        width=244.01492,
+        height=58.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_4(
+        type=meta::external::shared::format::executionPlan::UrlStreamExecutionNode,
+        position=(511.00000, 823.00000),
+        width=165.00000,
+        height=60.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_2(
+        type=meta::external::shared::format::executionPlan::DataQualityExecutionNode,
+        position=(273.00000, 824.00000),
+        width=181.35821,
+        height=58.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_5(
+        type=meta::external::shared::format::executionPlan::ExternalFormatDeserializeExecutionNode,
+        position=(1018.00000, 825.00000),
+        width=258.02985,
+        height=58.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_1(
+        type=meta::pure::executionPlan::ExecutionNode,
+        position=(621.00000, 461.00000),
+        width=264.52238,
+        height=156.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    GeneralizationView gview_0(
+        source=cview_2,
+        target=cview_1,
+        points=[(363.67911,853.00000),(364.00000,747.00000),(624.00000,585.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_1(
+        source=cview_3,
+        target=cview_1,
+        points=[(836.00000,833.00000),(753.26119,539.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_2(
+        source=cview_4,
+        target=cview_1,
+        points=[(593.50000,853.00000),(753.26119,539.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_3(
+        source=cview_5,
+        target=cview_1,
+        points=[(1147.01492,854.00000),(1144.00000,748.00000),(880.00000,580.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+}

--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/executionPlan/executionPlan_diagram.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/executionPlan/executionPlan_diagram.pure
@@ -1,0 +1,337 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Diagram
+Diagram meta::relational::executionPlan::diagram::RelationalExecutionNodeDiagram(width=0.0, height=0.0)
+{
+    TypeView cview_1(
+        type=meta::pure::executionPlan::ExecutionNode,
+        position=(584.00000, 67.00000),
+        width=274.00000,
+        height=156.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_8(
+        type=meta::relational::mapping::SQLExecutionNode,
+        position=(41.00000, 315.00000),
+        width=267.53732,
+        height=100.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_2(
+        type=meta::relational::mapping::RelationalInstantiationExecutionNode,
+        position=(155.00000, 471.00000),
+        width=235.97015,
+        height=30.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_3(
+        type=meta::relational::mapping::RelationalRelationDataInstantiationExecutionNode,
+        position=(53.00000, 633.00000),
+        width=253.31343,
+        height=30.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_4(
+        type=meta::relational::mapping::RelationalTdsInstantiationExecutionNode,
+        position=(98.00000, 690.00000),
+        width=257.29851,
+        height=30.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_5(
+        type=meta::relational::mapping::RelationalDataTypeInstantiationExecutionNode,
+        position=(220.00000, 790.00000),
+        width=254.41791,
+        height=30.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_6(
+        type=meta::relational::mapping::RelationalClassInstantiationExecutionNode,
+        position=(162.00000, 742.00000),
+        width=256.64178,
+        height=30.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_14(
+        type=meta::pure::graphFetch::executionPlan::GlobalGraphFetchExecutionNode,
+        position=(622.00000, 357.00000),
+        width=379.37313,
+        height=156.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_15(
+        type=meta::pure::graphFetch::executionPlan::LocalGraphFetchExecutionNode,
+        position=(1193.00000, 402.00000),
+        width=246.76119,
+        height=72.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_9(
+        type=meta::relational::graphFetch::executionPlan::RelationalGraphFetchExecutionNode,
+        position=(1179.00000, 547.00000),
+        width=277.31343,
+        height=58.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_10(
+        type=meta::relational::graphFetch::executionPlan::RelationalPrimitiveQueryGraphFetchExecutionNode,
+        position=(1342.00000, 711.00000),
+        width=270.00000,
+        height=72.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_11(
+        type=meta::relational::graphFetch::executionPlan::RelationalTempTableGraphFetchExecutionNode,
+        position=(1039.00000, 713.00000),
+        width=273.50746,
+        height=72.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_13(
+        type=meta::relational::graphFetch::executionPlan::RelationalClassQueryTempTableGraphFetchExecutionNode,
+        position=(1035.00000, 823.00000),
+        width=275.53731,
+        height=30.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_12(
+        type=meta::relational::graphFetch::executionPlan::RelationalRootQueryTempTableGraphFetchExecutionNode,
+        position=(1034.00000, 892.00000),
+        width=278.17911,
+        height=72.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_7(
+        type=meta::relational::mapping::CreateAndPopulateTempTableExecutionNode,
+        position=(501.00000, 589.00000),
+        width=330.41791,
+        height=86.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    GeneralizationView gview_0(
+        source=cview_2,
+        target=cview_1,
+        points=[(272.98508,486.00000),(721.00000,145.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_1(
+        source=cview_3,
+        target=cview_2,
+        points=[(179.65672,648.00000),(180.00000,475.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_2(
+        source=cview_4,
+        target=cview_2,
+        points=[(226.64925,705.00000),(233.00000,491.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_3(
+        source=cview_5,
+        target=cview_2,
+        points=[(347.20895,805.00000),(351.00000,500.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_4(
+        source=cview_6,
+        target=cview_2,
+        points=[(290.32089,757.00000),(292.00000,490.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_5(
+        source=cview_7,
+        target=cview_1,
+        points=[(666.20895,632.00000),(671.00000,207.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_6(
+        source=cview_8,
+        target=cview_1,
+        points=[(174.76866,365.00000),(177.00000,271.00000),(721.00000,145.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_7(
+        source=cview_10,
+        target=cview_9,
+        points=[(1477.00000,747.00000),(1477.00000,675.00000),(1317.65671,576.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_8(
+        source=cview_11,
+        target=cview_9,
+        points=[(1175.75373,749.00000),(1174.00000,684.00000),(1317.65671,576.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_9(
+        source=cview_12,
+        target=cview_13,
+        points=[(1173.08955,928.00000),(1172.76865,838.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_10(
+        source=cview_13,
+        target=cview_11,
+        points=[(1172.76865,838.00000),(1175.75373,749.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_11(
+        source=cview_14,
+        target=cview_1,
+        points=[(811.68656,435.00000),(814.00000,218.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_12(
+        source=cview_15,
+        target=cview_1,
+        points=[(1316.38060,438.00000),(1314.00000,359.00000),(856.00000,175.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_13(
+        source=cview_9,
+        target=cview_15,
+        points=[(1317.65671,576.00000),(1316.38060,438.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    PropertyView pview_0(
+        property=meta::pure::graphFetch::executionPlan::GlobalGraphFetchExecutionNode.localGraphFetchExecutionNode,
+        source=cview_14,
+        target=cview_15
+,        points=[(811.68656,435.00000),(1316.38060,438.00000)],
+        label='',
+        propertyPosition=(0.0,0.0),
+        multiplicityPosition=(0.0,0.0),
+        color=#000000,
+        lineWidth=-1.0,
+        stereotypesVisible=true,
+        nameVisible=true,
+        lineStyle=SIMPLE)
+}

--- a/legend-pure-code-compiled-core-servicestore/src/main/resources/core_servicestore/executionPlan/executionPlan_diagram.pure
+++ b/legend-pure-code-compiled-core-servicestore/src/main/resources/core_servicestore/executionPlan/executionPlan_diagram.pure
@@ -1,0 +1,71 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Diagram
+Diagram meta::external::store::service::executionPlan::diagram::ServiceStoreExecutionNodeDiagram(width=0.0, height=0.0)
+{
+    TypeView cview_1(
+        type=meta::external::store::service::executionPlan::nodes::RestServiceExecutionNode,
+        position=(141.00000, 417.00000),
+        width=216.29851,
+        height=100.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_3(
+        type=meta::pure::executionPlan::ExecutionNode,
+        position=(323.00000, 119.00000),
+        width=264.52238,
+        height=156.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_2(
+        type=meta::external::store::service::executionPlan::nodes::ServiceParametersResolutionExecutionNode,
+        position=(473.00000, 420.00000),
+        width=282.89552,
+        height=99.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    GeneralizationView gview_0(
+        source=cview_1,
+        target=cview_3,
+        points=[(249.14925,467.00000),(247.94776,376.00000),(455.26119,197.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_1(
+        source=cview_2,
+        target=cview_3,
+        points=[(609.00000,453.50000),(608.94776,378.00000),(532.94776,274.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+}

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_diagram.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/executionPlan_diagram.pure
@@ -1,0 +1,503 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Diagram
+Diagram meta::pure::executionPlan::diagram::ExecutionPlanDiagram(width=0.0, height=0.0)
+{
+    TypeView cview_2(
+        type=meta::pure::executionPlan::ExecutionNode,
+        position=(295.19464, 334.06593),
+        width=264.52238,
+        height=156.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_1(
+        type=meta::pure::executionPlan::ExecutionPlan,
+        position=(260.00000, 82.00000),
+        width=335.94030,
+        height=142.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_3(
+        type=meta::pure::executionPlan::PlatformImplementation,
+        position=(762.97015, 237.53297),
+        width=157.32835,
+        height=30.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_4(
+        type=meta::pure::executionPlan::JavaPlatformImplementation,
+        position=(735.97015, 358.53297),
+        width=216.23881,
+        height=72.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_5(
+        type=meta::pure::executionPlan::JavaClass,
+        position=(1041.97015, 351.53297),
+        width=136.13433,
+        height=86.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    GeneralizationView gview_0(
+        source=cview_4,
+        target=cview_3,
+        points=[(844.08956,394.53297),(841.63433,252.53297)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    PropertyView pview_0(
+        property=meta::pure::executionPlan::ExecutionPlan.rootExecutionNode,
+        source=cview_1,
+        target=cview_2
+,        points=[(427.97015,153.00000),(427.45583,412.06593)],
+        label='',
+        propertyPosition=(0.0,0.0),
+        multiplicityPosition=(0.0,0.0),
+        color=#000000,
+        lineWidth=-1.0,
+        stereotypesVisible=true,
+        nameVisible=true,
+        lineStyle=SIMPLE)
+
+    PropertyView pview_1(
+        property=meta::pure::executionPlan::ExecutionNode.implementation,
+        source=cview_2,
+        target=cview_3
+,        points=[(427.45583,412.06593),(691.97015,253.53297),(841.63433,252.53297)],
+        label='',
+        propertyPosition=(0.0,0.0),
+        multiplicityPosition=(0.0,0.0),
+        color=#000000,
+        lineWidth=-1.0,
+        stereotypesVisible=true,
+        nameVisible=true,
+        lineStyle=SIMPLE)
+
+    PropertyView pview_2(
+        property=meta::pure::executionPlan::ExecutionPlan.globalImplementationSupport,
+        source=cview_1,
+        target=cview_3
+,        points=[(427.97015,153.00000),(840.97015,152.53297),(841.63433,252.53297)],
+        label='',
+        propertyPosition=(0.0,0.0),
+        multiplicityPosition=(0.0,0.0),
+        color=#000000,
+        lineWidth=-1.0,
+        stereotypesVisible=true,
+        nameVisible=true,
+        lineStyle=SIMPLE)
+
+    PropertyView pview_3(
+        property=meta::pure::executionPlan::JavaPlatformImplementation.classes,
+        source=cview_4,
+        target=cview_5
+,        points=[(844.08956,394.53297),(1110.03732,394.53297)],
+        label='',
+        propertyPosition=(0.0,0.0),
+        multiplicityPosition=(0.0,0.0),
+        color=#000000,
+        lineWidth=-1.0,
+        stereotypesVisible=true,
+        nameVisible=true,
+        lineStyle=SIMPLE)
+}
+
+###Diagram
+Diagram meta::pure::executionPlan::diagram::ResultTypeDiagram(width=0.0, height=0.0)
+{
+    TypeView cview_1(
+        type=meta::pure::executionPlan::ResultType,
+        position=(663.00000, 119.00000),
+        width=184.05970,
+        height=58.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_3(
+        type=meta::pure::executionPlan::VoidResultType,
+        position=(453.00000, 404.00000),
+        width=108.88060,
+        height=44.50000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_6(
+        type=meta::pure::executionPlan::ClassResultType,
+        position=(972.00000, 406.00000),
+        width=241.85075,
+        height=44.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_5(
+        type=meta::pure::executionPlan::PartialClassResultType,
+        position=(940.00000, 512.00000),
+        width=306.52238,
+        height=44.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_7(
+        type=meta::pure::executionPlan::DataTypeResultType,
+        position=(599.00000, 405.00000),
+        width=136.89552,
+        height=44.50000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_2(
+        type=meta::pure::executionPlan::TDSResultType,
+        position=(771.00000, 406.00000),
+        width=166.64179,
+        height=44.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    GeneralizationView gview_0(
+        source=cview_2,
+        target=cview_1,
+        points=[(854.32089,428.00000),(850.26119,317.50000),(783.76119,235.50000),(783.76119,170.50000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_1(
+        source=cview_3,
+        target=cview_1,
+        points=[(507.44030,426.25000),(506.76119,328.50000),(676.00000,241.00000),(675.00000,175.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_2(
+        source=cview_6,
+        target=cview_1,
+        points=[(1092.92537,428.00000),(1092.76119,320.50000),(835.00000,238.00000),(833.00000,171.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_3(
+        source=cview_5,
+        target=cview_6,
+        points=[(1093.26119,534.00000),(1092.92537,428.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_4(
+        source=cview_7,
+        target=cview_1,
+        points=[(667.44776,427.25000),(666.26119,323.50000),(728.76119,236.50000),(727.76119,172.50000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+}
+
+###Diagram
+Diagram meta::pure::executionPlan::diagram::ExecutionNodeDiagram(width=0.0, height=0.0)
+{
+    TypeView cview_2(
+        type=meta::pure::executionPlan::AllocationExecutionNode,
+        position=(247.00000, 420.00000),
+        width=165.31343,
+        height=44.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_1(
+        type=meta::pure::executionPlan::ExecutionNode,
+        position=(647.00000, 61.00000),
+        width=325.00000,
+        height=170.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_4(
+        type=meta::pure::executionPlan::ErrorExecutionNode,
+        position=(472.00000, 420.00000),
+        width=136.67164,
+        height=44.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_5(
+        type=meta::pure::executionPlan::FreeMarkerConditionalExecutionNode,
+        position=(536.00000, 481.00000),
+        width=238.00000,
+        height=72.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_3(
+        type=meta::pure::executionPlan::ConstantExecutionNode,
+        position=(360.00000, 482.00000),
+        width=159.32835,
+        height=44.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_6(
+        type=meta::pure::executionPlan::FunctionParametersValidationNode,
+        position=(669.00000, 420.00000),
+        width=243.71642,
+        height=44.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_8(
+        type=meta::pure::executionPlan::PureExpressionPlatformExecutionNode,
+        position=(785.07656, 482.95694),
+        width=247.34328,
+        height=44.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_10(
+        type=meta::pure::graphFetch::executionPlan::GlobalGraphFetchExecutionNode,
+        position=(773.88995, 594.74641),
+        width=379.37313,
+        height=156.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_12(
+        type=meta::pure::executionPlan::SequenceExecutionNode,
+        position=(1200.19350, 428.99491),
+        width=164.00000,
+        height=30.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_11(
+        type=meta::pure::graphFetch::executionPlan::LocalGraphFetchExecutionNode,
+        position=(1066.04554, 482.74937),
+        width=246.76119,
+        height=72.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_13(
+        type=meta::pure::executionPlan::MultiResultSequenceExecutionNode,
+        position=(1323.59541, 483.54036),
+        width=228.65672,
+        height=30.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    GeneralizationView gview_0(
+        source=cview_2,
+        target=cview_1,
+        points=[(329.65672,442.00000),(328.00000,371.00000),(666.12607,258.87320),(666.00000,226.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_1(
+        source=cview_3,
+        target=cview_1,
+        points=[(439.66418,504.00000),(439.00000,370.00000),(702.12607,257.87320),(701.00000,225.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_2(
+        source=cview_4,
+        target=cview_1,
+        points=[(540.33582,442.00000),(541.00000,365.00000),(732.12607,257.87320),(731.00000,228.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_3(
+        source=cview_5,
+        target=cview_1,
+        points=[(648.00000,492.00000),(646.00000,364.00000),(761.12607,257.87320),(760.00000,230.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_4(
+        source=cview_6,
+        target=cview_1,
+        points=[(794.00000,440.00000),(792.00000,223.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_5(
+        source=cview_8,
+        target=cview_1,
+        points=[(928.07656,492.95694),(929.38010,353.39682),(822.20307,258.65998),(823.00000,223.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_6(
+        source=cview_10,
+        target=cview_1,
+        points=[(1048.04039,617.51165),(1045.16957,355.31070),(852.99017,257.43333),(853.78201,225.16716)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_7(
+        source=cview_11,
+        target=cview_1,
+        points=[(1187.75331,500.76524),(1184.88249,349.56907),(888.58339,258.28078),(889.18871,218.46859)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_8(
+        source=cview_12,
+        target=cview_1,
+        points=[(1282.19350,443.99491),(1279.61933,355.31070),(917.89685,256.74610),(916.93991,230.90878)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_9(
+        source=cview_13,
+        target=cview_1,
+        points=[(1381.96862,505.54993),(1378.18393,360.09539),(951.38967,255.78917),(950.43273,226.12409)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    PropertyView pview_0(
+        property=meta::pure::graphFetch::executionPlan::GlobalGraphFetchExecutionNode.localGraphFetchExecutionNode,
+        source=cview_10,
+        target=cview_11
+,        points=[(963.57652,672.74641),(1267.17914,669.18629),(1266.22221,535.21500)],
+        label='',
+        propertyPosition=(0.0,0.0),
+        multiplicityPosition=(0.0,0.0),
+        color=#000000,
+        lineWidth=-1.0,
+        stereotypesVisible=true,
+        nameVisible=true,
+        lineStyle=SIMPLE)
+}

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/executionPlan_diagram.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/mapping/m2m/executionPlan_diagram.pure
@@ -1,0 +1,190 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Diagram
+Diagram meta::pure::mapping::modelToModel::executionPlan::diagram::InMemoryExecutionNodeDiagram(width=0.0, height=0.0)
+{
+    TypeView cview_1(
+        type=meta::pure::executionPlan::ExecutionNode,
+        position=(379.00000, 83.00000),
+        width=264.52238,
+        height=156.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_2(
+        type=meta::pure::mapping::modelToModel::graphFetch::executionPlan::InMemoryGraphFetchExecutionNode,
+        position=(908.00000, 534.00000),
+        width=276.70149,
+        height=58.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_7(
+        type=meta::pure::graphFetch::executionPlan::GlobalGraphFetchExecutionNode,
+        position=(324.00000, 334.00000),
+        width=379.37313,
+        height=156.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_6(
+        type=meta::pure::mapping::modelToModel::graphFetch::executionPlan::StoreStreamReadingExecutionNode,
+        position=(14.00000, 335.00000),
+        width=239.00000,
+        height=154.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_8(
+        type=meta::pure::graphFetch::executionPlan::LocalGraphFetchExecutionNode,
+        position=(912.00000, 333.00000),
+        width=246.76119,
+        height=160.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_4(
+        type=meta::pure::mapping::modelToModel::graphFetch::executionPlan::InMemoryRootGraphFetchExecutionNode,
+        position=(766.00000, 660.00000),
+        width=258.65672,
+        height=58.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_3(
+        type=meta::pure::mapping::modelToModel::graphFetch::executionPlan::InMemoryPropertyGraphFetchExecutionNode,
+        position=(1093.00000, 662.00000),
+        width=281.00000,
+        height=59.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    TypeView cview_5(
+        type=meta::pure::mapping::modelToModel::graphFetch::executionPlan::InMemoryCrossStoreGraphFetchExecutionNode,
+        position=(748.46341, 784.80488),
+        width=292.61194,
+        height=58.00000,
+        stereotypesVisible=true,
+        attributesVisible=true,
+        attributeStereotypesVisible=true,
+        attributeTypesVisible=true,
+        color=#FFFFCC,
+        lineWidth=1.0)
+
+    GeneralizationView gview_0(
+        source=cview_3,
+        target=cview_2,
+        points=[(1233.50000,691.50000),(1233.00000,632.00000),(1135.96205,632.01434),(1137.00917,581.75256)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_1(
+        source=cview_4,
+        target=cview_2,
+        points=[(895.32836,689.00000),(895.00000,628.00000),(979.00000,629.00000),(977.00000,575.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_2(
+        source=cview_5,
+        target=cview_4,
+        points=[(894.76939,813.80488),(895.32836,689.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_3(
+        source=cview_6,
+        target=cview_1,
+        points=[(133.50000,412.00000),(137.00000,288.00000),(431.00000,285.00000),(431.00000,237.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_4(
+        source=cview_7,
+        target=cview_1,
+        points=[(513.68656,412.00000),(511.26119,161.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_5(
+        source=cview_2,
+        target=cview_8,
+        points=[(1046.35074,563.00000),(1035.38060,413.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    GeneralizationView gview_6(
+        source=cview_8,
+        target=cview_1,
+        points=[(1035.38060,413.00000),(1036.00000,282.00000),(590.00000,284.00000),(588.00000,224.00000)],
+        label='',
+        color=#000000,
+        lineWidth=-1.0,
+        lineStyle=SIMPLE)
+
+    PropertyView pview_0(
+        property=meta::pure::graphFetch::executionPlan::GlobalGraphFetchExecutionNode.localGraphFetchExecutionNode,
+        source=cview_7,
+        target=cview_8
+,        points=[(513.68656,412.00000),(1035.38060,413.00000)],
+        label='',
+        propertyPosition=(0.0,0.0),
+        multiplicityPosition=(0.0,0.0),
+        color=#000000,
+        lineWidth=-1.0,
+        stereotypesVisible=true,
+        nameVisible=true,
+        lineStyle=SIMPLE)
+}


### PR DESCRIPTION
Added below diagrams for execution plan metamodel (spread across different core repositories):

![ExecutionPlanDiagram](https://user-images.githubusercontent.com/72639930/148677691-cbfc3b89-6f37-48b5-ab7d-99f135978d9f.png)

![ResultTypeDiagram](https://user-images.githubusercontent.com/72639930/148677706-ec4834e8-ea22-4c9b-ac3b-a41bb2636b89.png)

![ExecutionNodeDiagram](https://user-images.githubusercontent.com/72639930/148677711-ef9d4c79-2d01-402f-aaff-3b0f99e4c74a.png)

![InMemoryExecutionNodeDiagram](https://user-images.githubusercontent.com/72639930/148677712-a9ddf9ed-ea1b-4acc-a2b3-fba9ae5c2c54.png)

![RelationalExecutionNodeDiagram](https://user-images.githubusercontent.com/72639930/148677720-3e7d7374-5768-4461-bf32-64041dcd5b30.png)

![ExternalSharedExecutionNodeDiagram](https://user-images.githubusercontent.com/72639930/148677726-e74ba410-dbab-4992-92b0-c62a036478c4.png)

![ServiceStoreExecutionNodeDiagram](https://user-images.githubusercontent.com/72639930/148677732-38e94204-33b4-429f-af5f-3c4ff9bc2ce7.png)

