### PR TITLE
Add java conventions for pow and decimal divide functions

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/java/metamodel_factories.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/java/metamodel_factories.pure
@@ -26,6 +26,7 @@ function meta::external::language::java::factory::javaRuntimeException():       
 function meta::external::language::java::factory::javaUnsupportedOperationException(): meta::external::language::java::metamodel::Class[1] { javaClass('java.lang.UnsupportedOperationException'); }
 function meta::external::language::java::factory::javaCharSequence():                  meta::external::language::java::metamodel::Class[1] { javaClass('java.lang.CharSequence'); }
 function meta::external::language::java::factory::javaMath():                          meta::external::language::java::metamodel::Class[1] { javaClass('java.lang.Math'); }
+function meta::external::language::java::factory::javaStrictMath():                    meta::external::language::java::metamodel::Class[1] { javaClass('java.lang.StrictMath'); }
 function meta::external::language::java::factory::javaSystem():                        meta::external::language::java::metamodel::Class[1] { javaClass('java.lang.System'); }
 function meta::external::language::java::factory::javaStringBuilder():                 meta::external::language::java::metamodel::Class[1] { javaClass('java.lang.StringBuilder'); }
 function meta::external::language::java::factory::javaAppendable():                    meta::external::language::java::metamodel::Class[1] { javaClass('java.lang.Appendable'); }
@@ -36,7 +37,7 @@ function meta::external::language::java::factory::javaReflectMethod():         m
 function meta::external::language::java::factory::javaInvocationTargetException():         meta::external::language::java::metamodel::Class[1] { javaClass('java.lang.reflect.InvocationTargetException'); }
 
 function meta::external::language::java::factory::javaMathContext():           meta::external::language::java::metamodel::Class[1] { javaClass('java.math.MathContext'); }
