### PR TITLE
Fix Snowflake indexOf SQL translation

### DIFF
--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
@@ -1335,7 +1335,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::getDy
                                                  choice(DatabaseType.MemSQL,       $allStates,            ^ToSql(format='LOCATE(%s)', transform={p:String[2] | $p->at(1) + ', ' + $p->at(0)})),
                                                  choice(DatabaseType.Presto,       $allStates,            ^ToSql(format='strpos(%s)', transform={p:String[2] | $p->at(0) + ', ' + $p->at(1)})),
                                                  choice(DatabaseType.Databricks,   $allStates,            ^ToSql(format='locate(%s)', transform={p:String[2] | $p->at(0) + ', ' + $p->at(1)})),
-                                                 choice(DatabaseType.Snowflake,    $allStates,            ^ToSql(format='CHARINDEX(%s)', transform={p:String[2] | $p->at(0) + ', ' + $p->at(1)}))]),
+                                                 choice(DatabaseType.Snowflake,    $allStates,            ^ToSql(format='CHARINDEX(%s)', transform={p:String[2] | $p->at(1) + ', ' + $p->at(0)}))]),
       forDynafunction('isDistinct',            [ choice($allTypes,                 $allStates,            ^ToSql(format='count(distinct(%s)) = count(%s)', transform={p:String[*]|assert($p->isNotEmpty(), |'"isDistinct" aggregation can be applied on primitive values only'); $p->concatenate($p);}))]),
       forDynafunction('isEmpty',               [ choice($aSybase,                  $selectOutsideWhen,    ^ToSql(format='case when (%s is null) then \'true\' else \'false\' end', parametersWithinWhenClause=true)),
                                                  choice($aSybase,                  $notSelectOutsideWhen, ^ToSql(format='%s is null')),

--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/transform/fromPure/tests/testToSQLString.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/transform/fromPure/tests/testToSQLString.pure
@@ -466,6 +466,15 @@ function <<test.Test>> meta::relational::tests::functions::sqlstring::testToSQLS
    assertEquals('select substr("root".FULLNAME, 0, position(\',\', "root".FULLNAME)-1) as "firstName" from personTable as "root"', $db2sql);
 }
 
+function <<test.Test>> meta::relational::tests::functions::sqlstring::testToSQLStringIndexOfSnowflake():Boolean[1]
+{
+   let sql = toSQLString(
+              |meta::relational::tests::model::simple::Person.all()->project(p|$p.firstName->indexOf('Jo'), 'index'),
+               meta::relational::tests::simpleRelationalMapping, DatabaseType.Snowflake, meta::pure::router::extension::defaultRelationalExtensions());
+
+   assertEquals('select CHARINDEX(\'Jo\', "root".FIRSTNAME) as "index" from personTable as "root"', $sql);
+}
+
 function <<test.Test>> meta::relational::tests::functions::sqlstring::testToSQLStringWithStdDevSample():Boolean[1]
 {
    [DatabaseType.SybaseIQ, DatabaseType.H2, DatabaseType.DB2, DatabaseType.Postgres, DatabaseType.Presto]->map(db|


### PR DESCRIPTION
Snowflake CHARINDEX function expects the string to look for as the first parameter and string to search in as the second parameter. Currently, parameters are being generated in the reverse order.

Reference: https://docs.snowflake.com/en/sql-reference/functions/charindex.html#varchar-expressions
