### PR TITLE
SqlQueryToString refactoring: move literal, window and semi-structured processing to extension

### DIFF
--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
@@ -85,6 +85,17 @@ Class meta::relational::functions::sqlQueryToString::DbExtension
    dynaFuncDispatch: meta::pure::metamodel::function::Function<{DynaFunction[1], GenerationState[1] -> DynaFunctionToSql[1]}>[1];
    isDbReservedIdentifier: meta::pure::metamodel::function::Function<{String[1] -> Boolean[1]}>[1];
    literalProcessor: meta::pure::metamodel::function::Function<{Type[1] -> LiteralProcessor[1]}>[1];
+   windowColumnProcessor: meta::pure::metamodel::function::Function<{WindowColumn[1], SqlGenerationContext[1] -> String[1]}>[1];
+   semiStructuredObjectNavigationProcessor: meta::pure::metamodel::function::Function<{SemiStructuredObjectNavigation[1], SqlGenerationContext[1] -> String[1]}>[1];
+}
+
+Class meta::relational::functions::sqlQueryToString::SqlGenerationContext
+{
+   dbConfig: DbConfig[1];
+   format: Format[1];
+   generationState: GenerationState[1];
+   config: Config[1];
+   extensions: RouterExtension[*];
 }
 
 function meta::relational::functions::sqlQueryToString::sqlQueryToString(sqlQuery:SQLQuery[1], dbType:DatabaseType[1], extensions:RouterExtension[*]):String[1]
