### PR TITLE
Annotation validation

### DIFF
--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/validator/ProfileValidator.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/validator/ProfileValidator.java
@@ -1,0 +1,55 @@
+package org.finos.legend.pure.m3.compiler.validation.validator;
+
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.map.MutableMap;
+import org.finos.legend.pure.m3.compiler.Context;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Annotation;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.tools.matcher.MatchRunner;
+import org.finos.legend.pure.m3.tools.matcher.Matcher;
+import org.finos.legend.pure.m3.tools.matcher.MatcherState;
+import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+import org.finos.legend.pure.m4.exception.PureCompilationException;
+
+public class ProfileValidator implements MatchRunner<Profile>
+{
+    @Override
+    public String getClassName()
+    {
+        return M3Paths.Profile;
+    }
+
+    @Override
+    public void run(Profile profile, MatcherState state, Matcher matcher, ModelRepository modelRepository, Context context) throws PureCompilationException
+    {
+        validateUniqueAnnotationValues(profile, profile._p_stereotypes(), "stereotype");
+        validateUniqueAnnotationValues(profile, profile._p_tags(), "tag");
+    }
+
+    private void validateUniqueAnnotationValues(Profile profile, Iterable<? extends Annotation> annotations, String description)
+    {
+        MutableMap<String, Annotation> values = Maps.mutable.empty();
+        annotations.forEach(a ->
+        {
+            String value = a._value();
+            Annotation other = values.put(value, a);
+            if (other != null)
+            {
+                StringBuilder builder = new StringBuilder("There is already a ").append(description).append(" named '").append(a._value()).append("' defined in ");
+                PackageableElement.writeUserPathForPackageableElement(builder, profile);
+                SourceInformation otherSourceInfo = other.getSourceInformation();
+                if (otherSourceInfo != null)
+                {
+                    builder.append(" (at ").append(otherSourceInfo.getSourceId())
+                            .append(" line:").append(otherSourceInfo.getLine())
+                            .append(" column:").append(otherSourceInfo.getColumn())
+                            .append(')');
+                }
+                throw new PureCompilationException(a.getSourceInformation(), builder.toString());
+            }
+        });
+    }
+}

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/M3AntlrParser.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/M3AntlrParser.java
@@ -96,6 +96,7 @@ import org.finos.legend.pure.m3.compiler.validation.validator.FunctionExpression
 import org.finos.legend.pure.m3.compiler.validation.validator.GenericTypeValidator;
 import org.finos.legend.pure.m3.compiler.validation.validator.InstanceValueValidator;
 import org.finos.legend.pure.m3.compiler.validation.validator.PackageValidator;
+import org.finos.legend.pure.m3.compiler.validation.validator.ProfileValidator;
 import org.finos.legend.pure.m3.compiler.validation.validator.PropertyValidator;
 import org.finos.legend.pure.m3.compiler.validation.validator.RepositoryPackageValidator;
 import org.finos.legend.pure.m3.compiler.validation.validator.TaggedValueValidator;
@@ -518,7 +519,8 @@ public class M3AntlrParser implements Parser
                 new ElementWithTaggedValueValidator(),
                 new AccessLevelValidator(),
                 new RepositoryPackageValidator(),
-                new PackageValidator()
+                new PackageValidator(),
+                new ProfileValidator()
         );
     }
 

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/validation/TestProfileValidation.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/validation/TestProfileValidation.java
@@ -1,0 +1,51 @@
+package org.finos.legend.pure.m3.tests.validation;
+
+import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+import org.finos.legend.pure.m4.exception.PureCompilationException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestProfileValidation extends AbstractPureTestWithCoreCompiledPlatform
+{
+    private static final String SOURCE_ID = "/test/profileTest.pure";
+
+    @BeforeClass
+    public static void setUp()
+    {
+        setUpRuntime(getExtra());
+    }
+
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete(SOURCE_ID);
+        runtime.compile();
+    }
+
+    @Test
+    public void testStereotypeNameConflict()
+    {
+        String code = "Profile test::BadProfile\n" +
+                "{\n" +
+                "    stereotypes : [abc, def, abc, ghi, def];\n" +
+                "}\n";
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(SOURCE_ID, code));
+        Assert.assertEquals(new SourceInformation(SOURCE_ID, 3, 30, 3, 30, 3, 32), e.getSourceInformation());
+        Assert.assertEquals("There is already a stereotype named 'abc' defined in test::BadProfile (at " + SOURCE_ID + " line:3 column:20)", e.getInfo());
+    }
+
+    @Test
+    public void testTagNameConflict()
+    {
+        String code = "Profile test::BadProfile\n" +
+                "{\n" +
+                "    tags : [abc, xyz, def, xyz, abc];\n" +
+                "}\n";
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(SOURCE_ID, code));
+        Assert.assertEquals(new SourceInformation(SOURCE_ID, 3, 28, 3, 28, 3, 30), e.getSourceInformation());
+        Assert.assertEquals("There is already a tag named 'xyz' defined in test::BadProfile (at " + SOURCE_ID + " line:3 column:18)", e.getInfo());
+    }
+}


### PR DESCRIPTION
Add validation to ensure a profile does not have name clashes among stereotypes or tags. Specifically, if there are multiple stereotypes with the same name or multiple tags with the same name, this validation will throw a PureCompilationException. (The name spaces for tags and stereotypes are separate, so there may be a stereotype with the same name as a tag.)