-function meta::external::language::java::factory::javaRoundingMode():          meta::external::language::java::metamodel::Class[1] { javaClass('java.math.RoundingMode'); }
+function meta::external::language::java::factory::javaRoundingMode():          meta::external::language::java::metamodel::Class[1] { javaEnum([], 'java.math.RoundingMode'); }
 
 function meta::external::language::java::factory::javaIOException():           meta::external::language::java::metamodel::Class[1] { javaClass('java.io.IOException'); }
 function meta::external::language::java::factory::javaBufferedInputStream():   meta::external::language::java::metamodel::Class[1] { javaClass('java.io.BufferedInputStream'); }

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/mathLibrary.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/mathLibrary.pure
@@ -47,6 +47,7 @@ function meta::pure::executionPlan::engine::java::registerMathsLibrary(conventio
          fc1(times_Decimal_MANY__Decimal_1_,                           {ctx,collection | maybeReduce($ctx, $collection, bigDecimalOne(), $library->j_methodReference('decimalMultiply', reduceFT(javaBigDecimal())))}),
              
          fc2(divide_Number_1__Number_1__Float_1_,                      {ctx,num1,num2  | $library->j_invoke('divide', [$num1, $num2], javaDouble())}),
+         fc3(divide_Decimal_1__Decimal_1__Integer_1__Decimal_1_,       {ctx,num1,num2,num3 | $num1->j_invoke('divide', [$num2, $num3->j_box()->j_invoke('intValue', []), javaRoundingMode()->j_field('HALF_UP')], javaBigDecimal())}),         
          fc2(rem_Number_1__Number_1__Number_1_,                        {ctx,num1,num2  | $library->j_invoke('rem', [$num1, $num2], javaNumber())}),
          fc1(average_Number_MANY__Float_1_,                            {ctx,collection | $library->j_invoke('average', $collection, javaDouble())}),
          fc( average_Integer_MANY__Float_1_,                           fcAlias(          average_Number_MANY__Float_1_)),
@@ -97,7 +98,8 @@ function meta::pure::executionPlan::engine::java::registerMathsLibrary(conventio
          fc (min_Float_$1_MANY$__Float_1_,                             fcAlias(          min_Float_MANY__Float_$0_1$_)),
 
          fc1(cos_Number_1__Float_1_,                                   {ctx,num        | javaMath()->j_invoke('cos', $num->j_box()->j_invoke('doubleValue', []), javaDouble())}),
-         fc1(sin_Number_1__Float_1_,                                   {ctx,num        | javaMath()->j_invoke('sin', $num->j_box()->j_invoke('doubleValue', []), javaDouble())})
+         fc1(sin_Number_1__Float_1_,                                   {ctx,num        | javaMath()->j_invoke('sin', $num->j_box()->j_invoke('doubleValue', []), javaDouble())}),
+         fc2(pow_Number_1__Number_1__Number_1_,                        {ctx,num1,num2  | javaStrictMath()->j_invoke('pow', [$num1->j_box()->j_invoke('doubleValue', []), $num2->j_box()->j_invoke('doubleValue', [])], javaDouble())})         
       ]);
 
    $conventions->registerLibrary($lib);

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/test/langLibraryTests.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/test/langLibraryTests.pure
@@ -181,17 +181,10 @@ function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly
 meta::pure::executionPlan::engine::java::tests::testLet() : Boolean[1]
 {
    let expectedForLambda = 
-      'java.util.Arrays.asList("a", "aa", "aaa").stream().map((String s) -> {\n'+
-      '    long l = (long) s.length();\n'+
-      '    return java.util.Arrays.asList(s, org.finos.legend.engine.plan.dependencies.util.Library.pureToString(l)).stream().collect(java.util.stream.Collectors.joining(""));\n'+
-      '}).filter((String x) -> x != null).collect(java.util.stream.Collectors.toList())';
+      'java.util.Arrays.asList("a", "aa", "aaa").stream().map((String s) -> { long l = (long) s.length(); return java.util.Arrays.asList(s, org.finos.legend.engine.plan.dependencies.util.Library.pureToString(l)).stream().collect(java.util.stream.Collectors.joining("")); }).filter((String x) -> x != null).collect(java.util.stream.Collectors.toList())';
 
    let expectedForLambdaWithLastLineAsLet = 
-      'java.util.Arrays.asList("a", "aa", "aaa").stream().map((String s) -> {\n'+
-      '    long l = (long) s.length();\n'+
-      '    String x = java.util.Arrays.asList(s, org.finos.legend.engine.plan.dependencies.util.Library.pureToString(l)).stream().collect(java.util.stream.Collectors.joining(""));\n'+
-      '    return x;\n'+
-      '}).filter((String x) -> x != null).collect(java.util.stream.Collectors.toList())';
+      'java.util.Arrays.asList("a", "aa", "aaa").stream().map((String s) -> { long l = (long) s.length(); String x = java.util.Arrays.asList(s, org.finos.legend.engine.plan.dependencies.util.Library.pureToString(l)).stream().collect(java.util.stream.Collectors.joining("")); return x; }).filter((String x) -> x != null).collect(java.util.stream.Collectors.toList())';
 
    javaExpressionTests(engineConventions([]))
       ->addTest('let as expression', {|let x = 1;}, '1L', javaLong())
@@ -206,7 +199,7 @@ meta::pure::executionPlan::engine::java::tests::testLet() : Boolean[1]
          ->assert('%s.contains("aa2")')
          ->assert('%s.contains("aaa3")')
          ->assert('%s.size() == 3')
-      ->addTest('let in functions', {|['a', 'aa', 'aaa']->oddLengths()}, '_pure.functions.Functions__meta_java_generation_tests_functions_lang.oddLengths_String_MANY__String_MANY_(java.util.Arrays.asList("a", "aa", "aaa"))', javaList(javaString()))
+      ->addTest('let in functions', {|['a', 'aa', 'aaa']->oddLengths()}, '_pure.functions.Functions__meta_pure_executionPlan_engine_java_tests.oddLengths_String_MANY__String_MANY_(java.util.Arrays.asList("a", "aa", "aaa"))', javaList(javaString()))
          ->assert('%s.contains("a1")')
          ->assert('%s.contains("aaa3")')
          ->assert('%s.size() == 2')         

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/test/mathLibraryTests.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/test/mathLibraryTests.pure
@@ -62,6 +62,8 @@ meta::pure::executionPlan::engine::java::tests::testBasicOperators() : Boolean[1
          ->assert('(%s).equals(new java.math.BigDecimal("13.1"))')
       ->addTest('Decimal n\'ary plus', {|[6.9D, 2.6D, 5.8D]->plus()}, 'java.util.Arrays.asList(new java.math.BigDecimal("6.9"), new java.math.BigDecimal("2.6"), new java.math.BigDecimal("5.8")).stream().reduce(java.math.BigDecimal.ZERO, org.finos.legend.engine.plan.dependencies.util.Library::decimalPlus)', javaBigDecimal())
          ->assert('(%s).equals(new java.math.BigDecimal("15.3"))')
+      ->addTest('Decimal Divide', {|10.10D->divide(2.1D, 1)}, 'new java.math.BigDecimal("10.10").divide(new java.math.BigDecimal("2.1"), new Long(1L).intValue(), java.math.RoundingMode.HALF_UP)', javaBigDecimal())
+         ->assert('(%s).equals(new java.math.BigDecimal("4.8"))')
       //Integer
       ->addTest('Integer Unary minus', {|-5}, '-5L', javaLong())
          ->assert('(%s) == -5L')
@@ -95,6 +97,19 @@ meta::pure::executionPlan::engine::java::tests::testBasicOperators() : Boolean[1
       // go
       ->runTests();
 }
+
+function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
+{  meta::pure::executionPlan::profiles::serverVersion.start='v1_11_0' }
+meta::pure::executionPlan::engine::java::tests::testPow() : Boolean[1]
+{
+   javaExpressionTests(engineConventions([]))
+      ->addTest('Number Pow (double numbers)', {|pow(5.0, 2.0)}, '(Number) new Double(StrictMath.pow(new Double(5.0).doubleValue(), new Double(2.0).doubleValue()))', javaNumber())
+         ->assert('(%s).doubleValue() == 25.0')
+      ->addTest('Number Pow (integer numbers)', {|pow(4, 3)}, '(Number) new Double(StrictMath.pow(new Long(4L).doubleValue(), new Long(3L).doubleValue()))', javaNumber())
+         ->assert('(%s).doubleValue() == 64.0')
+      ->runTests();
+}
+
 
 function <<meta::pure::profiles::test.Test, meta::pure::profiles::test.AlloyOnly>>
 {  meta::pure::executionPlan::profiles::serverVersion.start='v1_11_0' }

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/test/testUtils.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/executionPlan/javaPlatform/planConventions/test/testUtils.pure
@@ -120,13 +120,15 @@ function meta::pure::executionPlan::engine::java::tests::runTests(tests:JavaExpr
    let allAssertions = $tests->map(
       {test|
          let java = $test.lambda->cast(@FunctionDefinition<{->Any[*]}>)->evaluateAndDeactivate().expressionSequence->toOne()->cast(@ValueSpecification)->generateJava($test.conventions, $debug);
-         assertEquals($test.codeAssertion->codeToString(), $java->codeToString(), |$test.name+' code is incorrect\nexpected: '+$test.codeAssertion->codeToString()+'\nactual  : '+$java->codeToString()+'\n');   
+         let expectedCode = $test.codeAssertion->codeToString();
+         let actualCode = $java->codeToString()->split('\n')->map(x | $x->trim())->joinStrings(' ')->replace(' .', '.');
+         assertEquals($expectedCode, $actualCode, |$test.name+' code is incorrect\nexpected: '+$expectedCode+'\nactual  : '+$actualCode+'\n');   
          assertEquals($test.codeAssertion.type, $java.type, |$test.name+' expected type of \''+$test.codeAssertion.type->typeToString()+'\' but got \''+$java.type->typeToString()+'\'');   
          assert($test.assertionPatterns->isNotEmpty(), 'You must make some assertions');
         
          let assertions = $test.assertionPatterns->map(
             {a |
-               let assert = $a->format($java->codeToString());
+               let assert = $a->format($actualCode);
                let pass = j_string('PASS '+$test.name+': '+$assert+'\n');
                let fail = j_string('FAIL '+$test.name+': '+$assert+'\n');
 


### PR DESCRIPTION
This also cleans up "alloy only" test cases, which are not been executed on legend-engine in preparation to enable them.

Blocks: https://github.com/finos/legend-engine/pull/661