### PR TITLE
Bug fixes for Sonar

### DIFF
--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/tools/GraphPath.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/tools/GraphPath.java
@@ -38,7 +38,7 @@ import java.util.regex.Pattern;
 
 public class GraphPath
 {
-    private static final Pattern VALID_START_NODE_PATH = Pattern.compile("(::)|((\\w[\\w$]*+::)*+)*+\\w[\\w$~]*+");
+    private static final Pattern VALID_START_NODE_PATH = Pattern.compile("(::)|((\\w[\\w$]*+::)*+\\w[\\w$]*+(~[\\w$]++)?)");
 
     private final String startNodePath;
     private final ImmutableList<Edge> edges;

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/tools/PackageTreeIterable.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/tools/PackageTreeIterable.java
@@ -28,6 +28,7 @@ import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.Consumer;
@@ -138,7 +139,11 @@ public class PackageTreeIterable extends AbstractLazyIterable<Package>
         @Override
         public Package next()
         {
-            Package pkg = this.deque.removeFirst();
+            Package pkg = this.deque.pollFirst();
+            if (pkg == null)
+            {
+                throw new NoSuchElementException();
+            }
             pkg._children().forEach(this::possiblyAddChild);
             return pkg;
         }


### PR DESCRIPTION
Fix a bug in the start node path regex detected by Sonar.

Also, explicitly throw NoSuchElementException in PackageTreeIterable so that Sonar will no longer complain. This would have been thrown already, though via a call to Deque.removeFirst.

Also, simplify some logic in IncrementalCompiler_New so that (hopefully) Sonar will understand when repoTransaction is not null.