### PR TITLE
Require Java 11.0.13 or higher

### DIFF
--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
@@ -53,7 +53,6 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.proper
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.path.Path;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.path.PathElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.path.PropertyPathElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Generalization;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Any;
@@ -371,10 +370,7 @@ public class Pure
                 @Override
                 public Object value(Object o, ExecutionSupport es)
                 {
-                    // We specify the parameter types in the lambda below to work around a bug in the Java compiler:
-                    // https://bugs.openjdk.java.net/browse/JDK-8210495
-                    // This bug was fixed in 11.0.13, but the workaround ensures compatibility with 11.0.12 and earlier.
-                    RichIterable<?> result = ((Path<?, ?>) func)._path().injectInto(CompiledSupport.toPureCollection(o), (RichIterable<?> mutableList, PathElement path) ->
+                    RichIterable<?> result = ((Path<?, ?>) func)._path().injectInto(CompiledSupport.toPureCollection(o), (mutableList, path) ->
                     {
                         if (!(path instanceof PropertyPathElement))
                         {

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[11.0.10,12)</version>
+                                    <version>[11.0.13,12)</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
                                 <bannedDependencies>


### PR DESCRIPTION
Require Java 11.0.13 or higher for legend-pure builds. This version of Java contains a fix for this bug:

https://bugs.openjdk.java.net/browse/JDK-8210495

Also, remove a workaround for that bug.