### PR TITLE
Export default literal values for pk cols in union dataflow

### DIFF
--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_union.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_union.pure
@@ -124,7 +124,9 @@ function meta::relational::functions::pureToSqlQuery::union::managePrimaryKeys(a
                       let newKeys = $setImpls->map(s|if($s == $setImpl,
                                                           |$key,
                                                           |if($state.importDataFlow==true,
-                                                              |$s.resolvePrimaryKey()->map(p|^Alias(name='"'+$p->cast(@TableAliasColumn).column.name+'_'+$setImpls->indexOf($s)->toString()+'"', relationalElement = $sqlNull)),
+                                                              |$s.resolvePrimaryKey()->map(p|
+                                                                let column = $p->cast(@TableAliasColumn).column;
+                                                                ^Alias(name='"'+$column.name+'_'+$setImpls->indexOf($s)->toString()+'"', relationalElement = $column.type->getDefaultLiteralValue());),
                                                               |range(0, $s.resolvePrimaryKey()->size(), 1)->map(p| ^Alias(name='"pk_'+$p->toString()+'_'+$setImpls->indexOf($s)->toString()+'"', relationalElement = $sqlNull))
                                                            )
 
@@ -132,6 +134,22 @@ function meta::relational::functions::pureToSqlQuery::union::managePrimaryKeys(a
                                                    );
                       ^$q(columns=$newKeys);
                    );
+}
+
+function <<access.private>> meta::relational::functions::pureToSqlQuery::union::getDefaultLiteralValue(type: meta::relational::metamodel::datatype::DataType[1]): Literal[1]
+{
+  let pureTypeToDefaultValueMap = [
+    pair(Integer, 0),
+    pair(Float, 0.0),
+    pair(Number, 0.0),
+    pair(String, ''),
+    pair(Date, %9999-01-01T00:00:00),
+    pair(DateTime, %9999-01-01T00:00:00),
+    pair(StrictDate, %9999-01-01),
+    pair(Boolean, false)
+  ]->newMap();
+  let value = $pureTypeToDefaultValueMap->get($type->meta::relational::metamodel::datatype::dataTypeToCompatiblePureType())->toOne();
+  ^Literal(value=$value);
 }
 
 function meta::relational::functions::pureToSqlQuery::union::buildUnion(setImpls:RootRelationalInstanceSetImplementation[*], relationalPropertyMappings:RelationalPropertyMapping[*], inAsso:Boolean[1], inProject:Boolean[1], milestoningContext: TemporalMilestoningContext[0..1], nodeId:String[1], state:State[1], context:DebugContext[1], extensions:RouterExtension[*]):Union[1]

--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_union.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery_union.pure
@@ -126,7 +126,8 @@ function meta::relational::functions::pureToSqlQuery::union::managePrimaryKeys(a
                                                           |if($state.importDataFlow==true,
                                                               |$s.resolvePrimaryKey()->map(p|
                                                                 let column = $p->cast(@TableAliasColumn).column;
-                                                                ^Alias(name='"'+$column.name+'_'+$setImpls->indexOf($s)->toString()+'"', relationalElement = $column.type->getDefaultLiteralValue());),
+                                                                let relationalElement = if($state.importDataFlowImplementationCount->isEmpty(), |$column.type->getDefaultLiteralValue(), |$sqlNull);
+                                                                ^Alias(name='"'+$column.name+'_'+$setImpls->indexOf($s)->toString()+'"', relationalElement = $relationalElement);),
                                                               |range(0, $s.resolvePrimaryKey()->size(), 1)->map(p| ^Alias(name='"pk_'+$p->toString()+'_'+$setImpls->indexOf($s)->toString()+'"', relationalElement = $sqlNull))
                                                            )
 

--- a/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/tests/mapping/union/testUnion.pure
+++ b/legend-pure-code-compiled-core-relational/src/main/resources/core_relational/relational/tests/mapping/union/testUnion.pure
@@ -346,6 +346,14 @@ function <<test.Test>> meta::relational::tests::mapping::union::testChainedUnion
    assertSameElements(['New York', 'New York', 'New York', 'New York', 'New York', 'New York', 'Hoboken', 'Hoboken'], $result1.rows->map(r|$r.getString('address_name')));
 }
 
+function <<test.Test>> meta::relational::tests::mapping::union::testPksWithImportDataFlow():Boolean[1]
+{
+   let execCtx = ^RelationalExecutionContext(importDataFlow=true, importDataFlowAddFks=true);
+   let result = execute(|Person.all()->project([p|$p.lastName], ['name']), unionMapping, testRuntime(), $execCtx, meta::pure::router::extension::defaultRelationalExtensions()).values->at(0);
+   assertSameElements(['Anand, 2, 0', 'Roberts, 3, 0', 'Scott, 1, 0', 'Taylor, 0, 1', 'Wright, 0, 2'],
+    $result.rows->map(r|$r.getString('name') + ', ' + $r.getInteger('ID_0')->toString() + ', ' + $r.getInteger('ID_1')->toString()));
+}
+
 function meta::relational::tests::mapping::union::executeInDb2(sql:String[1], databaseConnection:DatabaseConnection[1]):ResultSet[1]
 {
     meta::relational::metamodel::execute::executeInDb($sql, $databaseConnection, 0, 1000);


### PR DESCRIPTION
It was reverted earlier. This time with a small fix, TC is green.