### PR TITLE
Add isDistinct to boolean returning dyna function list

### DIFF
--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
@@ -1036,7 +1036,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::forma
 function <<access.private>> meta::relational::functions::sqlQueryToString::isBooleanOperation(relationalElement:RelationalOperationElement[1], extensions:RouterExtension[*]):Boolean[1]
 {
    $relationalElement->match($extensions.moduleExtension('relational')->cast(@RelationalExtension).sqlQueryToString_isBooleanOperation->concatenate([
-      d:DynaFunction[1] | $d.name->in(['or', 'and', 'lessThan', 'lessThanEqual', 'greaterThan', 'greaterThanEqual', 'equal', 'notEqual', 'notEqualAnsi', 'startsWith', 'endsWith', 'contains', 'isEmpty', 'isNotEmpty', 'isNull', 'isNotNull','isAlphaNumeric', 'exists', 'not', 'in', 'isNumeric', 'matches'])
+      d:DynaFunction[1] | $d.name->in(['or', 'and', 'lessThan', 'lessThanEqual', 'greaterThan', 'greaterThanEqual', 'equal', 'notEqual', 'notEqualAnsi', 'startsWith', 'endsWith', 'contains', 'isEmpty', 'isNotEmpty', 'isNull', 'isNotNull','isAlphaNumeric', 'exists', 'not', 'in', 'isNumeric', 'matches', 'isDistinct'])
                                        || ($d.name == 'group' && $d.parameters->toOne()->isBooleanOperation($extensions));,
       a:Any[1] | false
    ])->toOneMany()

--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/transform/fromPure/tests/testToSQLString.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/transform/fromPure/tests/testToSQLString.pure
@@ -1594,3 +1594,24 @@ function <<test.Test>> meta::relational::tests::functions::sqlstring::testMemSQL
 
    assertEquals('select 	`root`.LEGALNAME as `legalName`, 	substring(`root`.LEGALNAME, 2 + 1, 3 - 2) as `subname` from firmTable as `root`', $result->replace('\n', ''));
 }
+
+function <<test.Test>> meta::relational::tests::functions::sqlstring::testIsDistinctSQLGeneration():Boolean[1]
+{
+   let func = {|Firm.all()->groupBy(
+      [t|$t.legalName],
+      [agg(x|$x.employees.firstName,y|$y->isDistinct())],
+      ['LegalName', 'IsDistinctFirstName']
+   )};
+
+   let h2 = toSQLString($func, simpleRelationalMapping, DatabaseType.H2, meta::pure::router::extension::defaultRelationalExtensions());
+   assertSameSQL('select "root".LEGALNAME as "LegalName", count(distinct("personTable_d#4_d_m1".FIRSTNAME)) = count("personTable_d#4_d_m1".FIRSTNAME) as "IsDistinctFirstName" from firmTable as "root" left outer join personTable as "personTable_d#4_d_m1" on ("root".ID = "personTable_d#4_d_m1".FIRMID) group by "LegalName"', $h2);
+
+   let iq = toSQLString($func, simpleRelationalMapping, DatabaseType.SybaseIQ, meta::pure::router::extension::defaultRelationalExtensions());
+   assertSameSQL('select "root".LEGALNAME as "LegalName", case when (count(distinct("personTable_d#4_d_m1".FIRSTNAME)) = count("personTable_d#4_d_m1".FIRSTNAME)) then \'true\' else \'false\' end as "IsDistinctFirstName" from firmTable as "root" left outer join personTable as "personTable_d#4_d_m1" on ("root".ID = "personTable_d#4_d_m1".FIRMID) group by "LegalName"', $iq);
+
+   let db2 = toSQLString($func, simpleRelationalMapping, DatabaseType.DB2, meta::pure::router::extension::defaultRelationalExtensions());
+   assertSameSQL('select "root".LEGALNAME as "LegalName", case when (count(distinct("personTable_d#4_d_m1".FIRSTNAME)) = count("personTable_d#4_d_m1".FIRSTNAME)) then \'true\' else \'false\' end as "IsDistinctFirstName" from firmTable as "root" left outer join personTable as "personTable_d#4_d_m1" on ("root".ID = "personTable_d#4_d_m1".FIRMID) group by "root".LEGALNAME', $db2);
+
+   let memSql = toSQLString($func, simpleRelationalMapping, DatabaseType.MemSQL, meta::pure::router::extension::defaultRelationalExtensions());
+   assertSameSQL('select `root`.LEGALNAME as `LegalName`, count(distinct(`personTable_d#4_d_m1`.FIRSTNAME)) = count(`personTable_d#4_d_m1`.FIRSTNAME) as `IsDistinctFirstName` from firmTable as `root` left outer join personTable as `personTable_d#4_d_m1` on (`root`.ID = `personTable_d#4_d_m1`.FIRMID) group by `LegalName`', $memSql);
+}


### PR DESCRIPTION
For databases which do not support conditional expressions in select columns, it is necessary to wrap such conditional expressions in case statements. Adding isDistinct function to boolean returning dyna function list will ensure that case statement generation happens.