@@ -129,13 +140,62 @@ function meta::relational::functions::sqlQueryToString::createDbConfig( dbType:D
 
 function meta::relational::functions::sqlQueryToString::createDbExtension(dbType:DatabaseType[1], dbTimeZone:String[0..1]):DbExtension[1]
 {
-   let reservedWords = dbReservedWords($dbType);
-   let literalProcessors = getLiteralProcessors($dbType, $dbTimeZone);
+   let reservedWords = [
+     option(DatabaseType.Postgres, |postgresReservedWords()),
+     option(DatabaseType.SybaseIQ, |sybaseReservedWords()),
+     option(DatabaseType.MemSQL, |memSQLReservedWords()),
+     option(DatabaseType.H2, |h2ReservedWords())
+   ]->evalByDbType($dbType, |['kerberos', 'date', 'first']);
+
+   let literalProcessors = getDefaultLiteralProcessors($dbTimeZone)->putAll([
+     option(DatabaseType.SybaseIQ, |getLiteralProcessorsForSybaseIQ($dbTimeZone)),
+     option(DatabaseType.Sybase, |getLiteralProcessorsForSybaseASE($dbTimeZone)),
+     option(DatabaseType.Databricks, |getLiteralProcessorsForDatabricks($dbTimeZone)),
+     option(DatabaseType.Postgres, |getLiteralProcessorsForPostgres($dbTimeZone)),
+     option(DatabaseType.Presto, |getLiteralProcessorsForPresto($dbTimeZone)),
+     option(DatabaseType.BigQuery, |getLiteralProcessorsForBigQuery($dbTimeZone)),
+     option(DatabaseType.Redshift, |getLiteralProcessorsForRedshift($dbTimeZone))
+   ]->evalByDbType($dbType, |newMap([]->cast(@Pair<Type, LiteralProcessor>))));
+
+   let windowColumnProcessor = [
+     option(
+       [DatabaseType.Sybase,DatabaseType.SybaseIQ,DatabaseType.DB2,DatabaseType.Hive,DatabaseType.H2,DatabaseType.MemSQL, DatabaseType.BigQuery, DatabaseType.Redshift, DatabaseType.Snowflake, DatabaseType.Databricks],
+       processWindowColumn_WindowColumn_1__SqlGenerationContext_1__String_1_
+     )
+   ]->selectByDbTypeElseError($dbType, 'Window Columns');
+
+   let semiStructuredObjectNavigationProcessor = [
+     option(DatabaseType.Snowflake, processSemiStructuredObjectNavigationForSnowflake_SemiStructuredObjectNavigation_1__SqlGenerationContext_1__String_1_),
+     option(DatabaseType.H2, processSemiStructuredObjectNavigationForH2_SemiStructuredObjectNavigation_1__SqlGenerationContext_1__String_1_)
+   ]->selectByDbTypeElseError($dbType, 'Semi structured navigation');
+
    ^DbExtension(
       dynaFuncDispatch = getDynaFunctionMappings($dbType),
       isDbReservedIdentifier = {str:String[1]| $str->in($reservedWords)},
-      literalProcessor = {type:Type[1]| $literalProcessors->get(if($type->instanceOf(Enumeration), | Enum, | $type))->toOne()}
+      literalProcessor = {type:Type[1]| $literalProcessors->get(if($type->instanceOf(Enumeration), | Enum, | $type))->toOne()},
+      windowColumnProcessor = $windowColumnProcessor,
+      semiStructuredObjectNavigationProcessor = $semiStructuredObjectNavigationProcessor
    );
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::evalByDbType<K|m>(options:Pair<List<DatabaseType>, meta::pure::metamodel::function::Function<{->K[m]}>>[*], dbType:DatabaseType[1], default:meta::pure::metamodel::function::Function<{->K[m]}>[1]): K[m]
+{
+   let option = $options->filter(o| $dbType->in($o.first.values));
+   assert($option->size() <= 1, 'Expected atmost one matching option for db type: ' + $dbType->toString() + ', found ' + $option->size()->toString());
+   if($option->isEmpty(), |$default->eval(), |$option->toOne().second->eval());
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::selectByDbTypeElseError<K>(options:Pair<List<DatabaseType>, K>[*], dbType:DatabaseType[1], selectionName:String[1]):K[1]
+{
+   let option = $options->filter(o| $dbType->in($o.first.values));
+   assert($option->size() <= 1, 'Expected atmost one matching option for db type: ' + $dbType->toString() + ', found ' + $option->size()->toString());
+   assert($option->isNotEmpty(), $selectionName + ' not supported for Database Type: '+$dbType->toString() +'. Supported Databases are: '+ $options.first.values->map(d|$d->toString())->joinStrings(',') +'.') ;
+   $option->toOne().second;
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::option<K>(dbTypes:DatabaseType[*], val:K[1]): Pair<List<DatabaseType>, K>[1]
+{
+   pair(list($dbTypes), $val);
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::indent(d:Format[1]):Format[1]
@@ -175,12 +235,13 @@ function meta::relational::functions::sqlQueryToString::processOperation(relatio
 
 function meta::relational::functions::sqlQueryToString::processOperation(relationalOperationElement:RelationalOperationElement[1], dbConfig : DbConfig[1], format:Format[1], generationState:GenerationState[1], config:Config[1], extensions:RouterExtension[*]):String[1]
 {
+   let sgc = ^SqlGenerationContext(dbConfig=$dbConfig, format=$format, generationState=$generationState, config=$config, extensions=$extensions);
    $relationalOperationElement->match($extensions->map(e|$e.moduleExtension('relational')->cast(@RelationalExtension).sqlQueryToString_processOperation)->map(f | $f->eval($dbConfig, $format, $generationState, $config, $extensions))->concatenate(
                                        [
                                           v:VarPlaceHolder[1]| '${'+$v.name+'}',
                                           v:VarSetPlaceHolder[1]| '${'+$v.varName+'}',
                                           v:VarCrossSetPlaceHolder[1]| '${'+$v.varName+'}',
-                                          w:WindowColumn[1]|$w->processWindowColumn($dbConfig, $format, $generationState, $config, $extensions) ,
+                                          w:WindowColumn[1]|$dbConfig.dbExtension.windowColumnProcessor->eval($w, $sgc),
                                           s:ViewSelectSQLQuery[1]|'('+$s.selectSQLQuery->processOperation($dbConfig, $format, $generationState, $config, $extensions)+')',
                                           t:Table[1]|$t->tableToString($dbConfig),
                                           js:JoinStrings[1] | processJoinStringsOperation($js, $dbConfig, $format, $generationState, $extensions),
@@ -218,22 +279,25 @@ function meta::relational::functions::sqlQueryToString::processOperation(relatio
                                           f:FreeMarkerOperationHolder[1]|processFreeMarkerOperationHolder($f, $dbConfig, $format, $generationState, $config, false, $extensions),
                                           d:DynaFunction[1]|processDynaFunction($d, $dbConfig, $format, $generationState, $config, $extensions),
                                           c:ColumnName[1]|processIdentifier($c.name->toOne(), $dbConfig),
-                                          s:SemiStructuredObjectNavigation[1]|processSemiStructuredObjectNavigation($s, $dbConfig, $format, $generationState, $config, $extensions),
+                                          s:SemiStructuredObjectNavigation[1]|$dbConfig.dbExtension.semiStructuredObjectNavigationProcessor->eval($s, $sgc),
                                           {f:meta::relational::metamodel::operation::Function[1]| assert(false, 'Don\'t know how to handle %s', $f->type()); 'TO DO'; }
                                        ])->toOneMany()
                                      );
 }
 
-function <<access.private>> meta::relational::functions::sqlQueryToString::processWindowColumn(w:WindowColumn[1], dbConfig : DbConfig[1], format:Format[1],generationState:GenerationState[1], config:Config[1], extensions:RouterExtension[*]):String[1]
+function meta::relational::functions::sqlQueryToString::processOperation(relationalOperationElement:RelationalOperationElement[1], sgc:SqlGenerationContext[1]):String[1]
 {
-   let supportedDbs = [DatabaseType.Sybase,DatabaseType.SybaseIQ,DatabaseType.DB2,DatabaseType.Hive,DatabaseType.H2,DatabaseType.MemSQL, DatabaseType.BigQuery, DatabaseType.Redshift, DatabaseType.Snowflake, DatabaseType.Databricks];
-   assert($supportedDbs->contains($dbConfig.dbType), 'Window Columns are not supported for Database Type: '+$dbConfig.dbType->toString() +'. Supported Databases are: '+ $supportedDbs->map(d|$d->toString())->joinStrings(',') +'.') ;
-   $w.func->processOperation($dbConfig, $format, $generationState, $config, $extensions) + ' OVER ('
+   $relationalOperationElement->processOperation($sgc.dbConfig, $sgc.format, $sgc.generationState, $sgc.config, $sgc.extensions);
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::processWindowColumn(w:WindowColumn[1], sgc:SqlGenerationContext[1]):String[1]
+{
+   $w.func->processOperation($sgc) + ' OVER ('
    + if($w.window.partition->isNotEmpty(),
-        |'Partition By ' + $w.window.partition->map(f|$f->processOperation($dbConfig, $format, $generationState, $config, $extensions))->joinStrings(',')+' ',
+        |'Partition By ' + $w.window.partition->map(f|$f->processOperation($sgc))->joinStrings(',')+' ',
         |'')
    + if($w.window.sortBy->isNotEmpty(),
-        |'Order By '+$w.window.sortBy->toOne()->processOperation($dbConfig, $format, $generationState, $config, $extensions)
+        |'Order By '+$w.window.sortBy->toOne()->processOperation($sgc)
               + if($w.window.sortDirection->isNotEmpty(), | ' ' +$w.window.sortDirection->toOne().name, | '')
               +')',
         |')') ;
@@ -261,9 +325,9 @@ function meta::relational::functions::sqlQueryToString::getLiteralProcessorForTy
       |$literalProcessor->eval($type));
 }
 
-function <<access.private>> meta::relational::functions::sqlQueryToString::getLiteralProcessors(dbType:DatabaseType[1], dbTimeZone:String[0..1]):Map<Type,LiteralProcessor>[1]
+function <<access.private>> meta::relational::functions::sqlQueryToString::getDefaultLiteralProcessors(dbTimeZone:String[0..1]):Map<Type,LiteralProcessor>[1]
 {
-   let default = newMap([
+   newMap([
       pair(Enum,           ^LiteralProcessor(format = '%s',     transform = toString_Any_1__String_1_)),
       pair(String,         ^LiteralProcessor(format = '\'%s\'', transform = convertStringToSQLString_String_1__String_1_)),
       pair(Number,         ^LiteralProcessor(format = '%s',     transform = toString_Any_1__String_1_)),
@@ -276,25 +340,6 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::getLi
       pair(DateTime,       ^LiteralProcessor(format = '\'%s\'', transform = {d:DateTime[1] | $d->convertDateToSqlString($dbTimeZone)})),
       pair(Date,           ^LiteralProcessor(format = '\'%s\'', transform = {d:Date[1] | $d->convertDateToSqlString($dbTimeZone)}))
    ]);
-
-   let specific = if ($dbType == DatabaseType.SybaseIQ,
-                      | getLiteralProcessorsForSybaseIQ($dbTimeZone),
-                      | if($dbType == DatabaseType.Sybase,
-                           | getLiteralProcessorsForSybaseASE($dbTimeZone),
-                              | if ($dbType == DatabaseType.Databricks,
-                              | getLiteralProcessorsForDatabricks($dbTimeZone),
-                                | if ($dbType == DatabaseType.Postgres,
-                                | getLiteralProcessorsForPostgres($dbTimeZone),
-                                | if ($dbType == DatabaseType.Presto,
-                                     | getLiteralProcessorsForPresto($dbTimeZone),
-                                     | if($dbType == DatabaseType.BigQuery,
-                                      | getLiteralProcessorsForBigQuery($dbTimeZone),
-                                        | if($dbType == DatabaseType.Redshift,
-                                        | getLiteralProcessorsForRedshift($dbTimeZone),
-                                      | newMap([]->cast(@Pair<Type, LiteralProcessor>))
-                                 )))))));
-
-   $default->putAll($specific);
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::getLiteralProcessorsForSybaseASE(dbTimeZone:String[0..1]):Map<Type,LiteralProcessor>[1]
@@ -973,21 +1018,11 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::proce
    '(' + $processedLeft + ' not in ' + if($processedRight->startsWith('(') && $processedRight->endsWith(')'), | $processedRight, | '(' + $processedRight + ')') + ' OR ' + $processedLeft + ' is null)';
 }
 
-function <<access.private>> meta::relational::functions::sqlQueryToString::processSemiStructuredObjectNavigation(s:SemiStructuredObjectNavigation[1], dbConfig:DbConfig[1], format:Format[1], generationState:GenerationState[1], config:Config[1], extensions:RouterExtension[*]): String[1]
-{
-   let supportedDbTypes = [DatabaseType.Snowflake, DatabaseType.H2];
-   assert($dbConfig.dbType->in($supportedDbTypes), | 'Semi structured navigation not supported for database type: ' + $dbConfig.dbType->toString() + '. Supported database types are: ' + $supportedDbTypes->map(d|$d->toString())->joinStrings(', '));
-
-   let processedOperand = $s.operand->processOperation($dbConfig, $format, $generationState, $config, $extensions);
-
-   if ($dbConfig.dbType == DatabaseType.Snowflake, | $s->processSemiStructuredObjectNavigationForSnowflake($processedOperand), |
-   if ($dbConfig.dbType == DatabaseType.H2, | $s->processSemiStructuredObjectNavigationForH2($processedOperand), |
-   fail('Unsupported database type ' +$dbConfig.dbType->toString()); '';));
-}
-
-function <<access.private>> meta::relational::functions::sqlQueryToString::processSemiStructuredObjectNavigationForSnowflake(s:SemiStructuredObjectNavigation[1], processedOperand:String[1]): String[1]
+function <<access.private>> meta::relational::functions::sqlQueryToString::processSemiStructuredObjectNavigationForSnowflake(s:SemiStructuredObjectNavigation[1], sgc:SqlGenerationContext[1]): String[1]
 {
    // https://docs.snowflake.com/en/user-guide/querying-semistructured.html
+
+   let processedOperand = $s.operand->processOperation($sgc);
 
    let elementAccess = $processedOperand + $s->match([
       p: SemiStructuredPropertyAccess[1]     | '[\'' + $p.property->cast(@Literal).value->cast(@String) + '\']' + if($p.index->isEmpty(),|'',|'['+ $p.index->toOne()->cast(@Literal).value->toString()+']'),
@@ -1002,9 +1037,11 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::proce
    $elementAccess + $castSuffix;
 }
 
-function <<access.private>> meta::relational::functions::sqlQueryToString::processSemiStructuredObjectNavigationForH2(s:SemiStructuredObjectNavigation[1], processedOperand:String[1]): String[1]
+function <<access.private>> meta::relational::functions::sqlQueryToString::processSemiStructuredObjectNavigationForH2(s:SemiStructuredObjectNavigation[1], sgc:SqlGenerationContext[1]): String[1]
 {
    // Use a user defined function for H2 (testing purpose)
+
+   let processedOperand = $s.operand->processOperation($sgc);
 
    let udfName = 'legend_h2_extension_json_navigate';
 
@@ -1890,24 +1927,9 @@ function meta::relational::functions::sqlQueryToString::processColumnName(name:S
     $mappedName->processIdentifier($dbConfig);
 }
 
-function <<access.private>> meta::relational::functions::sqlQueryToString::dbReservedWords(dbType : DatabaseType[1]):String[*]
+function <<access.private>> meta::relational::functions::sqlQueryToString::postgresReservedWords():String[*]
 {
-    if ($dbType == DatabaseType.Postgres,
-         | [],
-         | if ($dbType == DatabaseType.SybaseIQ,
-               |
-                  sybaseReservedWords(),
-               |
-                 if ($dbType == DatabaseType.MemSQL,
-                     |memSQLReservedWords(),
-                     | if($dbType == DatabaseType.H2,
-                          | h2ReservedWords(),
-                          | ['kerberos', 'date', 'first']
-                    )
-
-               )
-         )
-   );
+  [];
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::h2ReservedWords():String[*]

--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
@@ -78,6 +78,18 @@ Class meta::relational::functions::sqlQueryToString::DbConfig
    {
      getLiteralProcessorForType($type, $this.dbExtension.literalProcessor, $this.dbTimeZone);
    }: LiteralProcessor[1];
+
+   windowColumnProcessor(w:WindowColumn[1], sgc:SqlGenerationContext[1])
+   {
+     assert($this.dbExtension.windowColumnProcessor->isNotEmpty(), 'Window Columns not supported for Database Type: ' + $this.dbType->toString());
+     $this.dbExtension.windowColumnProcessor->toOne()->eval($w, $sgc);
+   }: String[1];
+
+   semiStructuredObjectNavigationProcessor(s:SemiStructuredObjectNavigation[1], sgc:SqlGenerationContext[1])
+   {
+     assert($this.dbExtension.semiStructuredObjectNavigationProcessor->isNotEmpty(), 'Semi structured navigation not supported for Database Type: ' + $this.dbType->toString());
+     $this.dbExtension.semiStructuredObjectNavigationProcessor->toOne()->eval($s, $sgc);
+   }: String[1];
 }
 
 Class meta::relational::functions::sqlQueryToString::DbExtension
@@ -85,8 +97,8 @@ Class meta::relational::functions::sqlQueryToString::DbExtension
    dynaFuncDispatch: meta::pure::metamodel::function::Function<{DynaFunction[1], GenerationState[1] -> DynaFunctionToSql[1]}>[1];
    isDbReservedIdentifier: meta::pure::metamodel::function::Function<{String[1] -> Boolean[1]}>[1];
    literalProcessor: meta::pure::metamodel::function::Function<{Type[1] -> LiteralProcessor[1]}>[1];
-   windowColumnProcessor: meta::pure::metamodel::function::Function<{WindowColumn[1], SqlGenerationContext[1] -> String[1]}>[1];
-   semiStructuredObjectNavigationProcessor: meta::pure::metamodel::function::Function<{SemiStructuredObjectNavigation[1], SqlGenerationContext[1] -> String[1]}>[1];
+   windowColumnProcessor: meta::pure::metamodel::function::Function<{WindowColumn[1], SqlGenerationContext[1] -> String[1]}>[0..1];
+   semiStructuredObjectNavigationProcessor: meta::pure::metamodel::function::Function<{SemiStructuredObjectNavigation[1], SqlGenerationContext[1] -> String[1]}>[0..1];
 }
 
 Class meta::relational::functions::sqlQueryToString::SqlGenerationContext
@@ -160,14 +172,14 @@ function meta::relational::functions::sqlQueryToString::createDbExtension(dbType
    let windowColumnProcessor = [
      option(
        [DatabaseType.Sybase,DatabaseType.SybaseIQ,DatabaseType.DB2,DatabaseType.Hive,DatabaseType.H2,DatabaseType.MemSQL, DatabaseType.BigQuery, DatabaseType.Redshift, DatabaseType.Snowflake, DatabaseType.Databricks],
-       processWindowColumn_WindowColumn_1__SqlGenerationContext_1__String_1_
+       |processWindowColumn_WindowColumn_1__SqlGenerationContext_1__String_1_
      )
-   ]->selectByDbTypeElseError($dbType, 'Window Columns');
+   ]->evalByDbType($dbType, |[]);
 
    let semiStructuredObjectNavigationProcessor = [
-     option(DatabaseType.Snowflake, processSemiStructuredObjectNavigationForSnowflake_SemiStructuredObjectNavigation_1__SqlGenerationContext_1__String_1_),
-     option(DatabaseType.H2, processSemiStructuredObjectNavigationForH2_SemiStructuredObjectNavigation_1__SqlGenerationContext_1__String_1_)
-   ]->selectByDbTypeElseError($dbType, 'Semi structured navigation');
+     option(DatabaseType.Snowflake, |processSemiStructuredObjectNavigationForSnowflake_SemiStructuredObjectNavigation_1__SqlGenerationContext_1__String_1_),
+     option(DatabaseType.H2, |processSemiStructuredObjectNavigationForH2_SemiStructuredObjectNavigation_1__SqlGenerationContext_1__String_1_)
+   ]->evalByDbType($dbType, |[]);
 
    ^DbExtension(
       dynaFuncDispatch = getDynaFunctionMappings($dbType),
@@ -183,14 +195,6 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::evalB
    let option = $options->filter(o| $dbType->in($o.first.values));
    assert($option->size() <= 1, 'Expected atmost one matching option for db type: ' + $dbType->toString() + ', found ' + $option->size()->toString());
    if($option->isEmpty(), |$default->eval(), |$option->toOne().second->eval());
-}
-
-function <<access.private>> meta::relational::functions::sqlQueryToString::selectByDbTypeElseError<K>(options:Pair<List<DatabaseType>, K>[*], dbType:DatabaseType[1], selectionName:String[1]):K[1]
-{
-   let option = $options->filter(o| $dbType->in($o.first.values));
-   assert($option->size() <= 1, 'Expected atmost one matching option for db type: ' + $dbType->toString() + ', found ' + $option->size()->toString());
-   assert($option->isNotEmpty(), $selectionName + ' not supported for Database Type: '+$dbType->toString() +'. Supported Databases are: '+ $options.first.values->map(d|$d->toString())->joinStrings(',') +'.') ;
-   $option->toOne().second;
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::option<K>(dbTypes:DatabaseType[*], val:K[1]): Pair<List<DatabaseType>, K>[1]
@@ -241,7 +245,7 @@ function meta::relational::functions::sqlQueryToString::processOperation(relatio
                                           v:VarPlaceHolder[1]| '${'+$v.name+'}',
                                           v:VarSetPlaceHolder[1]| '${'+$v.varName+'}',
                                           v:VarCrossSetPlaceHolder[1]| '${'+$v.varName+'}',
-                                          w:WindowColumn[1]|$dbConfig.dbExtension.windowColumnProcessor->eval($w, $sgc),
+                                          w:WindowColumn[1]|$dbConfig.windowColumnProcessor($w, $sgc),
                                           s:ViewSelectSQLQuery[1]|'('+$s.selectSQLQuery->processOperation($dbConfig, $format, $generationState, $config, $extensions)+')',
                                           t:Table[1]|$t->tableToString($dbConfig),
                                           js:JoinStrings[1] | processJoinStringsOperation($js, $dbConfig, $format, $generationState, $extensions),
@@ -279,7 +283,7 @@ function meta::relational::functions::sqlQueryToString::processOperation(relatio
                                           f:FreeMarkerOperationHolder[1]|processFreeMarkerOperationHolder($f, $dbConfig, $format, $generationState, $config, false, $extensions),
                                           d:DynaFunction[1]|processDynaFunction($d, $dbConfig, $format, $generationState, $config, $extensions),
                                           c:ColumnName[1]|processIdentifier($c.name->toOne(), $dbConfig),
-                                          s:SemiStructuredObjectNavigation[1]|$dbConfig.dbExtension.semiStructuredObjectNavigationProcessor->eval($s, $sgc),
+                                          s:SemiStructuredObjectNavigation[1]|$dbConfig.semiStructuredObjectNavigationProcessor($s, $sgc),
                                           {f:meta::relational::metamodel::operation::Function[1]| assert(false, 'Don\'t know how to handle %s', $f->type()); 'TO DO'; }
                                        ])->toOneMany()
                                      );

--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/sqlQueryToString/SQLQueryToString.pure
@@ -90,6 +90,12 @@ Class meta::relational::functions::sqlQueryToString::DbConfig
      assert($this.dbExtension.semiStructuredObjectNavigationProcessor->isNotEmpty(), 'Semi structured navigation not supported for Database Type: ' + $this.dbType->toString());
      $this.dbExtension.semiStructuredObjectNavigationProcessor->toOne()->eval($s, $sgc);
    }: String[1];
+
+   joinStringsProcessor(j:JoinStrings[1], sgc:SqlGenerationContext[1])
+   {
+     assert($this.dbExtension.joinStringsProcessor->isNotEmpty(), 'Join strings operation not supported for Database Type: ' + $this.dbType->toString());
+     $this.dbExtension.joinStringsProcessor->toOne()->eval($j, $sgc);
+   }: String[1];
 }
 
 Class meta::relational::functions::sqlQueryToString::DbExtension
@@ -99,6 +105,7 @@ Class meta::relational::functions::sqlQueryToString::DbExtension
    literalProcessor: meta::pure::metamodel::function::Function<{Type[1] -> LiteralProcessor[1]}>[1];
    windowColumnProcessor: meta::pure::metamodel::function::Function<{WindowColumn[1], SqlGenerationContext[1] -> String[1]}>[0..1];
    semiStructuredObjectNavigationProcessor: meta::pure::metamodel::function::Function<{SemiStructuredObjectNavigation[1], SqlGenerationContext[1] -> String[1]}>[0..1];
+   joinStringsProcessor: meta::pure::metamodel::function::Function<{JoinStrings[1], SqlGenerationContext[1] -> String[1]}>[0..1];
 }
 
 Class meta::relational::functions::sqlQueryToString::SqlGenerationContext
@@ -181,12 +188,25 @@ function meta::relational::functions::sqlQueryToString::createDbExtension(dbType
      option(DatabaseType.H2, |processSemiStructuredObjectNavigationForH2_SemiStructuredObjectNavigation_1__SqlGenerationContext_1__String_1_)
    ]->evalByDbType($dbType, |[]);
 
+   let joinStringsProcessor = [
+     option(DatabaseType.H2, |processJoinStringsOperationForH2_JoinStrings_1__SqlGenerationContext_1__String_1_),
+     option(DatabaseType.SybaseIQ, |processJoinStringsOperationForSybaseIQ_JoinStrings_1__SqlGenerationContext_1__String_1_),
+     option(DatabaseType.DB2, |processJoinStringsOperationForDB2_JoinStrings_1__SqlGenerationContext_1__String_1_),
+     option(DatabaseType.SqlServer, |processJoinStringsOperationForSqlServer_JoinStrings_1__SqlGenerationContext_1__String_1_),
+     option(DatabaseType.Postgres, |processJoinStringsOperationForPostgres_JoinStrings_1__SqlGenerationContext_1__String_1_),
+     option(
+       [DatabaseType.MemSQL, DatabaseType.Presto, DatabaseType.BigQuery, DatabaseType.Redshift, DatabaseType.Snowflake, DatabaseType.Databricks],
+       |processJoinStringsOperationWithConcatCall_JoinStrings_1__SqlGenerationContext_1__String_1_
+     )
+   ]->evalByDbType($dbType, |[]);
+
    ^DbExtension(
       dynaFuncDispatch = getDynaFunctionMappings($dbType),
       isDbReservedIdentifier = {str:String[1]| $str->in($reservedWords)},
       literalProcessor = {type:Type[1]| $literalProcessors->get(if($type->instanceOf(Enumeration), | Enum, | $type))->toOne()},
       windowColumnProcessor = $windowColumnProcessor,
-      semiStructuredObjectNavigationProcessor = $semiStructuredObjectNavigationProcessor
+      semiStructuredObjectNavigationProcessor = $semiStructuredObjectNavigationProcessor,
+      joinStringsProcessor = $joinStringsProcessor
    );
 }
 
@@ -248,7 +268,7 @@ function meta::relational::functions::sqlQueryToString::processOperation(relatio
                                           w:WindowColumn[1]|$dbConfig.windowColumnProcessor($w, $sgc),
                                           s:ViewSelectSQLQuery[1]|'('+$s.selectSQLQuery->processOperation($dbConfig, $format, $generationState, $config, $extensions)+')',
                                           t:Table[1]|$t->tableToString($dbConfig),
-                                          js:JoinStrings[1] | processJoinStringsOperation($js, $dbConfig, $format, $generationState, $extensions),
+                                          js:JoinStrings[1] | $dbConfig.joinStringsProcessor($js, ^$sgc(config=^Config())),
                                           alias:Alias[1]|
                                                 let innerTerm = $alias.relationalElement->match([
                                                    r : VarSetPlaceHolder[1]|$r->processOperation($dbConfig, $format, $generationState, $config, $extensions),
@@ -788,30 +808,52 @@ function meta::relational::functions::sqlQueryToString::convertDateToSqlString(d
 
 }
 
-function <<access.private>> meta::relational::functions::sqlQueryToString::processJoinStringsOperation(js:JoinStrings[1], dbConfig : DbConfig[1], format:Format[1], generationState:GenerationState[1], extensions:RouterExtension[*]):String[1]
+function <<access.private>> meta::relational::functions::sqlQueryToString::processJoinStringsOperation(js:JoinStrings[1], sgc:SqlGenerationContext[1],
+         groupByCat:meta::pure::metamodel::function::Function<{String[1], String[1] -> String[1]}>[0..1], stringCat:meta::pure::metamodel::function::Function<{String[*], String[1] -> String[1]}>[0..1]):String[1]
 {
-    let strings = $js.strings->map(s | $s->processOperation($dbConfig, $format, $generationState, $extensions));
+    let strings = $js.strings->map(s | $s->processOperation($sgc));
     let isGroupByCat = $js.strings->size() == 1;
 
-    let separator = if($js.separator->isEmpty(), |'\'\'', |$js.separator->toOne()->processOperation($dbConfig, $format, $generationState, $extensions));
-    let prefix = if($js.prefix->isEmpty(), |'\'\'', |$js.prefix->toOne()->processOperation($dbConfig, $format, $generationState, $extensions));
-    let suffix = if($js.suffix->isEmpty(), |'\'\'', |$js.suffix->toOne()->processOperation($dbConfig, $format, $generationState, $extensions));
+    let separator = if($js.separator->isEmpty(), |'\'\'', |$js.separator->toOne()->processOperation($sgc));
+    let prefix = if($js.prefix->isEmpty(), |'\'\'', |$js.prefix->toOne()->processOperation($sgc));
+    let suffix = if($js.suffix->isEmpty(), |'\'\'', |$js.suffix->toOne()->processOperation($sgc));
     let strs = if(eq($prefix, '\'\''),
                   | if(eq($suffix, '\'\''), | $strings, | $strings->add($suffix)),
                   | if(eq($suffix, '\'\''), | $strings->add(0, $prefix), | $strings->add(0, $prefix)->add($suffix)));
-    if ($strs->size() == 0, | $strs->at(0), | if ($isGroupByCat, |groupByCat($strs, $dbConfig.dbType, $separator),|stringCat($strs, $dbConfig.dbType, $separator)));
+    if ($strs->size() == 0, | $strs->at(0), | if ($isGroupByCat, 
+        |assert($groupByCat->isNotEmpty(), 'The database type \''+$sgc.dbConfig.dbType->id()+'\' is not supported yet!'); $groupByCat->toOne()->eval($strs->at(0), $separator);,
+        |assert($stringCat->isNotEmpty(), 'The database type \''+$sgc.dbConfig.dbType->id()+'\' is not supported yet!'); $stringCat->toOne()->eval($strs, $separator);));
 }
 
-function meta::relational::functions::sqlQueryToString::functions::groupByCat(vals : String[*], dbType:DatabaseType[1],separator : String[1]):String[1]
+function <<access.private>> meta::relational::functions::sqlQueryToString::processJoinStringsOperationForH2(js:JoinStrings[1], sgc:SqlGenerationContext[1]): String[1]
 {
-   let h2Sep = if ($separator == '\'\'', | '', | ' separator '+ $separator);
-   if ($dbType == DatabaseType.H2,
-      |'group_concat('+$vals->at(0)+ $h2Sep+' )',
-      |if ($dbType == DatabaseType.SybaseIQ,
-         |'list('+$vals->at(0)+','+ $separator+' )',
-         | fail('The database type \''+$dbType->id()+'\' is not supported yet!');'';
-      )
-    );
+   processJoinStringsOperation($js, $sgc, {col, sep| 'group_concat(' + $col + if($sep == '\'\'', |'', |' separator ' + $sep) + ' )'},
+    {strs, sep| $strs->joinStrings('concat(', if('\'\'' == $sep, |', ', |',' + $sep + ',') , ')')});
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::processJoinStringsOperationForSybaseIQ(js:JoinStrings[1], sgc:SqlGenerationContext[1]): String[1]
+{
+   processJoinStringsOperation($js, $sgc, {col, sep| 'list(' + $col + ',' + $sep + ' )'}, {strs, sep| $strs->joinStrings(if('\'\'' == $sep, |'+', |'+' + $sep + '+'))});
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::processJoinStringsOperationForDB2(js:JoinStrings[1], sgc:SqlGenerationContext[1]): String[1]
+{
+   processJoinStringsOperation($js, $sgc, [], {strs, sep| $strs->joinStrings('(', if('\'\'' == $sep, |' concat ', |' concat ' + $sep + ' concat '), ')')});
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::processJoinStringsOperationForSqlServer(js:JoinStrings[1], sgc:SqlGenerationContext[1]): String[1]
+{
+   processJoinStringsOperation($js, $sgc, [], {strs, sep| $strs->joinStrings(if('\'\'' == $sep, |'+', |'+' + $sep + '+'))});
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::processJoinStringsOperationForPostgres(js:JoinStrings[1], sgc:SqlGenerationContext[1]): String[1]
+{
+   processJoinStringsOperation($js, $sgc, [], {strs, sep| $strs->joinStrings('concat(', if('Text\'\'' == $sep, |', ', |',' + $sep + ',') , ')')});
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::processJoinStringsOperationWithConcatCall(js:JoinStrings[1], sgc:SqlGenerationContext[1]): String[1]
+{
+   processJoinStringsOperation($js, $sgc, [], {strs, sep| $strs->joinStrings('concat(', if('\'\'' == $sep, |', ', |',' + $sep + ',') , ')')});
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::printColumns(s:RelationalOperationElement[*], dbConfig : DbConfig[1], format:Format[1], extensions:RouterExtension[*]):String[1]
@@ -882,21 +924,6 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::table
                         | $table.schema.name
                      );
    if($schemaName == 'default', | $table.name->processIdentifier($dbConfig), | $schemaName->processIdentifier($dbConfig) + '.' + $table.name->processIdentifier($dbConfig));
-}
-
-function meta::relational::functions::sqlQueryToString::functions::stringCat(vals : String[*], dbType:DatabaseType[1], separator : String[1]):String[1]
-{
-   let emptyStr = if ($dbType == DatabaseType.Postgres, | 'Text\'\'', | '\'\'');
-   if ($dbType->in([DatabaseType.H2, DatabaseType.Postgres, DatabaseType.MemSQL, DatabaseType.Presto, DatabaseType.BigQuery, DatabaseType.Redshift, DatabaseType.Snowflake, DatabaseType.Databricks]),
-      |$vals->joinStrings('concat(', if($emptyStr == $separator, |', ', | ',' + $separator + ',') , ')'),
-      |if($dbType == DatabaseType.DB2,
-          | $vals->joinStrings('(',if($emptyStr == $separator, |' concat ', | ' concat ' + $separator + ' concat '), ')'),
-          | if ($dbType == DatabaseType.SybaseIQ || $dbType == DatabaseType.SqlServer,
-               |$vals->joinStrings(if($emptyStr == $separator, |'+', | '+' + $separator + '+')),
-               | fail('The database type \''+$dbType->id()+'\' is not supported yet!');'';
-               )
-          )
-    );
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::removeQuotes(s:String[1]):String[1]


### PR DESCRIPTION
This is a continuation of previously merged PR, which introduced the db extension. In this review, I am moving processing of literals, window, etc into db extension instead of being based on adhoc if else blocks on db type.