### PR TITLE
Improve error message when enum value is not found on enum mapping

### DIFF
--- a/legend-pure-m2-dsl-mapping/src/main/resources/platform/pure/mapping.pure
+++ b/legend-pure-m2-dsl-mapping/src/main/resources/platform/pure/mapping.pure
@@ -147,7 +147,9 @@ Class meta::pure::mapping::EnumerationMapping<T> extends meta::pure::mapping::Va
 
     toSourceValues(domainValue: Any[1])
     {
-        $this.enumValueMappings->filter( m | $m.enum == $domainValue )->toOne().sourceValues;
+        let enumValueMapping = $this.enumValueMappings->filter( m | $m.enum == $domainValue );
+        assertEquals(1, $enumValueMapping->size(), 'The system can\'t find source values in the enumMapping \''+$this.name+'\' for the enum \''+$this.enumeration->enumName()+ '.' +$domainValue->toString()+'\'');
+        $enumValueMapping->toOne().sourceValues;
     }:Any[*];
 
 }


### PR DESCRIPTION
When an enum mapping does not contain all possible enums, users can get cryptic errors when calling ->toOne().  This change aims to provide the user with a more meaningful error message that should help them self-troubleshot.  