### PR TITLE
Fix issues with sorting repositories by visibility

### DIFF
--- a/legend-pure-m2-dsl-mapping/src/test/java/org/finos/legend/pure/m2/ds/mapping/test/AbstractPureMappingTestWithCoreCompiled.java
+++ b/legend-pure-m2-dsl-mapping/src/test/java/org/finos/legend/pure/m2/ds/mapping/test/AbstractPureMappingTestWithCoreCompiled.java
@@ -14,14 +14,13 @@
 
 package org.finos.legend.pure.m2.ds.mapping.test;
 
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.ReferenceUsage;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
-import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.api.block.predicate.Predicate;
-import org.eclipse.collections.impl.factory.Lists;
 import org.junit.Assert;
 
 public class AbstractPureMappingTestWithCoreCompiled extends AbstractPureTestWithCoreCompiled
@@ -29,21 +28,13 @@ public class AbstractPureMappingTestWithCoreCompiled extends AbstractPureTestWit
     protected void assertSetSourceInformation(String source, String classPath)
     {
         String className = Lists.immutable.of(classPath.split("::")).getLast();
-        PackageableElement packageableElement = (PackageableElement)this.runtime.getCoreInstance(classPath);
-        RichIterable<? extends ReferenceUsage> typeViewReferenceUsages = packageableElement._referenceUsages().select(new Predicate<ReferenceUsage>()
-        {
-            @Override
-            public boolean accept(ReferenceUsage usage)
-            {
-                return usage._owner() instanceof SetImplementation;
-            }
-        });
-        String[] lines = source.split("\n");
-        for (ReferenceUsage referenceUsage : typeViewReferenceUsages)
+        PackageableElement packageableElement = (PackageableElement) runtime.getCoreInstance(classPath);
+        RichIterable<? extends ReferenceUsage> typeViewReferenceUsages = packageableElement._referenceUsages().select(usage -> usage._owner() instanceof SetImplementation);
+        String[] lines = source.split("\\R");
+        typeViewReferenceUsages.forEach(referenceUsage ->
         {
             SourceInformation sourceInformation = referenceUsage._ownerCoreInstance().getSourceInformation();
-            Assert.assertEquals(className, lines[sourceInformation.getLine()-1].substring(sourceInformation.getColumn() -1, sourceInformation.getColumn() + className.length() - 1));
-        }
-
+            Assert.assertEquals(className, lines[sourceInformation.getLine() - 1].substring(sourceInformation.getColumn() - 1, sourceInformation.getColumn() + className.length() - 1));
+        });
     }
 }

--- a/legend-pure-m2-dsl-mapping/src/test/java/org/finos/legend/pure/m2/ds/mapping/test/TestVisibility.java
+++ b/legend-pure-m2-dsl-mapping/src/test/java/org/finos/legend/pure/m2/ds/mapping/test/TestVisibility.java
@@ -15,8 +15,8 @@
 package org.finos.legend.pure.m2.ds.mapping.test;
 
 import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Sets;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Sets;
 import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.TestCodeRepositoryWithDependencies;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
@@ -31,8 +31,9 @@ import org.junit.Test;
 public class TestVisibility extends AbstractPureMappingTestWithCoreCompiled
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getCodeStorage(), getCodeRepositories(), null);
+    public static void setUp()
+    {
+        setUpRuntime(getCodeStorage());
     }
 
     @After
@@ -41,6 +42,9 @@ public class TestVisibility extends AbstractPureMappingTestWithCoreCompiled
         runtime.delete("/datamart_datamt/testFile.pure");
         runtime.delete("/datamart_datamt/testFile2.pure");
         runtime.delete("/system/testFile.pure");
+        runtime.delete("/system/testFile1.pure");
+        runtime.delete("/system/testFile2.pure");
+        runtime.compile();
     }
 
     protected static RichIterable<? extends CodeRepository> getCodeRepositories()
@@ -64,26 +68,19 @@ public class TestVisibility extends AbstractPureMappingTestWithCoreCompiled
         compileTestSource(
                 "/datamart_datamt/testFile2.pure",
                 "Class datamarts::datamt::domain::TestClass2 {}\n");
-        Assert.assertNotNull(this.runtime.getCoreInstance("datamarts::datamt::domain::TestClass2"));
+        Assert.assertNotNull(runtime.getCoreInstance("datamarts::datamt::domain::TestClass2"));
 
-        try
-        {
-            compileTestSource(
-                    "/system/testFile.pure",
-                    "function meta::pure::a():meta::pure::mapping::SetImplementation[*]{[]}\n" +
-                            "###Mapping\n" +
-                            "Mapping system::myMap(\n" +
-                            "   datamarts::datamt::domain::TestClass2[ppp]: Operation\n" +
-                            "           {\n" +
-                            "               meta::pure::a__SetImplementation_MANY_()\n" +
-                            "           }\n" +
-                            ")\n");
-            Assert.fail("Expected compilation error");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "datamarts::datamt::domain::TestClass2 is not visible in the file /system/testFile.pure", "/system/testFile.pure", 4, 31, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/system/testFile.pure",
+                "function meta::pure::a():meta::pure::mapping::SetImplementation[*]{[]}\n" +
+                        "###Mapping\n" +
+                        "Mapping system::myMap(\n" +
+                        "   datamarts::datamt::domain::TestClass2[ppp]: Operation\n" +
+                        "           {\n" +
+                        "               meta::pure::a__SetImplementation_MANY_()\n" +
+                        "           }\n" +
+                        ")\n"));
+        assertPureException(PureCompilationException.class, "datamarts::datamt::domain::TestClass2 is not visible in the file /system/testFile.pure", "/system/testFile.pure", 4, 31, e);
     }
 
     @Test
@@ -92,28 +89,20 @@ public class TestVisibility extends AbstractPureMappingTestWithCoreCompiled
         compileTestSource(
                 "/datamart_datamt/testFile.pure",
                 "Enum datamarts::datamt::domain::TestEnum1{ VAL }\n");
-        Assert.assertNotNull(this.runtime.getCoreInstance("datamarts::datamt::domain::TestEnum1"));
+        Assert.assertNotNull(runtime.getCoreInstance("datamarts::datamt::domain::TestEnum1"));
 
-        try
-        {
-
-            compileTestSource(
-                    "/system/testFile2.pure",
-                    "###Mapping\n" +
-                            "Mapping meta::pure::TestMapping1\n" +
-                            "(\n" +
-                            "\n" +
-                            "    datamarts::datamt::domain::TestEnum1: EnumerationMapping Foo\n" +
-                            "    {\n" +
-                            "        VAL:  'a'\n" +
-                            "    }\n" +
-                            ")\n");
-            Assert.fail("Expected compilation error");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "datamarts::datamt::domain::TestEnum1 is not visible in the file /system/testFile2.pure", "/system/testFile2.pure", 5, 32, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/system/testFile2.pure",
+                "###Mapping\n" +
+                        "Mapping meta::pure::TestMapping1\n" +
+                        "(\n" +
+                        "\n" +
+                        "    datamarts::datamt::domain::TestEnum1: EnumerationMapping Foo\n" +
+                        "    {\n" +
+                        "        VAL:  'a'\n" +
+                        "    }\n" +
+                        ")\n"));
+        assertPureException(PureCompilationException.class, "datamarts::datamt::domain::TestEnum1 is not visible in the file /system/testFile2.pure", "/system/testFile2.pure", 5, 32, e);
     }
 
     @Test
@@ -130,22 +119,14 @@ public class TestVisibility extends AbstractPureMappingTestWithCoreCompiled
                         "               datamarts::datamt::mapping::a__SetImplementation_MANY_()\n" +
                         "           }\n" +
                         ")\n");
-        Assert.assertNotNull(this.runtime.getCoreInstance("datamarts::datamt::domain::TestClass2"));
+        Assert.assertNotNull(runtime.getCoreInstance("datamarts::datamt::domain::TestClass2"));
 
-        try
-        {
-
-            compileTestSource(
-                    "/system/testFile1.pure",
-                    "###Mapping\n" +
-                            "Mapping system::myMap(\n" +
-                            "  include datamarts::datamt::mapping::myMap1\n" +
-                            ")\n");
-            Assert.fail("Expected compilation error");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "datamarts::datamt::mapping::myMap1 is not visible in the file /system/testFile1.pure", "/system/testFile1.pure", 2, 17, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/system/testFile1.pure",
+                "###Mapping\n" +
+                        "Mapping system::myMap(\n" +
+                        "  include datamarts::datamt::mapping::myMap1\n" +
+                        ")\n"));
+        assertPureException(PureCompilationException.class, "datamarts::datamt::mapping::myMap1 is not visible in the file /system/testFile1.pure", "/system/testFile1.pure", 2, 17, e);
     }
 }

--- a/legend-pure-m2-store-relational/pom.xml
+++ b/legend-pure-m2-store-relational/pom.xml
@@ -145,11 +145,6 @@
         </dependency>
 
         <dependency>
-            <groupId> org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4</artifactId>
         </dependency>

--- a/legend-pure-m2-store-relational/src/main/java/org/finos/legend/pure/m2/relational/serialization/grammar/v1/RelationalParser.java
+++ b/legend-pure-m2-store-relational/src/main/java/org/finos/legend/pure/m2/relational/serialization/grammar/v1/RelationalParser.java
@@ -17,14 +17,13 @@ package org.finos.legend.pure.m2.relational.serialization.grammar.v1;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.atn.PredictionMode;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.SetIterable;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Sets;
-import org.eclipse.collections.impl.list.mutable.FastList;
+import org.finos.legend.pure.m2.relational.serialization.grammar.v1.antlr.RelationalGraphBuilder;
 import org.finos.legend.pure.m2.relational.serialization.grammar.v1.navigation.EmbeddedRelationalInstanceSetImplementationNavigationHandler;
 import org.finos.legend.pure.m2.relational.serialization.grammar.v1.navigation.FilterMappingNavigationHandler;
 import org.finos.legend.pure.m2.relational.serialization.grammar.v1.navigation.JoinTreeNodeNavigationHandler;
@@ -32,7 +31,6 @@ import org.finos.legend.pure.m2.relational.serialization.grammar.v1.navigation.R
 import org.finos.legend.pure.m2.relational.serialization.grammar.v1.navigation.RelationalPropertyMappingNavigationHandler;
 import org.finos.legend.pure.m2.relational.serialization.grammar.v1.navigation.TableAliasColumnNavigationHandler;
 import org.finos.legend.pure.m2.relational.serialization.grammar.v1.navigation.TableAliasNavigationHandler;
-import org.finos.legend.pure.m2.relational.serialization.grammar.v1.antlr.RelationalGraphBuilder;
 import org.finos.legend.pure.m2.relational.serialization.grammar.v1.processor.DatabaseProcessor;
 import org.finos.legend.pure.m2.relational.serialization.grammar.v1.processor.RelationalAssociationImplementationProcessor;
 import org.finos.legend.pure.m2.relational.serialization.grammar.v1.processor.RelationalInstanceSetImplementationProcessor;
@@ -112,7 +110,7 @@ public class RelationalParser implements IRelationalParser
         {
             if (isAntlrRecognitionExceptionUsingFastParser(useFastParser, e))
             {
-                System.err.println("Error using fast Antlr Parser: " + ExceptionUtils.getStackTrace(e));
+//                System.err.println("Error using fast Antlr Parser: " + ExceptionUtils.getStackTrace(e));
                 return this.parseDefinition(false, code, sourceName, addLines, offset, repository, listener, context, count, importId);
             }
             else
@@ -141,7 +139,7 @@ public class RelationalParser implements IRelationalParser
         {
             if (isAntlrRecognitionExceptionUsingFastParser(useFastParser, e))
             {
-                System.err.println("Error using fast Antlr Parser: " + ExceptionUtils.getStackTrace(e));
+//                System.err.println("Error using fast Antlr Parser: " + ExceptionUtils.getStackTrace(e));
                 return this.parseMapping(false, content, id, extendsId, setSourceInfo, root, classPath, classSourceInfo, mappingPath, sourceName, offset, importId, repository, context);
             }
             else
@@ -178,7 +176,7 @@ public class RelationalParser implements IRelationalParser
         {
             if (isAntlrRecognitionExceptionUsingFastParser(useFastParser, e))
             {
-                System.err.println("Error using fast Antlr Parser: " + ExceptionUtils.getStackTrace(e));
+//                System.err.println("Error using fast Antlr Parser: " + ExceptionUtils.getStackTrace(e));
                 return this.parseMilestoningDefinition(false, type, content, sourceName, rowOffset, colOffset, importId);
             }
             else
@@ -191,31 +189,31 @@ public class RelationalParser implements IRelationalParser
     @Override
     public RichIterable<MatchRunner> getProcessors()
     {
-        return FastList.<MatchRunner>newListWith(new DatabaseProcessor(), new RelationalInstanceSetImplementationProcessor(), new RelationalAssociationImplementationProcessor());
+        return Lists.immutable.with(new DatabaseProcessor(), new RelationalInstanceSetImplementationProcessor(), new RelationalAssociationImplementationProcessor());
     }
 
     @Override
     public RichIterable<MatchRunner> getUnLoadWalkers()
     {
-        return Lists.immutable.<MatchRunner>with(new DatabaseUnloadWalker(), new TableAliasUnloadWalker(), new TableAliasColumnUnloadWalker(), new JoinTreeNodeUnloadWalker(), new FilterMappingUnloadWalker());
+        return Lists.immutable.with(new DatabaseUnloadWalker(), new TableAliasUnloadWalker(), new TableAliasColumnUnloadWalker(), new JoinTreeNodeUnloadWalker(), new FilterMappingUnloadWalker());
     }
 
     @Override
     public RichIterable<MatchRunner> getUnLoadUnbinders()
     {
-        return Lists.immutable.<MatchRunner>with(new DatabaseUnloadUnbind(), new RelationalInstanceSetImplementationUnloadUnbind(), new RelationalAssociationImplementationUnbind());
+        return Lists.immutable.with(new DatabaseUnloadUnbind(), new RelationalInstanceSetImplementationUnloadUnbind(), new RelationalAssociationImplementationUnbind());
     }
 
     @Override
     public RichIterable<MatchRunner> getValidators()
     {
-        return Lists.immutable.<MatchRunner>with(new RelationalInstanceSetImplementationValidator(), new RelationalAssociationImplementationValidator());
+        return Lists.immutable.with(new RelationalInstanceSetImplementationValidator(), new RelationalAssociationImplementationValidator());
     }
 
     @Override
     public RichIterable<NavigationHandler> getNavigationHandlers()
     {
-        return Lists.immutable.<NavigationHandler>with(new TableAliasNavigationHandler(), new JoinTreeNodeNavigationHandler(), new TableAliasColumnNavigationHandler(), new FilterMappingNavigationHandler(), new RelationalAssociationImplementationNavigationHandler(), new RelationalPropertyMappingNavigationHandler(), new EmbeddedRelationalInstanceSetImplementationNavigationHandler());
+        return Lists.immutable.with(new TableAliasNavigationHandler(), new JoinTreeNodeNavigationHandler(), new TableAliasColumnNavigationHandler(), new FilterMappingNavigationHandler(), new RelationalAssociationImplementationNavigationHandler(), new RelationalPropertyMappingNavigationHandler(), new EmbeddedRelationalInstanceSetImplementationNavigationHandler());
     }
 
     @Override

--- a/legend-pure-m2-store-relational/src/test/java/org/finos/legend/pure/m2/relational/AbstractPureRelationalTestWithCoreCompiled.java
+++ b/legend-pure-m2-store-relational/src/test/java/org/finos/legend/pure/m2/relational/AbstractPureRelationalTestWithCoreCompiled.java
@@ -15,6 +15,7 @@
 package org.finos.legend.pure.m2.relational;
 
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
+import org.junit.After;
 import org.junit.Before;
 
 public class AbstractPureRelationalTestWithCoreCompiled extends AbstractPureTestWithCoreCompiled
@@ -23,5 +24,11 @@ public class AbstractPureRelationalTestWithCoreCompiled extends AbstractPureTest
     public void _setUp()
     {
         setUpRuntime();
+    }
+
+    @After
+    public void _tearDown()
+    {
+        tearDownRuntime();
     }
 }

--- a/legend-pure-m2-store-relational/src/test/java/org/finos/legend/pure/m2/relational/TestEmbeddedGrammar.java
+++ b/legend-pure-m2-store-relational/src/test/java/org/finos/legend/pure/m2/relational/TestEmbeddedGrammar.java
@@ -15,22 +15,27 @@
 package org.finos.legend.pure.m2.relational;
 
 
-import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
 import org.finos.legend.pure.m2.dsl.mapping.M2MappingProperties;
 import org.finos.legend.pure.m2.dsl.mapping.serialization.grammar.v1.MappingParser;
 import org.finos.legend.pure.m2.dsl.mapping.serialization.grammar.v1.OperationParser;
 import org.finos.legend.pure.m2.relational.serialization.grammar.v1.RelationalParser;
 import org.finos.legend.pure.m3.CompiledStateIntegrityTestTools;
-import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.compiler.validation.ValidationType;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.serialization.Loader;
+import org.finos.legend.pure.m3.serialization.Loader.LoaderException;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
 import org.finos.legend.pure.m3.serialization.grammar.ParserLibrary;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3AntlrParser;
 import org.finos.legend.pure.m3.statelistener.VoidM3M4StateListener;
-import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.m4.serialization.grammar.antlr.PureParserException;
@@ -40,80 +45,27 @@ import org.junit.Test;
 
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompiled
 {
-
-    RelationalGraphWalker graphWalker;
+    private RelationalGraphWalker graphWalker;
 
     @Before
-    public void setUpRelational()
+    @Override
+    public void _setUp()
     {
-        this.graphWalker = new RelationalGraphWalker(this.runtime, this.processorSupport);
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
+        this.graphWalker = new RelationalGraphWalker(runtime, processorSupport);
     }
 
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return Lists.immutable.with(CodeRepository.newPlatformCodeRepository(), GenericCodeRepository.build("test", "((test)|(meta))(::.*)?", PlatformCodeRepository.NAME));
+    }
 
     @Test
     public void duplicatePropertyMappingInEmbeddedMappingCausesError()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "    employees:Person[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200)\n" +
-                            "   )\n" +
-                            "   Join firmJoin(employeeFirmDenormTable.firmId = {target}.firmId)\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Person: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm\n" +
-                            "        (\n" +
-                            "            legalName : [db]employeeFirmDenormTable.legalName,\n" +
-                            "            legalName : [db]employeeFirmDenormTable.legalName\n" +
-                            "        )\n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertOriginatingPureException("Duplicate mappings found for the property 'legalName(targetId:?)' in the embedded mapping for 'firm' in the mapping for class Person, the property should have one mapping.", 35, 13, e);
-        }
-    }
-
-    @Test
-    public void duplicateSetImplementationIdWithInEmbeddedMappingCausesError()
-    {
-        compileTestSource("/test/testModel.pure",
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
                 "import other::*;\n" +
                         "\n" +
                         "Class other::Person\n" +
@@ -125,9 +77,8 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
                         "{\n" +
                         "    legalName:String[1];\n" +
                         "    employees:Person[1];\n" +
-                        "}\n");
-        compileTestSource("/test/testStore.pure",
-                "###Relational\n" +
+                        "}\n" +
+                        "###Relational\n" +
                         "Database mapping::db(\n" +
                         "   Table employeeFirmDenormTable\n" +
                         "   (\n" +
@@ -137,51 +88,91 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
                         "    legalName VARCHAR(200)\n" +
                         "   )\n" +
                         "   Join firmJoin(employeeFirmDenormTable.firmId = {target}.firmId)\n" +
-                        ")\n");
-        try
-        {
-            compileTestSource("/test/testMapping.pure",
-                    "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Person[k]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm[k]\n" +
-                            "        (\n" +
-                            "            legalName : [db]employeeFirmDenormTable.legalName\n" +
-                            "        )\n" +
-                            "    }\n" +
-                            ")\n");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Duplicate mapping found with id: 'k' in mapping mappingPackage::myMapping", "/test/testMapping.pure", 6, 5, e);
-        }
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Person: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm\n" +
+                        "        (\n" +
+                        "            legalName : [db]employeeFirmDenormTable.legalName,\n" +
+                        "            legalName : [db]employeeFirmDenormTable.legalName\n" +
+                        "        )\n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertOriginatingPureException("Duplicate mappings found for the property 'legalName' (targetId: ?) in the embedded mapping for 'firm' in the mapping for class Person, the property should have one mapping.", 35, 13, e);
     }
 
     @Test
-    public void duplicateSetImplementationIdBetweenEmbeddedMappingsCausesError()
+    public void duplicateSetImplementationIdWithInEmbeddedMappingCausesError()
     {
         compileTestSource("/test/testModel.pure",
-                "import other::*;\n" +
+                "import test::other::*;\n" +
                         "\n" +
-                        "Class other::Person\n" +
+                        "Class test::other::Person\n" +
                         "{\n" +
                         "    name:String[1];\n" +
                         "    firm:Firm[1];\n" +
                         "}\n" +
-                        "Class other::Firm\n" +
+                        "Class test::other::Firm\n" +
                         "{\n" +
                         "    legalName:String[1];\n" +
                         "    employees:Person[1];\n" +
                         "}\n");
         compileTestSource("/test/testStore.pure",
                 "###Relational\n" +
-                        "Database mapping::db(\n" +
+                        "Database test::mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200)\n" +
+                        "   )\n" +
+                        "   Join firmJoin(employeeFirmDenormTable.firmId = {target}.firmId)\n" +
+                        ")\n");
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/test/testMapping.pure",
+                "###Mapping\n" +
+                        "import test::other::*;\n" +
+                        "import test::mapping::*;\n" +
+                        "Mapping test::mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Person[k]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm[k]\n" +
+                        "        (\n" +
+                        "            legalName : [db]employeeFirmDenormTable.legalName\n" +
+                        "        )\n" +
+                        "    }\n" +
+                        ")\n"));
+        assertPureException(PureCompilationException.class, "Duplicate mapping found with id: 'k' in mapping test::mappingPackage::myMapping", "/test/testMapping.pure", 6, 5, e);
+    }
+
+    @Test
+    public void duplicateSetImplementationIdBetweenEmbeddedMappingsCausesError()
+    {
+        compileTestSource("/test/testModel.pure",
+                "import test::other::*;\n" +
+                        "\n" +
+                        "Class test::other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class test::other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "    employees:Person[1];\n" +
+                        "}\n");
+        compileTestSource("/test/testStore.pure",
+                "###Relational\n" +
+                        "Database test::mapping::db(\n" +
                         "   Table employeeFirmDenormTable\n" +
                         "   (\n" +
                         "    id INT PRIMARY KEY,\n" +
@@ -197,37 +188,31 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
                         "    name VARCHAR(200)\n" +
                         "   )\n" +
                         ")\n");
-        try
-        {
-            compileTestSource("/test/testMapping.pure",
-                    "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Person: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm[k]\n" +
-                            "        (\n" +
-                            "            legalName : [db]employeeFirmDenormTable.legalName\n" +
-                            "        )\n" +
-                            "    }\n" +
-                            "    Firm: Relational\n" +
-                            "    {\n" +
-                            "        legalName : [db]firmEmployeeDenormTable.legalName,\n" +
-                            "        employees[k]\n" +
-                            "        (\n" +
-                            "            name : [db]firmEmployeeDenormTable.name\n" +
-                            "        )\n" +
-                            "    }\n" +
-                            ")\n");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Duplicate mapping found with id: 'k' in mapping mappingPackage::myMapping", "/test/testMapping.pure", 17, 9, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/test/testMapping.pure",
+                "###Mapping\n" +
+                        "import test::other::*;\n" +
+                        "import test::mapping::*;\n" +
+                        "Mapping test::mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Person: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm[k]\n" +
+                        "        (\n" +
+                        "            legalName : [db]employeeFirmDenormTable.legalName\n" +
+                        "        )\n" +
+                        "    }\n" +
+                        "    Firm: Relational\n" +
+                        "    {\n" +
+                        "        legalName : [db]firmEmployeeDenormTable.legalName,\n" +
+                        "        employees[k]\n" +
+                        "        (\n" +
+                        "            name : [db]firmEmployeeDenormTable.name\n" +
+                        "        )\n" +
+                        "    }\n" +
+                        ")\n"));
+        assertPureException(PureCompilationException.class, "Duplicate mapping found with id: 'k' in mapping test::mappingPackage::myMapping", "/test/testMapping.pure", 17, 9, e);
     }
 
     @Test
@@ -279,8 +264,8 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
                         "            legalName : [db]employeeFirmDenormTable.legalName\n" +
                         "        )\n" +
                         "    }\n" +
-                        ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-        this.runtime.compile();
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context);
+        runtime.compile();
     }
 
     @Test
@@ -338,59 +323,57 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
                         "            line1: [db]employeeFirmDenormTable.address\n" +
                         "        )\n" +
                         "    }\n" +
-                        ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-        this.runtime.compile();
-
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context);
+        runtime.compile();
 
         CoreInstance mapping = this.graphWalker.getMapping("mappingPackage::myMapping");
-        assertNotNull(mapping);
-        assertEquals(4, this.graphWalker.getClassMappings(mapping).size());
+        Assert.assertNotNull(mapping);
+        Assert.assertEquals(4, this.graphWalker.getClassMappings(mapping).size());
         CoreInstance personMapping = this.graphWalker.getClassMapping(mapping, "Person");
-        assertNotNull(personMapping);
+        Assert.assertNotNull(personMapping);
 
-        assertEquals("employeeFirmDenormTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(personMapping)));
-        assertEquals(3, this.graphWalker.getClassMappingImplementationPropertyMappings(personMapping).size());
+        Assert.assertEquals("employeeFirmDenormTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(personMapping)));
+        Assert.assertEquals(3, this.graphWalker.getClassMappingImplementationPropertyMappings(personMapping).size());
 
         CoreInstance namePropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(personMapping, "name");
-        assertNotNull(namePropMapping);
+        Assert.assertNotNull(namePropMapping);
         CoreInstance firmPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(personMapping, "firm");
-        assertNotNull(firmPropMapping);
+        Assert.assertNotNull(firmPropMapping);
 
         CoreInstance firmProp = firmPropMapping.getValueForMetaPropertyToOne(M3Properties.property);
         ListIterable<? extends CoreInstance> refUsages = firmProp.getValueForMetaPropertyToMany(M3Properties.referenceUsages);
-        assertEquals(1, refUsages.size());
-        assertEquals(firmPropMapping, refUsages.getFirst().getValueForMetaPropertyToOne(M3Properties.owner));
+        Assert.assertEquals(1, refUsages.size());
+        Assert.assertEquals(firmPropMapping, refUsages.getFirst().getValueForMetaPropertyToOne(M3Properties.owner));
 
         CoreInstance owner = firmPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner);
-        assertEquals(personMapping, owner);
-        assertEquals(personMapping, firmPropMapping.getValueForMetaPropertyToOne(M3Properties.owner));
+        Assert.assertEquals(personMapping, owner);
+        Assert.assertEquals(personMapping, firmPropMapping.getValueForMetaPropertyToOne(M3Properties.owner));
 
         ListIterable<? extends CoreInstance> pks = firmPropMapping.getValueForMetaPropertyToMany(M2RelationalProperties.primaryKey);
         CoreInstance pk = pks.getFirst();
-        assertEquals(personMapping, pk.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner));
+        Assert.assertEquals(personMapping, pk.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner));
 
         CoreInstance legalNamePropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(firmPropMapping, "legalName");
         CoreInstance nameColumnAlias = this.graphWalker.getClassMappingImplementationPropertyMappingRelationalOperationElement(legalNamePropMapping);
-        assertEquals("employeeFirmDenormTable", this.graphWalker.getTableAliasColumnAliasName(nameColumnAlias));
-        assertEquals("legalName", this.graphWalker.getTableAliasColumnColumnName(nameColumnAlias));
+        Assert.assertEquals("employeeFirmDenormTable", this.graphWalker.getTableAliasColumnAliasName(nameColumnAlias));
+        Assert.assertEquals("legalName", this.graphWalker.getTableAliasColumnColumnName(nameColumnAlias));
 
         CoreInstance firmAddressPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(firmPropMapping, "address");
-        assertEquals("other_Person_firm_address", firmAddressPropMapping.getValueForMetaPropertyToOne(M3Properties.id).getName());
+        Assert.assertEquals("other_Person_firm_address", firmAddressPropMapping.getValueForMetaPropertyToOne(M3Properties.id).getName());
         CoreInstance ownerFirmAddress = firmAddressPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner);
-        assertEquals(personMapping, ownerFirmAddress);
-        assertEquals(firmPropMapping, firmAddressPropMapping.getValueForMetaPropertyToOne(M3Properties.owner));
+        Assert.assertEquals(personMapping, ownerFirmAddress);
+        Assert.assertEquals(firmPropMapping, firmAddressPropMapping.getValueForMetaPropertyToOne(M3Properties.owner));
 
         CoreInstance addressLine1PropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(firmAddressPropMapping, "line1");
         CoreInstance addressLine1ColumnAlias = this.graphWalker.getClassMappingImplementationPropertyMappingRelationalOperationElement(addressLine1PropMapping);
-        assertEquals("employeeFirmDenormTable", this.graphWalker.getTableAliasColumnAliasName(addressLine1ColumnAlias));
-        assertEquals("address", this.graphWalker.getTableAliasColumnColumnName(addressLine1ColumnAlias));
+        Assert.assertEquals("employeeFirmDenormTable", this.graphWalker.getTableAliasColumnAliasName(addressLine1ColumnAlias));
+        Assert.assertEquals("address", this.graphWalker.getTableAliasColumnColumnName(addressLine1ColumnAlias));
 
         CoreInstance addressPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(personMapping, "address");
-        assertEquals("other_Person_address", addressPropMapping.getValueForMetaPropertyToOne(M3Properties.id).getName());
+        Assert.assertEquals("other_Person_address", addressPropMapping.getValueForMetaPropertyToOne(M3Properties.id).getName());
         CoreInstance ownerAddress = addressPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner);
-        assertEquals(personMapping, ownerAddress);
-        assertEquals(personMapping, addressPropMapping.getValueForMetaPropertyToOne(M3Properties.owner));
-
+        Assert.assertEquals(personMapping, ownerAddress);
+        Assert.assertEquals(personMapping, addressPropMapping.getValueForMetaPropertyToOne(M3Properties.owner));
     }
 
 
@@ -483,13 +466,12 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
                         "    {\n" +
                         "               meta::pure::router::operations::union_OperationSetImplementation_1__SetImplementation_MANY_( per1, per2 )   \n" +
                         "    }\n" +
-                        ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser(), new OperationParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-        this.runtime.compile();
-
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser(), new OperationParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context);
+        runtime.compile();
 
         CoreInstance mapping = this.graphWalker.getMapping("mappingPackage::myMapping");
-        assertNotNull(mapping);
-        assertEquals(9, this.graphWalker.getClassMappings(mapping).size());
+        Assert.assertNotNull(mapping);
+        Assert.assertEquals(9, this.graphWalker.getClassMappings(mapping).size());
         CoreInstance personMapping = this.graphWalker.getClassMappingById(mapping, "per1");
         validatePersonMapping(personMapping, "employeeFirmDenormTable");
 
@@ -499,57 +481,49 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
 
     private void validatePersonMapping(CoreInstance personMapping, String tableName)
     {
-        assertNotNull(personMapping);
+        Assert.assertNotNull(personMapping);
 
-        assertEquals(tableName, this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(personMapping)));
-        assertEquals(3, this.graphWalker.getClassMappingImplementationPropertyMappings(personMapping).size());
+        Assert.assertEquals(tableName, this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(personMapping)));
+        Assert.assertEquals(3, this.graphWalker.getClassMappingImplementationPropertyMappings(personMapping).size());
 
         CoreInstance namePropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(personMapping, "name");
-        assertNotNull(namePropMapping);
+        Assert.assertNotNull(namePropMapping);
         CoreInstance firmPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(personMapping, "firm");
-        assertNotNull(firmPropMapping);
+        Assert.assertNotNull(firmPropMapping);
 
         CoreInstance firmProp = firmPropMapping.getValueForMetaPropertyToOne(M3Properties.property);
         ListIterable<? extends CoreInstance> refUsages = firmProp.getValueForMetaPropertyToMany(M3Properties.referenceUsages);
-        assertEquals(2, refUsages.size());
-        Verify.assertContains(firmPropMapping, (Collection<?>)refUsages.collect(new Function<CoreInstance, CoreInstance>()
-        {
-            @Override
-            public CoreInstance valueOf(CoreInstance object)
-            {
-                return object.getValueForMetaPropertyToOne(M3Properties.owner);
-            }
-        }));
+        Assert.assertEquals(2, refUsages.size());
+        Verify.assertContains(firmPropMapping, (Collection<?>) refUsages.collect(object -> object.getValueForMetaPropertyToOne(M3Properties.owner)));
 
         CoreInstance owner = firmPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner);
-        assertEquals(personMapping, owner);
-        assertEquals(personMapping, firmPropMapping.getValueForMetaPropertyToOne(M3Properties.owner));
+        Assert.assertEquals(personMapping, owner);
+        Assert.assertEquals(personMapping, firmPropMapping.getValueForMetaPropertyToOne(M3Properties.owner));
 
         ListIterable<? extends CoreInstance> pks = firmPropMapping.getValueForMetaPropertyToMany(M2RelationalProperties.primaryKey);
         CoreInstance pk = pks.getFirst();
-        assertEquals(personMapping, pk.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner));
+        Assert.assertEquals(personMapping, pk.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner));
 
         CoreInstance legalNamePropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(firmPropMapping, "legalName");
         CoreInstance nameColumnAlias = this.graphWalker.getClassMappingImplementationPropertyMappingRelationalOperationElement(legalNamePropMapping);
-        assertEquals(tableName, this.graphWalker.getTableAliasColumnAliasName(nameColumnAlias));
-        assertEquals("legalName", this.graphWalker.getTableAliasColumnColumnName(nameColumnAlias));
+        Assert.assertEquals(tableName, this.graphWalker.getTableAliasColumnAliasName(nameColumnAlias));
+        Assert.assertEquals("legalName", this.graphWalker.getTableAliasColumnColumnName(nameColumnAlias));
 
         CoreInstance firmAddressPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(firmPropMapping, "address");
         CoreInstance ownerFirmAddress = firmAddressPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner);
-        assertEquals(personMapping, ownerFirmAddress);
-        assertEquals(firmPropMapping, firmAddressPropMapping.getValueForMetaPropertyToOne(M3Properties.owner));
+        Assert.assertEquals(personMapping, ownerFirmAddress);
+        Assert.assertEquals(firmPropMapping, firmAddressPropMapping.getValueForMetaPropertyToOne(M3Properties.owner));
 
         CoreInstance addressLine1PropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(firmAddressPropMapping, "line1");
         CoreInstance addressLine1ColumnAlias = this.graphWalker.getClassMappingImplementationPropertyMappingRelationalOperationElement(addressLine1PropMapping);
-        assertEquals(tableName, this.graphWalker.getTableAliasColumnAliasName(addressLine1ColumnAlias));
-        assertEquals("address", this.graphWalker.getTableAliasColumnColumnName(addressLine1ColumnAlias));
+        Assert.assertEquals(tableName, this.graphWalker.getTableAliasColumnAliasName(addressLine1ColumnAlias));
+        Assert.assertEquals("address", this.graphWalker.getTableAliasColumnColumnName(addressLine1ColumnAlias));
 
         CoreInstance addressPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(personMapping, "address");
         CoreInstance ownerAddress = addressPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner);
-        assertEquals(personMapping, ownerAddress);
-        assertEquals(personMapping, addressPropMapping.getValueForMetaPropertyToOne(M3Properties.owner));
+        Assert.assertEquals(personMapping, ownerAddress);
+        Assert.assertEquals(personMapping, addressPropMapping.getValueForMetaPropertyToOne(M3Properties.owner));
     }
-
 
     @Test
     public void embeddedMappingsCanBeReferenced()
@@ -605,57 +579,53 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
                         "        ),\n" +
                         "        address () Inline [alias2]\n" +
                         "    }\n" +
-                        ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-        this.runtime.compile();
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context);
+        runtime.compile();
 
 
         CoreInstance mapping = this.graphWalker.getMapping("mappingPackage::myMapping");
-        assertNotNull(mapping);
-        assertEquals(4, this.graphWalker.getClassMappings(mapping).size());
+        Assert.assertNotNull(mapping);
+        Assert.assertEquals(4, this.graphWalker.getClassMappings(mapping).size());
 
         CoreInstance personMapping = this.graphWalker.getClassMapping(mapping, "Person");
-        assertNotNull(personMapping);
+        Assert.assertNotNull(personMapping);
 
         CoreInstance addressMapping = this.graphWalker.getClassMapping(mapping, "Address");
-        assertNotNull(addressMapping);
+        Assert.assertNotNull(addressMapping);
 
-        CoreInstance relAddressMapping = addressMapping;
-        assertEquals("employeeFirmDenormTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(relAddressMapping)));
-        assertEquals(2, this.graphWalker.getClassMappingImplementationPropertyMappings(relAddressMapping).size());
+        Assert.assertEquals("employeeFirmDenormTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(addressMapping)));
+        Assert.assertEquals(2, this.graphWalker.getClassMappingImplementationPropertyMappings(addressMapping).size());
 
-        CoreInstance addressLine1PropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(relAddressMapping, "line1");
+        CoreInstance addressLine1PropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(addressMapping, "line1");
         CoreInstance addressLine1ColumnAlias = this.graphWalker.getClassMappingImplementationPropertyMappingRelationalOperationElement(addressLine1PropMapping);
-        assertEquals("employeeFirmDenormTable", this.graphWalker.getTableAliasColumnAliasName(addressLine1ColumnAlias));
-        assertEquals("address1", this.graphWalker.getTableAliasColumnColumnName(addressLine1ColumnAlias));
+        Assert.assertEquals("employeeFirmDenormTable", this.graphWalker.getTableAliasColumnAliasName(addressLine1ColumnAlias));
+        Assert.assertEquals("address1", this.graphWalker.getTableAliasColumnColumnName(addressLine1ColumnAlias));
 
 
-        CoreInstance relPersonMapping = personMapping;
+        Assert.assertEquals("employeeFirmDenormTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(personMapping)));
+        Assert.assertEquals(3, this.graphWalker.getClassMappingImplementationPropertyMappings(personMapping).size());
 
-        assertEquals("employeeFirmDenormTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(relPersonMapping)));
-        assertEquals(3, this.graphWalker.getClassMappingImplementationPropertyMappings(relPersonMapping).size());
-
-        CoreInstance firmPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(relPersonMapping, "firm");
-        assertNotNull(firmPropMapping);
+        CoreInstance firmPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(personMapping, "firm");
+        Assert.assertNotNull(firmPropMapping);
 
         CoreInstance firmProp = firmPropMapping.getValueForMetaPropertyToOne(M3Properties.property);
         ListIterable<? extends CoreInstance> refUsages = firmProp.getValueForMetaPropertyToMany(M3Properties.referenceUsages);
-        assertEquals(1, refUsages.size());
-        assertEquals(firmPropMapping, refUsages.getFirst().getValueForMetaPropertyToOne(M3Properties.owner));
-        assertNotNull(firmPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.propertyMappings));
+        Assert.assertEquals(1, refUsages.size());
+        Assert.assertEquals(firmPropMapping, refUsages.getFirst().getValueForMetaPropertyToOne(M3Properties.owner));
+        Assert.assertNotNull(firmPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.propertyMappings));
 
         CoreInstance owner = firmPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner);
-        assertEquals(personMapping, owner);
+        Assert.assertEquals(personMapping, owner);
 
         ListIterable<? extends CoreInstance> pks = firmPropMapping.getValueForMetaPropertyToMany(M2RelationalProperties.primaryKey);
         CoreInstance pk = pks.getFirst();
-        assertEquals(relPersonMapping, pk.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner));
+        Assert.assertEquals(personMapping, pk.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner));
 
-        CoreInstance addressPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(relPersonMapping, "address");
+        CoreInstance addressPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(personMapping, "address");
         CoreInstance ownerAddress = addressPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner);
-        assertEquals(personMapping, ownerAddress);
+        Assert.assertEquals(personMapping, ownerAddress);
 
-        assertNull(addressPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.propertyMappings));
-
+        Assert.assertNull(addressPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.propertyMappings));
     }
 
     @Test
@@ -712,52 +682,52 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
                         "            legalName : [db]employeeFirmDenormTable.legalName\n" +
                         "        ) Otherwise ( [firm1]:[db]@PersonFirmJoin) \n" +
                         "    }\n" +
-                        ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-        this.runtime.compile();
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context);
+        runtime.compile();
 
 
         CoreInstance mapping = this.graphWalker.getMapping("mappingPackage::myMapping");
-        assertNotNull(mapping);
-        assertEquals(3, this.graphWalker.getClassMappings(mapping).size());
+        Assert.assertNotNull(mapping);
+        Assert.assertEquals(3, this.graphWalker.getClassMappings(mapping).size());
 
 
         CoreInstance firmMapping = this.graphWalker.getClassMapping(mapping, "Firm");
-        assertNotNull(firmMapping);
-        assert (PrimitiveUtilities.getBooleanValue(firmMapping.getValueForMetaPropertyToOne(M3Properties.root)));
-        assertEquals("FirmInfoTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(firmMapping)));
-        assertEquals(2, this.graphWalker.getClassMappingImplementationPropertyMappings(firmMapping).size());
+        Assert.assertNotNull(firmMapping);
+        Assert.assertTrue(PrimitiveUtilities.getBooleanValue(firmMapping.getValueForMetaPropertyToOne(M3Properties.root)));
+        Assert.assertEquals("FirmInfoTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(firmMapping)));
+        Assert.assertEquals(2, this.graphWalker.getClassMappingImplementationPropertyMappings(firmMapping).size());
 
         CoreInstance personMapping = this.graphWalker.getClassMapping(mapping, "Person");
-        assertNotNull(personMapping);
-        assert (PrimitiveUtilities.getBooleanValue(personMapping.getValueForMetaPropertyToOne(M3Properties.root)));
-        assertEquals("employeeFirmDenormTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(personMapping)));
-        assertEquals(2, this.graphWalker.getClassMappingImplementationPropertyMappings(personMapping).size());
+        Assert.assertNotNull(personMapping);
+        Assert.assertTrue(PrimitiveUtilities.getBooleanValue(personMapping.getValueForMetaPropertyToOne(M3Properties.root)));
+        Assert.assertEquals("employeeFirmDenormTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(personMapping)));
+        Assert.assertEquals(2, this.graphWalker.getClassMappingImplementationPropertyMappings(personMapping).size());
 
         CoreInstance firmPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(personMapping, "firm");
-        assertNotNull(firmPropMapping);
-        assertFalse(PrimitiveUtilities.getBooleanValue(firmPropMapping.getValueForMetaPropertyToOne(M3Properties.root)));
+        Assert.assertNotNull(firmPropMapping);
+        Assert.assertFalse(PrimitiveUtilities.getBooleanValue(firmPropMapping.getValueForMetaPropertyToOne(M3Properties.root)));
 
         CoreInstance owner = firmPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner);
-        assertEquals(personMapping, owner);
+        Assert.assertEquals(personMapping, owner);
 
         CoreInstance firmProp = firmPropMapping.getValueForMetaPropertyToOne(M3Properties.property);
         ListIterable<? extends CoreInstance> refUsages = firmProp.getValueForMetaPropertyToMany(M3Properties.referenceUsages);
-        assertEquals(1, refUsages.size());
-        assertEquals(firmPropMapping, refUsages.getFirst().getValueForMetaPropertyToOne(M3Properties.owner));
-        assertNotNull(firmPropMapping.getValueForMetaPropertyToOne(M2MappingProperties.propertyMappings));
+        Assert.assertEquals(1, refUsages.size());
+        Assert.assertEquals(firmPropMapping, refUsages.getFirst().getValueForMetaPropertyToOne(M3Properties.owner));
+        Assert.assertNotNull(firmPropMapping.getValueForMetaPropertyToOne(M2MappingProperties.propertyMappings));
 
 
         CoreInstance otherwiseMapping = firmPropMapping.getValueForMetaPropertyToOne(M2MappingProperties.otherwisePropertyMapping);
-        assertNotNull(otherwiseMapping);
-        CompiledStateIntegrityTestTools.testPropertyIntegrity(otherwiseMapping, this.processorSupport);
-        assertEquals("alias1", PrimitiveUtilities.getStringValue(otherwiseMapping.getValueForMetaPropertyToOne(M2MappingProperties.sourceSetImplementationId), null));
-        assertEquals(1, this.graphWalker.getClassMappingImplementationPropertyMappings(firmPropMapping).size());
-        assertEquals(1, this.graphWalker.getClassMappingImplementationOtherwisePropertyMapping(firmPropMapping).size());
+        Assert.assertNotNull(otherwiseMapping);
+        CompiledStateIntegrityTestTools.testPropertyIntegrity(otherwiseMapping, processorSupport);
+        Assert.assertEquals("alias1", PrimitiveUtilities.getStringValue(otherwiseMapping.getValueForMetaPropertyToOne(M2MappingProperties.sourceSetImplementationId), null));
+        Assert.assertEquals(1, this.graphWalker.getClassMappingImplementationPropertyMappings(firmPropMapping).size());
+        Assert.assertEquals(1, this.graphWalker.getClassMappingImplementationOtherwisePropertyMapping(firmPropMapping).size());
 
         CoreInstance alias = otherwiseMapping.getValueForMetaPropertyToOne(M2RelationalProperties.relationalOperationElement)
                 .getValueForMetaPropertyToOne(M2RelationalProperties.joinTreeNode)
                 .getValueForMetaPropertyToOne(M2RelationalProperties.alias);
-        assertNotNull(alias);
+        Assert.assertNotNull(alias);
     }
 
     @Test
@@ -810,21 +780,21 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
                         "        name : [db]employeeFirmDenormTable.name,\n" +
                         "       firm[f1]:[db]@PersonFirmJoin \n" +
                         "    }\n" +
-                        ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-        this.runtime.compile();
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context);
+        runtime.compile();
 
 
         CoreInstance mapping = this.graphWalker.getMapping("mappingPackage::myMapping");
-        assertNotNull(mapping);
+        Assert.assertNotNull(mapping);
 
         CoreInstance personMapping = this.graphWalker.getClassMapping(mapping, "Person");
-        assertNotNull(personMapping);
+        Assert.assertNotNull(personMapping);
         CoreInstance firmPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(personMapping, "firm");
-        assertNotNull(firmPropMapping);
+        Assert.assertNotNull(firmPropMapping);
         CoreInstance opElement = firmPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.relationalOperationElement)
                 .getValueForMetaPropertyToOne(M2RelationalProperties.joinTreeNode).getValueForMetaPropertyToOne(M2RelationalProperties.alias);
 
-        assertNotNull(opElement);
+        Assert.assertNotNull(opElement);
     }
 
 
@@ -882,183 +852,167 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
                         "            legalName : [db]employeeFirmDenormTable.legalName\n" +
                         "        ) Otherwise ( [firm1]:[db]@PersonFirmJoin) \n" +
                         "    }\n" +
-                        ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-        this.runtime.compile();
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context);
+        runtime.compile();
 
 
         CoreInstance mapping = this.graphWalker.getMapping("mappingPackage::myMapping");
-        assertNotNull(mapping);
-        assertEquals(3, this.graphWalker.getClassMappings(mapping).size());
+        Assert.assertNotNull(mapping);
+        Assert.assertEquals(3, this.graphWalker.getClassMappings(mapping).size());
 
 
         CoreInstance firmMapping = this.graphWalker.getClassMapping(mapping, "Firm");
-        assertNotNull(firmMapping);
-        assert (PrimitiveUtilities.getBooleanValue(firmMapping.getValueForMetaPropertyToOne(M3Properties.root)));
-        assertEquals("FirmInfoTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(firmMapping)));
-        assertEquals(2, this.graphWalker.getClassMappingImplementationPropertyMappings(firmMapping).size());
+        Assert.assertNotNull(firmMapping);
+        Assert.assertTrue(PrimitiveUtilities.getBooleanValue(firmMapping.getValueForMetaPropertyToOne(M3Properties.root)));
+        Assert.assertEquals("FirmInfoTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(firmMapping)));
+        Assert.assertEquals(2, this.graphWalker.getClassMappingImplementationPropertyMappings(firmMapping).size());
 
         CoreInstance personMapping = this.graphWalker.getClassMapping(mapping, "Person");
-        assertNotNull(personMapping);
-        assert (PrimitiveUtilities.getBooleanValue(personMapping.getValueForMetaPropertyToOne(M3Properties.root)));
-        assertEquals("employeeFirmDenormTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(personMapping)));
-        assertEquals(2, this.graphWalker.getClassMappingImplementationPropertyMappings(personMapping).size());
+        Assert.assertNotNull(personMapping);
+        Assert.assertTrue(PrimitiveUtilities.getBooleanValue(personMapping.getValueForMetaPropertyToOne(M3Properties.root)));
+        Assert.assertEquals("employeeFirmDenormTable", this.graphWalker.getName(this.graphWalker.getClassMappingImplementationMainTable(personMapping)));
+        Assert.assertEquals(2, this.graphWalker.getClassMappingImplementationPropertyMappings(personMapping).size());
 
         CoreInstance firmPropMapping = this.graphWalker.getClassMappingImplementationPropertyMapping(personMapping, "firm");
-        assertNotNull(firmPropMapping);
-        assertFalse(PrimitiveUtilities.getBooleanValue(firmPropMapping.getValueForMetaPropertyToOne(M3Properties.root)));
+        Assert.assertNotNull(firmPropMapping);
+        Assert.assertFalse(PrimitiveUtilities.getBooleanValue(firmPropMapping.getValueForMetaPropertyToOne(M3Properties.root)));
 
         CoreInstance owner = firmPropMapping.getValueForMetaPropertyToOne(M2RelationalProperties.setMappingOwner);
-        assertEquals(personMapping, owner);
+        Assert.assertEquals(personMapping, owner);
 
         CoreInstance firmProp = firmPropMapping.getValueForMetaPropertyToOne(M3Properties.property);
         ListIterable<? extends CoreInstance> refUsages = firmProp.getValueForMetaPropertyToMany(M3Properties.referenceUsages);
-        assertEquals(1, refUsages.size());
-        assertEquals(firmPropMapping, refUsages.getFirst().getValueForMetaPropertyToOne(M3Properties.owner));
-        assertNotNull(firmPropMapping.getValueForMetaPropertyToOne(M2MappingProperties.propertyMappings));
+        Assert.assertEquals(1, refUsages.size());
+        Assert.assertEquals(firmPropMapping, refUsages.getFirst().getValueForMetaPropertyToOne(M3Properties.owner));
+        Assert.assertNotNull(firmPropMapping.getValueForMetaPropertyToOne(M2MappingProperties.propertyMappings));
 
 
         CoreInstance otherwiseMapping = firmPropMapping.getValueForMetaPropertyToOne(M2MappingProperties.otherwisePropertyMapping);
-        assertNotNull(otherwiseMapping);
-        assertEquals("other_Person", PrimitiveUtilities.getStringValue(otherwiseMapping.getValueForMetaPropertyToOne(M2MappingProperties.sourceSetImplementationId), null));
-        CompiledStateIntegrityTestTools.testPropertyIntegrity(otherwiseMapping, this.processorSupport);
-        assertEquals(1, this.graphWalker.getClassMappingImplementationPropertyMappings(firmPropMapping).size());
-        assertEquals(1, this.graphWalker.getClassMappingImplementationOtherwisePropertyMapping(firmPropMapping).size());
+        Assert.assertNotNull(otherwiseMapping);
+        Assert.assertEquals("other_Person", PrimitiveUtilities.getStringValue(otherwiseMapping.getValueForMetaPropertyToOne(M2MappingProperties.sourceSetImplementationId), null));
+        CompiledStateIntegrityTestTools.testPropertyIntegrity(otherwiseMapping, processorSupport);
+        Assert.assertEquals(1, this.graphWalker.getClassMappingImplementationPropertyMappings(firmPropMapping).size());
+        Assert.assertEquals(1, this.graphWalker.getClassMappingImplementationOtherwisePropertyMapping(firmPropMapping).size());
 
         CoreInstance alias = otherwiseMapping.getValueForMetaPropertyToOne(M2RelationalProperties.relationalOperationElement)
                 .getValueForMetaPropertyToOne(M2RelationalProperties.joinTreeNode)
                 .getValueForMetaPropertyToOne(M2RelationalProperties.alias);
-        assertNotNull(alias);
+        Assert.assertNotNull(alias);
     }
 
 
     @Test
     public void otherwiseMappingsWithInvalidTargetId()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "    otherInformation:String[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
-                            "   Table FirmInfoTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    other VARCHAR(200)\n" +
-                            "   )\n" +
-                            "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Firm: Relational\n" +
-                            "    {\n" +
-                            "       legalName : [db]FirmInfoTable.name ,\n" +
-                            "       otherInformation: [db]FirmInfoTable.other\n" +
-                            "    }\n" +
-                            "    Person[alias1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm\n" +
-                            "        (\n" +
-                            "            ~primaryKey ([db]employeeFirmDenormTable.legalName)\n" +
-                            "            legalName : [db]employeeFirmDenormTable.legalName\n" +
-                            "        ) Otherwise ([firm1]:[db]@PersonFirmJoin) \n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Invalid Otherwise mapping found for'firm' property, targetId firm1 does not exists.", "fromString.pure", 45, 9, e);
-        }
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "    otherInformation:String[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
+                        "   Table FirmInfoTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    other VARCHAR(200)\n" +
+                        "   )\n" +
+                        "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Firm: Relational\n" +
+                        "    {\n" +
+                        "       legalName : [db]FirmInfoTable.name ,\n" +
+                        "       otherInformation: [db]FirmInfoTable.other\n" +
+                        "    }\n" +
+                        "    Person[alias1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm\n" +
+                        "        (\n" +
+                        "            ~primaryKey ([db]employeeFirmDenormTable.legalName)\n" +
+                        "            legalName : [db]employeeFirmDenormTable.legalName\n" +
+                        "        ) Otherwise ([firm1]:[db]@PersonFirmJoin) \n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureCompilationException.class, "Invalid Otherwise mapping found for 'firm' property, targetId firm1 does not exists.", "fromString.pure", 45, 9, e.getCause());
     }
 
     @Test
     public void redundantOtherwiseMappingsWithTargetId()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "    otherInformation:String[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
-                            "   Table FirmInfoTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    other VARCHAR(200)\n" +
-                            "   )\n" +
-                            "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Firm: Relational\n" +
-                            "    {\n" +
-                            "       legalName : [db]FirmInfoTable.name ,\n" +
-                            "       otherInformation: [db]FirmInfoTable.other\n" +
-                            "    }\n" +
-                            "    Person[alias1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm\n" +
-                            "        (\n" +
-                            "        ) Otherwise ([firm1]:[db]@PersonFirmJoin) \n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Invalid Otherwise mapping found:'firm' property has no embedded mappings defined, please use a property mapping with Join instead.", "fromString.pure", 45, 9, e);
-        }
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "    otherInformation:String[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
+                        "   Table FirmInfoTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    other VARCHAR(200)\n" +
+                        "   )\n" +
+                        "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Firm: Relational\n" +
+                        "    {\n" +
+                        "       legalName : [db]FirmInfoTable.name ,\n" +
+                        "       otherInformation: [db]FirmInfoTable.other\n" +
+                        "    }\n" +
+                        "    Person[alias1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm\n" +
+                        "        (\n" +
+                        "        ) Otherwise ([firm1]:[db]@PersonFirmJoin) \n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureCompilationException.class, "Invalid Otherwise mapping found: 'firm' property has no embedded mappings defined, please use a property mapping with Join instead.", "fromString.pure", 45, 9, e.getCause());
     }
 
     @Test
@@ -1126,8 +1080,8 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
                         "           address[p1_firm,a1] : [db]@firmAddress\n" +
                         "        )\n" +
                         "    }\n" +
-                        ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-        this.runtime.compile();
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context);
+        runtime.compile();
 
     }
 
@@ -1200,723 +1154,633 @@ public class TestEmbeddedGrammar extends AbstractPureRelationalTestWithCoreCompi
                         "           address[p1_firm,a1] : [db]@firmAddress\n" +
                         "        )\n" +
                         "    }\n" +
-                        ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-        this.runtime.compile();
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context);
+        runtime.compile();
     }
 
     @Test
     public void inlinedEmbeddedMappingsCanBeReferencedInAssociationMappingAsSourceInvalidId()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    address:Address[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "}\n" +
-                            "Class other::Address\n" +
-                            "{\n" +
-                            "    line1:String[1];\n" +
-                            "    postcode:String[1];\n" +
-                            "}\n" +
-                            "Association other::Firm_Address\n" +
-                            "{\n" +
-                            "    address:Address[0..1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
-                            "   Join firmAddress(employeeFirmDenormTable.address1 = {target}.address1)\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Address[a1]: Relational\n" +
-                            "    {\n" +
-                            "       line1: [db]employeeFirmDenormTable.address1,\n" +
-                            "       postcode: [db]employeeFirmDenormTable.postcode\n" +
-                            "    }\n" +
-                            "    Person[p1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm\n" +
-                            "        (\n" +
-                            "            ~primaryKey ([db]employeeFirmDenormTable.legalName)\n" +
-                            "            legalName : [db]employeeFirmDenormTable.legalName\n" +
-                            "        )\n" +
-                            "    }\n" +
-                            "    Firm[f1]: Relational\n" +
-                            "    {\n" +
-                            "         legalName : [db]employeeFirmDenormTable.legalName\n" +
-                            "    }\n" +
-                            "    Firm_Address: Relational\n" +
-                            "    {\n" +
-                            "        AssociationMapping\n" +
-                            "        (\n" +
-                            "           address[p1_f1,a1] : [db]@firmAddress\n" +
-                            "        )\n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Unable to find source class mapping (id:p1_f1) for property 'address' in Association mapping 'Firm_Address'. Make sure that you have specified a valid Class mapping id as the source id and target id, using the syntax 'property[sourceId, targetId]: ...'.", "fromString.pure", 63, 12, e);
-        }
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    address:Address[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "}\n" +
+                        "Class other::Address\n" +
+                        "{\n" +
+                        "    line1:String[1];\n" +
+                        "    postcode:String[1];\n" +
+                        "}\n" +
+                        "Association other::Firm_Address\n" +
+                        "{\n" +
+                        "    address:Address[0..1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
+                        "   Join firmAddress(employeeFirmDenormTable.address1 = {target}.address1)\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Address[a1]: Relational\n" +
+                        "    {\n" +
+                        "       line1: [db]employeeFirmDenormTable.address1,\n" +
+                        "       postcode: [db]employeeFirmDenormTable.postcode\n" +
+                        "    }\n" +
+                        "    Person[p1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm\n" +
+                        "        (\n" +
+                        "            ~primaryKey ([db]employeeFirmDenormTable.legalName)\n" +
+                        "            legalName : [db]employeeFirmDenormTable.legalName\n" +
+                        "        )\n" +
+                        "    }\n" +
+                        "    Firm[f1]: Relational\n" +
+                        "    {\n" +
+                        "         legalName : [db]employeeFirmDenormTable.legalName\n" +
+                        "    }\n" +
+                        "    Firm_Address: Relational\n" +
+                        "    {\n" +
+                        "        AssociationMapping\n" +
+                        "        (\n" +
+                        "           address[p1_f1,a1] : [db]@firmAddress\n" +
+                        "        )\n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureCompilationException.class, "Unable to find source class mapping (id:p1_f1) for property 'address' in Association mapping 'Firm_Address'. Make sure that you have specified a valid Class mapping id as the source id and target id, using the syntax 'property[sourceId, targetId]: ...'.", "fromString.pure", 63, 12, e.getCause());
     }
 
     @Test
     public void inlinedEmbeddedMappingsCanNotBeReferencedInAssociationMappingAsTarget()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    address:Address[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "}\n" +
-                            "Class other::Address\n" +
-                            "{\n" +
-                            "    line1:String[1];\n" +
-                            "    postcode:String[1];\n" +
-                            "}\n" +
-                            "Association other::Firm_Address\n" +
-                            "{\n" +
-                            "    address:Address[0..1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
-                            "   Join firmAddress(employeeFirmDenormTable.address1 = {target}.address1)\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Address[a1]: Relational\n" +
-                            "    {\n" +
-                            "       line1: [db]employeeFirmDenormTable.address1,\n" +
-                            "       postcode: [db]employeeFirmDenormTable.postcode\n" +
-                            "    }\n" +
-                            "    Person[p1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm\n" +
-                            "        (\n" +
-                            "            ~primaryKey ([db]employeeFirmDenormTable.legalName)\n" +
-                            "            legalName : [db]employeeFirmDenormTable.legalName\n" +
-                            "        )\n" +
-                            "    }\n" +
-                            "    Firm[f1]: Relational\n" +
-                            "    {\n" +
-                            "         legalName : [db]employeeFirmDenormTable.legalName\n" +
-                            "    }\n" +
-                            "    Firm_Address: Relational\n" +
-                            "    {\n" +
-                            "        AssociationMapping\n" +
-                            "        (\n" +
-                            "           address[p1_firm,a1] : [db]@firmAddress,\n" +
-                            "           firm[a1,p1_firm] : [db]@firmAddress\n" +
-                            "        )\n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Invalid target class mapping for property 'firm' in Association mapping 'Firm_Address'. Target 'p1_firm' is an embedded class mapping, embedded mappings are only allowed to be the source in an Association Mapping.", "fromString.pure", 64, 12, e);
-        }
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    address:Address[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "}\n" +
+                        "Class other::Address\n" +
+                        "{\n" +
+                        "    line1:String[1];\n" +
+                        "    postcode:String[1];\n" +
+                        "}\n" +
+                        "Association other::Firm_Address\n" +
+                        "{\n" +
+                        "    address:Address[0..1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
+                        "   Join firmAddress(employeeFirmDenormTable.address1 = {target}.address1)\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Address[a1]: Relational\n" +
+                        "    {\n" +
+                        "       line1: [db]employeeFirmDenormTable.address1,\n" +
+                        "       postcode: [db]employeeFirmDenormTable.postcode\n" +
+                        "    }\n" +
+                        "    Person[p1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm\n" +
+                        "        (\n" +
+                        "            ~primaryKey ([db]employeeFirmDenormTable.legalName)\n" +
+                        "            legalName : [db]employeeFirmDenormTable.legalName\n" +
+                        "        )\n" +
+                        "    }\n" +
+                        "    Firm[f1]: Relational\n" +
+                        "    {\n" +
+                        "         legalName : [db]employeeFirmDenormTable.legalName\n" +
+                        "    }\n" +
+                        "    Firm_Address: Relational\n" +
+                        "    {\n" +
+                        "        AssociationMapping\n" +
+                        "        (\n" +
+                        "           address[p1_firm,a1] : [db]@firmAddress,\n" +
+                        "           firm[a1,p1_firm] : [db]@firmAddress\n" +
+                        "        )\n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureCompilationException.class, "Invalid target class mapping for property 'firm' in Association mapping 'Firm_Address'. Target 'p1_firm' is an embedded class mapping, embedded mappings are only allowed to be the source in an Association Mapping.", "fromString.pure", 64, 12, e.getCause());
     }
 
     @Test
     public void embeddedMappingsCannotBeReferencedInAssociationMappingAsTarget()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    address:Address[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "}\n" +
-                            "Class other::Address\n" +
-                            "{\n" +
-                            "    line1:String[1];\n" +
-                            "    postcode:String[1];\n" +
-                            "}\n" +
-                            "Association other::Firm_Address\n" +
-                            "{\n" +
-                            "    address:Address[0..1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
-                            "   Join firmAddress(employeeFirmDenormTable.address1 = {target}.address1)\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Address[a1]: Relational\n" +
-                            "    {\n" +
-                            "       line1: [db]employeeFirmDenormTable.address1,\n" +
-                            "       postcode: [db]employeeFirmDenormTable.postcode\n" +
-                            "    }\n" +
-                            "    Person[p1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm\n" +
-                            "        (\n" +
-                            "            ~primaryKey ([db]employeeFirmDenormTable.legalName)\n" +
-                            "            legalName : [db]employeeFirmDenormTable.legalName\n" +
-                            "        )\n" +
-                            "    }\n" +
-                            "    Firm_Address: Relational\n" +
-                            "    {\n" +
-                            "        AssociationMapping\n" +
-                            "        (\n" +
-                            "           firm[a1,p1_firm] : [db]@firmAddress\n" +
-                            "        )\n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Invalid target class mapping for property 'firm' in Association mapping 'Firm_Address'. Target 'p1_firm' is an embedded class mapping, embedded mappings are only allowed to be the source in an Association Mapping.", "fromString.pure", 59, 12, e);
-        }
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    address:Address[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "}\n" +
+                        "Class other::Address\n" +
+                        "{\n" +
+                        "    line1:String[1];\n" +
+                        "    postcode:String[1];\n" +
+                        "}\n" +
+                        "Association other::Firm_Address\n" +
+                        "{\n" +
+                        "    address:Address[0..1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
+                        "   Join firmAddress(employeeFirmDenormTable.address1 = {target}.address1)\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Address[a1]: Relational\n" +
+                        "    {\n" +
+                        "       line1: [db]employeeFirmDenormTable.address1,\n" +
+                        "       postcode: [db]employeeFirmDenormTable.postcode\n" +
+                        "    }\n" +
+                        "    Person[p1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm\n" +
+                        "        (\n" +
+                        "            ~primaryKey ([db]employeeFirmDenormTable.legalName)\n" +
+                        "            legalName : [db]employeeFirmDenormTable.legalName\n" +
+                        "        )\n" +
+                        "    }\n" +
+                        "    Firm_Address: Relational\n" +
+                        "    {\n" +
+                        "        AssociationMapping\n" +
+                        "        (\n" +
+                        "           firm[a1,p1_firm] : [db]@firmAddress\n" +
+                        "        )\n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureCompilationException.class, "Invalid target class mapping for property 'firm' in Association mapping 'Firm_Address'. Target 'p1_firm' is an embedded class mapping, embedded mappings are only allowed to be the source in an Association Mapping.", "fromString.pure", 59, 12, e.getCause());
     }
-
 
     @Test
     public void testOtherwiseEmbeddedWithNoJoin()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "    otherInformation:String[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
-                            "   Table FirmInfoTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    other VARCHAR(200)\n" +
-                            "   )\n" +
-                            "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Firm: Relational\n" +
-                            "    {\n" +
-                            "       legalName : [db]FirmInfoTable.name ,\n" +
-                            "       otherInformation: [db]FirmInfoTable.other\n" +
-                            "    }\n" +
-                            "    Person[alias1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm\n" +
-                            "        (\n" +
-                            "            ~primaryKey ([db]employeeFirmDenormTable.legalName)\n" +
-                            "            legalName : [db]employeeFirmDenormTable.legalName\n" +
-                            "        ) Otherwise () \n" + //
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureParserException.class, "expected: '[' found: ')'", "fromString.pure", 49, 22, e);
-        }
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "    otherInformation:String[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
+                        "   Table FirmInfoTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    other VARCHAR(200)\n" +
+                        "   )\n" +
+                        "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Firm: Relational\n" +
+                        "    {\n" +
+                        "       legalName : [db]FirmInfoTable.name ,\n" +
+                        "       otherInformation: [db]FirmInfoTable.other\n" +
+                        "    }\n" +
+                        "    Person[alias1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm\n" +
+                        "        (\n" +
+                        "            ~primaryKey ([db]employeeFirmDenormTable.legalName)\n" +
+                        "            legalName : [db]employeeFirmDenormTable.legalName\n" +
+                        "        ) Otherwise () \n" + //
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureParserException.class, "expected: '[' found: ')'", "fromString.pure", 49, 22, e.getCause());
     }
 
     @Test
     public void testOtherwiseEmbeddedWithNoJoinOrPropertyMappings()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "    otherInformation:String[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
-                            "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Person[alias1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm\n" +
-                            "        (\n" +
-                            "        ) Otherwise () \n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureParserException.class, "expected: '[' found: ')'", "fromString.pure", 36, 22, e);
-        }
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "    otherInformation:String[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
+                        "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Person[alias1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm\n" +
+                        "        (\n" +
+                        "        ) Otherwise () \n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureParserException.class, "expected: '[' found: ')'", "fromString.pure", 36, 22, e.getCause());
     }
 
     @Test
     public void testIncorrectInlineMapping()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "    otherInformation:String[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "    otherInformation:String[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
 
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Person[alias1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm()\n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Invalid Inline mapping found:'firm' mapping has not inline set defined, please use:firm() Inline[setid] .", "fromString.pure", 33, 9, e);
-
-        }
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Person[alias1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm()\n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureCompilationException.class, "Invalid Inline mapping found: 'firm' mapping has not inline set defined, please use: firm() Inline[setid].", "fromString.pure", 33, 9, e.getCause());
     }
 
     @Test
     public void testIncorrectSetIdInlineMapping()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "    otherInformation:String[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
-                            "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Person[alias1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm\n" +
-                            "        (\n" +
-                            "        ) Inline[] \n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureParserException.class, "expected: a valid identifier text; found: ']'", "fromString.pure", 36, 18, e);
-        }
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "    otherInformation:String[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
+                        "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Person[alias1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm\n" +
+                        "        (\n" +
+                        "        ) Inline[] \n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureParserException.class, "expected: a valid identifier text; found: ']'", "fromString.pure", 36, 18, e.getCause());
     }
 
     @Test
     public void testOtherwiseEmbeddedWithIncorrectJoin()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "    otherInformation:String[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
-                            "   Table FirmInfoTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    other VARCHAR(200)\n" +
-                            "   )\n" +
-                            "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Firm: Relational\n" +
-                            "    {\n" +
-                            "       legalName : [db]FirmInfoTable.name ,\n" +
-                            "       otherInformation: [db]FirmInfoTable.other\n" +
-                            "    }\n" +
-                            "    Person[alias1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm\n" +
-                            "        (\n" +
-                            "        ) Otherwise ([firm1]:[db]@InvalidPersonFirmJoin) \n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "The join 'InvalidPersonFirmJoin' has not been found in the database 'db'", "fromString.pure", 47, 35, e);
-        }
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "    otherInformation:String[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
+                        "   Table FirmInfoTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    other VARCHAR(200)\n" +
+                        "   )\n" +
+                        "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Firm: Relational\n" +
+                        "    {\n" +
+                        "       legalName : [db]FirmInfoTable.name ,\n" +
+                        "       otherInformation: [db]FirmInfoTable.other\n" +
+                        "    }\n" +
+                        "    Person[alias1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm\n" +
+                        "        (\n" +
+                        "        ) Otherwise ([firm1]:[db]@InvalidPersonFirmJoin) \n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureCompilationException.class, "The join 'InvalidPersonFirmJoin' has not been found in the database 'db'", "fromString.pure", 47, 35, e.getCause());
     }
 
     @Test
     public void testOtherwiseEmbeddedWithIncorrectOtherwisePropertyMapping()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "    otherInformation:String[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
-                            "   Table FirmInfoTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    other VARCHAR(200)\n" +
-                            "   )\n" +
-                            "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Firm[firm1]: Relational\n" +
-                            "    {\n" +
-                            "       legalName : [db]FirmInfoTable.name ,\n" +
-                            "       otherInformation: [db]FirmInfoTable.other\n" +
-                            "    }\n" +
-                            "    Person[alias1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm\n" +
-                            "        (\n" +
-                            "          legalName : [db]employeeFirmDenormTable.name \n" +
-                            "        ) Otherwise ([firm1]:[db]employeeFirmDenormTable.name) \n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureParserException.class, "expected: '@' found: 'employeeFirmDenormTable'", "fromString.pure", 48, 34, e);
-        }
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "    otherInformation:String[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
+                        "   Table FirmInfoTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    other VARCHAR(200)\n" +
+                        "   )\n" +
+                        "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Firm[firm1]: Relational\n" +
+                        "    {\n" +
+                        "       legalName : [db]FirmInfoTable.name ,\n" +
+                        "       otherInformation: [db]FirmInfoTable.other\n" +
+                        "    }\n" +
+                        "    Person[alias1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm\n" +
+                        "        (\n" +
+                        "          legalName : [db]employeeFirmDenormTable.name \n" +
+                        "        ) Otherwise ([firm1]:[db]employeeFirmDenormTable.name) \n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureParserException.class, "expected: '@' found: 'employeeFirmDenormTable'", "fromString.pure", 48, 34, e.getCause());
     }
 
     @Test
     public void testInlineEmbeddeedInvalidTarget()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "    otherInformation:String[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
-                            "   Table FirmInfoTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    other VARCHAR(200)\n" +
-                            "   )\n" +
-                            "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Firm: Relational\n" +
-                            "    {\n" +
-                            "       legalName : [db]FirmInfoTable.name ,\n" +
-                            "       otherInformation: [db]FirmInfoTable.other\n" +
-                            "    }\n" +
-                            "    Person[alias1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        firm\n" +
-                            "        (\n" +
-                            "        ) Inline [firm1] \n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Invalid Inline mapping found:'firm' property, inline set id firm1 does not exists.", "fromString.pure", 45, 9, e);
-        }
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "    otherInformation:String[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
+                        "   Table FirmInfoTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    other VARCHAR(200)\n" +
+                        "   )\n" +
+                        "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Firm: Relational\n" +
+                        "    {\n" +
+                        "       legalName : [db]FirmInfoTable.name ,\n" +
+                        "       otherInformation: [db]FirmInfoTable.other\n" +
+                        "    }\n" +
+                        "    Person[alias1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        firm\n" +
+                        "        (\n" +
+                        "        ) Inline [firm1] \n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureCompilationException.class, "Invalid Inline mapping found: 'firm' property, inline set id firm1 does not exists.", "fromString.pure", 45, 9, e.getCause());
     }
 
     @Test
     public void testIncorrectTypeSetIdInlineMapping()
     {
-        try
-        {
-            Loader.parseM3(
-                    "import other::*;\n" +
-                            "\n" +
-                            "Class other::Person\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "    firm:Firm[1];\n" +
-                            "    address:Address[1];\n" +
-                            "}\n" +
-                            "Class other::Address\n" +
-                            "{\n" +
-                            "    name:String[1];\n" +
-                            "}\n" +
-                            "Class other::Firm\n" +
-                            "{\n" +
-                            "    legalName:String[1];\n" +
-                            "}\n" +
-                            "###Relational\n" +
-                            "Database mapping::db(\n" +
-                            "   Table employeeFirmDenormTable\n" +
-                            "   (\n" +
-                            "    id INT PRIMARY KEY,\n" +
-                            "    name VARCHAR(200),\n" +
-                            "    firmId INT,\n" +
-                            "    legalName VARCHAR(200),\n" +
-                            "    address1 VARCHAR(200),\n" +
-                            "    postcode VARCHAR(10)\n" +
-                            "   )\n" +
-                            ")\n" +
-                            "###Mapping\n" +
-                            "import other::*;\n" +
-                            "import mapping::*;\n" +
-                            "Mapping mappingPackage::myMapping\n" +
-                            "(\n" +
-                            "    Firm[firm1]: Relational\n" +
-                            "    {\n" +
-                            "       legalName : [db]employeeFirmDenormTable.legalName \n" +
-                            "    }\n" +
-                            "    Person[alias1]: Relational\n" +
-                            "    {\n" +
-                            "        name : [db]employeeFirmDenormTable.name,\n" +
-                            "        address()Inline[firm1] \n" +
-                            "    }\n" +
-                            ")\n", this.repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, this.context);
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Mapping Error! The inlineSetImplementationId 'firm1' is implementing the class 'Firm' which is not a subType of 'Address' (return type of the mapped property 'address')", "fromString.pure", 41, 9, e);
-        }
+        LoaderException e = Assert.assertThrows(LoaderException.class, () -> Loader.parseM3(
+                "import other::*;\n" +
+                        "\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "    address:Address[1];\n" +
+                        "}\n" +
+                        "Class other::Address\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "}\n" +
+                        "###Relational\n" +
+                        "Database mapping::db(\n" +
+                        "   Table employeeFirmDenormTable\n" +
+                        "   (\n" +
+                        "    id INT PRIMARY KEY,\n" +
+                        "    name VARCHAR(200),\n" +
+                        "    firmId INT,\n" +
+                        "    legalName VARCHAR(200),\n" +
+                        "    address1 VARCHAR(200),\n" +
+                        "    postcode VARCHAR(10)\n" +
+                        "   )\n" +
+                        ")\n" +
+                        "###Mapping\n" +
+                        "import other::*;\n" +
+                        "import mapping::*;\n" +
+                        "Mapping mappingPackage::myMapping\n" +
+                        "(\n" +
+                        "    Firm[firm1]: Relational\n" +
+                        "    {\n" +
+                        "       legalName : [db]employeeFirmDenormTable.legalName \n" +
+                        "    }\n" +
+                        "    Person[alias1]: Relational\n" +
+                        "    {\n" +
+                        "        name : [db]employeeFirmDenormTable.name,\n" +
+                        "        address()Inline[firm1] \n" +
+                        "    }\n" +
+                        ")\n", repository, new ParserLibrary(Lists.immutable.with(new M3AntlrParser(), new MappingParser(), new RelationalParser())), ValidationType.DEEP, VoidM3M4StateListener.VOID_M3_M4_STATE_LISTENER, context));
+        assertPureException(PureCompilationException.class, "Mapping Error! The inlineSetImplementationId 'firm1' is implementing the class 'Firm' which is not a subType of 'Address' (return type of the mapped property 'address')", "fromString.pure", 41, 9, e.getCause());
     }
 }

--- a/legend-pure-m2-store-relational/src/test/java/org/finos/legend/pure/m2/relational/incremental/TestPureRuntimeClassMapping.java
+++ b/legend-pure-m2-store-relational/src/test/java/org/finos/legend/pure/m2/relational/incremental/TestPureRuntimeClassMapping.java
@@ -14,13 +14,12 @@
 
 package org.finos.legend.pure.m2.relational.incremental;
 
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Maps;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.finos.legend.pure.m2.relational.AbstractPureRelationalTestWithCoreCompiled;
 import org.finos.legend.pure.m2.relational.RelationalGraphWalker;
 import org.finos.legend.pure.m3.RuntimeTestScriptBuilder;
@@ -44,8 +43,7 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
     private static final String CLASS_MAPPING_SOURCE_ID = "classMappingSourceId.pure";
     private static final String MAPPING = "###Mapping\n";
     private static final String CLASS_MAPPING_PERSON_RELATIONAL = "Mapping myMap(Person:Relational{name : [db]myTable.name})";
-    private static final String CLASS_MAPPING = MAPPING +
-            CLASS_MAPPING_PERSON_RELATIONAL;
+    private static final String CLASS_MAPPING = MAPPING + CLASS_MAPPING_PERSON_RELATIONAL;
 
     private static final String FUNCTION_TEST_CLASS_MAPPINGS_SIZE = "###Pure\n" +
             "function test():Boolean[1]{assert(1 == myMap.classMappings->size(), |'');}";
@@ -65,27 +63,28 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
 
     private static final String ORG_TABLE =
             "Table orgTable\n" +
-            "    (\n" +
-            "        id INT,\n" +
-            "        filterVal INT,\n" +
-            "        parentId INT,\n" +
-            "        name VARCHAR(200),\n" +
-            "        employeeCount INT\n" +
-            "    )\n";
+                    "    (\n" +
+                    "        id INT,\n" +
+                    "        filterVal INT,\n" +
+                    "        parentId INT,\n" +
+                    "        name VARCHAR(200),\n" +
+                    "        employeeCount INT\n" +
+                    "    )\n";
 
     private static final String ORG_TABLE_WITHOUT_EMPLOYEE_COUNT =
             "Table orgTable\n" +
-            "    (\n" +
-            "        id INT,\n" +
-            "        filterVal INT,\n" +
-            "        parentId INT,\n" +
-            "        name VARCHAR(200)\n"+
-            "    )\n";
+                    "    (\n" +
+                    "        id INT,\n" +
+                    "        filterVal INT,\n" +
+                    "        parentId INT,\n" +
+                    "        name VARCHAR(200)\n" +
+                    "    )\n";
 
-    private static final String getComplexDatabase(String orgTable){
-        return  RELATIONAL + "Database myDB\n" +
+    private static String getComplexDatabase(String orgTable)
+    {
+        return RELATIONAL + "Database myDB\n" +
                 "(\n" +
-                    orgTable +
+                orgTable +
                 "    \n" +
                 "    Table otherTable\n" +
                 "    (\n" +
@@ -110,7 +109,8 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
                 ")";
     }
 
-    private static final String getComplexMapping(MutableList<String> extraAttributes){
+    private static String getComplexMapping(MutableList<String> extraAttributes)
+    {
         return MAPPING + "Mapping myMap\n" +
                 "(\n" +
                 "    Org: Relational\n" +
@@ -119,12 +119,12 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
                 "        name: [myDB]orgTable.name,\n" +
                 "        parent : [myDB]@OrgOrgParent,\n" +
                 "        children : [myDB]@OrgParentOrg\n" +
-                (extraAttributes.isEmpty() ? "" :extraAttributes.makeString("\t\t,","","\n"))+
+                (extraAttributes.isEmpty() ? "" : extraAttributes.makeString("\t\t,", "", "\n")) +
                 "    }\n" +
                 ")";
     }
 
-    private static String childOrgEmployeeCountAttr = "childOrgEmployeeCount : [myDB]@OrgParentOrg | max([myDB]orgTable.employeeCount)";
+    private static final String childOrgEmployeeCountAttr = "childOrgEmployeeCount : [myDB]@OrgParentOrg | max([myDB]orgTable.employeeCount)";
 
     private static final ImmutableMap<String, String> TEST_SOURCES = Maps.immutable.with(
             CLASS_MAPPING_SOURCE_ID, CLASS_MAPPING,
@@ -132,7 +132,7 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
             RELATIONAL_DB_SOURCE_ID, RELATIONAL_DATABASE);
 
     private static final ImmutableMap<String, String> COMPLEX_TEST_SOURCES = Maps.immutable.with(
-            CLASS_MAPPING_SOURCE_ID, getComplexMapping(FastList.<String>newListWith(childOrgEmployeeCountAttr)),
+            CLASS_MAPPING_SOURCE_ID, getComplexMapping(Lists.mutable.with(childOrgEmployeeCountAttr)),
             CLASS_SOURCE_ID, CLASS_ORG,
             RELATIONAL_DB_SOURCE_ID, getComplexDatabase(ORG_TABLE));
 
@@ -174,53 +174,49 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
             RELATIONAL_DB_SOURCE_ID, DB_FOR_TRANSFORM);
 
     @Test
-    public void testDeleteAndReloadEachSource() throws Exception
+    public void testDeleteAndReloadEachSource()
     {
-        this.testDeleteAndReloadEachSource(
-                TEST_SOURCES, FUNCTION_TEST_CLASS_MAPPINGS_SIZE);
+        testDeleteAndReloadEachSource(TEST_SOURCES, FUNCTION_TEST_CLASS_MAPPINGS_SIZE);
     }
 
     @Test
-    public void testDeleteAndReloadEachComplexSource() throws Exception
+    public void testDeleteAndReloadEachComplexSource()
     {
-        this.testDeleteAndReloadEachSource(
-                COMPLEX_TEST_SOURCES, FUNCTION_TEST_CLASS_MAPPINGS_SIZE);
+        testDeleteAndReloadEachSource(COMPLEX_TEST_SOURCES, FUNCTION_TEST_CLASS_MAPPINGS_SIZE);
     }
 
     @Test
-    public void testDeleteAndReloadEachSourceWithTransform() throws Exception
+    public void testDeleteAndReloadEachSourceWithTransform()
     {
-        this.testDeleteAndReloadEachSource(
-                TEST_SOURCES_WITH_MAPPING_TRANSFORM, FUNCTION_TEST_CLASS_MAPPINGS_SIZE);
+        testDeleteAndReloadEachSource(TEST_SOURCES_WITH_MAPPING_TRANSFORM, FUNCTION_TEST_CLASS_MAPPINGS_SIZE);
     }
 
     public void testDeleteAndReloadEachSource(ImmutableMap<String, String> sources, String testFunctionSource)
     {
         for (Pair<String, String> source : sources.keyValuesView())
         {
-            System.out.println("Deleting " + source.getOne());
+//            System.out.println("Deleting " + source.getOne());
             new RuntimeTestScriptBuilder().createInMemorySources(sources)
                     .createInMemorySource("functionSourceId.pure", testFunctionSource)
-                    .compile().run(this.runtime, this.functionExecution);
+                    .compile().run(runtime, functionExecution);
 
-            RuntimeVerifier.deleteCompileAndReloadMultipleTimesIsStable(this.runtime, this.functionExecution,
+            RuntimeVerifier.deleteCompileAndReloadMultipleTimesIsStable(runtime, functionExecution,
                     Lists.fixedSize.of(source), this.getAdditionalVerifiers());
 
             //reset so that the next iteration has a clean environment
-            this.setUpRuntime();
+            setUpRuntime();
         }
-
     }
 
     @Test
-    public void testDeleteAndReloadSourcePairs() throws Exception
+    public void testDeleteAndReloadSourcePairs()
     {
         this.testDeleteAndReloadTwoSources(
                 TEST_SOURCES, FUNCTION_TEST_CLASS_MAPPINGS_SIZE);
     }
 
     @Test
-    public void testDeleteAndReloadComplexSourcePairs() throws Exception
+    public void testDeleteAndReloadComplexSourcePairs()
     {
         this.testDeleteAndReloadTwoSources(
                 COMPLEX_TEST_SOURCES, FUNCTION_TEST_CLASS_MAPPINGS_SIZE);
@@ -238,17 +234,16 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
             {
                 new RuntimeTestScriptBuilder().createInMemorySources(sources)
                         .createInMemorySource("functionSourceId.pure", testFunctionSource)
-                        .compile().run(this.runtime, this.functionExecution);
+                        .compile().run(runtime, functionExecution);
 
-                RuntimeVerifier.deleteCompileAndReloadMultipleTimesIsStable(this.runtime, this.functionExecution,
+                RuntimeVerifier.deleteCompileAndReloadMultipleTimesIsStable(runtime, functionExecution,
                         Lists.fixedSize.of(source, secondSource),
                         this.getAdditionalVerifiers());
 
                 //reset so that the next iteration has a clean environment
-                this.setUpRuntime();
+                setUpRuntime();
             }
         }
-
     }
 
     @Test
@@ -311,93 +306,93 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
     public void testOtherwiseEmbeddedUnbind()
     {
 
-        String classSource =  "import other::*;\n" +
-                        "\n" +
-                        "Class other::Person\n" +
-                        "{\n" +
-                        "    name:String[1];\n" +
-                        "    firm:Firm[1];\n" +
-                        "}\n" +
-                        "Class other::Firm\n" +
-                        "{\n" +
-                        "    legalName:String[1];\n" +
-                        "    otherInformation:String[1];\n" +
-                        "}\n" ;
+        String classSource = "import other::*;\n" +
+                "\n" +
+                "Class other::Person\n" +
+                "{\n" +
+                "    name:String[1];\n" +
+                "    firm:Firm[1];\n" +
+                "}\n" +
+                "Class other::Firm\n" +
+                "{\n" +
+                "    legalName:String[1];\n" +
+                "    otherInformation:String[1];\n" +
+                "}\n";
 
-        String dbSource =  "###Relational\n" +
-                        "Database mapping::db(\n" +
-                        "   Table employeeFirmDenormTable\n" +
-                        "   (\n" +
-                        "    id INT PRIMARY KEY,\n" +
-                        "    name VARCHAR(200),\n" +
-                        "    firmId INT,\n" +
-                        "    legalName VARCHAR(200),\n" +
-                        "    address1 VARCHAR(200),\n" +
-                        "    postcode VARCHAR(10)\n" +
-                        "   )\n" +
-                        "   Table FirmInfoTable\n" +
-                        "   (\n" +
-                        "    id INT PRIMARY KEY,\n" +
-                        "    name VARCHAR(200),\n" +
-                        "    other VARCHAR(200)\n" +
-                        "   )\n" +
-                        "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
-                        ")\n" ;
+        String dbSource = "###Relational\n" +
+                "Database mapping::db(\n" +
+                "   Table employeeFirmDenormTable\n" +
+                "   (\n" +
+                "    id INT PRIMARY KEY,\n" +
+                "    name VARCHAR(200),\n" +
+                "    firmId INT,\n" +
+                "    legalName VARCHAR(200),\n" +
+                "    address1 VARCHAR(200),\n" +
+                "    postcode VARCHAR(10)\n" +
+                "   )\n" +
+                "   Table FirmInfoTable\n" +
+                "   (\n" +
+                "    id INT PRIMARY KEY,\n" +
+                "    name VARCHAR(200),\n" +
+                "    other VARCHAR(200)\n" +
+                "   )\n" +
+                "   Join PersonFirmJoin(employeeFirmDenormTable.firmId = FirmInfoTable.id)\n" +
+                ")\n";
 
 
         String mappingSource = "###Mapping\n" +
-                        "import other::*;\n" +
-                        "import mapping::*;\n" +
-                        "Mapping mappingPackage::myMapping\n" +
-                        "(\n" +
-                        "    Firm[firm1]: Relational\n" +
-                        "    {\n" +
-                        "       legalName : [db]FirmInfoTable.name ,\n" +
-                        "       otherInformation: [db]FirmInfoTable.other\n" +
-                        "    }\n" +
-                        "    Person[alias1]: Relational\n" +
-                        "    {\n" +
-                        "        name : [db]employeeFirmDenormTable.name,\n" +
-                        "        firm\n" +
-                        "        (\n" +
-                        "            legalName : [db]employeeFirmDenormTable.legalName\n" +
-                        "        ) Otherwise ( [firm1]:[db]@PersonFirmJoin) \n" +
-                        "    }\n" +
-                        ")\n";
+                "import other::*;\n" +
+                "import mapping::*;\n" +
+                "Mapping mappingPackage::myMapping\n" +
+                "(\n" +
+                "    Firm[firm1]: Relational\n" +
+                "    {\n" +
+                "       legalName : [db]FirmInfoTable.name ,\n" +
+                "       otherInformation: [db]FirmInfoTable.other\n" +
+                "    }\n" +
+                "    Person[alias1]: Relational\n" +
+                "    {\n" +
+                "        name : [db]employeeFirmDenormTable.name,\n" +
+                "        firm\n" +
+                "        (\n" +
+                "            legalName : [db]employeeFirmDenormTable.legalName\n" +
+                "        ) Otherwise ( [firm1]:[db]@PersonFirmJoin) \n" +
+                "    }\n" +
+                ")\n";
 
         this.testDeleteAndReloadEachSource(Maps.immutable.of("1.pure", classSource, "2.pure", dbSource, "3.pure", mappingSource),
                 "###Pure\n function test():Boolean[1]{assert(2 == mappingPackage::myMapping.classMappings->size(), |'');}");
     }
 
     @Test
-    public void testUnbindingOfRelationalOperationElementWithJoin() throws Exception
+    public void testUnbindingOfRelationalOperationElementWithJoin()
     {
         new RuntimeTestScriptBuilder().createInMemorySources(COMPLEX_TEST_SOURCES)
-                .compile().run(this.runtime, this.functionExecution);
+                .compile().run(runtime, functionExecution);
 
-        RelationalGraphWalker graphWalker = new RelationalGraphWalker(this.runtime, this.processorSupport);
+        RelationalGraphWalker graphWalker = new RelationalGraphWalker(runtime, processorSupport);
 
         CoreInstance childOrgEmployeeCountsAttr = getPropertyMapping(graphWalker, "myMap", "Org", "childOrgEmployeeCount");
         Assert.assertNotNull(childOrgEmployeeCountsAttr);
 
-        new RuntimeTestScriptBuilder().deleteSource(CLASS_MAPPING_SOURCE_ID).createInMemorySource(CLASS_MAPPING_SOURCE_ID, getComplexMapping(FastList.<String>newList())).compile().run(this.runtime, this.functionExecution);
+        new RuntimeTestScriptBuilder().deleteSource(CLASS_MAPPING_SOURCE_ID).createInMemorySource(CLASS_MAPPING_SOURCE_ID, getComplexMapping(Lists.mutable.empty())).compile().run(runtime, functionExecution);
         CoreInstance childOrgEmployeeCountsAttr2 = getPropertyMapping(graphWalker, "myMap", "Org", "childOrgEmployeeCount");
         Assert.assertNull(childOrgEmployeeCountsAttr2);
     }
 
     @Test
-    public void testBindUnbindOfColumnMappedToInputParamOfDynaFunction() throws Exception
+    public void testBindUnbindOfColumnMappedToInputParamOfDynaFunction()
     {
-            RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(COMPLEX_TEST_SOURCES)
-                            .compile(),
-                    new RuntimeTestScriptBuilder()
-                            .deleteSource(RELATIONAL_DB_SOURCE_ID)
-                            .createInMemorySource(RELATIONAL_DB_SOURCE_ID, getComplexDatabase(ORG_TABLE_WITHOUT_EMPLOYEE_COUNT))
-                            .compileWithExpectedCompileFailure("The column 'employeeCount' can't be found in the table 'orgTable'", null, 10, 69)
-                            .deleteSource(RELATIONAL_DB_SOURCE_ID)
-                            .createInMemorySource(RELATIONAL_DB_SOURCE_ID, getComplexDatabase(ORG_TABLE))
-                            .compile()
-                    , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+        RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(COMPLEX_TEST_SOURCES)
+                        .compile(),
+                new RuntimeTestScriptBuilder()
+                        .deleteSource(RELATIONAL_DB_SOURCE_ID)
+                        .createInMemorySource(RELATIONAL_DB_SOURCE_ID, getComplexDatabase(ORG_TABLE_WITHOUT_EMPLOYEE_COUNT))
+                        .compileWithExpectedCompileFailure("The column 'employeeCount' can't be found in the table 'orgTable'", null, 10, 69)
+                        .deleteSource(RELATIONAL_DB_SOURCE_ID)
+                        .createInMemorySource(RELATIONAL_DB_SOURCE_ID, getComplexDatabase(ORG_TABLE))
+                        .compile()
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
 
@@ -406,18 +401,18 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
     {
         String classSource =
                 "import other::*;\n" +
-                "Class other::Person\n" +
-                "{\n" +
-                "    name:String[1];\n" +
-                "    firm:Firm[1];\n" +
-                "    addressLine1:String[1];\n" +
-                "}\n" +
-                "Class other::Firm\n" +
-                "{\n" +
-                "    legalName:String[1];\n" +
-                "    employees:Person[*];\n" +
-                "}";
-        String dbSource =   "###Relational\n" +
+                        "Class other::Person\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "    firm:Firm[1];\n" +
+                        "    addressLine1:String[1];\n" +
+                        "}\n" +
+                        "Class other::Firm\n" +
+                        "{\n" +
+                        "    legalName:String[1];\n" +
+                        "    employees:Person[*];\n" +
+                        "}";
+        String dbSource = "###Relational\n" +
                 "Database mapping::db(\n" +
                 "   Table employeeTable\n" +
                 "   (\n" +
@@ -443,8 +438,8 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
                 "    employeeFirmId : employeeTable.firmId,\n" +
                 "    addressLine :  @employee_address | addressTable.line\n" +
                 "   )\n" +
-                "   Join employee_address(employeeTable.id=addressTable.id)\n "+
-                "   Join firm_employees(firmTable.id=employeeAddressView.employeeFirmId)\n"+
+                "   Join employee_address(employeeTable.id=addressTable.id)\n " +
+                "   Join firm_employees(firmTable.id=employeeAddressView.employeeFirmId)\n" +
                 ")";
         String mappingSource =
                 "###Mapping\n" +
@@ -455,7 +450,7 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
                         "    Person: Relational\n" +
                         "    {\n" +
                         "        name : [db]employeeAddressView.employeeName,\n" +
-                       "         addressLine1 : [db]employeeAddressView.addressLine" +
+                        "         addressLine1 : [db]employeeAddressView.addressLine" +
                         "    }\n" +
                         "    Firm: Relational\n" +
                         "    {\n" +
@@ -464,14 +459,14 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
                         "    }\n" +
                         ")\n";
 
-         this.testDeleteAndReloadEachSource(Maps.immutable.of("1.pure", classSource, "2.pure", dbSource, "3.pure", mappingSource),
+        this.testDeleteAndReloadEachSource(Maps.immutable.of("1.pure", classSource, "2.pure", dbSource, "3.pure", mappingSource),
                 "###Pure\n function test():Boolean[1]{assert(1 == mappingPackage::myMapping.classMappings->size(), |'');}");
     }
 
     @Test
     public void testMilestoningMappingUnbindStability()
     {
-        String modelTrade="Class my::Trade{\n" +
+        String modelTrade = "Class my::Trade{\n" +
                 "   id:Integer[1];\n" +
                 "   product:my::Product[1];\n" +
                 "}";
@@ -481,7 +476,7 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
         String modelProductTemporal = "Class <<temporal.businesstemporal>> my::Product{\n" +
                 "   id:Integer[1];\n" +
                 "}";
-        String storeAndMapping="###Mapping\n" +
+        String storeAndMapping = "###Mapping\n" +
                 "import meta::relational::tests::*;\n" +
                 "import my::*;\n" +
                 "\n" +
@@ -512,10 +507,11 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
                         .deleteSource("modelProduct.pure")
                         .createInMemorySource("modelProductTemporal.pure", modelProductTemporal)
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
-    private CoreInstance getPropertyMapping(RelationalGraphWalker graphWalker, String mappingName, String className, String attributeName){
+    private CoreInstance getPropertyMapping(RelationalGraphWalker graphWalker, String mappingName, String className, String attributeName)
+    {
         CoreInstance mapping = graphWalker.getMapping(mappingName);
         CoreInstance orgMapping = graphWalker.getClassMapping(mapping, className);
         return graphWalker.getClassMappingImplementationPropertyMapping(orgMapping, attributeName);
@@ -525,5 +521,4 @@ public class TestPureRuntimeClassMapping extends AbstractPureRelationalTestWithC
     {
         return Lists.fixedSize.of();
     }
-
 }

--- a/legend-pure-m2-store-relational/src/test/java/org/finos/legend/pure/m2/relational/incremental/TestPureRuntimeInlineEmbeddedMapping.java
+++ b/legend-pure-m2-store-relational/src/test/java/org/finos/legend/pure/m2/relational/incremental/TestPureRuntimeInlineEmbeddedMapping.java
@@ -14,8 +14,8 @@
 
 package org.finos.legend.pure.m2.relational.incremental;
 
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Maps;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
 import org.finos.legend.pure.m2.relational.AbstractPureRelationalTestWithCoreCompiled;
 import org.finos.legend.pure.m3.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.RuntimeVerifier;
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 public class TestPureRuntimeInlineEmbeddedMapping extends AbstractPureRelationalTestWithCoreCompiled
 {
-
     private static final String INITIAL_DATA = "import other::*;\n" +
             "Class other::Person\n" +
             "{\n" +
@@ -215,7 +214,7 @@ public class TestPureRuntimeInlineEmbeddedMapping extends AbstractPureRelational
 
 
     @Test
-    public void testCreateAndDeleteInlineEmbeddedMappingFile() throws Exception
+    public void testCreateAndDeleteInlineEmbeddedMappingFile()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("source1.pure", INITIAL_DATA, "source3.pure", STORE))
@@ -225,11 +224,11 @@ public class TestPureRuntimeInlineEmbeddedMapping extends AbstractPureRelational
                         .compile()
                         .deleteSource("source4.pure")
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
     @Test
-    public void testCreateAndDeleteInlineEmbeddedMappingSameFile() throws Exception
+    public void testCreateAndDeleteInlineEmbeddedMappingSameFile()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                         Maps.mutable.with("source1.pure", INITIAL_DATA, "source3.pure", STORE, "source4.pure", INITIAL_MAPPING))
@@ -239,54 +238,54 @@ public class TestPureRuntimeInlineEmbeddedMapping extends AbstractPureRelational
                         .compile()
                         .updateSource("source4.pure", INITIAL_MAPPING)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
     @Test
-    public void testChangeRootIDForInlineMapping() throws Exception
+    public void testChangeRootIDForInlineMapping()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("source1.pure", INITIAL_DATA, "source3.pure", STORE, "source4.pure", INITIAL_MAPPING))
                         .compile(),
                 new RuntimeTestScriptBuilder()
                         .updateSource("source4.pure", MAPPING_CHANGE_INLINE_SETID)
-                        .compileWithExpectedCompileFailure("Invalid Inline mapping found:'firm' property, inline set id firm1 does not exists.", "source4.pure", 13, 9)
+                        .compileWithExpectedCompileFailure("Invalid Inline mapping found: 'firm' property, inline set id firm1 does not exists.", "source4.pure", 13, 9)
                         .updateSource("source4.pure", INITIAL_MAPPING)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
     @Test
-    public void testChangeInlineTargetMapping() throws Exception
+    public void testChangeInlineTargetMapping()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("source1.pure", INITIAL_DATA, "source3.pure", STORE, "source4.pure", INITIAL_MAPPING))
                         .compile(),
                 new RuntimeTestScriptBuilder()
                         .updateSource("source4.pure", MAPPING_INVALID_INLINE)
-                        .compileWithExpectedCompileFailure("Invalid Inline mapping found:'firm' property, inline set id firm2 does not exists.", "source4.pure", 13, 9)
+                        .compileWithExpectedCompileFailure("Invalid Inline mapping found: 'firm' property, inline set id firm2 does not exists.", "source4.pure", 13, 9)
                         .updateSource("source4.pure", INITIAL_MAPPING)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
 
     @Test
-    public void testDeleteInlineMapping() throws Exception
+    public void testDeleteInlineMapping()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("source1.pure", INITIAL_DATA, "source3.pure", STORE, "source4.pure", INITIAL_MAPPING))
                         .compile(),
                 new RuntimeTestScriptBuilder()
                         .updateSource("source4.pure", MAPPING_DELETED_INLINE)
-                        .compileWithExpectedCompileFailure("Invalid Inline mapping found:'firm' property, inline set id firm1 does not exists.", "source4.pure", 9, 9)
+                        .compileWithExpectedCompileFailure("Invalid Inline mapping found: 'firm' property, inline set id firm1 does not exists.", "source4.pure", 9, 9)
                         .updateSource("source4.pure", INITIAL_MAPPING)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
     @Test
-    public void testEmptyInlineMapping() throws Exception
+    public void testEmptyInlineMapping()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("source1.pure", INITIAL_DATA, "source3.pure", STORE, "source4.pure", INITIAL_MAPPING))
@@ -296,25 +295,25 @@ public class TestPureRuntimeInlineEmbeddedMapping extends AbstractPureRelational
                         .compileWithExpectedParserFailure("expected: a valid identifier text; found: ']'", "source4.pure", 14, 19)
                         .updateSource("source4.pure", INITIAL_MAPPING)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
     @Test
-    public void testRemoveInlineKeyword() throws Exception
+    public void testRemoveInlineKeyword()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("source1.pure", INITIAL_DATA, "source3.pure", STORE, "source4.pure", INITIAL_MAPPING))
                         .compile(),
                 new RuntimeTestScriptBuilder()
                         .updateSource("source4.pure", MAPPING_REMOVE_INLINE_KEYWORD)
-                        .compileWithExpectedCompileFailure("Invalid Inline mapping found:'firm' mapping has not inline set defined, please use:firm() Inline[setid] .", "source4.pure", 13, 9)
+                        .compileWithExpectedCompileFailure("Invalid Inline mapping found: 'firm' mapping has not inline set defined, please use: firm() Inline[setid].", "source4.pure", 13, 9)
                         .updateSource("source4.pure", INITIAL_MAPPING)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
     @Test
-    public void testChangeInlineEmbeddedMappingSameFileToNormalEmbedded() throws Exception
+    public void testChangeInlineEmbeddedMappingSameFileToNormalEmbedded()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("source1.pure", INITIAL_DATA, "source3.pure", STORE, "source4.pure", INITIAL_MAPPING))
@@ -324,11 +323,11 @@ public class TestPureRuntimeInlineEmbeddedMapping extends AbstractPureRelational
                         .compile()
                         .updateSource("source4.pure", INITIAL_MAPPING)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
     @Test
-    public void testChangeToInvalidTarget() throws Exception
+    public void testChangeToInvalidTarget()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("source1.pure", INITIAL_DATA, "source3.pure", STORE, "source4.pure", INITIAL_MAPPING))
@@ -338,6 +337,6 @@ public class TestPureRuntimeInlineEmbeddedMapping extends AbstractPureRelational
                         .compileWithExpectedCompileFailure("Mapping Error! The inlineSetImplementationId 'address1' is implementing the class 'Address' which is not a subType of 'Firm' (return type of the mapped property 'firm')", "source4.pure", 17, 9)
                         .updateSource("source4.pure", INITIAL_MAPPING)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 }

--- a/legend-pure-m2-store-relational/src/test/java/org/finos/legend/pure/m2/relational/incremental/TestPureRuntimeOtherwiseEmbeddedMapping.java
+++ b/legend-pure-m2-store-relational/src/test/java/org/finos/legend/pure/m2/relational/incremental/TestPureRuntimeOtherwiseEmbeddedMapping.java
@@ -14,8 +14,8 @@
 
 package org.finos.legend.pure.m2.relational.incremental;
 
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Maps;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
 import org.finos.legend.pure.m2.relational.AbstractPureRelationalTestWithCoreCompiled;
 import org.finos.legend.pure.m3.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.RuntimeVerifier;
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 public class TestPureRuntimeOtherwiseEmbeddedMapping extends AbstractPureRelationalTestWithCoreCompiled
 {
-
     private static final String INITIAL_DATA = "import other::*;\n" +
             "Class other::Person\n" +
             "{\n" +
@@ -164,7 +163,7 @@ public class TestPureRuntimeOtherwiseEmbeddedMapping extends AbstractPureRelatio
 
 
     @Test
-    public void testCreateAndDeleteOtherwiseEmbeddedMappingSameFile() throws Exception
+    public void testCreateAndDeleteOtherwiseEmbeddedMappingSameFile()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                         Maps.mutable.with("source1.pure", INITIAL_DATA, "source3.pure", STORE, "source4.pure", INITIAL_MAPPING))
@@ -174,26 +173,26 @@ public class TestPureRuntimeOtherwiseEmbeddedMapping extends AbstractPureRelatio
                         .compile()
                         .updateSource("source4.pure", INITIAL_MAPPING)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
     @Test
-    public void testChangeOtherwiseTargetMapping() throws Exception
+    public void testChangeOtherwiseTargetMapping()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("source1.pure", INITIAL_DATA, "source3.pure", STORE, "source4.pure", INITIAL_MAPPING))
                         .compile(),
                 new RuntimeTestScriptBuilder()
                         .updateSource("source4.pure", MAPPING1)
-                        .compileWithExpectedCompileFailure("Invalid Otherwise mapping found for'firm' property, targetId firm2 does not exists.", "source4.pure", 14, 9)
+                        .compileWithExpectedCompileFailure("Invalid Otherwise mapping found for 'firm' property, targetId firm2 does not exists.", "source4.pure", 14, 9)
                         .updateSource("source4.pure", INITIAL_MAPPING)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
 
     @Test
-    public void testDeleteAndRecreateStore() throws Exception
+    public void testDeleteAndRecreateStore()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                         Maps.mutable.with("source1.pure", INITIAL_DATA, "source2.pure",STORE, "source3.pure", INITIAL_MAPPING))
@@ -203,12 +202,12 @@ public class TestPureRuntimeOtherwiseEmbeddedMapping extends AbstractPureRelatio
                         .compileWithExpectedCompileFailure(null, null, 0, 0)
                         .updateSource("source2.pure", STORE)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
 
     @Test
-    public void testChangeOtherwisePropertyMappingFromJoinToOther() throws Exception
+    public void testChangeOtherwisePropertyMappingFromJoinToOther()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("source1.pure", INITIAL_DATA, "source2.pure",STORE, "source3.pure", INITIAL_MAPPING))
@@ -218,6 +217,6 @@ public class TestPureRuntimeOtherwiseEmbeddedMapping extends AbstractPureRelatio
                         .compileWithExpectedParserFailure("expected: '@' found: 'employeeFirmDenormTable'", "source3.pure", 17, 35)
                         .updateSource("source3.pure", INITIAL_MAPPING)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 }

--- a/legend-pure-m2-store-relational/src/test/java/org/finos/legend/pure/m2/relational/incremental/TestView.java
+++ b/legend-pure-m2-store-relational/src/test/java/org/finos/legend/pure/m2/relational/incremental/TestView.java
@@ -14,11 +14,17 @@
 
 package org.finos.legend.pure.m2.relational.incremental;
 
-import org.finos.legend.pure.m2.relational.AbstractPureRelationalTestWithCoreCompiled;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
+import org.finos.legend.pure.m2.relational.AbstractPureRelationalTestWithCoreCompiled;
 import org.finos.legend.pure.m3.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.RuntimeVerifier;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
+import org.junit.Before;
 import org.junit.Test;
 
 public class TestView extends AbstractPureRelationalTestWithCoreCompiled
@@ -55,27 +61,39 @@ public class TestView extends AbstractPureRelationalTestWithCoreCompiled
             "   }\n" +
             ")";
 
+    @Before
+    @Override
+    public void _setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return org.eclipse.collections.api.factory.Lists.immutable.with(CodeRepository.newPlatformCodeRepository(), GenericCodeRepository.build("test", "((test)|(meta))(::.*)?", PlatformCodeRepository.NAME));
+    }
+
     @Test
     public void testGroupByIncrementalSyntaticStoreChange()
     {
         String viewDynaColName = "orderPnl";
-        String groupByStore = GroupByStoreTemplate.format(GroupByStoreTemplate, viewDynaColName);
-        String groupByMapping = GroupByMappingTemplate.format(GroupByMappingTemplate, viewDynaColName);
+        String groupByStore = String.format(GroupByStoreTemplate, viewDynaColName);
+        String groupByMapping = String.format(GroupByMappingTemplate, viewDynaColName);
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("store.pure", groupByStore, "model.pure", GroupByModel, "mapping.pure", groupByMapping))
                         .compile(),
                 new RuntimeTestScriptBuilder()
                         .updateSource("store.pure", groupByStore + " ")
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
     @Test
     public void testGroupByIncrementalModelChange()
     {
         String viewDynaColName = "orderPnl";
-        String groupByStore = GroupByStoreTemplate.format(GroupByStoreTemplate, viewDynaColName);
-        String groupByMapping = GroupByMappingTemplate.format(GroupByMappingTemplate, viewDynaColName);
+        String groupByStore = String.format(GroupByStoreTemplate, viewDynaColName);
+        String groupByMapping = String.format(GroupByMappingTemplate, viewDynaColName);
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("store.pure", groupByStore, "model.pure", GroupByModel, "mapping.pure", groupByMapping))
                         .compile(),
@@ -84,18 +102,18 @@ public class TestView extends AbstractPureRelationalTestWithCoreCompiled
                         .compile()
                         .updateSource("model.pure", GroupByModel)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
     @Test
     public void testGroupByIncrementalStoreAndMappingChange()
     {
         String viewDynaColName = "orderPnl";
-        String groupByStore = GroupByStoreTemplate.format(GroupByStoreTemplate, viewDynaColName);
-        String groupByMapping = GroupByMappingTemplate.format(GroupByMappingTemplate, viewDynaColName);
+        String groupByStore = String.format(GroupByStoreTemplate, viewDynaColName);
+        String groupByMapping = String.format(GroupByMappingTemplate, viewDynaColName);
         String viewDynaColNameUpdated = "orderPnlUpdated";
-        String groupByStoreUpdated = GroupByStoreTemplate.format(GroupByStoreTemplate, viewDynaColNameUpdated);
-        String groupByMappingUpdated = GroupByMappingTemplate.format(GroupByMappingTemplate, viewDynaColNameUpdated);
+        String groupByStoreUpdated = String.format(GroupByStoreTemplate, viewDynaColNameUpdated);
+        String groupByMappingUpdated = String.format(GroupByMappingTemplate, viewDynaColNameUpdated);
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySources(
                 Maps.mutable.with("store.pure", groupByStore, "model.pure", GroupByModel, "mapping.pure", groupByMapping))
                         .compile(),
@@ -104,7 +122,7 @@ public class TestView extends AbstractPureRelationalTestWithCoreCompiled
                         .compile()
                         .updateSource("store.pure", groupByStore).updateSource("mapping.pure", groupByMapping)
                         .compile()
-                , this.runtime, this.functionExecution, Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of());
+                , runtime, functionExecution, Lists.fixedSize.empty());
     }
 
     @Test
@@ -142,6 +160,6 @@ public class TestView extends AbstractPureRelationalTestWithCoreCompiled
                         .deleteSource(includedDB1Source)
                         .createInMemorySource(includedDB1Source, includedDB1)
                         .compile(),
-                this.runtime, this.functionExecution, Lists.immutable.<RuntimeVerifier.FunctionExecutionStateVerifier>empty());
+                runtime, functionExecution, Lists.immutable.empty());
     }
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/visibility/AccessLevel.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/visibility/AccessLevel.java
@@ -14,17 +14,17 @@
 
 package org.finos.legend.pure.m3.compiler.visibility;
 
-import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.factory.Lists;
-import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.pure.m3.compiler.Context;
-import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.ElementWithStereotypes;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Stereotype;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function;
+import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
 /**
@@ -72,12 +72,12 @@ public enum AccessLevel
      * @param processorSupport processor support
      * @return whether the instance has an explicit access level
      */
-    public static boolean hasExplicitAccessLevel(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function instance, ProcessorSupport processorSupport)
+    public static boolean hasExplicitAccessLevel(Function<?> instance, ProcessorSupport processorSupport)
     {
-        ListIterable<? extends Stereotype> stereotypes = (ListIterable<? extends Stereotype>)ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>)instance._stereotypesCoreInstance(), processorSupport);
+        ListIterable<? extends Stereotype> stereotypes = (ListIterable<? extends Stereotype>) ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>) instance._stereotypesCoreInstance(), processorSupport);
         if (stereotypes.notEmpty())
         {
-            Profile profile = (Profile)processorSupport.package_getByUserPath(M3Paths.access);
+            Profile profile = (Profile) processorSupport.package_getByUserPath(M3Paths.access);
             for (Stereotype st : stereotypes)
             {
                 if (st._profile() == profile)
@@ -98,7 +98,7 @@ public enum AccessLevel
      */
     public static ListIterable<Stereotype> getAccessLevelStereotypes(ElementWithStereotypes packageableElement, ProcessorSupport processorSupport)
     {
-        ListIterable<Stereotype> stereotypes = (ListIterable<Stereotype>)ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>)packageableElement._stereotypesCoreInstance(), processorSupport);
+        ListIterable<Stereotype> stereotypes = (ListIterable<Stereotype>) ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>) packageableElement._stereotypesCoreInstance(), processorSupport);
         if (stereotypes.isEmpty())
         {
             return Lists.immutable.empty();
@@ -125,24 +125,19 @@ public enum AccessLevel
      * @param processorSupport   processor support
      * @return access level
      */
-    public static AccessLevel getAccessLevel(ElementWithStereotypes packageableElement, Context context, final ProcessorSupport processorSupport)
+    public static AccessLevel getAccessLevel(ElementWithStereotypes packageableElement, Context context, ProcessorSupport processorSupport)
     {
-        return (context == null) ? calculateAccessLevel(packageableElement, processorSupport) : context.getIfAbsentPutAccessLevel(packageableElement, new Function<CoreInstance, AccessLevel>()
-        {
-            @Override
-            public AccessLevel valueOf(CoreInstance instance)
-            {
-                return calculateAccessLevel((ElementWithStereotypes)instance, processorSupport);
-            }
-        });
+        return (context == null) ?
+                calculateAccessLevel(packageableElement, processorSupport) :
+                context.getIfAbsentPutAccessLevel(packageableElement, instance -> calculateAccessLevel((ElementWithStereotypes) instance, processorSupport));
     }
 
     private static AccessLevel calculateAccessLevel(ElementWithStereotypes packageableElement, ProcessorSupport processorSupport)
     {
-        ListIterable<? extends Stereotype> stereotypes = (ListIterable<? extends Stereotype>)ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>)packageableElement._stereotypesCoreInstance(), processorSupport);
+        ListIterable<? extends Stereotype> stereotypes = (ListIterable<? extends Stereotype>) ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>) packageableElement._stereotypesCoreInstance(), processorSupport);
         if (stereotypes.notEmpty())
         {
-            Profile accessProfile = (Profile)processorSupport.package_getByUserPath(M3Paths.access);
+            Profile accessProfile = (Profile) processorSupport.package_getByUserPath(M3Paths.access);
             for (Stereotype st : stereotypes)
             {
                 if (st._profile() == accessProfile)

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/Loader.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/Loader.java
@@ -14,10 +14,10 @@
 
 package org.finos.legend.pure.m3.serialization;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.multimap.list.ListMultimap;
 import org.eclipse.collections.api.set.SetIterable;
-import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.compiler.postprocessing.PostProcessor;
 import org.finos.legend.pure.m3.compiler.validation.ValidationType;
@@ -33,8 +33,8 @@ import org.finos.legend.pure.m3.serialization.grammar.top.TopParser;
 import org.finos.legend.pure.m3.serialization.runtime.IncrementalCompiler;
 import org.finos.legend.pure.m3.statelistener.M3M4StateListener;
 import org.finos.legend.pure.m3.statelistener.M3StateListener;
-import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.m4.exception.PureException;
 
@@ -75,13 +75,11 @@ public class Loader
             Validator.validateM3(newInstances, validationType, library, new InlineDSLLibrary(), new PureCodeStorage(null), repository, context, processorSupport);
             stateListener.finishedValidation();
         }
-        catch (PureException exception)
+        catch (PureException e)
         {
-            String space = "      ";
-            throw new RuntimeException(exception+" in\n"+space+code.replace("\n","\n"+space), exception);
+            throw new LoaderException(e, code);
         }
     }
-
 
 
     private static void processExcludes(ModelRepository repository, ProcessorSupport processorSupport, M3StateListener listener) throws PureCompilationException
@@ -89,5 +87,25 @@ public class Loader
         listener.startProcessingIncludes();
         SetIterable<CoreInstance> excludes = IncrementalCompiler.rebuildExclusionSet(repository, processorSupport);
         listener.finishedProcessingIncludes(excludes);
+    }
+
+    public static class LoaderException extends RuntimeException
+    {
+        private LoaderException(PureException e, String code)
+        {
+            super(generateMessage(e, code), e);
+        }
+
+        @Override
+        public PureException getCause()
+        {
+            return (PureException) super.getCause();
+        }
+
+        private static String generateMessage(PureException e, String code)
+        {
+            String space = "      ";
+            return e + " in\n" + space + code.replace("\n","\n" + space);
+        }
     }
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/repository/CodeRepository.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/repository/CodeRepository.java
@@ -14,6 +14,15 @@
 
 package org.finos.legend.pure.m3.serialization.filesystem.repository;
 
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.list.mutable.ListAdapter;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 public abstract class CodeRepository
@@ -71,7 +80,7 @@ public abstract class CodeRepository
             return false;
         }
 
-        return this.name.equals(((CodeRepository)other).getName());
+        return this.name.equals(((CodeRepository) other).getName());
     }
 
     @Override
@@ -99,5 +108,93 @@ public abstract class CodeRepository
     public static CodeRepository newScratchCodeRepository()
     {
         return new ScratchCodeRepository();
+    }
+
+    /**
+     * Produce a list of repositories sorted by visibility. In the resulting list, is one repository is visible to
+     * another, then the visible repository will be earlier in the list. E.g., if repository A is visible to B, then A
+     * will appear before B in the list. Two repositories which are not visible to each other may appear in any order.
+     * An exception will be thrown if a visibility loop is detected. The result will be a new list, and othe original
+     * will not be modified.
+     *
+     * @param repositories repositories to sort
+     * @param <T>          repository type
+     * @return list of repositories sorted by visibility
+     */
+    public static <T extends CodeRepository> MutableList<T> toSortedRepositoryList(Iterable<T> repositories)
+    {
+        if (repositories instanceof ListIterable)
+        {
+            return toSortedRepositoryList((ListIterable<T>) repositories);
+        }
+        if (repositories instanceof List)
+        {
+            return toSortedRepositoryList(ListAdapter.adapt((List<T>) repositories));
+        }
+        return toSortedRepositoryList(Lists.mutable.withAll(repositories));
+    }
+
+    /**
+     * Produce a list of repositories sorted by visibility. In the resulting list, is one repository is visible to
+     * another, then the visible repository will be earlier in the list. E.g., if repository A is visible to B, then A
+     * will appear before B in the list. Two repositories which are not visible to each other may appear in any order.
+     * An exception will be thrown if a visibility loop is detected. The result will be a new list, and othe original
+     * will not be modified.
+     *
+     * @param repositories repositories to sort
+     * @param <T>          repository type
+     * @return list of repositories sorted by visibility
+     */
+    public static <T extends CodeRepository> MutableList<T> toSortedRepositoryList(ListIterable<T> repositories)
+    {
+        if (repositories.size() <= 1)
+        {
+            return Lists.mutable.withAll(repositories);
+        }
+
+        MutableList<T> result = Lists.mutable.ofInitialCapacity(repositories.size());
+
+        // We use a LinkedHashMap so that iteration order will be deterministic, which in turn ensures a deterministic result.
+        Map<T, MutableList<T>> remaining = new LinkedHashMap<>(repositories.size());
+        repositories.forEach(r ->
+        {
+            MutableList<T> visible = repositories.select(r2 -> (r2 != r) && r.isVisible(r2), Lists.mutable.empty());
+            if (visible.isEmpty())
+            {
+                // no other repositories visible, can go straight into result
+                result.add(r);
+            }
+            else
+            {
+                remaining.put(r, visible);
+            }
+        });
+
+        while (!remaining.isEmpty())
+        {
+            int beforeSize = remaining.size();
+            Iterator<Map.Entry<T, MutableList<T>>> iterator = remaining.entrySet().iterator();
+            while (iterator.hasNext())
+            {
+                Map.Entry<T, MutableList<T>> entry = iterator.next();
+                MutableList<T> visible = entry.getValue();
+                visible.removeIf(r -> !remaining.containsKey(r));
+                if (visible.isEmpty())
+                {
+                    result.add(entry.getKey());
+                    iterator.remove();
+                }
+            }
+            if (remaining.size() == beforeSize)
+            {
+                // could not make progress - there must be a visibility loop
+                StringBuilder builder = new StringBuilder("Could not consistently order the following repositories:");
+                remaining.forEach((r, vis) -> vis.asLazy().collect(CodeRepository::getName).appendString(builder.append(" ").append(r.getName()), " (visible: ", ", ", "),"));
+                builder.deleteCharAt(builder.length() - 1);
+                throw new RuntimeException(builder.toString());
+            }
+        }
+
+        return result;
     }
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/RuntimeOptions.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/RuntimeOptions.java
@@ -17,4 +17,19 @@ package org.finos.legend.pure.m3.serialization.runtime;
 public interface RuntimeOptions
 {
     boolean isOptionSet(String name);
+
+    static RuntimeOptions noOptionsSet()
+    {
+        return name -> false;
+    }
+
+    static RuntimeOptions systemPropertyOptions()
+    {
+        return systemPropertyOptions(null);
+    }
+
+    static RuntimeOptions systemPropertyOptions(String prefix)
+    {
+        return (prefix == null) ? Boolean::getBoolean : name -> Boolean.getBoolean(prefix + name);
+    }
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/binary/AbstractPureRepositoryJarLibrary.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/binary/AbstractPureRepositoryJarLibrary.java
@@ -317,7 +317,7 @@ public abstract class AbstractPureRepositoryJarLibrary implements PureRepository
                 String old = instanceDefinitions.put(instancePath, filePath);
                 if (old != null)
                 {
-                    throw new IllegalArgumentException("Multiple definition files for " + instancePath);
+                    throw new IllegalArgumentException("Multiple definition files for " + instancePath + ": " + old + " and " + filePath);
                 }
             });
             metadata.getExternalReferenceIndex().forEachKeyValue((filePath, instancePaths) ->

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/pattern/PurePattern.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/pattern/PurePattern.java
@@ -14,61 +14,37 @@
 
 package org.finos.legend.pure.m3.serialization.runtime.pattern;
 
-import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.set.ImmutableSet;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Sets;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.finos.legend.pure.m3.navigation.M3Paths;
-import org.finos.legend.pure.m3.navigation.Instance;
-import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
-import org.finos.legend.pure.m3.navigation.function.FunctionDescriptor;
-import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
+import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
+import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.function.FunctionDescriptor;
+import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
+import org.finos.legend.pure.m3.tools.ListHelper;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
-import org.apache.commons.lang3.StringUtils;
 
 import java.net.URLDecoder;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class PurePattern
 {
-    public static final org.eclipse.collections.api.block.function.Function<PurePattern, String> GET_SRC_PATTERN = new org.eclipse.collections.api.block.function.Function<PurePattern, String>()
-    {
-        @Override
-        public String valueOf(PurePattern pattern)
-        {
-            return pattern.getSrcPattern();
-        }
-    };
-
-    public static final org.eclipse.collections.api.block.function.Function<PurePattern, String> GET_REAL_PATTERN = new org.eclipse.collections.api.block.function.Function<PurePattern, String>()
-    {
-        @Override
-        public String valueOf(PurePattern pattern)
-        {
-            return pattern.pattern.pattern();
-        }
-    };
-
-    public static final org.eclipse.collections.api.block.function.Function<PurePattern, CoreInstance> GET_FUNCTION = new org.eclipse.collections.api.block.function.Function<PurePattern, CoreInstance>()
-    {
-        @Override
-        public CoreInstance valueOf(PurePattern pattern)
-        {
-            return pattern.getFunction();
-        }
-    };
+    public static final Function<PurePattern, String> GET_SRC_PATTERN = PurePattern::getSrcPattern;
+    public static final Function<PurePattern, String> GET_REAL_PATTERN = PurePattern::getRealPattern;
+    public static final Function<PurePattern, CoreInstance> GET_FUNCTION = PurePattern::getFunction;
 
     private final Pattern pattern;
     private final CoreInstance function;
@@ -95,95 +71,112 @@ public class PurePattern
         return this.srcPattern;
     }
 
+    public String getRealPattern()
+    {
+        return this.pattern.pattern();
+    }
+
     public Pair<CoreInstance, Map<String, String[]>> execute(String url, ProcessorSupport processorSupport, Map<String, String[]> params)
     {
         Matcher matcher = this.pattern.matcher(url);
-
-        if (matcher.matches())
+        if (!matcher.matches())
         {
-            Map<String, String[]> requestParams = UnifiedMap.newMap();
+            return null;
+        }
 
-            requestParams.put("func", new String[]{FunctionDescriptor.getFunctionDescriptor(this.function, processorSupport)});
+        Map<String, String[]> requestParams = Maps.mutable.empty();
 
-            RichIterable<? extends VariableExpression> parameters = ((FunctionType)processorSupport.function_getFunctionType(this.function))._parameters();
-            String[] toReturnParams = new String[parameters.size()];
+        requestParams.put("func", new String[]{FunctionDescriptor.getFunctionDescriptor(this.function, processorSupport)});
 
-            CoreInstance stringType = processorSupport.package_getByUserPath(M3Paths.String);
-            ImmutableSet<CoreInstance> dateTypes = Sets.immutable.with(
-                    processorSupport.package_getByUserPath(M3Paths.Date),
-                    processorSupport.package_getByUserPath(M3Paths.DateTime),
-                    processorSupport.package_getByUserPath(M3Paths.StrictDate));
+        ListIterable<? extends VariableExpression> parameters = ListHelper.wrapListIterable(((FunctionType) processorSupport.function_getFunctionType(this.function))._parameters());
+        String[] toReturnParams = new String[parameters.size()];
 
-            int i = 0;
-            for (VariableExpression c : parameters)
+        CoreInstance stringType = processorSupport.package_getByUserPath(M3Paths.String);
+        Predicate<CoreInstance> isDateType = Sets.immutable.with(
+                processorSupport.package_getByUserPath(M3Paths.Date),
+                processorSupport.package_getByUserPath(M3Paths.DateTime),
+                processorSupport.package_getByUserPath(M3Paths.StrictDate))::contains;
+
+        parameters.forEachWithIndex((c, i) ->
+        {
+            String name = c._name();
+            Type type = (Type) ImportStub.withImportStubByPass(c._genericType()._rawTypeCoreInstance(), processorSupport);
+
+            String value;
+            if (this.urlArguments.contains(name))
             {
-                String name = c._name();
-                Type type = (Type)ImportStub.withImportStubByPass(c._genericType()._rawTypeCoreInstance(), processorSupport);
-
-                String value;
-                if (urlArguments.contains(name)) {
-                    String arg = URLDecoder.decode(matcher.group(name));
-                    value = convertValue(arg, type, stringType, dateTypes, processorSupport);
-                } else {
-                    value = convertValues(params.get(name), type, stringType, dateTypes, processorSupport);
-                }
-
-                toReturnParams[i] = value;
-                i++;
+                String arg = URLDecoder.decode(matcher.group(name));
+                value = convertValue(arg, type, stringType, isDateType, processorSupport);
             }
-            requestParams.put("param", toReturnParams);
+            else
+            {
+                value = convertValues(params.get(name), type, stringType, isDateType, processorSupport);
+            }
 
-            return Tuples.pair(this.function, requestParams);
-        }
+            toReturnParams[i] = value;
+        });
+        requestParams.put("param", toReturnParams);
 
-        return null;
+        return Tuples.pair(this.function, requestParams);
     }
 
-    private String convertValues(String[] values, final CoreInstance type, final CoreInstance stringType, final ImmutableSet<CoreInstance> dateTypes, final ProcessorSupport processorSupport) {
-        values = values == null ? new String[]{} : values;
-
-        switch(values.length) {
-            case 0: return "[]";
-            case 1: return convertValue(values[0], type, stringType, dateTypes, processorSupport);
+    private String convertValues(String[] values, CoreInstance type, CoreInstance stringType, Predicate<CoreInstance> isDateType, ProcessorSupport processorSupport)
+    {
+        if (values == null)
+        {
+            return "[]";
+        }
+        switch (values.length)
+        {
+            case 0:
+            {
+                return "[]";
+            }
+            case 1:
+            {
+                return convertValue(values[0], type, stringType, isDateType, processorSupport);
+            }
             default:
-                MutableList<String> args = FastList.newListWith(values).collect(new Function<String, String>() {
-
-                    @Override
-                    public String valueOf(String value)
-                    {
-                        return convertValue(value, type, stringType, dateTypes, processorSupport);
-                    }
-                });
-                return "[" + StringUtils.join(args, ",") + "]";
+            {
+                return ArrayIterate.collect(values, value -> convertValue(value, type, stringType, isDateType, processorSupport)).makeString("[", ",", "]");
+            }
         }
     }
 
-    private static String convertValue(String value, CoreInstance type, CoreInstance stringType, ImmutableSet<CoreInstance> dateTypes, ProcessorSupport processorSupport) {
-        if (type == stringType) {
+    private static String convertValue(String value, CoreInstance type, CoreInstance stringType, Predicate<CoreInstance> isDateType, ProcessorSupport processorSupport)
+    {
+        if (type == stringType)
+        {
             return convertString(value);
-        } else if (dateTypes.contains(type)) {
+        }
+        if (isDateType.test(type))
+        {
             return convertDate(value);
-        } else if (Instance.instanceOf(type, M3Paths.Enumeration, processorSupport)) {
+        }
+        if (Instance.instanceOf(type, M3Paths.Enumeration, processorSupport))
+        {
             return convertEnum(value, type);
         }
-
         return value;
     }
 
-    private static String convertString(String value) {
-        String part = value.startsWith("'") && value.endsWith("'")
-                ? StringUtils.substring(value, 1, value.length() - 1)
+    private static String convertString(String value)
+    {
+        String part = (value.length() >= 2) && value.startsWith("'") && value.endsWith("'")
+                ? value.substring(1, value.length() - 1)
                 : value;
-        return "'" + part.replace("'", "\'") + "'";
+        return "'" + part.replace("'", "\\'") + "'";
     }
 
-    private static String convertDate(String value) {
-        return value.startsWith("%") ? value : "%" + value;
+    private static String convertDate(String value)
+    {
+        return value.startsWith("%") ? value : ("%" + value);
     }
 
-    private static String convertEnum(String value, CoreInstance type){
+    private static String convertEnum(String value, CoreInstance type)
+    {
         String prefix = PackageableElement.getUserPathForPackageableElement(type) + '.';
-        return value.startsWith(prefix) ? value : prefix + value;
+        return value.startsWith(prefix) ? value : (prefix + value);
     }
 
     public CoreInstance getFunction()

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/AbstractPureTestWithCoreCompiledPlatform.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/AbstractPureTestWithCoreCompiledPlatform.java
@@ -14,17 +14,19 @@
 
 package org.finos.legend.pure.m3;
 
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableCodeStorage;
 
 public class AbstractPureTestWithCoreCompiledPlatform extends AbstractPureTestWithCoreCompiled
 {
-    public static Pair<String, String> extra = Tuples.pair("/system/extra.pure",
-            "Profile meta::pure::profiles::test\n" +
-                    "{\n" +
-                    "    stereotypes : [Test, BeforePackage, AfterPackage, ToFix, ExcludeAlloy, ExcludeLazy, AlloyOnly, ExcludeAlloyTextMode];\n" +
-                    "    tags: [excludePlatform, sensitiveToStereotype];\n" +
-                    "}" +
+    public static final Pair<String, String> EXTRA = Tuples.pair("/system/extra.pure",
                     "Profile meta::pure::profiles::typemodifiers\n" +
                     "{\n" +
                     "    stereotypes: [abstract];\n" +
@@ -81,6 +83,26 @@ public class AbstractPureTestWithCoreCompiledPlatform extends AbstractPureTestWi
 
     public static Pair<String, String> getExtra()
     {
-        return extra;
+        return EXTRA;
+    }
+
+    public static void setUpRuntime()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage(), getFactoryRegistryOverride(), getOptions(), getExtra());
+    }
+
+    public static void setUpRuntime(Pair<String, String> extra)
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage(), getFactoryRegistryOverride(), getOptions(), extra);
+    }
+
+    protected static MutableCodeStorage getCodeStorage()
+    {
+        return PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories());
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return Lists.immutable.with(CodeRepository.newPlatformCodeRepository(), GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", PlatformCodeRepository.NAME));
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/filesystem/TestCodeRepositoryWithDependencies.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/filesystem/TestCodeRepositoryWithDependencies.java
@@ -14,25 +14,32 @@
 
 package org.finos.legend.pure.m3.serialization.filesystem;
 
-import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.set.SetIterable;
+import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
+import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 
 import java.util.regex.Pattern;
 
 public class TestCodeRepositoryWithDependencies extends CodeRepository
 {
-    private final MutableSet<String> deps;
+    private final SetIterable<String> dependencies;
 
-    public TestCodeRepositoryWithDependencies(String name, Pattern allowedPackagesPattern, MutableSet<CodeRepository> deps)
+    public TestCodeRepositoryWithDependencies(String name, Pattern allowedPackagesPattern, Iterable<? extends CodeRepository> dependencies)
     {
         super(name, allowedPackagesPattern);
-        this.deps = deps.collect(CodeRepository::getName);
+        this.dependencies = Iterate.collect(dependencies, CodeRepository::getName, Sets.mutable.empty());
+    }
+
+    public TestCodeRepositoryWithDependencies(String name, Pattern allowedPackagesPattern, CodeRepository... dependencies)
+    {
+        this(name, allowedPackagesPattern, ArrayAdapter.adapt(dependencies));
     }
 
     @Override
     public boolean isVisible(CodeRepository other)
     {
-        return other == this || this.deps.contains(other.getName());
+        return (other == this) || ((other != null) && this.dependencies.contains(other.getName()));
     }
 }
-

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/filesystem/repository/TestCodeRepository.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/filesystem/repository/TestCodeRepository.java
@@ -1,0 +1,119 @@
+package org.finos.legend.pure.m3.serialization.filesystem.repository;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestCodeRepository
+{
+    @Test
+    public void testToSortedRepositoriesList_Empty()
+    {
+        assertSort(Lists.fixedSize.empty());
+    }
+
+    @Test
+    public void testToSortedRepositoriesList_Single()
+    {
+        CodeRepository platformRepo = CodeRepository.newPlatformCodeRepository();
+        CodeRepository repo1 = GenericCodeRepository.build("repo_one", "meta::pure::\\.*", "platform");
+        CodeRepository repo2 = GenericCodeRepository.build("repo_two", "meta::pure::\\.*", "platform");
+        CodeRepository repo3 = GenericCodeRepository.build("repo_three", "meta::pure::\\.*", "platform", "repo_one");
+        CodeRepository repo4 = GenericCodeRepository.build("repo_four", "meta::pure::\\.*", "platform", "repo_one", "repo_two");
+
+        assertSort(Lists.fixedSize.with(platformRepo), platformRepo);
+        assertSort(Lists.fixedSize.with(repo1), repo1);
+        assertSort(Lists.fixedSize.with(repo2), repo2);
+        assertSort(Lists.fixedSize.with(repo3), repo3);
+        assertSort(Lists.fixedSize.with(repo4), repo4);
+    }
+
+    @Test
+    public void testToSortedRepositoriesList_General()
+    {
+        CodeRepository platformRepo = CodeRepository.newPlatformCodeRepository();
+        CodeRepository repo1 = GenericCodeRepository.build("repo_one", "meta::pure::\\.*", "platform");
+        CodeRepository repo2 = GenericCodeRepository.build("repo_two", "meta::pure::\\.*", "platform");
+        CodeRepository repo3 = GenericCodeRepository.build("repo_three", "meta::pure::\\.*", "platform", "repo_one");
+        CodeRepository repo4 = GenericCodeRepository.build("repo_four", "meta::pure::\\.*", "platform", "repo_one", "repo_two");
+        CodeRepository repo5 = GenericCodeRepository.build("repo_five", "meta::pure::\\.*", "platform", "repo_two");
+
+        assertSort(Lists.fixedSize.with(platformRepo, repo1), repo1, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repo1), platformRepo, repo1);
+
+        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2), repo1, repo2, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2), repo1, platformRepo, repo2);
+        assertSort(Lists.fixedSize.with(platformRepo, repo2, repo1), repo2, platformRepo, repo1);
+
+        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2, repo3, repo4), repo3, repo4, repo1, repo2, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2, repo3, repo4), repo3, repo1, repo4, repo2, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repo2, repo1, repo4, repo3), repo4, repo3, repo2, repo1, platformRepo);
+
+        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo5, repo4, repo3), repo4, repo3, repo1, repo5, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repo5, repo1, repo4, repo3), repo4, repo3, repo5, repo1, platformRepo);
+
+        assertSort(Lists.fixedSize.with(platformRepo, repo2, repo1, repo5, repo4, repo3), repo4, repo3, repo2, repo1, repo5, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2, repo5, repo4, repo3), repo4, repo3, repo1, repo2, repo5, platformRepo);
+    }
+
+    @Test
+    public void testToSortedRepositoriesList_Loop()
+    {
+        CodeRepository platformRepo = CodeRepository.newPlatformCodeRepository();
+        CodeRepository repo1 = GenericCodeRepository.build("repo_one", "meta::pure::\\.*", "platform");
+        CodeRepository repo2 = GenericCodeRepository.build("repo_two", "meta::pure::\\.*", "platform", "repo_one");
+        CodeRepository repo3 = GenericCodeRepository.build("repo_three", "meta::pure::\\.*", "platform", "repo_two", "repo_five");
+        CodeRepository repo4 = GenericCodeRepository.build("repo_four", "meta::pure::\\.*", "platform", "repo_one", "repo_three");
+        CodeRepository repo5 = GenericCodeRepository.build("repo_five", "meta::pure::\\.*", "platform", "repo_four", "repo_two");
+
+        // No loops
+        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2, repo3, repo4), platformRepo, repo1, repo2, repo3, repo4);
+        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2, repo5, repo3), platformRepo, repo1, repo2, repo3, repo5);
+        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2, repo4, repo5), platformRepo, repo1, repo2, repo4, repo5);
+
+        // Loops
+        RuntimeException e1 = Assert.assertThrows(RuntimeException.class, () -> CodeRepository.toSortedRepositoryList(Lists.fixedSize.with(platformRepo, repo1, repo2, repo3, repo4, repo5)));
+        Assert.assertEquals("Could not consistently order the following repositories: repo_three (visible: repo_five), repo_four (visible: repo_three), repo_five (visible: repo_four)", e1.getMessage());
+
+        RuntimeException e2 = Assert.assertThrows(RuntimeException.class, () -> CodeRepository.toSortedRepositoryList(Lists.fixedSize.with(platformRepo, repo2, repo3, repo4, repo5)));
+        Assert.assertEquals("Could not consistently order the following repositories: repo_three (visible: repo_five), repo_four (visible: repo_three), repo_five (visible: repo_four)", e2.getMessage());
+
+        RuntimeException e3 = Assert.assertThrows(RuntimeException.class, () -> CodeRepository.toSortedRepositoryList(Lists.fixedSize.with(platformRepo, repo3, repo4, repo5)));
+        Assert.assertEquals("Could not consistently order the following repositories: repo_three (visible: repo_five), repo_four (visible: repo_three), repo_five (visible: repo_four)", e3.getMessage());
+
+        RuntimeException e4 = Assert.assertThrows(RuntimeException.class, () -> CodeRepository.toSortedRepositoryList(Lists.fixedSize.with(repo3, repo4, repo5)));
+        Assert.assertEquals("Could not consistently order the following repositories: repo_three (visible: repo_five), repo_four (visible: repo_three), repo_five (visible: repo_four)", e4.getMessage());
+    }
+
+    private void assertSort(ListIterable<? extends CodeRepository> expected, CodeRepository... repositories)
+    {
+        assertSort(expected, ArrayAdapter.adapt(repositories));
+    }
+
+    private void assertSort(ListIterable<? extends CodeRepository> expected, Iterable<? extends CodeRepository> repositories)
+    {
+        MutableList<? extends CodeRepository> actual = CodeRepository.toSortedRepositoryList(repositories);
+        Assert.assertEquals(expected, actual);
+        if (!isSorted(actual))
+        {
+            Assert.fail("Not properly sorted: " + actual);
+        }
+    }
+
+    private static boolean isSorted(ListIterable<? extends CodeRepository> repositories)
+    {
+        int i = 0;
+        for (CodeRepository repo : repositories)
+        {
+            int start = ++i;
+            if ((start < repositories.size()) && repositories.subList(start, repositories.size()).anySatisfy(repo::isVisible))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestBinarySourceSerializer.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestBinarySourceSerializer.java
@@ -14,32 +14,43 @@
 
 package org.finos.legend.pure.m3.serialization.runtime;
 
-import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
 import org.eclipse.collections.api.multimap.list.ListMultimap;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.factory.Multimaps;
-import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.factory.primitive.IntObjectMaps;
-import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
 import org.finos.legend.pure.m3.serialization.grammar.Parser;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 
-public class TestBinarySourceSerializer extends AbstractPureTestWithCoreCompiledPlatform
+public class TestBinarySourceSerializer extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getExtra());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return Lists.immutable.with(CodeRepository.newPlatformCodeRepository(),
+                GenericCodeRepository.build("test", "test(::.*)?", PlatformCodeRepository.NAME));
     }
 
     @Test
@@ -52,56 +63,53 @@ public class TestBinarySourceSerializer extends AbstractPureTestWithCoreCompiled
     public void testWithEmptyFile()
     {
         compileTestSource("/test/emptySource.pure", "");
-        Assert.assertEquals("", this.runtime.getSourceById("/test/emptySource.pure").getContent());
+        Assert.assertEquals("", runtime.getSourceById("/test/emptySource.pure").getContent());
         testSerializationForCurrentRuntime();
     }
 
     @Test
     public void testWithUncompiledFile()
     {
-        this.runtime.createInMemorySource("/test/uncompiledSource.pure", "Class test::Class1 {}");
-        Assert.assertFalse(this.runtime.getSourceById("/test/uncompiledSource.pure").isCompiled());
+        runtime.createInMemorySource("/test/uncompiledSource.pure", "Class test::Class1 {}");
+        Assert.assertFalse(runtime.getSourceById("/test/uncompiledSource.pure").isCompiled());
         testSerializationForCurrentRuntime();
     }
 
     private void testSerializationForCurrentRuntime()
     {
         ByteArrayOutputStream serialization = new ByteArrayOutputStream();
-        BinarySourceSerializer.serialize(serialization, this.runtime.getSourceRegistry());
+        BinarySourceSerializer.serialize(serialization, runtime.getSourceRegistry());
 
-        SourceRegistry sourceRegistry = this.runtime.getSourceRegistry();
+        SourceRegistry sourceRegistry = runtime.getSourceRegistry();
         MutableIntObjectMap<CoreInstance> instancesById = IntObjectMaps.mutable.empty();
         MutableSet<CoreInstance> classifiers = Sets.mutable.empty();
-        for (Source source : sourceRegistry.getSources())
+        sourceRegistry.getSources().forEach(source ->
         {
             ListIterable<? extends CoreInstance> newInstances = source.getNewInstances();
             if (newInstances != null)
             {
-                for (CoreInstance instance : newInstances)
+                newInstances.forEach(instance ->
                 {
                     instancesById.put(instance.getSyntheticId(), instance);
                     classifiers.add(instance.getClassifier());
-                }
+                });
             }
-        }
+        });
 
-        SourceRegistry targetRegistry = new SourceRegistry(this.runtime.getCodeStorage(), this.runtime.getIncrementalCompiler().getParserLibrary());
+        SourceRegistry targetRegistry = new SourceRegistry(runtime.getCodeStorage(), runtime.getIncrementalCompiler().getParserLibrary());
         Context targetContext = new Context();
-        BinarySourceSerializer.build(serialization.toByteArray(), targetRegistry, instancesById, this.runtime.getIncrementalCompiler().getParserLibrary(), targetContext);
+        BinarySourceSerializer.build(serialization.toByteArray(), targetRegistry, instancesById, runtime.getIncrementalCompiler().getParserLibrary(), targetContext);
 
         Assert.assertEquals(sourceRegistry.getSourceIds().toSet(), targetRegistry.getSourceIds().toSet());
-        for (Source source : sourceRegistry.getSources())
+        sourceRegistry.getSources().forEach(source ->
         {
             Source targetSource = targetRegistry.getSource(source.getId());
             Assert.assertEquals(source.getId(), source.getContent(), targetSource.getContent());
             Assert.assertEquals(source.getId(), source.isImmutable(), targetSource.isImmutable());
             Assert.assertEquals(source.getId(), source.isCompiled(), targetSource.isCompiled());
             Assert.assertEquals(getElementsByParserName(source), getElementsByParserName(targetSource));
-        }
-        for (CoreInstance classifier : classifiers)
-        {
-            Assert.assertEquals(PackageableElement.getUserPathForPackageableElement(classifier), this.context.getClassifierInstances(classifier), targetContext.getClassifierInstances(classifier));
-        }
+        });
+        classifiers.forEach(classifier -> Assert.assertEquals(PackageableElement.getUserPathForPackageableElement(classifier), context.getClassifierInstances(classifier), targetContext.getClassifierInstances(classifier)));
     }
 
     private ListMultimap<String, CoreInstance> getElementsByParserName(Source source)
@@ -112,15 +120,8 @@ public class TestBinarySourceSerializer extends AbstractPureTestWithCoreCompiled
             return null;
         }
 
-        final MutableListMultimap<String, CoreInstance> elementsByParserName = Multimaps.mutable.list.empty();
-        elementsByParser.forEachKeyMultiValues(new Procedure2<Parser, Iterable<CoreInstance>>()
-        {
-            @Override
-            public void value(Parser parser, Iterable<CoreInstance> elements)
-            {
-                elementsByParserName.putAll(parser.getName(), elements);
-            }
-        });
+        MutableListMultimap<String, CoreInstance> elementsByParserName = Multimaps.mutable.list.empty();
+        elementsByParser.forEachKeyMultiValues((parser, elements) -> elementsByParserName.putAll(parser.getName(), elements));
         return elementsByParserName;
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestPureRuntime.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestPureRuntime.java
@@ -14,11 +14,12 @@
 
 package org.finos.legend.pure.m3.serialization.runtime;
 
-import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
-import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
 import org.finos.legend.pure.m3.serialization.runtime.IncrementalCompiler.IncrementalCompilerTransaction;
@@ -26,7 +27,6 @@ import org.finos.legend.pure.m3.serialization.runtime.cache.CompressedMemoryPure
 import org.finos.legend.pure.m3.serialization.runtime.cache.PureGraphCache;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
-import org.finos.legend.pure.m4.exception.PureException;
 import org.finos.legend.pure.m4.transaction.framework.ThreadLocalTransactionContext;
 import org.junit.Assert;
 import org.junit.Test;
@@ -74,7 +74,7 @@ public class TestPureRuntime
     }
 
     @Test
-    public void testThreadLocalState() throws Exception
+    public void testThreadLocalState()
     {
         PureRuntime runtime = new PureRuntimeBuilder(new PureCodeStorage(Paths.get("..", "pure-code", "local"), new ClassLoaderCodeStorage(CodeRepository.newPlatformCodeRepository()))).build();
         runtime.loadAndCompileCore();
@@ -99,7 +99,7 @@ public class TestPureRuntime
             t.start();
             t.join();
         }
-        catch (InterruptedException e)
+        catch (InterruptedException ignore)
         {
         }
 
@@ -117,20 +117,19 @@ public class TestPureRuntime
             t.start();
             t.join();
         }
-        catch (InterruptedException e)
+        catch (InterruptedException ignore)
         {
         }
 
-        Assert.assertNotNull("Another thread can access core instances that have been committed",
-                otherThreadFunctionAccessor.getFunctionInstance());
+        Assert.assertNotNull("Another thread can access core instances that have been committed", otherThreadFunctionAccessor.getFunctionInstance());
     }
 
     @Test
     public void testCompiles()
     {
-        PureRuntime runtime = new PureRuntimeBuilder(new PureCodeStorage(Paths.get("..", "pure-code", "local"), new ClassLoaderCodeStorage(CodeRepository.newPlatformCodeRepository()))).build();
+        PureRuntime runtime = new PureRuntimeBuilder(new PureCodeStorage(Paths.get("..", "pure-code", "local"), new ClassLoaderCodeStorage(CodeRepository.newPlatformCodeRepository(), GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", PlatformCodeRepository.NAME)))).build();
         runtime.loadAndCompileCore();
-        runtime.createInMemoryAndCompile(AbstractPureTestWithCoreCompiledPlatform.extra);
+        runtime.createInMemoryAndCompile(AbstractPureTestWithCoreCompiledPlatform.EXTRA);
 
         Assert.assertTrue(runtime.compiles("1 + 2"));
         Assert.assertTrue(runtime.compiles("split('the quick brown fox', ' ')"));
@@ -145,22 +144,14 @@ public class TestPureRuntime
         PureRuntime runtime = new PureRuntimeBuilder(new PureCodeStorage(Paths.get("..", "pure-code", "local"), new ClassLoaderCodeStorage(CodeRepository.newPlatformCodeRepository()))).build();
         runtime.loadAndCompileCore();
 
-        try
-        {
-            runtime.createInMemoryAndCompile(
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> runtime.createInMemoryAndCompile(
                     Tuples.pair("/platform/testFile.pure", "function meta::pure::testFn():String[1] {'the quick brown fox'}"),
                     Tuples.pair("testBad.pure", "function sandbox::testFn2():Integer[1] { 1 + '7'}")
-            );
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            PureException pe = PureException.findPureException(e);
-            Assert.assertNotNull(pe);
-            Verify.assertInstanceOf(PureCompilationException.class, pe);
-            Assert.assertNotNull(pe.getSourceInformation());
-            Assert.assertEquals("testBad.pure", pe.getSourceInformation().getSourceId());
-        }
+            ));
+
+        Assert.assertNotNull(e.getSourceInformation());
+        Assert.assertEquals("testBad.pure", e.getSourceInformation().getSourceId());
+
         Source testFile = runtime.getSourceById("/platform/testFile.pure");
         Assert.assertNotNull(testFile);
         Assert.assertTrue(testFile.isCompiled());
@@ -170,7 +161,7 @@ public class TestPureRuntime
         Assert.assertFalse(testBad.isCompiled());
     }
 
-    private class FunctionAccessor implements Runnable
+    private static class FunctionAccessor implements Runnable
     {
         private final PureRuntime runtime;
         private CoreInstance functionInstance;
@@ -190,6 +181,5 @@ public class TestPureRuntime
         {
             return this.functionInstance;
         }
-
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestPureRuntime.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestPureRuntime.java
@@ -41,14 +41,8 @@ public class TestPureRuntime
         PureRuntime runtime = new PureRuntimeBuilder(new PureCodeStorage(Paths.get("..", "pure-code", "local"), new ClassLoaderCodeStorage(CodeRepository.newPlatformCodeRepository()))).build();
         runtime.loadAndCompileCore();
 
-        try
-        {
-            runtime.loadSource.valueOf("/platform/pure/path.pure");
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("/platform/pure/path.pure is already loaded", e.getMessage());
-        }
+        RuntimeException e = Assert.assertThrows(RuntimeException.class, () -> runtime.loadSource("/platform/pure/path.pure"));
+        Assert.assertEquals("/platform/pure/path.pure is already loaded", e.getMessage());
     }
 
     @Test

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestRepositoryComparator.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestRepositoryComparator.java
@@ -47,7 +47,7 @@ public class TestRepositoryComparator extends AbstractPureTestWithCoreCompiledPl
                 CodeRepository.newPlatformCodeRepository()
         ).withAll(CodeRepositoryProviderHelper.findCodeRepositories());
         repositoriesByName = repositories.groupByUniqueKey(CodeRepository::getName);
-        setUpRuntime(new PureCodeStorage(null, new ClassLoaderCodeStorage(repositories)), repositories, getExtra());
+        setUpRuntime(new PureCodeStorage(null, new ClassLoaderCodeStorage(repositories)), getExtra());
     }
 
     @Test

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/binary/AbstractPureRepositoryJarLibraryTest.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/binary/AbstractPureRepositoryJarLibraryTest.java
@@ -27,7 +27,6 @@ import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.SetIterable;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.factory.Multimaps;
-import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.test.Verify;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
@@ -51,8 +50,9 @@ public abstract class AbstractPureRepositoryJarLibraryTest extends AbstractPureT
     protected PureRepositoryJarLibrary library;
 
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getExtra());
+    public static void setUp()
+    {
+        setUpRuntime();
     }
 
     @Before
@@ -313,7 +313,7 @@ public abstract class AbstractPureRepositoryJarLibraryTest extends AbstractPureT
     {
         MapIterable<String, byte[]> bytesByFile = library.readFiles(files);
 
-        MutableMap<String, byte[]> expected = UnifiedMap.newMap(files.length);
+        MutableMap<String, byte[]> expected = Maps.mutable.ofInitialCapacity(files.length);
         ByteArrayOutputStream expectedStream = new ByteArrayOutputStream();
         Writer writer = BinaryWriters.newBinaryWriter(expectedStream);
         for (String binPath : files)
@@ -363,7 +363,7 @@ public abstract class AbstractPureRepositoryJarLibraryTest extends AbstractPureT
         MutableMap<String, byte[]> expected = Maps.mutable.empty();
         ByteArrayOutputStream expectedStream = new ByteArrayOutputStream();
         Writer writer = BinaryWriters.newBinaryWriter(expectedStream);
-        for (Source source : runtime.getSourceRegistry().getSources().select(s->!s.isInMemory()))
+        for (Source source : runtime.getSourceRegistry().getSources().select(s -> !s.isInMemory()))
         {
             String purePath = source.getId();
             String repo = getRepo(purePath);

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/binary/TestBinaryModelSourceSerializer.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/binary/TestBinaryModelSourceSerializer.java
@@ -15,24 +15,24 @@
 package org.finos.legend.pure.m3.serialization.runtime.binary;
 
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.SetIterable;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.block.factory.Functions;
-import org.eclipse.collections.impl.block.factory.Predicates;
-import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Multimaps;
-import org.eclipse.collections.impl.factory.Sets;
-import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
-import org.eclipse.collections.impl.utility.LazyIterate;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.navigation.imports.Imports;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
 import org.finos.legend.pure.m3.serialization.runtime.Message;
 import org.finos.legend.pure.m3.serialization.runtime.PureRuntime;
 import org.finos.legend.pure.m3.serialization.runtime.PureRuntimeBuilder;
@@ -48,24 +48,35 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Collection;
+import java.util.Set;
 
 public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCompiledPlatform
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getExtra());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return Lists.immutable.with(CodeRepository.newPlatformCodeRepository(),
+                GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", PlatformCodeRepository.NAME),
+                GenericCodeRepository.build("test", "test(::.*)?", PlatformCodeRepository.NAME, "system"));
     }
 
     @After
-    public void clearRuntime() {
+    public void clearRuntime()
+    {
         runtime.delete("/test/model/testSource.pure");
         runtime.delete("/test/model/testSource2.pure");
+        runtime.compile();
     }
 
     @Test
     public void testSimpleClassSerialization()
     {
-        this.compileTestSource("/test/model/testSource.pure",
+        compileTestSource("/test/model/testSource.pure",
                 "import test::*;\n" +
                         "Class test::ClassA\n" +
                         "{\n" +
@@ -83,23 +94,23 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
         SetIterable<String> expectedInstances = Sets.mutable.with("test::ClassA", "test::ClassB", "test::ClassC", "system::imports::import__test_model_testSource_pure_1");
         SetIterable<String> expectedReferences = Sets.mutable.with("Float", "Integer", "String", "meta::pure::metamodel::function::property::AggregationKind", "meta::pure::metamodel::function::property::Property", "meta::pure::metamodel::multiplicity::OneMany", "meta::pure::metamodel::multiplicity::PureOne", "meta::pure::metamodel::multiplicity::ZeroMany", "meta::pure::metamodel::relationship::Generalization", "meta::pure::metamodel::type::Any", "meta::pure::metamodel::type::Class", "meta::pure::metamodel::type::generics::GenericType", "meta::pure::metamodel::import::Import", "meta::pure::metamodel::import::ImportGroup", "meta::pure::metamodel::import::ImportStub");
 
-        Pair<SourceSerializationResult, byte[]> serializationResult = this.serializeSource("/test/model/testSource.pure");
+        Pair<SourceSerializationResult, byte[]> serializationResult = serializeSource("/test/model/testSource.pure");
         SourceSerializationResult result = serializationResult.getOne();
         byte[] serialized = serializationResult.getTwo();
 
-        this.assertSetsEqual(expectedInstances, result.getSerializedInstances());
-        this.assertSetsEqual(expectedReferences, result.getExternalReferences());
-        this.assertExternalReferencePathsResolvable(result.getExternalReferences());
+        assertSetsEqual(expectedInstances, result.getSerializedInstances());
+        assertSetsEqual(expectedReferences, result.getExternalReferences());
+        assertExternalReferencePathsResolvable(result.getExternalReferences());
 
         SourceDeserializationResult deserializationResult = BinaryModelSourceDeserializer.readIndexes(BinaryReaders.newBinaryReader(serialized));
-        this.assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
-        this.assertSetsEqual(expectedReferences, deserializationResult.getExternalReferences());
+        assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
+        assertSetsEqual(expectedReferences, deserializationResult.getExternalReferences());
     }
 
     @Test
     public void testSimpleProfileSerialization()
     {
-        this.compileTestSource("/test/model/testSource.pure",
+        compileTestSource("/test/model/testSource.pure",
                 "Profile test::profiles::MyProfile\n" +
                         "{\n" +
                         "    stereotypes: [st1, st2];\n" +
@@ -108,17 +119,17 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
         SetIterable<String> expectedInstances = Sets.mutable.with("test::profiles::MyProfile", "system::imports::import__test_model_testSource_pure_1");
         SetIterable<String> expectedReferences = Sets.mutable.with("meta::pure::metamodel::extension::Profile", "meta::pure::metamodel::extension::Stereotype", "meta::pure::metamodel::extension::Tag", "meta::pure::metamodel::import::ImportGroup");
 
-        Pair<SourceSerializationResult, byte[]> serializationResult = this.serializeSource("/test/model/testSource.pure");
+        Pair<SourceSerializationResult, byte[]> serializationResult = serializeSource("/test/model/testSource.pure");
         SourceSerializationResult result = serializationResult.getOne();
         byte[] serialized = serializationResult.getTwo();
 
-        this.assertSetsEqual(expectedInstances, result.getSerializedInstances());
-        this.assertSetsEqual(expectedReferences, result.getExternalReferences());
-        this.assertExternalReferencePathsResolvable(result.getExternalReferences());
+        assertSetsEqual(expectedInstances, result.getSerializedInstances());
+        assertSetsEqual(expectedReferences, result.getExternalReferences());
+        assertExternalReferencePathsResolvable(result.getExternalReferences());
 
         SourceDeserializationResult deserializationResult = BinaryModelSourceDeserializer.readIndexes(BinaryReaders.newBinaryReader(serialized));
-        this.assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
-        this.assertSetsEqual(expectedReferences, deserializationResult.getExternalReferences());
+        assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
+        assertSetsEqual(expectedReferences, deserializationResult.getExternalReferences());
     }
 
     @Test
@@ -133,14 +144,14 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
 
         SetIterable<String> expectedInstances = Sets.mutable.with("test::testFn__String_1_", "system::imports::import__test_model_testSource_pure_1");
 
-        Pair<SourceSerializationResult, byte[]> serializationResult = this.serializeSource("/test/model/testSource.pure");
+        Pair<SourceSerializationResult, byte[]> serializationResult = serializeSource("/test/model/testSource.pure");
         SourceSerializationResult result = serializationResult.getOne();
         byte[] serialized = serializationResult.getTwo();
 
         assertSetsEqual(expectedInstances, result.getSerializedInstances());
         assertExternalReferencePathsResolvable(result.getExternalReferences());
 
-        SourceDeserializationResult deserializationResult = BinaryModelSourceDeserializer.deserialize(BinaryReaders.newBinaryReader(serialized), ExternalReferenceSerializerLibrary.newLibrary(this.runtime));
+        SourceDeserializationResult deserializationResult = BinaryModelSourceDeserializer.deserialize(BinaryReaders.newBinaryReader(serialized), ExternalReferenceSerializerLibrary.newLibrary(runtime));
         assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
         Assert.assertEquals(sourceCode, deserializationResult.getSource().getContent());
     }
@@ -148,7 +159,7 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
     @Test
     public void testNonConcreteGenericTypeReference()
     {
-        this.compileTestSourceM3("/test/model/testSource.pure",
+        compileTestSourceM3("/test/model/testSource.pure",
                 "import test::*;\n" +
                         "\n" +
                         "Class test::TopClass<X,Y>\n" +
@@ -165,7 +176,7 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
                         "{\n" +
                         "}");
 
-        this.compileTestSourceM3("/test/model/testSource2.pure",
+        compileTestSourceM3("/test/model/testSource2.pure",
                 "import test::*;\n" +
                         "\n" +
                         "function test::testFn<X,Y>(lefts:LeftClass<Any>[*], rights:RightClass<X,Y>[*]):TopClass<Any,Any>[*]\n" +
@@ -175,23 +186,23 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
         SetIterable<String> expectedInstances = Sets.mutable.with("test::testFn_LeftClass_MANY__RightClass_MANY__TopClass_MANY_", "system::imports::import__test_model_testSource2_pure_1");
         SetIterable<String> someExpectedReferences = Sets.mutable.with("meta::pure::functions::collection::concatenate_T_MANY__T_MANY__T_MANY_", "meta::pure::metamodel::function::ConcreteFunctionDefinition", "meta::pure::metamodel::multiplicity::ZeroMany", "meta::pure::metamodel::type::Any", "meta::pure::metamodel::type::FunctionType", "meta::pure::metamodel::type::generics::GenericType", "meta::pure::metamodel::type::generics::TypeParameter", "meta::pure::metamodel::valuespecification::VariableExpression", "test::LeftClass", "test::RightClass", "test::TopClass");
 
-        Pair<SourceSerializationResult, byte[]> serializationResult = this.serializeSource("/test/model/testSource2.pure");
+        Pair<SourceSerializationResult, byte[]> serializationResult = serializeSource("/test/model/testSource2.pure");
         SourceSerializationResult result = serializationResult.getOne();
         byte[] serialized = serializationResult.getTwo();
 
-        this.assertSetsEqual(expectedInstances, result.getSerializedInstances());
-        this.assertContainsAll(someExpectedReferences, result.getExternalReferences());
-        this.assertExternalReferencePathsResolvable(result.getExternalReferences());
+        assertSetsEqual(expectedInstances, result.getSerializedInstances());
+        assertContainsAll(someExpectedReferences, result.getExternalReferences());
+        assertExternalReferencePathsResolvable(result.getExternalReferences());
 
         SourceDeserializationResult deserializationResult = BinaryModelSourceDeserializer.readIndexes(BinaryReaders.newBinaryReader(serialized));
-        this.assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
-        this.assertContainsAll(someExpectedReferences, deserializationResult.getExternalReferences());
+        assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
+        assertContainsAll(someExpectedReferences, deserializationResult.getExternalReferences());
     }
 
     @Test
     public void testNonConcreteMultiplicityReference()
     {
-        this.compileTestSourceM3("/test/model/testSource.pure",
+        compileTestSourceM3("/test/model/testSource.pure",
                 "function test::testFn(class:Class<Any>[1]) : AbstractProperty<Any>[*]\n" +
                         "{\n" +
                         "  []\n" +
@@ -203,23 +214,23 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
         SetIterable<String> expectedInstances = Sets.mutable.with("test::testFn_Class_1__AbstractProperty_MANY_", "system::imports::import__test_model_testSource_pure_1");
         SetIterable<String> someExpectedReferences = Sets.mutable.with("meta::pure::functions::collection::concatenate_T_MANY__T_MANY__T_MANY_", "meta::pure::metamodel::function::ConcreteFunctionDefinition", "meta::pure::metamodel::function::property::AbstractProperty", "meta::pure::metamodel::function::property::Property", "meta::pure::metamodel::function::property::QualifiedProperty", "meta::pure::metamodel::multiplicity::PureOne", "meta::pure::metamodel::multiplicity::PureZero", "meta::pure::metamodel::multiplicity::ZeroMany", "meta::pure::metamodel::type::Any", "meta::pure::metamodel::type::Class", "meta::pure::metamodel::type::Nil");
 
-        Pair<SourceSerializationResult, byte[]> serializationResult = this.serializeSource("/test/model/testSource.pure");
+        Pair<SourceSerializationResult, byte[]> serializationResult = serializeSource("/test/model/testSource.pure");
         SourceSerializationResult result = serializationResult.getOne();
         byte[] serialized = serializationResult.getTwo();
 
-        this.assertSetsEqual(expectedInstances, result.getSerializedInstances());
-        this.assertContainsAll(someExpectedReferences, result.getExternalReferences());
-        this.assertExternalReferencePathsResolvable(result.getExternalReferences());
+        assertSetsEqual(expectedInstances, result.getSerializedInstances());
+        assertContainsAll(someExpectedReferences, result.getExternalReferences());
+        assertExternalReferencePathsResolvable(result.getExternalReferences());
 
         SourceDeserializationResult deserializationResult = BinaryModelSourceDeserializer.readIndexes(BinaryReaders.newBinaryReader(serialized));
-        this.assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
-        this.assertContainsAll(someExpectedReferences, deserializationResult.getExternalReferences());
+        assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
+        assertContainsAll(someExpectedReferences, deserializationResult.getExternalReferences());
     }
 
     @Test
     public void testFunctionTypeReference()
     {
-        this.runtime.createInMemorySource("/test/model/testSource.pure",
+        runtime.createInMemorySource("/test/model/testSource.pure",
                 "import test::matrix::*;\n" +
                         "\n" +
                         "Class test::matrix::Matrix\n" +
@@ -236,34 +247,34 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
                         "{\n" +
                         "  ^$matrix(rows=$matrix.rows->filter($func))\n" +
                         "}");
-        this.runtime.compile();
-        this.runtime.createInMemorySource("/test/model/testSource2.pure",
+        runtime.compile();
+        runtime.createInMemorySource("/test/model/testSource2.pure",
                 "import test::matrix::*;\n" +
                         "function test::matrix::testFn(m:Matrix[1]):Matrix[1]\n" +
                         "{\n" +
                         "  $m->filter(r | $r.values->forAll(x | $x < 5))\n" +
                         "}");
-        this.runtime.compile();
+        runtime.compile();
         SetIterable<String> expectedInstances = Sets.mutable.with("test::matrix::testFn_Matrix_1__Matrix_1_", "system::imports::import__test_model_testSource2_pure_1");
         SetIterable<String> someExpectedReferences = Sets.mutable.with("test::matrix::Matrix", "test::matrix::Row", "test::matrix::filter_Matrix_1__Function_1__Matrix_1_");
 
-        Pair<SourceSerializationResult, byte[]> serializationResult = this.serializeSource("/test/model/testSource2.pure");
+        Pair<SourceSerializationResult, byte[]> serializationResult = serializeSource("/test/model/testSource2.pure");
         SourceSerializationResult result = serializationResult.getOne();
         byte[] serialized = serializationResult.getTwo();
 
-        this.assertSetsEqual(expectedInstances, result.getSerializedInstances());
-        this.assertContainsAll(someExpectedReferences, result.getExternalReferences());
-        this.assertExternalReferencePathsResolvable(result.getExternalReferences());
+        assertSetsEqual(expectedInstances, result.getSerializedInstances());
+        assertContainsAll(someExpectedReferences, result.getExternalReferences());
+        assertExternalReferencePathsResolvable(result.getExternalReferences());
 
         SourceDeserializationResult deserializationResult = BinaryModelSourceDeserializer.readIndexes(BinaryReaders.newBinaryReader(serialized));
-        this.assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
-        this.assertContainsAll(someExpectedReferences, deserializationResult.getExternalReferences());
+        assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
+        assertContainsAll(someExpectedReferences, deserializationResult.getExternalReferences());
     }
 
     @Test
     public void testTreePath()
     {
-        this.compileTestSource("/test/model/testSource.pure",
+        compileTestSource("/test/model/testSource.pure",
                 "import test::treepath::*;\n" +
                         "Class test::treepath::TestClass1\n" +
                         "{\n" +
@@ -277,7 +288,7 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
                         "  mainName : String[1];\n" +
                         "  otherNames : String[*];\n" +
                         "}");
-        this.compileTestSource("/test/model/testSource2.pure",
+        compileTestSource("/test/model/testSource2.pure",
                 "import test::treepath::*;\n" +
                         "function test::treepath::simpleTreePath():Any[*]\n" +
                         "{\n" +
@@ -294,44 +305,44 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
         SetIterable<String> expectedInstances = Sets.mutable.with("test::treepath::simpleTreePath__Any_MANY_", "system::imports::import__test_model_testSource2_pure_1");
         SetIterable<String> someExpectedReferences = Sets.mutable.with("test::treepath::TestClass1", "test::treepath::TestClass2");
 
-        Pair<SourceSerializationResult, byte[]> serializationResult = this.serializeSource("/test/model/testSource2.pure");
+        Pair<SourceSerializationResult, byte[]> serializationResult = serializeSource("/test/model/testSource2.pure");
         SourceSerializationResult result = serializationResult.getOne();
         byte[] serialized = serializationResult.getTwo();
 
-        this.assertSetsEqual(expectedInstances, result.getSerializedInstances());
-        this.assertContainsAll(someExpectedReferences, result.getExternalReferences());
-        this.assertExternalReferencePathsResolvable(result.getExternalReferences());
+        assertSetsEqual(expectedInstances, result.getSerializedInstances());
+        assertContainsAll(someExpectedReferences, result.getExternalReferences());
+        assertExternalReferencePathsResolvable(result.getExternalReferences());
 
         SourceDeserializationResult deserializationResult = BinaryModelSourceDeserializer.readIndexes(BinaryReaders.newBinaryReader(serialized));
-        this.assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
-        this.assertContainsAll(someExpectedReferences, deserializationResult.getExternalReferences());
+        assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
+        assertContainsAll(someExpectedReferences, deserializationResult.getExternalReferences());
     }
 
     @Test
     public void testM3Serialization()
     {
-        Source source = this.runtime.getSourceById("/platform/pure/m3.pure");
-        SetIterable<String> expectedInstances = this.collectInstancePaths(source.getNewInstances(), Sets.mutable.with("meta", "meta::pure", "meta::pure::functions", "meta::pure::functions::lang", "meta::pure::metamodel", "meta::pure::metamodel::extension", "meta::pure::metamodel::function", "meta::pure::metamodel::function::property", "meta::pure::metamodel::import", "meta::pure::metamodel::multiplicity", "meta::pure::metamodel::relationship", "meta::pure::metamodel::treepath", "meta::pure::metamodel::type", "meta::pure::metamodel::type::generics", "meta::pure::metamodel::constraint", "meta::pure::metamodel::valuespecification", "meta::pure::router", "meta::pure::tools", "system", "system::imports"));
+        Source source = runtime.getSourceById("/platform/pure/m3.pure");
+        SetIterable<String> expectedInstances = collectInstancePaths(source.getNewInstances(), Sets.mutable.with("meta", "meta::pure", "meta::pure::functions", "meta::pure::functions::lang", "meta::pure::metamodel", "meta::pure::metamodel::extension", "meta::pure::metamodel::function", "meta::pure::metamodel::function::property", "meta::pure::metamodel::import", "meta::pure::metamodel::multiplicity", "meta::pure::metamodel::relationship", "meta::pure::metamodel::treepath", "meta::pure::metamodel::type", "meta::pure::metamodel::type::generics", "meta::pure::metamodel::constraint", "meta::pure::metamodel::valuespecification", "meta::pure::router", "meta::pure::tools", "system", "system::imports"));
         SetIterable<String> expectedReferences = Sets.mutable.with();
 
-        Pair<SourceSerializationResult, byte[]> serializationResult = this.serializeSource(source);
+        Pair<SourceSerializationResult, byte[]> serializationResult = serializeSource(source);
         SourceSerializationResult result = serializationResult.getOne();
         byte[] serialized = serializationResult.getTwo();
 
-        this.assertSetsEqual(expectedInstances, result.getSerializedInstances());
-        this.assertSetsEqual(expectedReferences, result.getExternalReferences());
-        this.assertExternalReferencePathsResolvable(result.getExternalReferences());
+        assertSetsEqual(expectedInstances, result.getSerializedInstances());
+        assertSetsEqual(expectedReferences, result.getExternalReferences());
+        assertExternalReferencePathsResolvable(result.getExternalReferences());
 
         SourceDeserializationResult deserializationResult = BinaryModelSourceDeserializer.readIndexes(BinaryReaders.newBinaryReader(serialized));
-        this.assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
-        this.assertSetsEqual(expectedReferences, deserializationResult.getExternalReferences());
+        assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
+        assertSetsEqual(expectedReferences, deserializationResult.getExternalReferences());
     }
 
     @Test
     public void testPlatformSerialization()
     {
         MutableListMultimap<String, String> importGroupsByBaseName = Multimaps.mutable.list.empty();
-        CoreInstance systemImports = this.runtime.getCoreInstance("system::imports");
+        CoreInstance systemImports = runtime.getCoreInstance("system::imports");
         if (systemImports != null)
         {
             for (CoreInstance importGroup : systemImports.getValueForMetaPropertyToMany(M3Properties.children))
@@ -341,37 +352,37 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
         }
 
 
-        for (Source source : this.runtime.getSourceRegistry().getSources())
+        for (Source source : runtime.getSourceRegistry().getSources())
         {
-            MutableSet<String> expectedInstances = this.getInstancePaths(source.getNewInstances());
+            MutableSet<String> expectedInstances = getInstancePaths(source.getNewInstances());
             expectedInstances.addAllIterable(importGroupsByBaseName.get(Source.formatForImportGroupId(source.getId())));
             if ("/platform/pure/m3.pure".equals(source.getId()))
             {
                 expectedInstances.addAllIterable(Lists.mutable.with("meta", "meta::pure", "meta::pure::functions", "meta::pure::functions::lang", "meta::pure::metamodel", "meta::pure::metamodel::constraint", "meta::pure::metamodel::extension", "meta::pure::metamodel::function", "meta::pure::metamodel::function::property", "meta::pure::metamodel::import", "meta::pure::metamodel::multiplicity", "meta::pure::metamodel::relationship", "meta::pure::metamodel::treepath", "meta::pure::metamodel::type", "meta::pure::metamodel::type::generics", "meta::pure::metamodel::valuespecification", "meta::pure::router", "meta::pure::tools", "system", "system::imports"));
             }
 
-            Pair<SourceSerializationResult, byte[]> serializationResult = this.serializeSource(source);
+            Pair<SourceSerializationResult, byte[]> serializationResult = serializeSource(source);
             SourceSerializationResult result = serializationResult.getOne();
             byte[] serialized = serializationResult.getTwo();
 
-            this.assertSetsEqual(expectedInstances, result.getSerializedInstances());
-            this.assertExternalReferencePathsResolvable(result.getExternalReferences(), source.getId());
+            assertSetsEqual(expectedInstances, result.getSerializedInstances());
+            assertExternalReferencePathsResolvable(result.getExternalReferences(), source.getId());
 
             SourceDeserializationResult deserializationResult = BinaryModelSourceDeserializer.readIndexes(BinaryReaders.newBinaryReader(serialized));
-            this.assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
-            this.assertSetsEqual(result.getExternalReferences(), deserializationResult.getExternalReferences());
+            assertSetsEqual(expectedInstances, deserializationResult.getInstances().toSet());
+            assertSetsEqual(result.getExternalReferences(), deserializationResult.getExternalReferences());
         }
     }
 
     @Test
     public void testBinaryStability_SameRuntime()
     {
-        for (Source source : this.runtime.getSourceRegistry().getSources())
+        for (Source source : runtime.getSourceRegistry().getSources())
         {
             for (int i = 0; i < 10; i++)
             {
-                byte[] bytes1 = this.serializeSource(source).getTwo();
-                byte[] bytes2 = this.serializeSource(source).getTwo();
+                byte[] bytes1 = serializeSource(source).getTwo();
+                byte[] bytes2 = serializeSource(source).getTwo();
                 Assert.assertArrayEquals("Failure for source '" + source.getId() + "' on iteration #" + (i + 1), bytes1, bytes2);
             }
         }
@@ -382,18 +393,18 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
     {
         for (int i = 0; i < 10; i++)
         {
-            PureRuntime runtime2 = new PureRuntimeBuilder(this.runtime.getCodeStorage())
-                    .withRuntimeStatus(this.getPureRuntimeStatus()).build();
-            this.getFunctionExecution().init(runtime2, new Message(""));
+            PureRuntime runtime2 = new PureRuntimeBuilder(runtime.getCodeStorage())
+                    .withRuntimeStatus(getPureRuntimeStatus()).build();
+            getFunctionExecution().init(runtime2, new Message(""));
             runtime2.loadAndCompileCore();
 
-            Assert.assertEquals(this.runtime.getSourceRegistry().getSources().select(s->!s.isInMemory()).collect(s->s.getId()).toSet(), runtime2.getSourceRegistry().getSourceIds().toSet());
+            Assert.assertEquals(runtime.getSourceRegistry().getSources().select(s -> !s.isInMemory()).collect(s -> s.getId()).toSet(), runtime2.getSourceRegistry().getSourceIds().toSet());
 
-            for (Source source1 : this.runtime.getSourceRegistry().getSources().select(s->!s.isInMemory()))
+            for (Source source1 : runtime.getSourceRegistry().getSources().select(s -> !s.isInMemory()))
             {
                 Source source2 = runtime2.getSourceById(source1.getId());
-                byte[] bytes1 = this.serializeSource(source1).getTwo();
-                byte[] bytes2 = this.serializeSource(source2, runtime2).getTwo();
+                byte[] bytes1 = serializeSource(source1).getTwo();
+                byte[] bytes2 = serializeSource(source2, runtime2).getTwo();
                 Assert.assertArrayEquals("Failure for source '" + source1.getId() + "' on iteration #" + (i + 1), bytes1, bytes2);
             }
         }
@@ -401,14 +412,14 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
 
     protected Pair<SourceSerializationResult, byte[]> serializeSource(String sourceId)
     {
-        Source source = this.runtime.getSourceById(sourceId);
+        Source source = runtime.getSourceById(sourceId);
         Assert.assertNotNull("Unknown source: " + sourceId, source);
-        return this.serializeSource(source);
+        return serializeSource(source);
     }
 
     protected Pair<SourceSerializationResult, byte[]> serializeSource(Source source)
     {
-        return this.serializeSource(source, this.runtime);
+        return serializeSource(source, runtime);
     }
 
     protected Pair<SourceSerializationResult, byte[]> serializeSource(Source source, PureRuntime runtime)
@@ -420,41 +431,29 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
 
     protected MutableSet<String> getInstancePaths(RichIterable<? extends CoreInstance> instances)
     {
-        return this.collectInstancePaths(instances, UnifiedSet.<String>newSet(instances.size()));
+        return instances.collect(PackageableElement::getUserPathForPackageableElement, Sets.mutable.ofInitialCapacity(instances.size()));
     }
 
     protected <T extends Collection<? super String>> T collectInstancePaths(Iterable<? extends CoreInstance> instances, T target)
     {
-        for (CoreInstance instance : instances)
-        {
-            target.add(PackageableElement.getUserPathForPackageableElement(instance));
-        }
+        instances.forEach(i -> target.add(PackageableElement.getUserPathForPackageableElement(i)));
         return target;
     }
 
     protected void assertExternalReferencePathsResolvable(Iterable<String> paths)
     {
-        this.assertExternalReferencePathsResolvable(paths, null);
+        assertExternalReferencePathsResolvable(paths, null);
     }
 
     protected void assertExternalReferencePathsResolvable(Iterable<String> paths, String sourceId)
     {
-        MutableList<String> badPaths = Lists.mutable.empty();
-        for (String path : paths)
-        {
-            CoreInstance instance = this.processorSupport.package_getByUserPath(path);
-            if (instance == null)
-            {
-                badPaths.add(path);
-            }
-        }
+        MutableList<String> badPaths = Iterate.select(paths, p -> processorSupport.package_getByUserPath(p) == null, Lists.mutable.empty());
         if (badPaths.notEmpty())
         {
             StringBuilder message = new StringBuilder("Could not resolve the following external reference paths");
             if (sourceId != null)
             {
-                message.append(" for source ");
-                message.append(sourceId);
+                message.append(" for source ").append(sourceId);
             }
             badPaths.sortThis().appendString(message, ": ", ", ", "");
             Assert.fail(message.toString());
@@ -463,7 +462,7 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
 
     protected <T> void assertSetsEqual(SetIterable<T> expected, SetIterable<T> actual)
     {
-        this.assertSetsEqual(null, expected, actual);
+        assertSetsEqual(null, expected, actual);
     }
 
     protected <T> void assertSetsEqual(String description, SetIterable<T> expected, SetIterable<T> actual)
@@ -479,9 +478,7 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
             SetIterable<T> extra = actual.difference(expected);
             if (missing.notEmpty())
             {
-                message.append("Missing ");
-                message.append(description);
-                missing.toSortedList().appendString(message, ": ", ", ", "");
+                missing.toSortedList().appendString(message.append("Missing ").append(description), ": ", ", ", "");
             }
             if (extra.notEmpty())
             {
@@ -489,9 +486,7 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
                 {
                     message.append("; ");
                 }
-                message.append("Unexpected ");
-                message.append(description);
-                extra.toSortedList().appendString(message, ": ", ", ", "");
+                extra.toSortedList().appendString(message.append("Unexpected ").append(description), ": ", ", ", "");
             }
             Assert.fail(message.toString());
         }
@@ -499,18 +494,16 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
 
     protected <T> void assertContainsAll(Iterable<T> expected, Iterable<T> actual)
     {
-        this.assertContainsAll(null, expected, actual);
+        assertContainsAll(null, expected, actual);
     }
 
     protected <T> void assertContainsAll(String description, Iterable<T> expected, Iterable<T> actual)
     {
-        Collection<T> missing = Iterate.select(expected, Predicates.notIn(actual));
-        if (!missing.isEmpty())
+        MutableList<T> missing = Iterate.reject(expected, ((actual instanceof Set) ? ((Set<T>) actual) : Sets.mutable.withAll(actual))::contains, Lists.mutable.empty());
+        if (missing.notEmpty())
         {
-            StringBuilder message = new StringBuilder("Missing ");
-            message.append(description == null ? "elements" : description);
-            message.append(": ");
-            LazyIterate.collect(missing, Functions.getToString()).toSortedList().appendString(message, ", ");
+            StringBuilder message = new StringBuilder("Missing ").append(description == null ? "elements" : description).append(": ");
+            Iterate.collect(missing, Object::toString, Lists.mutable.empty()).sortThis().appendString(message, ", ");
             Assert.fail(message.toString());
         }
     }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/pattern/TestURLPatternLibraryOrder.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/pattern/TestURLPatternLibraryOrder.java
@@ -14,8 +14,8 @@
 
 package org.finos.legend.pure.m3.serialization.runtime.pattern;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -24,18 +24,18 @@ public class TestURLPatternLibraryOrder
     @Test
     public void testOrder()
     {
-        MutableList<PurePattern> patterns = FastList.newListWith(
-                new PurePattern(null, "/pure/diagram/{diagramPath}", null, null, FastList.<String>newList()),
-                new PurePattern(null, "/pure/diagram/colors", null, null, FastList.<String>newList()),
-                new PurePattern(null, "/gggg/ppppppppp/current/account/{accountId}/{user}", null, null, FastList.<String>newList()),
-                new PurePattern(null, "/gggg/ppppppppp/current/{user}", null, null, FastList.<String>newList()));
+        MutableList<PurePattern> patterns = Lists.mutable.with(
+                new PurePattern(null, "/pure/diagram/{diagramPath}", null, null, Lists.fixedSize.empty()),
+                new PurePattern(null, "/pure/diagram/colors", null, null, Lists.fixedSize.empty()),
+                new PurePattern(null, "/gggg/ppppppppp/current/account/{accountId}/{user}", null, null, Lists.fixedSize.empty()),
+                new PurePattern(null, "/gggg/ppppppppp/current/{user}", null, null, Lists.fixedSize.empty()));
 
         MutableList<PurePattern> res = patterns.sortThis(URLPatternLibrary.URLPatternComparator);
 
-        Assert.assertEquals(FastList.newListWith("/pure/diagram/colors",
+        Assert.assertEquals(Lists.mutable.with("/pure/diagram/colors",
                 "/gggg/ppppppppp/current/account/{accountId}/{user}",
                 "/gggg/ppppppppp/current/{user}",
                 "/pure/diagram/{diagramPath}"),
-                res.collect(PurePattern.GET_SRC_PATTERN));
+                res.collect(PurePattern::getSrcPattern));
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/json/AbstractTestToJson.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/json/AbstractTestToJson.java
@@ -14,23 +14,31 @@
 
 package org.finos.legend.pure.m3.tests.function.base.json;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.TestCodeRepositoryWithDependencies;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.json.simple.JSONValue;
 import org.json.simple.parser.ParseException;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 public abstract class AbstractTestToJson extends AbstractPureTestWithCoreCompiled
 {
-    @Before
-    public void compileInliner()
+    @After
+    public void cleanRuntime()
     {
-        this.compileTestSourceFromResource("/org/finos/legend/pure/m3/toJson/toJson.pure");
+        runtime.delete("fromString.pure");
+        runtime.delete("/test/testFile.pure");
+        runtime.compile();
     }
 
     /*
@@ -38,9 +46,9 @@ public abstract class AbstractTestToJson extends AbstractPureTestWithCoreCompile
      */
 
     @Test
-    public void testSerializationPrimitiveTypes() throws Exception
+    public void testSerializationPrimitiveTypes()
     {
-       compileTestSource("fromString.pure",
+        compileTestSource("fromString.pure",
                 "import meta::json::*;\n" +
                         "function meta::pure::functions::asserts::assertJsonStringsEqual(expected:String[1], actual:String[1]):Boolean[1]\n" +
                         "{\n" +
@@ -53,13 +61,13 @@ public abstract class AbstractTestToJson extends AbstractPureTestWithCoreCompile
                         "                                         dateTimeType=date(2018,4,12,0,0,1), decimalType=3.14159265358979d);" +
                         "   assertJsonStringsEqual('{\"stringType\":\"Yoda\",\"dateTimeType\":\"2018-04-12T00:00:01+0000\",\"booleanType\":false,\"strictDateType\":\"2018-04-12\",\"floatType\":3.14159265358979,\"dateType\":\"2018\",\"integerType\":42,\"decimalType\":3.14159265358979}', $t->toJsonBeta(^meta::json::JSONSerializationConfig(typeKeyName='__TYPE', includeType=false, fullyQualifiedTypePath=false, serializeQualifiedProperties=false, serializePackageableElementName=false, removePropertiesWithEmptyValues=false)));\n" +
                         "}\n");
-        this.execute("test():Boolean[1]");
+        execute("test():Boolean[1]");
     }
 
     @Test
-    public void testSerializationEnumProperty() throws Exception
+    public void testSerializationEnumProperty()
     {
-       compileTestSource("fromString.pure",
+        compileTestSource("fromString.pure",
                 "import meta::json::*;\n" +
                         "function test():Boolean[1]\n" +
                         "{\n" +
@@ -68,13 +76,13 @@ public abstract class AbstractTestToJson extends AbstractPureTestWithCoreCompile
                         "let expected2 = '{\"enumProperty\":\"M\",\"simple\":[]}';\n" +
                         "assert($t->toJsonBeta(^meta::json::JSONSerializationConfig(typeKeyName='__TYPE', includeType=false, fullyQualifiedTypePath=false, serializeQualifiedProperties=false, serializePackageableElementName=false, removePropertiesWithEmptyValues=false)) == $expected1 || $t->toJsonBeta(^meta::json::JSONSerializationConfig(typeKeyName='__TYPE', includeType=false, fullyQualifiedTypePath=false, serializeQualifiedProperties=false, serializePackageableElementName=false, removePropertiesWithEmptyValues=false)) == $expected2, |'');\n" +
                         "}");
-        this.execute("test():Boolean[1]");
+        execute("test():Boolean[1]");
     }
 
     @Test
-    public void testSerializationClassProperty() throws Exception
+    public void testSerializationClassProperty()
     {
-       compileTestSource("fromString.pure",
+        compileTestSource("fromString.pure",
                 "import meta::json::*;\n" +
                         "function test():Boolean[1]\n" +
                         "{\n" +
@@ -83,13 +91,13 @@ public abstract class AbstractTestToJson extends AbstractPureTestWithCoreCompile
                         "let expected2 = '{\"nestedClassProperty\":{\"enumProperty\":\"M\",\"simple\":[]}}';\n" +
                         "assert($t->toJsonBeta(^meta::json::JSONSerializationConfig(typeKeyName='__TYPE', includeType=false, fullyQualifiedTypePath=false, serializeQualifiedProperties=false, serializePackageableElementName=false, removePropertiesWithEmptyValues=false)) == $expected1 || $t->toJsonBeta(^meta::json::JSONSerializationConfig(typeKeyName='__TYPE', includeType=false, fullyQualifiedTypePath=false, serializeQualifiedProperties=false, serializePackageableElementName=false, removePropertiesWithEmptyValues=false)) == $expected2, |'');\n" +
                         "}");
-        this.execute("test():Boolean[1]");
+        execute("test():Boolean[1]");
     }
 
     @Test
-    public void testSerializationClassWithAssociation() throws Exception
+    public void testSerializationClassWithAssociation()
     {
-       compileTestSource("fromString.pure",
+        compileTestSource("fromString.pure",
                 "import meta::json::*;\n" +
                         "function test():Boolean[1]\n" +
                         "{\n" +
@@ -98,7 +106,7 @@ public abstract class AbstractTestToJson extends AbstractPureTestWithCoreCompile
                         "let expected2 = '{\"prop\":[42,1],\"c2\":{\"str\":\"Hey\"}}';\n" +
                         "assert($t->toJsonBeta(^meta::json::JSONSerializationConfig(typeKeyName='__TYPE', includeType=false, fullyQualifiedTypePath=false, serializeQualifiedProperties=false, serializePackageableElementName=false, removePropertiesWithEmptyValues=false)) == $expected1 || $t->toJsonBeta(^meta::json::JSONSerializationConfig(typeKeyName='__TYPE', includeType=false, fullyQualifiedTypePath=false, serializeQualifiedProperties=false, serializePackageableElementName=false, removePropertiesWithEmptyValues=false)) == $expected2, |'');\n" +
                         "}");
-        this.execute("test():Boolean[1]");
+        execute("test():Boolean[1]");
     }
 
     @Test
@@ -351,5 +359,18 @@ public abstract class AbstractTestToJson extends AbstractPureTestWithCoreCompile
             throw new RuntimeException("Error parsing actual JSON: " + actualJson, e);
         }
         Assert.assertEquals(expected, actual);
+    }
+
+    protected static MutableCodeStorage getCodeStorage()
+    {
+        CodeRepository platform = CodeRepository.newPlatformCodeRepository();
+        CodeRepository test = new TestCodeRepositoryWithDependencies("test", null, platform);
+        return new PureCodeStorage(null, new ClassLoaderCodeStorage(platform, test));
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        String code = readTextResource("org/finos/legend/pure/m3/toJson/toJson.pure", AbstractTestToJson.class.getClassLoader());
+        return Tuples.pair("/test/toJson.pure", code);
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/lang/AbstractTestCast.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/lang/AbstractTestCast.java
@@ -14,26 +14,25 @@
 
 package org.finos.legend.pure.m3.tests.function.base.lang;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.TestCodeRepositoryWithDependencies;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 {
-    @Before
-    public void compileInliner()
-    {
-        compileTestSourceFromResource("/org/finos/legend/pure/m3/cast/cast.pure");
-    }
-
     @After
     public void cleanRuntime()
     {
         runtime.delete("fromString.pure");
-        runtime.delete("/org/finos/legend/pure/m3/cast/cast.pure");
         runtime.compile();
     }
 
@@ -41,7 +40,7 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
     public void testCastError()
     {
         compileTestSource("fromString.pure",
-                        "Class A\n" +
+                "Class A\n" +
                         "{\n" +
                         "  prop3:String[1];\n" +
                         "}\n" +
@@ -84,7 +83,7 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 
     protected void checkInvalidCastWithTypeParametersRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: List<X> cannot be cast to List<Y>", "/org/finos/legend/pure/m3/cast/cast.pure", 46, 11);
+        checkException(findRootException(e), "Cast exception: List<X> cannot be cast to List<Y>", "/test/cast.pure", 46, 11);
     }
 
     @Test
@@ -120,7 +119,7 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 
     protected void checkPrimitiveConcreteOneRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: Integer cannot be cast to String", "/org/finos/legend/pure/m3/cast/cast.pure", 31, 10);
+        checkException(findRootException(e), "Cast exception: Integer cannot be cast to String", "/test/cast.pure", 31, 10);
     }
 
     @Test
@@ -143,7 +142,7 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 
     protected void checkPrimitiveConcreteManyRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: String cannot be cast to Number", "/org/finos/legend/pure/m3/cast/cast.pure", 36, 13);
+        checkException(findRootException(e), "Cast exception: String cannot be cast to Number", "/test/cast.pure", 36, 13);
     }
 
     @Test
@@ -166,7 +165,7 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 
     protected void checkNonPrimitiveConcreteOneRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: X cannot be cast to Y", "/org/finos/legend/pure/m3/cast/cast.pure", 41, 12);
+        checkException(findRootException(e), "Cast exception: X cannot be cast to Y", "/test/cast.pure", 41, 12);
     }
 
     @Test
@@ -189,7 +188,7 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 
     protected void checkNonPrimitiveConcreteManyRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: X cannot be cast to Y", "/org/finos/legend/pure/m3/cast/cast.pure", 41, 12);
+        checkException(findRootException(e), "Cast exception: X cannot be cast to Y", "/test/cast.pure", 41, 12);
     }
 
     @Test
@@ -212,7 +211,7 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 
     protected void checkPrimitiveNonConcreteOneRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: Integer cannot be cast to String", "/org/finos/legend/pure/m3/cast/cast.pure", 67, 26);
+        checkException(findRootException(e), "Cast exception: Integer cannot be cast to String", "/test/cast.pure", 67, 26);
     }
 
     @Test
@@ -235,7 +234,7 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 
     protected void checkPrimitiveNonConcreteManyRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: String cannot be cast to Number", "/org/finos/legend/pure/m3/cast/cast.pure", 68, 17);
+        checkException(findRootException(e), "Cast exception: String cannot be cast to Number", "/test/cast.pure", 68, 17);
     }
 
     @Test
@@ -258,7 +257,7 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 
     protected void checkNonPrimitiveNonConcreteOneRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: X cannot be cast to Y", "/org/finos/legend/pure/m3/cast/cast.pure", 67, 26);
+        checkException(findRootException(e), "Cast exception: X cannot be cast to Y", "/test/cast.pure", 67, 26);
     }
 
     @Test
@@ -281,7 +280,7 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 
     protected void checkNonPrimitiveNonConcreteManyRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: X cannot be cast to Y", "/org/finos/legend/pure/m3/cast/cast.pure", 68, 17);
+        checkException(findRootException(e), "Cast exception: X cannot be cast to Y", "/test/cast.pure", 68, 17);
     }
 
     @Test
@@ -304,7 +303,7 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 
     protected void checkEnumToStringCastRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: Month cannot be cast to String", "/org/finos/legend/pure/m3/cast/cast.pure", 31, 10);
+        checkException(findRootException(e), "Cast exception: Month cannot be cast to String", "/test/cast.pure", 31, 10);
     }
 
     @Test
@@ -342,5 +341,18 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
             }
         }
         return (t instanceof Exception) ? (Exception) t : null;
+    }
+
+    protected static MutableCodeStorage getCodeStorage()
+    {
+        CodeRepository platform = CodeRepository.newPlatformCodeRepository();
+        CodeRepository test = new TestCodeRepositoryWithDependencies("test", null, platform);
+        return new PureCodeStorage(null, new ClassLoaderCodeStorage(platform, test));
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        String code = readTextResource("org/finos/legend/pure/m3/cast/cast.pure", AbstractTestCast.class.getClassLoader());
+        return Tuples.pair("/test/cast.pure", code);
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/lang/AbstractTestCopyAtRuntime.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/lang/AbstractTestCopyAtRuntime.java
@@ -15,14 +15,19 @@
 package org.finos.legend.pure.m3.tests.function.base.lang;
 
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 public abstract class AbstractTestCopyAtRuntime extends AbstractPureTestWithCoreCompiled
 {
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete("fromString.pure");
+    }
+
     @Test
     public void testCopyWithReverseZeroToOneProperty()
     {
@@ -57,13 +62,13 @@ public abstract class AbstractTestCopyAtRuntime extends AbstractPureTestWithCore
         try
         {
             this.execute("test():Any[*]");
-            assertEquals("'1'", this.functionExecution.getConsole().getLine(0));
-            assertEquals("'1'", this.functionExecution.getConsole().getLine(1));
-            assertEquals("'Veyron'", this.functionExecution.getConsole().getLine(2));
+            Assert.assertEquals("'1'", functionExecution.getConsole().getLine(0));
+            Assert.assertEquals("'1'", functionExecution.getConsole().getLine(1));
+            Assert.assertEquals("'Veyron'", functionExecution.getConsole().getLine(2));
         }
         catch (Exception e)
         {
-            fail("Failed to set the reverse properties for a zero-to-one association.");
+            Assert.fail("Assert.failed to set the reverse properties for a zero-to-one association.");
         }
     }
 
@@ -88,12 +93,12 @@ public abstract class AbstractTestCopyAtRuntime extends AbstractPureTestWithCore
         try
         {
             this.execute("test():Any[*]");
-            assertEquals("1", this.functionExecution.getConsole().getLine(0).substring(0,1));
+            Assert.assertEquals("1", functionExecution.getConsole().getLine(0).substring(0,1));
         }
         catch (Exception e)
         {
             //e.printStackTrace();
-            fail("Failed to increment the Integer property on Copy.");
+            Assert.fail("Assert.failed to increment the Integer property on Copy.");
         }
     }
 
@@ -131,13 +136,13 @@ public abstract class AbstractTestCopyAtRuntime extends AbstractPureTestWithCore
         try
         {
             this.execute("test():Any[*]");
-            assertEquals("'1'", this.functionExecution.getConsole().getLine(0));
-            assertEquals("'1'", this.functionExecution.getConsole().getLine(1));
-            assertEquals("'Veyron'", this.functionExecution.getConsole().getLine(2));
+            Assert.assertEquals("'1'", functionExecution.getConsole().getLine(0));
+            Assert.assertEquals("'1'", functionExecution.getConsole().getLine(1));
+            Assert.assertEquals("'Veyron'", functionExecution.getConsole().getLine(2));
         }
         catch (Exception e)
         {
-            fail("Failed to set the reverse properties for a zero-to-many association.");
+            Assert.fail("Assert.failed to set the reverse properties for a zero-to-many association.");
         }
     }
 
@@ -175,13 +180,13 @@ public abstract class AbstractTestCopyAtRuntime extends AbstractPureTestWithCore
         try
         {
             this.execute("test():Any[*]");
-            assertEquals("'1'", this.functionExecution.getConsole().getLine(0));
-            assertEquals("'1'", this.functionExecution.getConsole().getLine(1));
-            assertEquals("'Veyron'", this.functionExecution.getConsole().getLine(2));
+            Assert.assertEquals("'1'", functionExecution.getConsole().getLine(0));
+            Assert.assertEquals("'1'", functionExecution.getConsole().getLine(1));
+            Assert.assertEquals("'Veyron'", functionExecution.getConsole().getLine(2));
         }
         catch (Exception e)
         {
-            fail("Failed to set the reverse properties for a one-to-one association.");
+            Assert.fail("Assert.failed to set the reverse properties for a one-to-one association.");
         }
     }
 
@@ -219,13 +224,13 @@ public abstract class AbstractTestCopyAtRuntime extends AbstractPureTestWithCore
         try
         {
             this.execute("test():Any[*]");
-            assertEquals("'1'", this.functionExecution.getConsole().getLine(0));
-            assertEquals("'1'", this.functionExecution.getConsole().getLine(1));
-            assertEquals("'Veyron'", this.functionExecution.getConsole().getLine(2));
+            Assert.assertEquals("'1'", functionExecution.getConsole().getLine(0));
+            Assert.assertEquals("'1'", functionExecution.getConsole().getLine(1));
+            Assert.assertEquals("'Veyron'", functionExecution.getConsole().getLine(2));
         }
         catch (Exception e)
         {
-            fail("Failed to set the reverse properties for a one-to-many association.");
+            Assert.fail("Assert.failed to set the reverse properties for a one-to-many association.");
         }
     }
 
@@ -267,14 +272,14 @@ public abstract class AbstractTestCopyAtRuntime extends AbstractPureTestWithCore
         try
         {
             this.execute("test():Any[*]");
-            assertEquals("'3'", this.functionExecution.getConsole().getLine(0));
-            assertEquals("'Audi'", this.functionExecution.getConsole().getLine(1));
-            assertEquals("'Bugatti'", this.functionExecution.getConsole().getLine(2));
-            assertEquals("'Veyron'", this.functionExecution.getConsole().getLine(3));
+            Assert.assertEquals("'3'", functionExecution.getConsole().getLine(0));
+            Assert.assertEquals("'Audi'", functionExecution.getConsole().getLine(1));
+            Assert.assertEquals("'Bugatti'", functionExecution.getConsole().getLine(2));
+            Assert.assertEquals("'Veyron'", functionExecution.getConsole().getLine(3));
         }
         catch (Exception e)
         {
-            fail("Failed to set the reverse property of a child for a one-to-many association.");
+            Assert.fail("Assert.failed to set the reverse property of a child for a one-to-many association.");
         }
     }
 
@@ -313,11 +318,11 @@ public abstract class AbstractTestCopyAtRuntime extends AbstractPureTestWithCore
         try
         {
             this.execute("test():Any[*]");
-            assertEquals("'1'", this.functionExecution.getConsole().getLine(0));
+            Assert.assertEquals("'1'", functionExecution.getConsole().getLine(0));
         }
         catch (Exception e)
         {
-            fail("Failed to set the reverse property of a child for a many-to-many association.");
+            Assert.fail("Assert.failed to set the reverse property of a child for a many-to-many association.");
         }
     }
 
@@ -357,11 +362,11 @@ public abstract class AbstractTestCopyAtRuntime extends AbstractPureTestWithCore
         try
         {
             this.execute("test():Any[*]");
-            assertEquals("false", this.functionExecution.getConsole().getLine(0));
+            Assert.assertEquals("false", functionExecution.getConsole().getLine(0));
         }
         catch (Exception e)
         {
-            fail("Failed to set the reverse property of a child for a many-to-many association.");
+            Assert.fail("Assert.failed to set the reverse property of a child for a many-to-many association.");
         }
     }
 

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/runtime/AbstractTestIsOptionSet.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/runtime/AbstractTestIsOptionSet.java
@@ -14,18 +14,25 @@
 
 package org.finos.legend.pure.m3.tests.function.base.runtime;
 
+import org.eclipse.collections.api.map.primitive.ObjectBooleanMap;
+import org.eclipse.collections.impl.factory.primitive.ObjectBooleanMaps;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.navigation.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m3.serialization.runtime.RuntimeOptions;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Map;
-import java.util.TreeMap;
-
 public abstract class AbstractTestIsOptionSet extends AbstractPureTestWithCoreCompiled
 {
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete("fromString.pure");
+        runtime.compile();
+    }
+
     @Test
     public void testOptionThatIsSetOn()
     {
@@ -35,7 +42,7 @@ public abstract class AbstractTestIsOptionSet extends AbstractPureTestWithCoreCo
                         "    meta::pure::runtime::isOptionSet('TestSetOn');" +
                         "}\n");
         CoreInstance result = this.execute("test():Boolean[1]");
-        Assert.assertEquals("true", ValueSpecification.getValue(result, this.processorSupport).getName());
+        Assert.assertEquals("true", ValueSpecification.getValue(result, processorSupport).getName());
     }
 
     @Test
@@ -47,7 +54,7 @@ public abstract class AbstractTestIsOptionSet extends AbstractPureTestWithCoreCo
                         "    meta::pure::runtime::isOptionSet('TestSetOff');" +
                         "}\n");
         CoreInstance result = this.execute("test():Boolean[1]");
-        Assert.assertEquals("false", ValueSpecification.getValue(result, this.processorSupport).getName());
+        Assert.assertEquals("false", ValueSpecification.getValue(result, processorSupport).getName());
     }
 
     @Test
@@ -59,22 +66,14 @@ public abstract class AbstractTestIsOptionSet extends AbstractPureTestWithCoreCo
                         "    meta::pure::runtime::isOptionSet('TestUnset');" +
                         "}\n");
         CoreInstance result = this.execute("test():Boolean[1]");
-        Assert.assertEquals("false", ValueSpecification.getValue(result, this.processorSupport).getName());
+        Assert.assertEquals("false", ValueSpecification.getValue(result, processorSupport).getName());
     }
 
     protected static RuntimeOptions getOptions()
     {
-        final Map<String, Boolean> testOptions = new TreeMap<>();
-        testOptions.put("TestSetOn", true);
-        testOptions.put("TestSetOff", false);
-        return new RuntimeOptions()
-        {
-            @Override
-            public boolean isOptionSet(String name)
-            {
-                return testOptions.containsKey(name) && testOptions.get(name);
-            }
-        };
+        ObjectBooleanMap<String> testOptions = ObjectBooleanMaps.mutable.<String>empty()
+                .withKeyValue("TestSetOn", true)
+                .withKeyValue("TestSetOff", false);
+        return name -> testOptions.getIfAbsent(name, false);
     }
-
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/TestMultipleRepoIncrementalCompilation.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/TestMultipleRepoIncrementalCompilation.java
@@ -15,8 +15,8 @@
 package org.finos.legend.pure.m3.tests.incremental;
 
 import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Sets;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Sets;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.RuntimeVerifier;
@@ -32,15 +32,18 @@ import org.junit.Test;
 public class TestMultipleRepoIncrementalCompilation extends AbstractPureTestWithCoreCompiledPlatform
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getCodeStorage(), getCodeRepositories(), getExtra());
+    public static void setUp()
+    {
+        setUpRuntime(getCodeStorage(), getExtra());
     }
 
     @After
-    public void clearRuntime() {
+    public void clearRuntime()
+    {
         runtime.delete("/model/sourceId.pure");
         runtime.delete("/datamart_other/file1.pure");
         runtime.delete("/datamart_other/file2.pure");
+        runtime.compile();
     }
 
     protected static RichIterable<? extends CodeRepository> getCodeRepositories()
@@ -71,7 +74,7 @@ public class TestMultipleRepoIncrementalCompilation extends AbstractPureTestWith
                         .updateSource("/datamart_other/file1.pure", "function datamarts::dmt::doStuff1():Nil[0]{print(domain::A.all(),1);}")
                         .updateSource("/model/sourceId.pure", "Class domain::A{version : Integer[*];}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
 
@@ -91,7 +94,6 @@ public class TestMultipleRepoIncrementalCompilation extends AbstractPureTestWith
                         //Put it back
                         .updateSource("/model/sourceId.pure", "Class domain::A{cats : Integer[1];}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
-
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_AsFunctionReturn.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_AsFunctionReturn.java
@@ -14,14 +14,20 @@
 
 package org.finos.legend.pure.m3.tests.incremental._class;
 
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.ImmutableMap;
-import org.eclipse.collections.impl.factory.Maps;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
-import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.RuntimeVerifier;
 import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation._class._Class;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.junit.After;
@@ -32,25 +38,28 @@ import org.junit.Test;
 public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithCoreCompiledPlatform
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getExtra());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return Lists.immutable.with(CodeRepository.newPlatformCodeRepository(),
+                GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", PlatformCodeRepository.NAME),
+                GenericCodeRepository.build("test", "test(::.*)?", PlatformCodeRepository.NAME, "system"));
     }
 
     @After
-    public void clearRuntime() {
+    public void clearRuntime()
+    {
         runtime.delete("other.pure");
         runtime.delete("userId.pure");
         runtime.delete("sourceId.pure");
         runtime.delete("sourceId2.pure");
         runtime.delete("/test/testFileB.pure");
         runtime.delete("/test/testFileA.pure");
-
-        try
-        {
-          runtime.compile();
-        } catch (PureCompilationException e) {
-            setUp();
-        }
+        runtime.compile();
     }
 
     @Test
@@ -66,7 +75,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compileWithExpectedCompileFailure("A has not been defined!", "userId.pure", 1, 14)
                         .createInMemorySource("sourceId.pure", "Class A{}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
@@ -95,7 +104,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                                         "{\n" +
                                         "}\n")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
@@ -110,7 +119,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compileWithExpectedCompileFailure("A has not been defined!", "userId.pure", 1, 78)
                         .createInMemorySource("sourceId.pure", "Class A{}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
@@ -128,7 +137,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compileWithExpectedCompileFailure("A has not been defined!", null, 1, 14)
                         .updateSource("sourceId.pure", "Class A{}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
@@ -143,7 +152,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compileWithExpectedCompileFailure("A has not been defined!", "other.pure", 1, 14)
                         .createInMemorySource("sourceId.pure", "Class A{} Class B{a:A[1];}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
 
     }
 
@@ -161,7 +170,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compileWithExpectedCompileFailure("A has not been defined!", "other.pure", 1, 14)
                         .updateSource("sourceId.pure", "Class A{} Class B{a:A[1];}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
@@ -175,7 +184,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compileWithExpectedCompileFailure("A has not been defined!", "userId.pure", 1, 11)
                         .createInMemorySource("sourceId.pure", "Class A{}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
@@ -204,7 +213,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                                         "{\n" +
                                         "}\n")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
@@ -233,7 +242,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                                         "{\n" +
                                         "}\n")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
@@ -262,7 +271,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                                         "{\n" +
                                         "}\n")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
@@ -278,7 +287,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compileWithExpectedCompileFailure("A has not been defined!", "userId.pure", 1, 11)
                         .updateSource("sourceId.pure", "Class A{}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
@@ -293,22 +302,22 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compileWithExpectedCompileFailure("A has not been defined!", "other.pure", 1, 14)
                         .createInMemorySource("sourceId.pure", "Class A{} Class C{a:A[1];} Class B extends C{}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
 
         Assert.assertEquals("B instance Class\n" +
-                            "    classifierGenericType(Property):\n" +
-                            "        Anonymous_StripedId instance GenericType\n" +
-                            "            [... >0]\n" +
-                            "    generalizations(Property):\n" +
-                            "        Anonymous_StripedId instance Generalization\n" +
-                            "            [... >0]\n" +
-                            "    name(Property):\n" +
-                            "        B instance String\n" +
-                            "    package(Property):\n" +
-                            "        Root instance Package\n" +
-                            "    referenceUsages(Property):\n" +
-                            "        Anonymous_StripedId instance ReferenceUsage\n" +
-                            "            [... >0]", this.runtime.getCoreInstance("B").printWithoutDebug("",0));
+                "    classifierGenericType(Property):\n" +
+                "        Anonymous_StripedId instance GenericType\n" +
+                "            [... >0]\n" +
+                "    generalizations(Property):\n" +
+                "        Anonymous_StripedId instance Generalization\n" +
+                "            [... >0]\n" +
+                "    name(Property):\n" +
+                "        B instance String\n" +
+                "    package(Property):\n" +
+                "        Root instance Package\n" +
+                "    referenceUsages(Property):\n" +
+                "        Anonymous_StripedId instance ReferenceUsage\n" +
+                "            [... >0]", runtime.getCoreInstance("B").printWithoutDebug("", 0));
     }
 
     @Test
@@ -325,48 +334,41 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compileWithExpectedCompileFailure("Can't find the property 'a' in the class B", "userId.pure", 1, 37)
                         .updateSource("sourceId.pure", "Class A{} Class C{a:A[1];} Class B extends C{}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
-    public void testPureRuntimeClassAsQualifiedPropertyReturn() throws Exception
+    public void testPureRuntimeClassAsQualifiedPropertyReturn()
     {
         ImmutableMap<String, String> sources = Maps.immutable.with(
                 "sourceId.pure", "Class A{}",
                 "sourceId2.pure", "Class B{prop(){^A()}:A[1];}"
         );
-        this.runtime.createInMemorySource("sourceId.pure", sources.get("sourceId.pure"));
-        this.runtime.createInMemorySource("sourceId2.pure", sources.get("sourceId2.pure"));
-        this.runtime.compile();
+        runtime.createInMemorySource("sourceId.pure", sources.get("sourceId.pure"));
+        runtime.createInMemorySource("sourceId2.pure", sources.get("sourceId2.pure"));
+        runtime.compile();
 
-        int size = this.repository.serialize().length;
-        CoreInstance classA = this.processorSupport.package_getByUserPath("A");
-        CoreInstance classB = this.processorSupport.package_getByUserPath("B");
-        CoreInstance prop = _Class.getQualifiedPropertiesByName(classB, this.processorSupport).get("prop()");
-        Assert.assertSame(classA, Instance.getValueForMetaPropertyToOneResolved(prop, M3Properties.genericType, M3Properties.rawType, this.processorSupport));
+        int size = repository.serialize().length;
+        CoreInstance classA = processorSupport.package_getByUserPath("A");
+        CoreInstance classB = processorSupport.package_getByUserPath("B");
+        CoreInstance prop = _Class.getQualifiedPropertiesByName(classB, processorSupport).get("prop()");
+        Assert.assertSame(classA, Instance.getValueForMetaPropertyToOneResolved(prop, M3Properties.genericType, M3Properties.rawType, processorSupport));
 
         for (int i = 0; i < 10; i++)
         {
-            this.runtime.delete("sourceId.pure");
-            try
-            {
-                this.runtime.compile();
-                Assert.fail("Expected a compile exception");
-            }
-            catch (Exception e)
-            {
-                assertPureException(PureCompilationException.class, "A has not been defined!", "sourceId2.pure", e);
-            }
+            runtime.delete("sourceId.pure");
+            PureCompilationException e = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+            assertPureException(PureCompilationException.class, "A has not been defined!", "sourceId2.pure", e);
 
-            this.runtime.createInMemorySource("sourceId.pure", sources.get("sourceId.pure"));
-            this.runtime.compile();
+            runtime.createInMemorySource("sourceId.pure", sources.get("sourceId.pure"));
+            runtime.compile();
 
-            classA = this.processorSupport.package_getByUserPath("A");
-            classB = this.processorSupport.package_getByUserPath("B");
-            prop = _Class.getQualifiedPropertiesByName(classB, this.processorSupport).get("prop()");
-            Assert.assertSame(classA, Instance.getValueForMetaPropertyToOneResolved(prop, M3Properties.genericType, M3Properties.rawType, this.processorSupport));
+            classA = processorSupport.package_getByUserPath("A");
+            classB = processorSupport.package_getByUserPath("B");
+            prop = _Class.getQualifiedPropertiesByName(classB, processorSupport).get("prop()");
+            Assert.assertSame(classA, Instance.getValueForMetaPropertyToOneResolved(prop, M3Properties.genericType, M3Properties.rawType, processorSupport));
 
-            Assert.assertEquals(size, this.repository.serialize().length);
+            Assert.assertEquals(size, repository.serialize().length);
         }
     }
 
@@ -382,7 +384,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compileWithExpectedCompileFailure("A has not been defined!", "other.pure", 1, 14)
                         .createInMemorySource("sourceId.pure", "Class A{}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
@@ -399,7 +401,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compileWithExpectedCompileFailure("A has not been defined!", "other.pure", 1, 14)
                         .updateSource("sourceId.pure", "Class A{}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
 
@@ -416,7 +418,7 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compileWithExpectedCompileFailure("A has not been defined!", null, 1, 14)
                         .createInMemorySource("sourceId.pure", "Class A{}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
 
     }
 
@@ -436,7 +438,6 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .deleteSource("sourceId.pure")
                         .createInMemorySource("sourceId.pure", "Class A{}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
-
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/milestoning/AbstractTestMilestoning.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/milestoning/AbstractTestMilestoning.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.pure.m3.tests.milestoning;
 
-
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/milestoning/TestMilestoningClassProcessor.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/milestoning/TestMilestoningClassProcessor.java
@@ -15,7 +15,7 @@
 package org.finos.legend.pure.m3.tests.milestoning;
 
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.milestoning.MilestoningFunctions;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
@@ -31,7 +31,7 @@ public class TestMilestoningClassProcessor extends AbstractTestMilestoning
     @BeforeClass
     public static void setUp()
     {
-        setUpRuntime(getExtra());
+        setUpRuntime();
     }
 
     @After
@@ -41,6 +41,8 @@ public class TestMilestoningClassProcessor extends AbstractTestMilestoning
         runtime.delete("sourceId2.pure");
         runtime.delete("domain.pure");
         runtime.delete("singleInheritance.pure");
+
+        runtime.compile();
     }
 
     @Test

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/milestoning/TestMilestoningPropertyProcessor.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/milestoning/TestMilestoningPropertyProcessor.java
@@ -16,14 +16,12 @@ package org.finos.legend.pure.m3.tests.milestoning;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.multimap.list.ListMultimap;
 import org.eclipse.collections.impl.block.factory.Predicates;
 import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.navigation.Instance;
@@ -49,7 +47,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     @BeforeClass
     public static void setUp()
     {
-        setUpRuntime(getExtra());
+        setUpRuntime();
     }
 
     @After
@@ -60,22 +58,16 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         runtime.delete("sourceId3.pure");
         runtime.delete("domain.pure");
         runtime.delete("mainModel.pure");
+        runtime.delete("otherModel.pure");
 
-        try
-        {
-            runtime.compile();
-        }
-        catch (PureCompilationException e)
-        {
-            setUp();
-        }
+        runtime.compile();
     }
 
     @Rule
     public final ExpectedException expectedEx = ExpectedException.none();
 
     @Test
-    public void testSynthesizedPropertiesMultiplicities() throws Exception
+    public void testSynthesizedPropertiesMultiplicities()
     {
         this.compileTestSourceM3("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -112,7 +104,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testAdditionOfSynthesizedQualifiedPropertiesForBusinessTemporalProperties() throws Exception
+    public void testAdditionOfSynthesizedQualifiedPropertiesForBusinessTemporalProperties()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -128,12 +120,12 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         runtime.compile();
         CoreInstance order = runtime.getCoreInstance("meta::test::domain::Order");
         ListIterable<? extends CoreInstance> orderProperties = Instance.getValueForMetaPropertyToManyResolved(order, M3Properties.properties, processorSupport);
-        ListIterable<String> productPropertiesAsStrings = orderProperties.collect(CoreInstance.GET_NAME);
-        Assert.assertEquals(FastList.newListWith("orderId", "productAllVersions"), productPropertiesAsStrings);
+        ListIterable<String> productPropertiesAsStrings = orderProperties.collect(CoreInstance::getName);
+        Assert.assertEquals(Lists.mutable.with("orderId", "productAllVersions"), productPropertiesAsStrings);
 
         ListIterable<? extends CoreInstance> srcOrderProperties = Instance.getValueForMetaPropertyToManyResolved(order, M3Properties.originalMilestonedProperties, processorSupport);
-        ListIterable<String> srcOrderPropertiesAsStrings = srcOrderProperties.collect(CoreInstance.GET_NAME);
-        Assert.assertEquals(FastList.newListWith("product"), srcOrderPropertiesAsStrings);
+        ListIterable<String> srcOrderPropertiesAsStrings = srcOrderProperties.collect(CoreInstance::getName);
+        Assert.assertEquals(Lists.mutable.with("product"), srcOrderPropertiesAsStrings);
 
         ListIterable<? extends CoreInstance> qualifiedProperties = Instance.getValueForMetaPropertyToManyResolved(order, M3Properties.qualifiedProperties, processorSupport);
         Verify.assertSize(2, qualifiedProperties);
@@ -156,7 +148,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testGeneratedMilestonedQualifiedPropertiesMultiplicity() throws Exception
+    public void testGeneratedMilestonedQualifiedPropertiesMultiplicity()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -179,14 +171,14 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         ArrayAdapter.adapt(Tuples.pair("product_0", "[1]"), Tuples.pair("productOptional_0", "[0..1]"), Tuples.pair("productTwo_0", "[*]"), Tuples.pair("productMany_0", "[*]"), Tuples.pair("productRange_0", "[*]"))
                 .forEach(propertyNameToExpectedMultiplicity ->
                 {
-                    CoreInstance product = qualifiedProperties.detect(Predicates.attributeEqual(CoreInstance.GET_NAME, propertyNameToExpectedMultiplicity.getOne()));
+                    CoreInstance product = qualifiedProperties.detect(Predicates.attributeEqual(CoreInstance::getName, propertyNameToExpectedMultiplicity.getOne()));
                     String multiplicityString = Multiplicity.print(product.getValueForMetaPropertyToOne(M3Properties.multiplicity));
                     Assert.assertEquals(propertyNameToExpectedMultiplicity.getTwo(), multiplicityString);
                 });
     }
 
     @Test
-    public void testAdditionOfSynthesizedQualifiedPropertiesForProcessingTemporalProperties() throws Exception
+    public void testAdditionOfSynthesizedQualifiedPropertiesForProcessingTemporalProperties()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -203,8 +195,8 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         runtime.compile();
         CoreInstance order = runtime.getCoreInstance("meta::test::domain::Order");
         ListIterable<? extends CoreInstance> orderProperties = Instance.getValueForMetaPropertyToManyResolved(order, M3Properties.properties, processorSupport);
-        ListIterable<String> productPropertiesAsStrings = orderProperties.collect(CoreInstance.GET_NAME);
-        Assert.assertEquals(FastList.newListWith("orderId", "productAllVersions"), productPropertiesAsStrings);
+        ListIterable<String> productPropertiesAsStrings = orderProperties.collect(CoreInstance::getName);
+        Assert.assertEquals(Lists.mutable.with("orderId", "productAllVersions"), productPropertiesAsStrings);
 
         ListIterable<? extends CoreInstance> qualifiedProperties = Instance.getValueForMetaPropertyToManyResolved(order, M3Properties.qualifiedProperties, processorSupport);
         Verify.assertSize(2, qualifiedProperties);
@@ -227,7 +219,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testGeneratedPropertiesIncludeSourcePropertyTaggedValuesAndStereotypes() throws Exception
+    public void testGeneratedPropertiesIncludeSourcePropertyTaggedValuesAndStereotypes()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -244,17 +236,10 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         runtime.compile();
         CoreInstance order = runtime.getCoreInstance("meta::test::domain::Order");
         CoreInstance productProperty = Instance.getValueForMetaPropertyToOneResolved(order, M3Properties.properties, processorSupport);
-        Assert.assertEquals("productAllVersions", CoreInstance.GET_NAME.valueOf(productProperty));
+        Assert.assertEquals("productAllVersions", productProperty.getName());
 
         CoreInstance servicePackage = processorSupport.package_getByUserPath(M3Paths.service);
-        CoreInstance disableStreamingStereotype = servicePackage.getValueForMetaPropertyToMany(M3Properties.p_stereotypes).detect(new Predicate<CoreInstance>()
-        {
-            @Override
-            public boolean accept(CoreInstance serviceStereotype)
-            {
-                return CoreInstance.GET_NAME.valueOf(serviceStereotype).equals("disableStreaming");
-            }
-        });
+        CoreInstance disableStreamingStereotype = servicePackage.getValueForMetaPropertyToMany(M3Properties.p_stereotypes).detect(serviceStereotype -> "disableStreaming".equals(serviceStereotype.getName()));
 
         ListIterable<? extends CoreInstance> stereotypes = Instance.getValueForMetaPropertyToManyResolved(productProperty, M3Properties.stereotypes, processorSupport);
         Assert.assertEquals(2, stereotypes.size());
@@ -267,7 +252,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testGeneratedPropertiesIncludeAggregationProperty() throws Exception
+    public void testGeneratedPropertiesIncludeAggregationProperty()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -300,13 +285,13 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         CoreInstance order = runtime.getCoreInstance("meta::test::domain::Order");
         ListIterable<? extends CoreInstance> orderProperties = Instance.getValueForMetaPropertyToManyResolved(order, M3Properties.properties, processorSupport);
 
-        CoreInstance orderDetailsNonTemporalCompositeProperty = orderProperties.detect(Predicates.attributeEqual(CoreInstance.GET_NAME, "orderDetailsNonTemporalComposite"));
+        CoreInstance orderDetailsNonTemporalCompositeProperty = orderProperties.detect(Predicates.attributeEqual(CoreInstance::getName, "orderDetailsNonTemporalComposite"));
         CoreInstance compositeAggregation = orderDetailsNonTemporalCompositeProperty.getValueForMetaPropertyToOne(M3Properties.aggregation);
-        CoreInstance orderDetailsNonTemporalSharedProperty = orderProperties.detect(Predicates.attributeEqual(CoreInstance.GET_NAME, "orderDetailsNonTemporalShared"));
+        CoreInstance orderDetailsNonTemporalSharedProperty = orderProperties.detect(Predicates.attributeEqual(CoreInstance::getName, "orderDetailsNonTemporalShared"));
         CoreInstance sharedAggregation = orderDetailsNonTemporalSharedProperty.getValueForMetaPropertyToOne(M3Properties.aggregation);
 
-        CoreInstance orderDetailsTemporalCompositeProperty = orderProperties.detect(Predicates.attributeEqual(CoreInstance.GET_NAME, "orderDetailsCompositeAllVersions"));
-        CoreInstance orderDetailsTemporalSharedProperty = orderProperties.detect(Predicates.attributeEqual(CoreInstance.GET_NAME, "orderDetailsSharedAllVersions"));
+        CoreInstance orderDetailsTemporalCompositeProperty = orderProperties.detect(Predicates.attributeEqual(CoreInstance::getName, "orderDetailsCompositeAllVersions"));
+        CoreInstance orderDetailsTemporalSharedProperty = orderProperties.detect(Predicates.attributeEqual(CoreInstance::getName, "orderDetailsSharedAllVersions"));
         CoreInstance orderDetailsTemporalCompositePropertyAgg = orderDetailsTemporalCompositeProperty.getValueForMetaPropertyToOne(M3Properties.aggregation);
         CoreInstance orderDetailsTemporalSharedPropertyAgg = orderDetailsTemporalSharedProperty.getValueForMetaPropertyToOne(M3Properties.aggregation);
 
@@ -315,14 +300,14 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
 
         CoreInstance orderDetailsAssn = runtime.getCoreInstance("meta::test::domain::Order_OrderDetails");
         ListIterable<? extends CoreInstance> orderDetailsAssnProperties = Instance.getValueForMetaPropertyToManyResolved(orderDetailsAssn, M3Properties.properties, processorSupport);
-        CoreInstance orderDetailsViaAssnCompositeAllVersions = orderDetailsAssnProperties.detect(Predicates.attributeEqual(CoreInstance.GET_NAME, "orderDetailsViaAssnCompositeAllVersions"));
+        CoreInstance orderDetailsViaAssnCompositeAllVersions = orderDetailsAssnProperties.detect(Predicates.attributeEqual(CoreInstance::getName, "orderDetailsViaAssnCompositeAllVersions"));
         CoreInstance orderDetailsViaAssnCompositeAllVersionsAgg = orderDetailsViaAssnCompositeAllVersions.getValueForMetaPropertyToOne(M3Properties.aggregation);
         Assert.assertEquals(compositeAggregation, orderDetailsViaAssnCompositeAllVersionsAgg);
     }
 
 
     @Test
-    public void testAdditionOfSynthesizedQualifiedPropertiesForBusinessTemporalAssociations() throws Exception
+    public void testAdditionOfSynthesizedQualifiedPropertiesForBusinessTemporalAssociations()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -344,7 +329,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         Assert.assertNotNull(productClass);
 
         ListIterable<? extends CoreInstance> orderProperties = Instance.getValueForMetaPropertyToManyResolved(orderClass, M3Properties.propertiesFromAssociations, processorSupport);
-        ListIterable<String> productPropertiesAsStrings = orderProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> productPropertiesAsStrings = orderProperties.collect(CoreInstance::getName);
         Assert.assertEquals(Lists.mutable.with("productAllVersions"), productPropertiesAsStrings);
 
         ListIterable<? extends CoreInstance> qualifiedProperties = Instance.getValueForMetaPropertyToManyResolved(orderClass, M3Properties.qualifiedPropertiesFromAssociations, processorSupport);
@@ -368,7 +353,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testQualifiedPropertyVisibility() throws Exception
+    public void testQualifiedPropertyVisibility()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -415,8 +400,8 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         Assert.assertNotNull(otherClass);
 
         ListIterable<? extends CoreInstance> orderProperties = Instance.getValueForMetaPropertyToManyResolved(mainClass, M3Properties.propertiesFromAssociations, processorSupport);
-        ListIterable<String> productPropertiesAsStrings = orderProperties.collect(CoreInstance.GET_NAME);
-        Assert.assertEquals(FastList.newListWith("mainToOtherAllVersions"), productPropertiesAsStrings);
+        ListIterable<String> productPropertiesAsStrings = orderProperties.collect(CoreInstance::getName);
+        Assert.assertEquals(Lists.mutable.with("mainToOtherAllVersions"), productPropertiesAsStrings);
 
         ListIterable<? extends CoreInstance> qualifiedProperties = Instance.getValueForMetaPropertyToManyResolved(mainClass, M3Properties.qualifiedPropertiesFromAssociations, processorSupport);
         Verify.assertSize(2, qualifiedProperties);
@@ -463,7 +448,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         Assert.assertNotNull(otherClass);
 
         ListIterable<? extends CoreInstance> orderProperties = Instance.getValueForMetaPropertyToManyResolved(mainClass, M3Properties.propertiesFromAssociations, processorSupport);
-        ListIterable<String> productPropertiesAsStrings = orderProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> productPropertiesAsStrings = orderProperties.collect(CoreInstance::getName);
         Assert.assertEquals(Lists.mutable.with("mainToOtherAllVersions"), productPropertiesAsStrings);
 
         ListIterable<? extends CoreInstance> qualifiedProperties = Instance.getValueForMetaPropertyToManyResolved(mainClass, M3Properties.qualifiedPropertiesFromAssociations, processorSupport);
@@ -520,7 +505,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         Assert.assertNotNull(otherClass);
 
         ListIterable<? extends CoreInstance> orderProperties = Instance.getValueForMetaPropertyToManyResolved(mainClass, M3Properties.propertiesFromAssociations, processorSupport);
-        ListIterable<String> productPropertiesAsStrings = orderProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> productPropertiesAsStrings = orderProperties.collect(CoreInstance::getName);
         Assert.assertEquals(Lists.mutable.with("mainToOtherAllVersions"), productPropertiesAsStrings);
 
         ListIterable<? extends CoreInstance> qualifiedProperties = Instance.getValueForMetaPropertyToManyResolved(mainClass, M3Properties.qualifiedPropertiesFromAssociations, processorSupport);
@@ -544,7 +529,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testRemovalOfOriginalMilestonedPropertyAndMilestonedPropertyGeneration() throws Exception
+    public void testRemovalOfOriginalMilestonedPropertyAndMilestonedPropertyGeneration()
     {
         expectedEx.expect(PureCompilationException.class);
         expectedEx.expectMessage("Compilation error at (resource:sourceId.pure line:8 column:7), \"The property 'account' is milestoned with stereotypes: [ businesstemporal ] and requires date parameters: [ businessDate ]");
@@ -573,7 +558,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testRemovalOfOriginalMilestonedPropertyAndGenerationOfAllPropertyViaAssociation() throws Exception
+    public void testRemovalOfOriginalMilestonedPropertyAndGenerationOfAllPropertyViaAssociation()
     {
         expectedEx.expect(PureCompilationException.class);
         expectedEx.expectMessage("Compilation error at (resource:sourceId.pure line:8 column:7), \"The property 'account' is milestoned with stereotypes: [ businesstemporal ] and requires date parameters: [ businessDate ]");
@@ -599,7 +584,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testNoArgPropertyNotGeneratedWhenSourceClassIsNotTemporal() throws Exception
+    public void testNoArgPropertyNotGeneratedWhenSourceClassIsNotTemporal()
     {
         expectedEx.expectMessage("The property 'legalEntity' is milestoned with stereotypes: [ businesstemporal ] and requires date parameters: [ businessDate ]");
         runtime.createInMemorySource("sourceId.pure",
@@ -619,7 +604,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testGenerationOfNoArgQualifiedPropertyFromAssociationWhereTargetClassInheritsFromClassWithBusinessTemporalStereotype() throws Exception
+    public void testGenerationOfNoArgQualifiedPropertyFromAssociationWhereTargetClassInheritsFromClassWithBusinessTemporalStereotype()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import model::domain::subdom1::account::*;" +
@@ -642,7 +627,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testGenerationOfNoArgQualifiedPropertyFromAssociationWhereTargetClassInheritsFromClassWithBusinessTemporalStereotypeWithMultipleSources() throws Exception
+    public void testGenerationOfNoArgQualifiedPropertyFromAssociationWhereTargetClassInheritsFromClassWithBusinessTemporalStereotypeWithMultipleSources()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "" +
@@ -673,7 +658,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testPropertiesInterceptedAndTransformedToQualifiedPropertiesWhereSourceAndTargetAreBusinessTemporal() throws Exception
+    public void testPropertiesInterceptedAndTransformedToQualifiedPropertiesWhereSourceAndTargetAreBusinessTemporal()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import model::domain::subdom1::entity::*;" +
@@ -692,7 +677,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testValidationOfOverridenProperties() throws Exception
+    public void testValidationOfOverridenProperties()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import model::domain::subdom1::entity::*;" +
@@ -717,7 +702,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testPropertyOwnerSetOnMilestonedProperties() throws Exception
+    public void testPropertyOwnerSetOnMilestonedProperties()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -744,16 +729,16 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         CoreInstance assn = runtime.getCoreInstance("meta::relational::tests::milestoning::OrderProduct");
         ListIterable<? extends CoreInstance> assnProperties = Instance.getValueForMetaPropertyToManyResolved(assn, M3Properties.properties, processorSupport);
         Verify.assertSize(2, assnProperties);
-        Verify.assertContainsAll(assnProperties.collect(CoreInstance.GET_NAME), "orders", "assocProductAllVersions");
+        Verify.assertContainsAll(assnProperties.collect(CoreInstance::getName), "orders", "assocProductAllVersions");
 
         //test Order
         CoreInstance orderClass = runtime.getCoreInstance("meta::test::domain::Order");
 
         ListIterable<? extends CoreInstance> orderProperties = Instance.getValueForMetaPropertyToManyResolved(orderClass, M3Properties.properties, processorSupport);
-        ListIterable<String> orderPropertiesAsStrings = orderProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> orderPropertiesAsStrings = orderProperties.collect(CoreInstance::getName);
         Verify.assertContainsAll(orderPropertiesAsStrings, "productAllVersions");
         ListIterable<? extends CoreInstance> orderPropertiesFromAssociations = Instance.getValueForMetaPropertyToManyResolved(orderClass, M3Properties.propertiesFromAssociations, processorSupport);
-        ListIterable<String> orderPropertiesFromAssociationsAsStrings = orderPropertiesFromAssociations.collect(CoreInstance.GET_NAME);
+        ListIterable<String> orderPropertiesFromAssociationsAsStrings = orderPropertiesFromAssociations.collect(CoreInstance::getName);
         Verify.assertContainsAll(orderPropertiesFromAssociationsAsStrings, "assocProduct2AllVersions", "assocProductAllVersions");
     }
 
@@ -781,7 +766,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testQualifiedPropertyGenerationForAssociations() throws Exception
+    public void testQualifiedPropertyGenerationForAssociations()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -800,25 +785,25 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         CoreInstance orderClass = runtime.getCoreInstance("meta::test::domain::A");
 
         ListIterable<? extends CoreInstance> aProperties = Instance.getValueForMetaPropertyToManyResolved(orderClass, M3Properties.propertiesFromAssociations, processorSupport);
-        ListIterable<String> aPropertiesAsStrings = aProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> aPropertiesAsStrings = aProperties.collect(CoreInstance::getName);
         Verify.assertContainsAll(aPropertiesAsStrings, "bAllVersions");
 
         ListIterable<? extends CoreInstance> aQpProperties = Instance.getValueForMetaPropertyToManyResolved(orderClass, M3Properties.qualifiedPropertiesFromAssociations, processorSupport);
-        ListIterable<String> orderPropertiesAsStrings = aQpProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> orderPropertiesAsStrings = aQpProperties.collect(CoreInstance::getName);
         Assert.assertEquals(Lists.immutable.with("b_0", "b_1", "bAllVersionsInRange_2"), orderPropertiesAsStrings);
 
         CoreInstance assn = runtime.getCoreInstance("meta::test::domain::AC");
         ListIterable<? extends CoreInstance> assnProperties = Instance.getValueForMetaPropertyToManyResolved(assn, M3Properties.properties, processorSupport);
         Verify.assertSize(2, assnProperties);
-        ListIterable<String> assnPopertiesAsStrings = assnProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> assnPopertiesAsStrings = assnProperties.collect(CoreInstance::getName);
         Verify.assertContainsAll(assnPopertiesAsStrings, "aAllVersions", "bAllVersions");
         ListIterable<? extends CoreInstance> assnQualifiedProperties = Instance.getValueForMetaPropertyToManyResolved(assn, M3Properties.qualifiedProperties, processorSupport);
-        ListIterable<String> assnQualifiedPropertiesAsStrings = assnQualifiedProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> assnQualifiedPropertiesAsStrings = assnQualifiedProperties.collect(CoreInstance::getName);
         Verify.assertContainsAll(assnQualifiedPropertiesAsStrings, "a_3", "b_0");
     }
 
     @Test
-    public void testQualifiedPropertyGenerationForAssociationsInDifferentSources() throws Exception
+    public void testQualifiedPropertyGenerationForAssociationsInDifferentSources()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -845,36 +830,36 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
 
         //validate edge point properties
         ListIterable<? extends CoreInstance> aProperties = Instance.getValueForMetaPropertyToManyResolved(aCi, M3Properties.propertiesFromAssociations, processorSupport);
-        ListIterable<String> aPropertiesAsStrings = aProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> aPropertiesAsStrings = aProperties.collect(CoreInstance::getName);
         Assert.assertEquals(1, aPropertiesAsStrings.size());
         Verify.assertContainsAll(aPropertiesAsStrings, "bAllVersions");
         Assert.assertEquals(acCi, aProperties.getFirst().getValueForMetaPropertyToOne(M3Properties.owner));
 
         CoreInstance bCi = runtime.getCoreInstance("meta::test::domain::B");
         ListIterable<? extends CoreInstance> bProperties = Instance.getValueForMetaPropertyToManyResolved(bCi, M3Properties.propertiesFromAssociations, processorSupport);
-        ListIterable<String> bPropertiesAsStrings = bProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> bPropertiesAsStrings = bProperties.collect(CoreInstance::getName);
         Assert.assertEquals(1, bPropertiesAsStrings.size());
         Verify.assertContainsAll(bPropertiesAsStrings, "aAllVersions");
 
         ListIterable<? extends CoreInstance> aQpProperties = Instance.getValueForMetaPropertyToManyResolved(aCi, M3Properties.qualifiedPropertiesFromAssociations, processorSupport);
-        ListIterable<String> orderPropertiesAsStrings = aQpProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> orderPropertiesAsStrings = aQpProperties.collect(CoreInstance::getName);
         Assert.assertEquals(Lists.immutable.with("b_0", "b_1", "bAllVersionsInRange_2"), orderPropertiesAsStrings);
         ListIterable<CoreInstance> qpExprSeqFunc = aQpProperties.collect(qp -> qp.getValueForMetaPropertyToOne(M3Properties.expressionSequence).getValueForMetaPropertyToOne(M3Properties.func));
         Assert.assertEquals(3, qpExprSeqFunc.size());
-        Assert.assertEquals(Sets.mutable.with("filter_T_MANY__Function_1__T_MANY_"), qpExprSeqFunc.toSet().collect(CoreInstance.GET_NAME));
+        Assert.assertEquals(Sets.mutable.with("filter_T_MANY__Function_1__T_MANY_"), qpExprSeqFunc.toSet().collect(CoreInstance::getName));
 
         CoreInstance assn = runtime.getCoreInstance("meta::test::domain::AC");
         ListIterable<? extends CoreInstance> assnProperties = Instance.getValueForMetaPropertyToManyResolved(assn, M3Properties.properties, processorSupport);
         Assert.assertEquals(2, assnProperties.size());
-        ListIterable<String> assnPopertiesAsStrings = assnProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> assnPopertiesAsStrings = assnProperties.collect(CoreInstance::getName);
         Verify.assertContainsAll(assnPopertiesAsStrings, "bAllVersions", "aAllVersions");
         ListIterable<? extends CoreInstance> assnQualifiedProperties = Instance.getValueForMetaPropertyToManyResolved(assn, M3Properties.qualifiedProperties, processorSupport);
-        ListIterable<String> assnQualifiedPropertiesAsStrings = assnQualifiedProperties.collect(CoreInstance.GET_NAME);
+        ListIterable<String> assnQualifiedPropertiesAsStrings = assnQualifiedProperties.collect(CoreInstance::getName);
         Verify.assertContainsAll(assnQualifiedPropertiesAsStrings, "b_0", "a_3");
     }
 
     @Test
-    public void testEdgePointPropertyOwnerIsNotOverriddenWhenMultiplePropertiesAreProcessedViaAssociation() throws Exception
+    public void testEdgePointPropertyOwnerIsNotOverriddenWhenMultiplePropertiesAreProcessedViaAssociation()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -908,29 +893,23 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         b = runtime.getCoreInstance("meta::test::domain::B");
         bAssnProperties = Instance.getValueForMetaPropertyToManyResolved(b, M3Properties.propertiesFromAssociations, processorSupport);
         Assert.assertEquals(2, bAssnProperties.size());
-        CoreInstance propA = bAssnProperties.detect(Predicates.attributeEqual(CoreInstance.GET_NAME, "aAllVersions"));
-        CoreInstance propc = bAssnProperties.detect(Predicates.attributeEqual(CoreInstance.GET_NAME, "cAllVersions"));
+        CoreInstance propA = bAssnProperties.detect(Predicates.attributeEqual(CoreInstance::getName, "aAllVersions"));
+        CoreInstance propc = bAssnProperties.detect(Predicates.attributeEqual(CoreInstance::getName, "cAllVersions"));
 
         Assert.assertEquals(assnAB, propA.getValueForMetaPropertyToOne(M3Properties.owner));
         Assert.assertEquals(assnAC, propc.getValueForMetaPropertyToOne(M3Properties.owner));
     }
 
     @Test
-    public void testSourceInformationOfGeneratedMilestonedProperties() throws Exception
+    public void testSourceInformationOfGeneratedMilestonedProperties()
     {
-        Function<Boolean, String> source = new Function<Boolean, String>()
-        {
-            @Override
-            public String valueOf(Boolean isBTemporal)
-            {
-                return "import meta::test::domain::*;\n" +
-                        "Class meta::test::domain::A{\n" +
-                        "b : B[*];}\n" +
-                        "Association AB{ a2:A[0..1]; b2:B[0..1];}\n" +
-                        "Class " + (isBTemporal ? "<<temporal.businesstemporal>>" : "") + "meta::test::domain::B{}\n" +
-                        "function go():Any[*]{let a = ^A();" + (isBTemporal ? "$a.bAllVersions;$a.b(%2015);$a.b2AllVersions;$a.b2(%2015);" : "$a.b;$a.b2;") + "}\n";
-            }
-        };
+        Function<Boolean, String> source = isBTemporal ->
+                "import meta::test::domain::*;\n" +
+                "Class meta::test::domain::A{\n" +
+                "b : B[*];}\n" +
+                "Association AB{ a2:A[0..1]; b2:B[0..1];}\n" +
+                "Class " + (isBTemporal ? "<<temporal.businesstemporal>>" : "") + "meta::test::domain::B{}\n" +
+                "function go():Any[*]{let a = ^A();" + (isBTemporal ? "$a.bAllVersions;$a.b(%2015);$a.b2AllVersions;$a.b2(%2015);" : "$a.b;$a.b2;") + "}\n";
         runtime.createInMemorySource("sourceId.pure", source.valueOf(false));
         runtime.compile();
         CoreInstance goFunction = runtime.getFunction("go__Any_MANY_");
@@ -962,7 +941,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
     }
 
     @Test
-    public void testAssociationPropertiesWithSamePropertyNameProcessTypeArgumentsCorrectly() throws Exception
+    public void testAssociationPropertiesWithSamePropertyNameProcessTypeArgumentsCorrectly()
     {
         runtime.createInMemorySource("sourceId.pure",
                 "import meta::test::domain::*;" +
@@ -994,21 +973,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         ListIterable<CoreInstance> associationPropertyATypeArguments = Lists.mutable.with(bRawType, aRawType);
 
         ListIterable<? extends CoreInstance> originalMilestonedProperties = Instance.getValueForMetaPropertyToManyResolved(assn, M3Properties.originalMilestonedProperties, processorSupport);
-        ListIterable<ListIterable<CoreInstance>> propertiesTypeArguments = originalMilestonedProperties.collect(new Function<CoreInstance, ListIterable<CoreInstance>>()
-        {
-            @Override
-            public ListIterable<CoreInstance> valueOf(CoreInstance coreInstance)
-            {
-                return coreInstance.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToMany(M3Properties.typeArguments).collect(new Function<CoreInstance, CoreInstance>()
-                {
-                    @Override
-                    public CoreInstance valueOf(CoreInstance coreInstance)
-                    {
-                        return Instance.getValueForMetaPropertyToOneResolved(coreInstance, M3Properties.rawType, processorSupport);
-                    }
-                });
-            }
-        });
+        ListIterable<ListIterable<CoreInstance>> propertiesTypeArguments = originalMilestonedProperties.collect(ci -> ci.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToMany(M3Properties.typeArguments).collect(ci1 -> Instance.getValueForMetaPropertyToOneResolved(ci1, M3Properties.rawType, processorSupport)));
 
         Assert.assertEquals(associationPropertyATypeArguments, propertiesTypeArguments.get(0));
         Assert.assertEquals(associationPropertyATypeArguments.asReversed().toList(), propertiesTypeArguments.get(1));
@@ -1032,13 +997,13 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         runtime.compile();
         CoreInstance order = runtime.getCoreInstance("meta::relational::tests::milestoning::Order");
         ListIterable<? extends CoreInstance> orderQps = Instance.getValueForMetaPropertyToManyResolved(order, M3Properties.qualifiedProperties, processorSupport);
-        ListMultimap<String, ? extends CoreInstance> qualifiedPropertiesByName = orderQps.groupBy(CoreInstance.GET_NAME);
+        ListMultimap<String, ? extends CoreInstance> qualifiedPropertiesByName = orderQps.groupBy(CoreInstance::getName);
 
         Verify.assertContainsAll(qualifiedPropertiesByName.keysView(), "other_0", "other2_1", "createdLocation_2", "createdLocation_3", "createdLocation_4", "createdLocation_5");
     }
 
     @Test
-    public void testBiTemporalPropertyGeneration() throws Exception
+    public void testBiTemporalPropertyGeneration()
     {
         String domain = "import meta::relational::tests::milestoning::*;" +
                 "Class meta::relational::tests::milestoning::Order { createdLocation : Location[0..1]; }\n" +
@@ -1098,14 +1063,7 @@ public class TestMilestoningPropertyProcessor extends AbstractTestMilestoning
         Assert.assertEquals(propertyName, Instance.getValueForMetaPropertyToManyResolved(property, M3Properties.functionName, processorSupport).getFirst().getName());
         CoreInstance functionType = property.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToOne(M3Properties.typeArguments).getValueForMetaPropertyToOne(M3Properties.rawType);
         RichIterable<? extends CoreInstance> params = ListHelper.tail(functionType.getValueForMetaPropertyToMany(M3Properties.parameters));
-        Assert.assertTrue(params.allSatisfy(new Predicate<CoreInstance>()
-        {
-            @Override
-            public boolean accept(CoreInstance coreInstance)
-            {
-                return coreInstance.getValueForMetaPropertyToOne(M3Properties.genericType).getValueForMetaPropertyToOne(M3Properties.rawType) == _Package.getByUserPath(M3Paths.Date, processorSupport);
-            }
-        }));
+        Assert.assertTrue(params.allSatisfy(ci -> ci.getValueForMetaPropertyToOne(M3Properties.genericType).getValueForMetaPropertyToOne(M3Properties.rawType) == _Package.getByUserPath(M3Paths.Date, processorSupport)));
         Assert.assertEquals(dateParamSize, params.size());
         assertMilestoningProperty(property, genericType, multiplicity);
     }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/profile/TestProfile.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/profile/TestProfile.java
@@ -14,14 +14,21 @@
 
 package org.finos.legend.pure.m3.tests.profile;
 
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.factory.Sets;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.impl.test.Verify;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Stereotype;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Tag;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
+import org.finos.legend.pure.m3.tools.ListHelper;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -30,29 +37,39 @@ import org.junit.Test;
 public class TestProfile extends AbstractPureTestWithCoreCompiledPlatform
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getExtra());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return Lists.immutable.with(CodeRepository.newPlatformCodeRepository(),
+                GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", PlatformCodeRepository.NAME),
+                GenericCodeRepository.build("test", "test(::.*)?", PlatformCodeRepository.NAME, "system"));
     }
 
     @After
-    public void cleanRuntime() {
+    public void cleanRuntime()
+    {
         runtime.delete("/test/testSource.pure");
         runtime.delete("fromString.pure");
+        runtime.compile();
     }
 
     @Test
     public void testProfile()
     {
-        compileTestSource("fromString.pure","Profile test::myProfile\n" +
+        compileTestSource("fromString.pure", "Profile test::myProfile\n" +
                 "{\n" +
                 "  stereotypes: [st1, st2];\n" +
                 "  tags: [t1, t2, t3];\n" +
                 "}");
 
-        Profile profile = (Profile)this.runtime.getCoreInstance("test::myProfile");
+        Profile profile = (Profile) runtime.getCoreInstance("test::myProfile");
         Assert.assertNotNull(profile);
 
-        ListIterable<Stereotype> stereotypes = (ListIterable<Stereotype>)profile._p_stereotypes();
+        ListIterable<? extends Stereotype> stereotypes = ListHelper.wrapListIterable(profile._p_stereotypes());
         Verify.assertSize(2, stereotypes);
         MutableSet<String> stereotypeValues = Sets.mutable.empty();
         for (Stereotype stereotype : stereotypes)
@@ -62,7 +79,7 @@ public class TestProfile extends AbstractPureTestWithCoreCompiledPlatform
         }
         Verify.assertSetsEqual(Sets.mutable.with("st1", "st2"), stereotypeValues);
 
-        ListIterable<Tag> tags = (ListIterable<Tag>)profile._p_tags();
+        ListIterable<? extends Tag> tags = ListHelper.wrapListIterable(profile._p_tags());
         Verify.assertSize(3, tags);
         MutableSet<String> tagValues = Sets.mutable.empty();
         for (Tag tag : tags)
@@ -78,29 +95,29 @@ public class TestProfile extends AbstractPureTestWithCoreCompiledPlatform
     {
         compileTestSource("/test/testSource.pure",
                 "Profile test::myProfile\n" +
-                "{\n" +
-                "  stereotypes: [st1, st2, st3];\n" +
-                "}");
+                        "{\n" +
+                        "  stereotypes: [st1, st2, st3];\n" +
+                        "}");
 
-        Profile profile = (Profile)this.runtime.getCoreInstance("test::myProfile");
+        Profile profile = (Profile) runtime.getCoreInstance("test::myProfile");
         Assert.assertNotNull(profile);
 
-        ListIterable<Stereotype> stereotypes = (ListIterable<Stereotype>)profile._p_stereotypes();
+        ListIterable<? extends Stereotype> stereotypes = ListHelper.wrapListIterable(profile._p_stereotypes());
         Verify.assertSize(3, stereotypes);
 
-        Stereotype st1 = (Stereotype)org.finos.legend.pure.m3.navigation.profile.Profile.findStereotype(profile, "st1");
+        Stereotype st1 = (Stereotype) org.finos.legend.pure.m3.navigation.profile.Profile.findStereotype(profile, "st1");
         Assert.assertNotNull(st1);
         Assert.assertEquals("st1", st1._value());
         Assert.assertSame(profile, st1._profile());
         assertSourceInformation("/test/testSource.pure", 3, 17, 3, 17, 3, 19, st1.getSourceInformation());
 
-        Stereotype st2 = (Stereotype)org.finos.legend.pure.m3.navigation.profile.Profile.findStereotype(profile, "st2");
+        Stereotype st2 = (Stereotype) org.finos.legend.pure.m3.navigation.profile.Profile.findStereotype(profile, "st2");
         Assert.assertNotNull(st1);
         Assert.assertEquals("st2", st2._value());
         Assert.assertSame(profile, st2._profile());
         assertSourceInformation("/test/testSource.pure", 3, 22, 3, 22, 3, 24, st2.getSourceInformation());
 
-        Stereotype st3 = (Stereotype)org.finos.legend.pure.m3.navigation.profile.Profile.findStereotype(profile, "st3");
+        Stereotype st3 = (Stereotype) org.finos.legend.pure.m3.navigation.profile.Profile.findStereotype(profile, "st3");
         Assert.assertNotNull(st1);
         Assert.assertEquals("st3", st3._value());
         Assert.assertSame(profile, st3._profile());
@@ -112,30 +129,30 @@ public class TestProfile extends AbstractPureTestWithCoreCompiledPlatform
     {
         compileTestSource("/test/testSource.pure",
                 "Profile test::myProfile\n" +
-                "{\n" +
-                "  stereotypes: [st1, st2];\n" +
-                "  tags: [t1, t2, t3];\n" +
-                "}");
+                        "{\n" +
+                        "  stereotypes: [st1, st2];\n" +
+                        "  tags: [t1, t2, t3];\n" +
+                        "}");
 
-        Profile profile = (Profile)this.runtime.getCoreInstance("test::myProfile");
+        Profile profile = (Profile) runtime.getCoreInstance("test::myProfile");
         Assert.assertNotNull(profile);
 
-        ListIterable<Tag> tags = (ListIterable<Tag>)profile._p_tags();
+        ListIterable<? extends Tag> tags = ListHelper.wrapListIterable(profile._p_tags());
         Verify.assertSize(3, tags);
 
-        Tag t1 = (Tag)org.finos.legend.pure.m3.navigation.profile.Profile.findTag(profile, "t1");
+        Tag t1 = (Tag) org.finos.legend.pure.m3.navigation.profile.Profile.findTag(profile, "t1");
         Assert.assertNotNull(t1);
         Assert.assertEquals("t1", t1._value());
         Assert.assertSame(profile, t1._profile());
         assertSourceInformation("/test/testSource.pure", 4, 10, 4, 10, 4, 11, t1.getSourceInformation());
 
-        Tag t2 = (Tag)org.finos.legend.pure.m3.navigation.profile.Profile.findTag(profile, "t2");
+        Tag t2 = (Tag) org.finos.legend.pure.m3.navigation.profile.Profile.findTag(profile, "t2");
         Assert.assertNotNull(t2);
         Assert.assertEquals("t2", t2._value());
         Assert.assertSame(profile, t2._profile());
         assertSourceInformation("/test/testSource.pure", 4, 14, 4, 14, 4, 15, t2.getSourceInformation());
 
-        Tag t3 = (Tag)org.finos.legend.pure.m3.navigation.profile.Profile.findTag(profile, "t3");
+        Tag t3 = (Tag) org.finos.legend.pure.m3.navigation.profile.Profile.findTag(profile, "t3");
         Assert.assertNotNull(t3);
         Assert.assertEquals("t3", t3._value());
         Assert.assertSame(profile, t3._profile());

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/property/AbstractTestDefaultValue.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/property/AbstractTestDefaultValue.java
@@ -14,15 +14,15 @@
 
 package org.finos.legend.pure.m3.tests.property;
 
-import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.junit.Assert;
 import org.junit.Test;
 
-public abstract class AbstractTestDefaultValue extends AbstractPureTestWithCoreCompiledPlatform {
-
-    private static String DECLARATION = "import test::long::path::*;\n"
+public abstract class AbstractTestDefaultValue extends AbstractPureTestWithCoreCompiledPlatform
+{
+    private static final String DECLARATION = "import test::long::path::*;\n"
             + "Class my::exampleRootType\n"
             + "{\n"
             + "}\n"
@@ -59,22 +59,22 @@ public abstract class AbstractTestDefaultValue extends AbstractPureTestWithCoreC
         compileTestSource("defaultValueSource.pure", DECLARATION
                 + "function testDefaultValue():Any[*]\n"
                 + "{"
-                +    "   print(^test::long::path::A(),5);\n"
+                + "   print(^test::long::path::A(),5);\n"
                 + "}\n"
                 + "function setAllValues():Any[*]\n"
                 + "{"
                 + "   print(^test::long::path::A(stringProperty='default', "
-                +         "classProperty=^my::exampleRootType(), "
-                +         "enumProperty = EnumWithDefault.DefaultValue,"
-                +         "floatProperty = 0.12,"
-                +         "inheritProperty = 0.12,"
-                +         "booleanProperty = false,"
-                +         "integerProperty = 0,"
-                +         "collectionProperty=['one', 'two'],"
-                +         "enumCollection=[EnumWithDefault.DefaultValue, EnumWithDefault.AnotherValue],"
-                +         "classCollection=[^my::exampleRootType(), ^my::exampleSubType()],"
-                +         "singleProperty=['one'],"
-                +         "anyProperty='anyString'),5);\n"
+                + "classProperty=^my::exampleRootType(), "
+                + "enumProperty = EnumWithDefault.DefaultValue,"
+                + "floatProperty = 0.12,"
+                + "inheritProperty = 0.12,"
+                + "booleanProperty = false,"
+                + "integerProperty = 0,"
+                + "collectionProperty=['one', 'two'],"
+                + "enumCollection=[EnumWithDefault.DefaultValue, EnumWithDefault.AnotherValue],"
+                + "classCollection=[^my::exampleRootType(), ^my::exampleSubType()],"
+                + "singleProperty=['one'],"
+                + "anyProperty='anyString'),5);\n"
                 + "}"
 
         );
@@ -100,7 +100,7 @@ public abstract class AbstractTestDefaultValue extends AbstractPureTestWithCoreC
         );
 
         CoreInstance func = runtime.getFunction("testDefaultValueOverridden():Any[*]");
-        functionExecution.start(func, FastList.<CoreInstance>newList());
+        functionExecution.start(func, Lists.immutable.empty());
     }
 
     @Test
@@ -125,13 +125,13 @@ public abstract class AbstractTestDefaultValue extends AbstractPureTestWithCoreC
     public void testDefaultValueWithDynamicNew()
     {
         compileTestSource("defaultValueSource.pure", DECLARATION
-                        + "function test():Any[*] \n{"
-                        + " let r = dynamicNew(A, \n"
-                        + "     [ ^KeyValue(key='stringProperty',value='dynamicNew')]);\n"
-                        + " print($r, 1);\n"
-                        + "}\n");
+                + "function test():Any[*] \n{"
+                + " let r = dynamicNew(A, \n"
+                + "     [ ^KeyValue(key='stringProperty',value='dynamicNew')]);\n"
+                + " print($r, 1);\n"
+                + "}\n");
         CoreInstance func = runtime.getFunction("test():Any[*]");
-        functionExecution.start(func, FastList.<CoreInstance>newList());
+        functionExecution.start(func, Lists.immutable.empty());
     }
 
     @Test
@@ -146,6 +146,6 @@ public abstract class AbstractTestDefaultValue extends AbstractPureTestWithCoreC
                 + " print($r, 1);\n"
                 + "}\n");
         CoreInstance func = runtime.getFunction("test():Any[*]");
-        functionExecution.start(func, FastList.<CoreInstance>newList());
+        functionExecution.start(func, Lists.immutable.empty());
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/validation/TestAccess.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/validation/TestAccess.java
@@ -14,17 +14,22 @@
 
 package org.finos.legend.pure.m3.tests.validation;
 
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.compiler.visibility.AccessLevel;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function;
+import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
-import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.tuple.Tuples;
-import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.type.Type;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.junit.After;
@@ -34,31 +39,36 @@ import org.junit.Test;
 
 public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
 {
-    // Private function applications and references in the same package
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getExtra());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return Lists.immutable.with(CodeRepository.newPlatformCodeRepository(),
+                GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", PlatformCodeRepository.NAME),
+                GenericCodeRepository.build("test", "test(::.*)?", PlatformCodeRepository.NAME, "system"));
     }
 
     @After
-    public void cleanRuntime() {
+    public void cleanRuntime()
+    {
         runtime.delete("/test/testSource.pure");
         runtime.delete("/test/testSource1.pure");
         runtime.delete("/test/testSource2.pure");
         runtime.delete("fromString.pure");
+        runtime.delete("source1.pure");
+        runtime.delete("source2.pure");
 
-        try {
-            runtime.compile();
-        } catch (PureCompilationException e)
-        {
-            setUp();
-        }
+        runtime.compile();
     }
 
     @Test
     public void testPrivateFunctionApplicationInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.private>> pkg::privateFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -70,21 +80,21 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    pkg::privateFunc($s, ' from public')\n" +
                 "}");
 
-        CoreInstance privateFunc = this.runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
+        CoreInstance privateFunc = runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(privateFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc(String[1]):String[1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc(String[1]):String[1]");
         Assert.assertNotNull(publicFunc);
-        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, this.processorSupport);
+        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, processorSupport);
         Assert.assertEquals(1, expressions.size());
-        Assert.assertTrue(Instance.instanceOf(expressions.get(0), M3Paths.FunctionExpression, this.processorSupport));
-        Assert.assertSame(privateFunc, Instance.getValueForMetaPropertyToOneResolved(expressions.get(0), M3Properties.func, this.processorSupport));
+        Assert.assertTrue(Instance.instanceOf(expressions.get(0), M3Paths.FunctionExpression, processorSupport));
+        Assert.assertSame(privateFunc, Instance.getValueForMetaPropertyToOneResolved(expressions.get(0), M3Properties.func, processorSupport));
     }
 
     @Test
     public void testPrivateFunctionIndirectApplicationInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.private>> pkg::privateFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -96,10 +106,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    plus(['one string plus ', pkg::privateFunc($s, ' from public'), ' plus another string'])\n" +
                 "}");
 
-        CoreInstance privateFunc = this.runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
+        CoreInstance privateFunc = runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(privateFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc(String[1]):String[1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc(String[1]):String[1]");
         Assert.assertNotNull(publicFunc);
         // TODO verify the privateFunc reference
     }
@@ -107,7 +117,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testPrivateFunctionApplicationInCollectInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.private>> pkg::privateFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -119,10 +129,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    $strings->map(s | pkg::privateFunc($s, ' from public'))\n" +
                 "}");
 
-        CoreInstance privateFunc = this.runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
+        CoreInstance privateFunc = runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(privateFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc(String[*]):String[*]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc(String[*]):String[*]");
         Assert.assertNotNull(publicFunc);
         // TODO verify the privateFunc reference
     }
@@ -130,7 +140,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testPrivateFunctionApplicationInLetInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.private>> pkg::privateFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -143,10 +153,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    $strings->map($f);\n" +
                 "}");
 
-        CoreInstance privateFunc = this.runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
+        CoreInstance privateFunc = runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(privateFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc(String[*]):String[*]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc(String[*]):String[*]");
         Assert.assertNotNull(publicFunc);
         // TODO verify the privateFunc reference
     }
@@ -154,7 +164,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testPrivateFunctionApplicationInKeyExpressionInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class pkg::MyClass\n" +
                 "{\n" +
@@ -171,10 +181,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    ^pkg::MyClass(sprop=$strings->map(s | pkg::privateFunc($s, ' from public')))\n" +
                 "}");
 
-        CoreInstance privateFunc = this.runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
+        CoreInstance privateFunc = runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(privateFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc(String[*]):MyClass[1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc(String[*]):MyClass[1]");
         Assert.assertNotNull(publicFunc);
         // TODO verify the privateFunc reference
     }
@@ -182,7 +192,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testPrivateFunctionReferenceInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.private>> pkg::privateFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -194,15 +204,15 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    pkg::privateFunc_String_1__String_1__String_1_.functionName\n" +
                 "}");
 
-        CoreInstance privateFunc = this.runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
+        CoreInstance privateFunc = runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(privateFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc():String[0..1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc():String[0..1]");
         Assert.assertNotNull(publicFunc);
-        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, this.processorSupport);
+        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, processorSupport);
         Assert.assertEquals(1, expressions.size());
-        Assert.assertTrue(Instance.instanceOf(expressions.get(0), M3Paths.FunctionExpression, this.processorSupport));
-        Assert.assertSame(privateFunc, Instance.getValueForMetaPropertyToOneResolved(Instance.getValueForMetaPropertyToManyResolved(expressions.get(0), M3Properties.parametersValues, this.processorSupport).get(0), M3Properties.values, this.processorSupport));
+        Assert.assertTrue(Instance.instanceOf(expressions.get(0), M3Paths.FunctionExpression, processorSupport));
+        Assert.assertSame(privateFunc, Instance.getValueForMetaPropertyToOneResolved(Instance.getValueForMetaPropertyToManyResolved(expressions.get(0), M3Properties.parametersValues, processorSupport).get(0), M3Properties.values, processorSupport));
     }
 
     // Private function applications and references in a different package
@@ -387,7 +397,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedFunctionApplicationInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.protected>> pkg::protectedFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -399,21 +409,21 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    pkg::protectedFunc($s, ' from public')\n" +
                 "}");
 
-        CoreInstance protectedFunc = this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        CoreInstance protectedFunc = runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc(String[1]):String[1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc(String[1]):String[1]");
         Assert.assertNotNull(publicFunc);
-        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, this.processorSupport);
+        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, processorSupport);
         Assert.assertEquals(1, expressions.size());
-        Assert.assertTrue(Instance.instanceOf(expressions.get(0), M3Paths.FunctionExpression, this.processorSupport));
-        Assert.assertSame(protectedFunc, Instance.getValueForMetaPropertyToOneResolved(expressions.get(0), M3Properties.func, this.processorSupport));
+        Assert.assertTrue(Instance.instanceOf(expressions.get(0), M3Paths.FunctionExpression, processorSupport));
+        Assert.assertSame(protectedFunc, Instance.getValueForMetaPropertyToOneResolved(expressions.get(0), M3Properties.func, processorSupport));
     }
 
     @Test
     public void testProtectedFunctionIndirectApplicationInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.protected>> pkg::protectedFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -425,10 +435,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    plus(['one string plus ', pkg::protectedFunc($s, ' from public'), ' plus another string'])\n" +
                 "}");
 
-        CoreInstance protectedFunc = this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        CoreInstance protectedFunc = runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc(String[1]):String[1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc(String[1]):String[1]");
         Assert.assertNotNull(publicFunc);
         // TODO verify the protectedFunc reference
     }
@@ -436,7 +446,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedFunctionApplicationInCollectInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.protected>> pkg::protectedFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -448,10 +458,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    $strings->map(s | pkg::protectedFunc($s, ' from public'))\n" +
                 "}");
 
-        CoreInstance protectedFunc = this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        CoreInstance protectedFunc = runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc(String[*]):String[*]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc(String[*]):String[*]");
         Assert.assertNotNull(publicFunc);
         // TODO verify the protectedFunc reference
     }
@@ -459,7 +469,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedFunctionApplicationInLetInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.protected>> pkg::protectedFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -472,10 +482,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    $strings->map($f);\n" +
                 "}");
 
-        CoreInstance protectedFunc = this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        CoreInstance protectedFunc = runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc(String[*]):String[*]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc(String[*]):String[*]");
         Assert.assertNotNull(publicFunc);
         // TODO verify the protectedFunc reference
     }
@@ -483,7 +493,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedFunctionApplicationInKeyExpressionInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class pkg::MyClass\n" +
                 "{\n" +
@@ -500,10 +510,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    ^pkg::MyClass(sprop=$strings->map(s | pkg::protectedFunc($s, ' from public')))\n" +
                 "}");
 
-        CoreInstance protectedFunc = this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        CoreInstance protectedFunc = runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc(String[*]):MyClass[1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc(String[*]):MyClass[1]");
         Assert.assertNotNull(publicFunc);
         // TODO verify the protectedFunc reference
     }
@@ -511,7 +521,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedFunctionReferenceInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.protected>> pkg::protectedFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -523,15 +533,15 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    pkg::protectedFunc_String_1__String_1__String_1_.functionName\n" +
                 "}");
 
-        CoreInstance protectedFunc = this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        CoreInstance protectedFunc = runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc():String[0..1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc():String[0..1]");
         Assert.assertNotNull(publicFunc);
-        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, this.processorSupport);
+        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, processorSupport);
         Assert.assertEquals(1, expressions.size());
-        Assert.assertTrue(Instance.instanceOf(expressions.get(0), M3Paths.FunctionExpression, this.processorSupport));
-        Assert.assertSame(protectedFunc, Instance.getValueForMetaPropertyToOneResolved(Instance.getValueForMetaPropertyToManyResolved(expressions.get(0), M3Properties.parametersValues, this.processorSupport).get(0), M3Properties.values, this.processorSupport));
+        Assert.assertTrue(Instance.instanceOf(expressions.get(0), M3Paths.FunctionExpression, processorSupport));
+        Assert.assertSame(protectedFunc, Instance.getValueForMetaPropertyToOneResolved(Instance.getValueForMetaPropertyToManyResolved(expressions.get(0), M3Properties.parametersValues, processorSupport).get(0), M3Properties.values, processorSupport));
     }
 
     // Protected function applications and references in a sub-package
@@ -539,7 +549,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedFunctionApplicationInSubPackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.protected>> pkg::protectedFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -551,21 +561,21 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    pkg::protectedFunc($s, ' from public')\n" +
                 "}");
 
-        CoreInstance protectedFunc = this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        CoreInstance protectedFunc = runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::sub::publicFunc(String[1]):String[1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::sub::publicFunc(String[1]):String[1]");
         Assert.assertNotNull(publicFunc);
-        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, this.processorSupport);
+        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, processorSupport);
         Assert.assertEquals(1, expressions.size());
-        Assert.assertTrue(Instance.instanceOf(expressions.get(0), M3Paths.FunctionExpression, this.processorSupport));
-        Assert.assertSame(protectedFunc, Instance.getValueForMetaPropertyToOneResolved(expressions.get(0), M3Properties.func, this.processorSupport));
+        Assert.assertTrue(Instance.instanceOf(expressions.get(0), M3Paths.FunctionExpression, processorSupport));
+        Assert.assertSame(protectedFunc, Instance.getValueForMetaPropertyToOneResolved(expressions.get(0), M3Properties.func, processorSupport));
     }
 
     @Test
     public void testProtectedFunctionIndirectApplicationInSubPackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.protected>> pkg::protectedFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -577,10 +587,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    plus(['one string plus ', pkg::protectedFunc($s, ' from public'), ' plus another string'])\n" +
                 "}");
 
-        CoreInstance protectedFunc = this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        CoreInstance protectedFunc = runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::sub::publicFunc(String[1]):String[1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::sub::publicFunc(String[1]):String[1]");
         Assert.assertNotNull(publicFunc);
         // TODO verify the protectedFunc reference
     }
@@ -588,7 +598,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedFunctionApplicationInCollectInSubPackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.protected>> pkg::protectedFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -600,10 +610,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    $strings->map(s | pkg::protectedFunc($s, ' from public'))\n" +
                 "}");
 
-        CoreInstance protectedFunc = this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        CoreInstance protectedFunc = runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::sub::publicFunc(String[*]):String[*]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::sub::publicFunc(String[*]):String[*]");
         Assert.assertNotNull(publicFunc);
         // TODO verify the protectedFunc reference
     }
@@ -611,7 +621,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedFunctionApplicationInLetInSubPackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.protected>> pkg::protectedFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -624,10 +634,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    $strings->map($f);\n" +
                 "}");
 
-        CoreInstance protectedFunc = this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        CoreInstance protectedFunc = runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::sub::publicFunc(String[*]):String[*]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::sub::publicFunc(String[*]):String[*]");
         Assert.assertNotNull(publicFunc);
         // TODO verify the protectedFunc reference
     }
@@ -635,7 +645,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedFunctionApplicationInKeyExpressionInSubPackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class pkg::MyClass\n" +
                 "{\n" +
@@ -652,10 +662,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    ^pkg::MyClass(sprop=$strings->map(s | pkg::protectedFunc($s, ' from public')))\n" +
                 "}");
 
-        CoreInstance protectedFunc = this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        CoreInstance protectedFunc = runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::sub::publicFunc(String[*]):MyClass[1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::sub::publicFunc(String[*]):MyClass[1]");
         Assert.assertNotNull(publicFunc);
         // TODO verify the protectedFunc reference
     }
@@ -663,7 +673,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedFunctionReferenceInSubPackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.protected>> pkg::protectedFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -675,15 +685,15 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    pkg::protectedFunc_String_1__String_1__String_1_.functionName\n" +
                 "}");
 
-        CoreInstance protectedFunc = this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        CoreInstance protectedFunc = runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::sub::publicFunc():String[0..1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::sub::publicFunc():String[0..1]");
         Assert.assertNotNull(publicFunc);
-        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, this.processorSupport);
+        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, processorSupport);
         Assert.assertEquals(1, expressions.size());
-        Assert.assertTrue(Instance.instanceOf(expressions.get(0), M3Paths.FunctionExpression, this.processorSupport));
-        Assert.assertSame(protectedFunc, Instance.getValueForMetaPropertyToOneResolved(Instance.getValueForMetaPropertyToManyResolved(expressions.get(0), M3Properties.parametersValues, this.processorSupport).get(0), M3Properties.values, this.processorSupport));
+        Assert.assertTrue(Instance.instanceOf(expressions.get(0), M3Paths.FunctionExpression, processorSupport));
+        Assert.assertSame(protectedFunc, Instance.getValueForMetaPropertyToOneResolved(Instance.getValueForMetaPropertyToManyResolved(expressions.get(0), M3Properties.parametersValues, processorSupport).get(0), M3Properties.values, processorSupport));
     }
 
     // Protected function applications and references in a different package
@@ -867,7 +877,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testPrivateClassReferenceInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class <<access.private>> pkg::PrivateClass\n" +
                 "{\n" +
@@ -879,23 +889,23 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    ^pkg::PrivateClass(name=$s)\n" +
                 "}");
 
-        CoreInstance privateClass = this.runtime.getCoreInstance("pkg::PrivateClass");
+        CoreInstance privateClass = runtime.getCoreInstance("pkg::PrivateClass");
         Assert.assertNotNull(privateClass);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc(String[1]):PrivateClass[1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc(String[1]):PrivateClass[1]");
         Assert.assertNotNull(publicFunc);
-        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, this.processorSupport);
+        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, processorSupport);
         Assert.assertEquals(1, expressions.size());
         CoreInstance expression = expressions.get(0);
-        Assert.assertTrue(Instance.instanceOf(expression, M3Paths.FunctionExpression, this.processorSupport));
-        CoreInstance parameterValue = Instance.getValueForMetaPropertyToManyResolved(expression, M3Properties.parametersValues, this.processorSupport).get(0);
-        Assert.assertSame(privateClass, Instance.getValueForMetaPropertyToOneResolved(parameterValue, M3Properties.genericType, M3Properties.typeArguments, M3Properties.rawType, this.processorSupport));
+        Assert.assertTrue(Instance.instanceOf(expression, M3Paths.FunctionExpression, processorSupport));
+        CoreInstance parameterValue = Instance.getValueForMetaPropertyToManyResolved(expression, M3Properties.parametersValues, processorSupport).get(0);
+        Assert.assertSame(privateClass, Instance.getValueForMetaPropertyToOneResolved(parameterValue, M3Properties.genericType, M3Properties.typeArguments, M3Properties.rawType, processorSupport));
     }
 
     @Test
     public void testPrivateClassExtensionInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class <<access.private>> pkg::PrivateClass\n" +
                 "{\n" +
@@ -906,18 +916,18 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "{\n" +
                 "}");
 
-        CoreInstance privateClass = this.runtime.getCoreInstance("pkg::PrivateClass");
+        CoreInstance privateClass = runtime.getCoreInstance("pkg::PrivateClass");
         Assert.assertNotNull(privateClass);
 
-        CoreInstance publicSubclass = this.runtime.getCoreInstance("pkg::PublicSubclass");
+        CoreInstance publicSubclass = runtime.getCoreInstance("pkg::PublicSubclass");
         Assert.assertNotNull(publicSubclass);
-        Assert.assertSame(privateClass, Type.getGeneralizationResolutionOrder(publicSubclass, this.processorSupport).get(1));
+        Assert.assertSame(privateClass, Type.getGeneralizationResolutionOrder(publicSubclass, processorSupport).get(1));
     }
 
     @Test
     public void testPrivateClassPropertyTypeInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class <<access.private>> pkg::PrivateClass\n" +
                 "{\n" +
@@ -929,10 +939,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    prop : pkg::PrivateClass[1];\n" +
                 "}");
 
-        CoreInstance privateClass = this.runtime.getCoreInstance("pkg::PrivateClass");
+        CoreInstance privateClass = runtime.getCoreInstance("pkg::PrivateClass");
         Assert.assertNotNull(privateClass);
 
-        CoreInstance publicClass = this.runtime.getCoreInstance("pkg::PublicClass");
+        CoreInstance publicClass = runtime.getCoreInstance("pkg::PublicClass");
         Assert.assertNotNull(publicClass);
         // TODO validate property generic type
     }
@@ -940,7 +950,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testPrivateClassAssociationPropertyTypeInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class <<access.private>> pkg::PrivateClass\n" +
                 "{\n" +
@@ -957,13 +967,13 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    right : pkg::PublicClass[1];\n" +
                 "}");
 
-        CoreInstance privateClass = this.runtime.getCoreInstance("pkg::PrivateClass");
+        CoreInstance privateClass = runtime.getCoreInstance("pkg::PrivateClass");
         Assert.assertNotNull(privateClass);
 
-        CoreInstance publicClass = this.runtime.getCoreInstance("pkg::PublicClass");
+        CoreInstance publicClass = runtime.getCoreInstance("pkg::PublicClass");
         Assert.assertNotNull(publicClass);
 
-        CoreInstance publicAssociation = this.runtime.getCoreInstance("pkg::PublicAssociation");
+        CoreInstance publicAssociation = runtime.getCoreInstance("pkg::PublicAssociation");
         Assert.assertNotNull(publicAssociation);
         // TODO validate property generic type
     }
@@ -1075,7 +1085,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedClassReferenceInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class <<access.protected>> pkg::ProtectedClass\n" +
                 "{\n" +
@@ -1087,23 +1097,23 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    ^pkg::ProtectedClass(name=$s)\n" +
                 "}");
 
-        CoreInstance protectedClass = this.runtime.getCoreInstance("pkg::ProtectedClass");
+        CoreInstance protectedClass = runtime.getCoreInstance("pkg::ProtectedClass");
         Assert.assertNotNull(protectedClass);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::publicFunc(String[1]):ProtectedClass[1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::publicFunc(String[1]):ProtectedClass[1]");
         Assert.assertNotNull(publicFunc);
-        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, this.processorSupport);
+        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, processorSupport);
         Assert.assertEquals(1, expressions.size());
         CoreInstance expression = expressions.get(0);
-        Assert.assertTrue(Instance.instanceOf(expression, M3Paths.FunctionExpression, this.processorSupport));
-        CoreInstance parameterValue = Instance.getValueForMetaPropertyToManyResolved(expression, M3Properties.parametersValues, this.processorSupport).get(0);
-        Assert.assertSame(protectedClass, Instance.getValueForMetaPropertyToOneResolved(parameterValue, M3Properties.genericType, M3Properties.typeArguments, M3Properties.rawType, this.processorSupport));
+        Assert.assertTrue(Instance.instanceOf(expression, M3Paths.FunctionExpression, processorSupport));
+        CoreInstance parameterValue = Instance.getValueForMetaPropertyToManyResolved(expression, M3Properties.parametersValues, processorSupport).get(0);
+        Assert.assertSame(protectedClass, Instance.getValueForMetaPropertyToOneResolved(parameterValue, M3Properties.genericType, M3Properties.typeArguments, M3Properties.rawType, processorSupport));
     }
 
     @Test
     public void testProtectedClassExtensionInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class <<access.protected>> pkg::ProtectedClass\n" +
                 "{\n" +
@@ -1114,18 +1124,18 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "{\n" +
                 "}");
 
-        CoreInstance protectedClass = this.runtime.getCoreInstance("pkg::ProtectedClass");
+        CoreInstance protectedClass = runtime.getCoreInstance("pkg::ProtectedClass");
         Assert.assertNotNull(protectedClass);
 
-        CoreInstance publicSubclass = this.runtime.getCoreInstance("pkg::PublicSubclass");
+        CoreInstance publicSubclass = runtime.getCoreInstance("pkg::PublicSubclass");
         Assert.assertNotNull(publicSubclass);
-        Assert.assertSame(protectedClass, Type.getGeneralizationResolutionOrder(publicSubclass, this.processorSupport).get(1));
+        Assert.assertSame(protectedClass, Type.getGeneralizationResolutionOrder(publicSubclass, processorSupport).get(1));
     }
 
     @Test
     public void testProtectedClassPropertyTypeInSamePackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class <<access.protected>> pkg::ProtectedClass\n" +
                 "{\n" +
@@ -1137,10 +1147,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    prop : pkg::ProtectedClass[1];\n" +
                 "}");
 
-        CoreInstance protectedClass = this.runtime.getCoreInstance("pkg::ProtectedClass");
+        CoreInstance protectedClass = runtime.getCoreInstance("pkg::ProtectedClass");
         Assert.assertNotNull(protectedClass);
 
-        CoreInstance publicClass = this.runtime.getCoreInstance("pkg::PublicClass");
+        CoreInstance publicClass = runtime.getCoreInstance("pkg::PublicClass");
         Assert.assertNotNull(publicClass);
         // TODO validate property generic type
     }
@@ -1150,7 +1160,7 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedClassReferenceInSubPackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class <<access.protected>> pkg::ProtectedClass\n" +
                 "{\n" +
@@ -1162,23 +1172,23 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    ^pkg::ProtectedClass(name=$s)\n" +
                 "}");
 
-        CoreInstance protectedClass = this.runtime.getCoreInstance("pkg::ProtectedClass");
+        CoreInstance protectedClass = runtime.getCoreInstance("pkg::ProtectedClass");
         Assert.assertNotNull(protectedClass);
 
-        CoreInstance publicFunc = this.runtime.getFunction("pkg::sub::publicFunc(String[1]):ProtectedClass[1]");
+        CoreInstance publicFunc = runtime.getFunction("pkg::sub::publicFunc(String[1]):ProtectedClass[1]");
         Assert.assertNotNull(publicFunc);
-        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, this.processorSupport);
+        ListIterable<? extends CoreInstance> expressions = Instance.getValueForMetaPropertyToManyResolved(publicFunc, M3Properties.expressionSequence, processorSupport);
         Assert.assertEquals(1, expressions.size());
         CoreInstance expression = expressions.get(0);
-        Assert.assertTrue(Instance.instanceOf(expression, M3Paths.FunctionExpression, this.processorSupport));
-        CoreInstance parameterValue = Instance.getValueForMetaPropertyToManyResolved(expression, M3Properties.parametersValues, this.processorSupport).get(0);
-        Assert.assertSame(protectedClass, Instance.getValueForMetaPropertyToOneResolved(parameterValue, M3Properties.genericType, M3Properties.typeArguments, M3Properties.rawType, this.processorSupport));
+        Assert.assertTrue(Instance.instanceOf(expression, M3Paths.FunctionExpression, processorSupport));
+        CoreInstance parameterValue = Instance.getValueForMetaPropertyToManyResolved(expression, M3Properties.parametersValues, processorSupport).get(0);
+        Assert.assertSame(protectedClass, Instance.getValueForMetaPropertyToOneResolved(parameterValue, M3Properties.genericType, M3Properties.typeArguments, M3Properties.rawType, processorSupport));
     }
 
     @Test
     public void testProtectedClassExtensionInSubPackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class <<access.protected>> pkg::ProtectedClass\n" +
                 "{\n" +
@@ -1189,18 +1199,18 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "{\n" +
                 "}");
 
-        CoreInstance protectedClass = this.runtime.getCoreInstance("pkg::ProtectedClass");
+        CoreInstance protectedClass = runtime.getCoreInstance("pkg::ProtectedClass");
         Assert.assertNotNull(protectedClass);
 
-        CoreInstance publicSubclass = this.runtime.getCoreInstance("pkg::sub::PublicSubclass");
+        CoreInstance publicSubclass = runtime.getCoreInstance("pkg::sub::PublicSubclass");
         Assert.assertNotNull(publicSubclass);
-        Assert.assertSame(protectedClass, Type.getGeneralizationResolutionOrder(publicSubclass, this.processorSupport).get(1));
+        Assert.assertSame(protectedClass, Type.getGeneralizationResolutionOrder(publicSubclass, processorSupport).get(1));
     }
 
     @Test
     public void testProtectedClassPropertyTypeInSubPackage()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "Class <<access.protected>> pkg::ProtectedClass\n" +
                 "{\n" +
@@ -1212,10 +1222,10 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    prop : pkg::ProtectedClass[1];\n" +
                 "}");
 
-        CoreInstance protectedClass = this.runtime.getCoreInstance("pkg::ProtectedClass");
+        CoreInstance protectedClass = runtime.getCoreInstance("pkg::ProtectedClass");
         Assert.assertNotNull(protectedClass);
 
-        CoreInstance publicClass = this.runtime.getCoreInstance("pkg::sub::PublicClass");
+        CoreInstance publicClass = runtime.getCoreInstance("pkg::sub::PublicClass");
         Assert.assertNotNull(publicClass);
         // TODO validate property generic type
     }
@@ -1225,72 +1235,57 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedClassReferenceInDifferentPackage()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
-                    "\n" +
-                    "Class <<access.protected>> pkg1::ProtectedClass\n" +
-                    "{\n" +
-                    "    name : String[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "function pkg2::publicFunc(s:String[1]):pkg1::ProtectedClass[1]\n" +
-                    "{\n" +
-                    "    ^pkg1::ProtectedClass(name=$s)\n" +
-                    "}");
-            Assert.fail("Expected a compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "pkg1::ProtectedClass is not accessible in pkg2", "fromString.pure", 8, 46, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "import meta::pure::profiles::*;\n" +
+                        "\n" +
+                        "Class <<access.protected>> pkg1::ProtectedClass\n" +
+                        "{\n" +
+                        "    name : String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "function pkg2::publicFunc(s:String[1]):pkg1::ProtectedClass[1]\n" +
+                        "{\n" +
+                        "    ^pkg1::ProtectedClass(name=$s)\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "pkg1::ProtectedClass is not accessible in pkg2", "fromString.pure", 8, 46, e);
     }
 
     @Test
     public void testProtectedClassExtensionInDifferentPackage()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
-                    "\n" +
-                    "Class <<access.protected>> pkg1::ProtectedClass\n" +
-                    "{\n" +
-                    "    name : String[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "Class pkg2::PublicSubclass extends pkg1::ProtectedClass\n" +
-                    "{\n" +
-                    "}");
-            Assert.fail("Expected a compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "pkg1::ProtectedClass is not accessible in pkg2", "fromString.pure", 8, 42, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "import meta::pure::profiles::*;\n" +
+                        "\n" +
+                        "Class <<access.protected>> pkg1::ProtectedClass\n" +
+                        "{\n" +
+                        "    name : String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class pkg2::PublicSubclass extends pkg1::ProtectedClass\n" +
+                        "{\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "pkg1::ProtectedClass is not accessible in pkg2", "fromString.pure", 8, 42, e);
     }
 
     @Test
     public void testProtectedClassPropertyTypeInDifferentPackage()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
-                    "\n" +
-                    "Class <<access.protected>> pkg1::ProtectedClass\n" +
-                    "{\n" +
-                    "    name : String[1];\n" +
-                    "}\n" +
-                    "\n" +
-                    "Class pkg2::PublicClass\n" +
-                    "{\n" +
-                    "    prop : pkg1::ProtectedClass[1];\n" +
-                    "}");
-            Assert.fail("Expected a compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "pkg1::ProtectedClass is not accessible in pkg2", "fromString.pure", 10, 18, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "import meta::pure::profiles::*;\n" +
+                        "\n" +
+                        "Class <<access.protected>> pkg1::ProtectedClass\n" +
+                        "{\n" +
+                        "    name : String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class pkg2::PublicClass\n" +
+                        "{\n" +
+                        "    prop : pkg1::ProtectedClass[1];\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "pkg1::ProtectedClass is not accessible in pkg2", "fromString.pure", 10, 18, e);
     }
 
     // Private properties are not allowed
@@ -1298,20 +1293,15 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testPrivateProperty()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
-                    "\n" +
-                    "Class pkg1::TestClass\n" +
-                    "{\n" +
-                    "    <<access.private>> name : String[1];\n" +
-                    "}");
-            Assert.fail("Expected a compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Only classes and functions may have an access level", "fromString.pure", 5, 24, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "import meta::pure::profiles::*;\n" +
+                        "\n" +
+                        "Class pkg1::TestClass\n" +
+                        "{\n" +
+                        "    <<access.private>> name : String[1];\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Only classes and functions may have an access level", "fromString.pure", 5, 24, e);
     }
 
     // Protected properties are not allowed
@@ -1319,20 +1309,15 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testProtectedProperty()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
-                    "\n" +
-                    "Class pkg1::TestClass\n" +
-                    "{\n" +
-                    "    <<access.protected>> name : String[1];\n" +
-                    "}");
-            Assert.fail("Expected a compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Only classes and functions may have an access level", "fromString.pure", 5, 26, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "import meta::pure::profiles::*;\n" +
+                        "\n" +
+                        "Class pkg1::TestClass\n" +
+                        "{\n" +
+                        "    <<access.protected>> name : String[1];\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Only classes and functions may have an access level", "fromString.pure", 5, 26, e);
     }
 
     // Private with incremental compilation
@@ -1358,22 +1343,15 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "}";
 
         // compile source1 and source2, which should work
-        this.runtime.createInMemoryAndCompile(Tuples.pair("source1.pure", source1), Tuples.pair("source2.pure", source2));
+        runtime.createInMemoryAndCompile(Tuples.pair("source1.pure", source1), Tuples.pair("source2.pure", source2));
 
         // remove source2
-        this.runtime.delete("source2.pure");
-        this.runtime.compile();
+        runtime.delete("source2.pure");
+        runtime.compile();
 
         // now compile source3, which should fail
-        try
-        {
-            this.runtime.createInMemoryAndCompile(Tuples.pair("source2.pure", source22));
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "pkg1::privateFunc(String[1], String[1]):String[1] is not accessible in pkg2", "source2.pure", 4, 11, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> runtime.createInMemoryAndCompile(Tuples.pair("source2.pure", source22)));
+        assertPureException(PureCompilationException.class, "pkg1::privateFunc(String[1], String[1]):String[1] is not accessible in pkg2", "source2.pure", 4, 11, e);
     }
 
     @Test
@@ -1397,30 +1375,16 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    pkg1::privateFunc($s, ' from public')\n" +
                 "}";
         // compile source1 and source2, which should work
-        this.runtime.createInMemoryAndCompile(Tuples.pair("source1.pure", source1), Tuples.pair("source2.pure", source2));
+        runtime.createInMemoryAndCompile(Tuples.pair("source1.pure", source1), Tuples.pair("source2.pure", source2));
 
         // remove source1
-        this.runtime.delete("source1.pure");
-        try
-        {
-            this.runtime.compile();
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "The system can't find a match for the function: pkg1::privateFunc(_:String[1],_:String[1])", "source2.pure", 4, 11, e);
-        }
+        runtime.delete("source1.pure");
+        PureCompilationException e1 = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+        assertPureException(PureCompilationException.class, "The system can't find a match for the function: pkg1::privateFunc(_:String[1],_:String[1])", "source2.pure", 4, 11, e1);
 
         // now compile source12, which should fail
-        try
-        {
-            this.runtime.createInMemoryAndCompile(Tuples.pair("source1.pure", source12));
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "pkg1::privateFunc(String[1], String[1]):String[1] is not accessible in pkg2", "source2.pure", 4, 11, e);
-        }
+        PureCompilationException e2 = Assert.assertThrows(PureCompilationException.class, () -> runtime.createInMemoryAndCompile(Tuples.pair("source1.pure", source12)));
+        assertPureException(PureCompilationException.class, "pkg1::privateFunc(String[1], String[1]):String[1] is not accessible in pkg2", "source2.pure", 4, 11, e2);
     }
 
     // Protected with incremental compilation
@@ -1446,22 +1410,15 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "}";
 
         // compile source1 and source2, which should work
-        this.runtime.createInMemoryAndCompile(Tuples.pair("source1.pure", source1), Tuples.pair("source2.pure", source2));
+        runtime.createInMemoryAndCompile(Tuples.pair("source1.pure", source1), Tuples.pair("source2.pure", source2));
 
         // remove source2
-        this.runtime.delete("source2.pure");
-        this.runtime.compile();
+        runtime.delete("source2.pure");
+        runtime.compile();
 
         // now compile source3, which should fail
-        try
-        {
-            this.runtime.createInMemoryAndCompile(Tuples.pair("source2.pure", source22));
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "pkg1::protectedFunc(String[1], String[1]):String[1] is not accessible in pkg2", "source2.pure", 4, 11, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> runtime.createInMemoryAndCompile(Tuples.pair("source2.pure", source22)));
+        assertPureException(PureCompilationException.class, "pkg1::protectedFunc(String[1], String[1]):String[1] is not accessible in pkg2", "source2.pure", 4, 11, e);
     }
 
     @Test
@@ -1485,30 +1442,16 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    pkg1::protectedFunc($s, ' from public')\n" +
                 "}";
         // compile source1 and source2, which should work
-        this.runtime.createInMemoryAndCompile(Tuples.pair("source1.pure", source1), Tuples.pair("source2.pure", source2));
+        runtime.createInMemoryAndCompile(Tuples.pair("source1.pure", source1), Tuples.pair("source2.pure", source2));
 
         // remove source1
-        this.runtime.delete("source1.pure");
-        try
-        {
-            this.runtime.compile();
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "The system can't find a match for the function: pkg1::protectedFunc(_:String[1],_:String[1])", "source2.pure", 4, 11, e);
-        }
+        runtime.delete("source1.pure");
+        PureCompilationException e1 = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+        assertPureException(PureCompilationException.class, "The system can't find a match for the function: pkg1::protectedFunc(_:String[1],_:String[1])", "source2.pure", 4, 11, e1);
 
         // now compile source12, which should fail
-        try
-        {
-            this.runtime.createInMemoryAndCompile(Tuples.pair("source1.pure", source12));
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "pkg1::protectedFunc(String[1], String[1]):String[1] is not accessible in pkg2", "source2.pure", 4, 11, e);
-        }
+        PureCompilationException e2 = Assert.assertThrows(PureCompilationException.class, () -> runtime.createInMemoryAndCompile(Tuples.pair("source1.pure", source12)));
+        assertPureException(PureCompilationException.class, "pkg1::protectedFunc(String[1], String[1]):String[1] is not accessible in pkg2", "source2.pure", 4, 11, e2);
     }
 
     // Externalizable non-function
@@ -1516,18 +1459,12 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testExternalizableClass()
     {
-        try
-        {
-            compileTestSource("/test/testSource.pure",
-                    "Class <<access.externalizable>> TestClass\n" +
-                            "{\n" +
-                            "}");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Only functions may have an access level of externalizable", "/test/testSource.pure", 1, 1, 1, 33, 3, 1, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/test/testSource.pure",
+                "Class <<access.externalizable>> TestClass\n" +
+                        "{\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Only functions may have an access level of externalizable", "/test/testSource.pure", 1, 1, 1, 33, 3, 1, e);
     }
 
     // Externalizable with invalid parameter types
@@ -1535,81 +1472,56 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testExternalizableFunctionWithInvalidParameterType()
     {
-        try
-        {
-            compileTestSource("/test/testSource.pure",
-                    "function <<access.externalizable>> pkg1::extFunc(primitiveParam:String[1], nonPrimitiveParam:List<String>[0..1]):String[*]\n" +
-                            "{\n" +
-                            "  []\n" +
-                            "}\n");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Functions with access level externalizable may only have primitive types or 'Maps' as parameter types; found List<String> for the type of parameter 'nonPrimitiveParam'", "/test/testSource.pure", 1, 1, 1, 42, 4, 1, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/test/testSource.pure",
+                "function <<access.externalizable>> pkg1::extFunc(primitiveParam:String[1], nonPrimitiveParam:List<String>[0..1]):String[*]\n" +
+                        "{\n" +
+                        "  []\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Functions with access level externalizable may only have primitive types or 'Maps' as parameter types; found List<String> for the type of parameter 'nonPrimitiveParam'", "/test/testSource.pure", 1, 1, 1, 42, 4, 1, e);
     }
 
     @Test
     public void testExternalizableFunctionWithInvalidParameterMultiplicity()
     {
-        try
-        {
-            compileTestSource("/test/testSource.pure",
-                    "function <<access.externalizable>> pkg1::extFunc(toOneParam:String[1], zeroToOneParam:Integer[0..1], toManyParam:Number[*], toOneManyParam:Boolean[1..*]):String[*]\n" +
-                            "{\n" +
-                            "  []\n" +
-                            "}\n");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Functions with access level externalizable may only have parameters with multiplicity 0..1, 1, or *; found 1..* for the multiplicity of parameter 'toOneManyParam'", "/test/testSource.pure", 1, 1, 1, 42, 4, 1, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/test/testSource.pure",
+                "function <<access.externalizable>> pkg1::extFunc(toOneParam:String[1], zeroToOneParam:Integer[0..1], toManyParam:Number[*], toOneManyParam:Boolean[1..*]):String[*]\n" +
+                        "{\n" +
+                        "  []\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Functions with access level externalizable may only have parameters with multiplicity 0..1, 1, or *; found 1..* for the multiplicity of parameter 'toOneManyParam'", "/test/testSource.pure", 1, 1, 1, 42, 4, 1, e);
     }
 
     @Test
     public void testExternalizableFunctionWithInvalidReturnType()
     {
-        try
-        {
-            compileTestSource("/test/testSource.pure",
-                    "function <<access.externalizable>> pkg1::extFunc(toOneParam:String[1]):List<String>[1]\n" +
-                            "{\n" +
-                            "  ^List<String>(values=$toOneParam)\n" +
-                            "}\n");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Functions with access level externalizable may only have primitive types as return types; found List<String>", "/test/testSource.pure", 1, 1, 1, 42, 4, 1, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/test/testSource.pure",
+                "function <<access.externalizable>> pkg1::extFunc(toOneParam:String[1]):List<String>[1]\n" +
+                        "{\n" +
+                        "  ^List<String>(values=$toOneParam)\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Functions with access level externalizable may only have primitive types as return types; found List<String>", "/test/testSource.pure", 1, 1, 1, 42, 4, 1, e);
     }
 
     @Test
     public void testExternalizableFunctionWithNameConflict()
     {
         compileTestSource("/test/testSource1.pure",
-                "function <<access.externalizable>> pkg1::extFunc(strings:String[*]):String[1]\n" +
+                "function <<access.externalizable>> test::pkg1::extFunc(strings:String[*]):String[1]\n" +
                         "{\n" +
                         "  'k'\n" +
                         "}\n");
-        try
-        {
-            compileTestSource("/test/testSource2.pure",
-                    "function <<access.externalizable>> pkg2::extFunc(string:String[1], n:Integer[1]):String[1]\n" +
-                            "{\n" +
-                            "  'z'\n" +
-                            "}\n");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Externalizable function name conflict - multiple functions with the name 'extFunc':\n" +
-                    "\tpkg1::extFunc(String[*]):String[1] (/test/testSource1.pure:1c1-4c1)\n" +
-                    "\tpkg2::extFunc(String[1], Integer[1]):String[1] (/test/testSource2.pure:1c1-4c1)", "/test/testSource2.pure", 1, 1, 1, 42, 4, 1, e);
-        }
-
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/test/testSource2.pure",
+                "function <<access.externalizable>> test::pkg2::extFunc(string:String[1], n:Integer[1]):String[1]\n" +
+                        "{\n" +
+                        "  'z'\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Externalizable function name conflict - multiple functions with the name 'extFunc':\n" +
+                "\ttest::pkg1::extFunc(String[*]):String[1] (/test/testSource1.pure:1c1-4c1)\n" +
+                "\ttest::pkg2::extFunc(String[1], Integer[1]):String[1] (/test/testSource2.pure:1c1-4c1)", "/test/testSource2.pure", 1, 1, 1, 48, 4, 1, e);
     }
 
     // Multiple access levels are not allowed
@@ -1617,27 +1529,21 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testMultipleAccessLevels()
     {
-        try
-        {
-            compileTestSource("fromString.pure",
-                    "import meta::pure::profiles::*;\n" +
-                            "\n" +
-                            "function <<access.private, access.protected>> pkg::func(string1:String[1], string2:String[1]):String[1]\n" +
-                            "{\n" +
-                            "    $string1 + $string2 + ' (from private)'\n" +
-                            "}");
-            Assert.fail("Expected a compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "pkg::func(String[1], String[1]):String[1] has multiple access level stereotypes", "fromString.pure", 3, 52, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "import meta::pure::profiles::*;\n" +
+                        "\n" +
+                        "function <<access.private, access.protected>> pkg::func(string1:String[1], string2:String[1]):String[1]\n" +
+                        "{\n" +
+                        "    $string1 + $string2 + ' (from private)'\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "pkg::func(String[1], String[1]):String[1] has multiple access level stereotypes", "fromString.pure", 3, 52, e);
     }
 
     @Test
     public void testHasExplicitAccessLevel()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.private>> pkg::privateFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -1649,19 +1555,19 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "    pkg::privateFunc($s, ' from public')\n" +
                 "}");
 
-        Function privateFunc = (Function)this.runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
+        Function<?> privateFunc = (Function<?>) runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(privateFunc);
-        Assert.assertTrue(AccessLevel.hasExplicitAccessLevel(privateFunc, this.processorSupport));
+        Assert.assertTrue(AccessLevel.hasExplicitAccessLevel(privateFunc, processorSupport));
 
-        Function publicFunc = (Function)this.runtime.getFunction("pkg::publicFunc(String[1]):String[1]");
+        Function<?> publicFunc = (Function<?>) runtime.getFunction("pkg::publicFunc(String[1]):String[1]");
         Assert.assertNotNull(publicFunc);
-        Assert.assertFalse(AccessLevel.hasExplicitAccessLevel(publicFunc, this.processorSupport));
+        Assert.assertFalse(AccessLevel.hasExplicitAccessLevel(publicFunc, processorSupport));
     }
 
     @Test
     public void testGetAccessLevelStereotypes()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.private>> pkg::privateFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -1688,31 +1594,31 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "  $s + ' (from externalizable)'\n" +
                 "}");
 
-        Function privateFunc = (Function)this.runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
+        Function<?> privateFunc = (Function<?>) runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(privateFunc);
-        Assert.assertEquals(ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>)privateFunc._stereotypesCoreInstance(), this.processorSupport), AccessLevel.getAccessLevelStereotypes(privateFunc, this.processorSupport));
+        Assert.assertEquals(ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>) privateFunc._stereotypesCoreInstance(), processorSupport), AccessLevel.getAccessLevelStereotypes(privateFunc, processorSupport));
 
-        Function protectedFunc = (Function)this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        Function<?> protectedFunc = (Function<?>) runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
-        Assert.assertEquals(ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>)protectedFunc._stereotypesCoreInstance(), this.processorSupport), AccessLevel.getAccessLevelStereotypes(protectedFunc, this.processorSupport));
+        Assert.assertEquals(ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>) protectedFunc._stereotypesCoreInstance(), processorSupport), AccessLevel.getAccessLevelStereotypes(protectedFunc, processorSupport));
 
-        Function explicitPublicFunc = (Function)this.runtime.getFunction("pkg::explicitPublicFunc(String[1]):String[1]");
+        Function<?> explicitPublicFunc = (Function<?>) runtime.getFunction("pkg::explicitPublicFunc(String[1]):String[1]");
         Assert.assertNotNull(explicitPublicFunc);
-        Assert.assertEquals(ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>)explicitPublicFunc._stereotypesCoreInstance(), this.processorSupport), AccessLevel.getAccessLevelStereotypes(explicitPublicFunc, this.processorSupport));
+        Assert.assertEquals(ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>) explicitPublicFunc._stereotypesCoreInstance(), processorSupport), AccessLevel.getAccessLevelStereotypes(explicitPublicFunc, processorSupport));
 
-        Function implicitPublicFunc = (Function)this.runtime.getFunction("pkg::implicitPublicFunc(String[1]):String[1]");
+        Function<?> implicitPublicFunc = (Function<?>) runtime.getFunction("pkg::implicitPublicFunc(String[1]):String[1]");
         Assert.assertNotNull(implicitPublicFunc);
-        Assert.assertEquals(Lists.immutable.with(), AccessLevel.getAccessLevelStereotypes(implicitPublicFunc, this.processorSupport));
+        Assert.assertEquals(Lists.immutable.with(), AccessLevel.getAccessLevelStereotypes(implicitPublicFunc, processorSupport));
 
-        Function externalizableFunc = (Function)this.runtime.getFunction("pkg::externalizableFunc(String[1]):String[1]");
+        Function<?> externalizableFunc = (Function<?>) runtime.getFunction("pkg::externalizableFunc(String[1]):String[1]");
         Assert.assertNotNull(externalizableFunc);
-        Assert.assertEquals(ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>)externalizableFunc._stereotypesCoreInstance(), this.processorSupport), AccessLevel.getAccessLevelStereotypes(externalizableFunc, this.processorSupport));
+        Assert.assertEquals(ImportStub.withImportStubByPasses((ListIterable<? extends CoreInstance>) externalizableFunc._stereotypesCoreInstance(), processorSupport), AccessLevel.getAccessLevelStereotypes(externalizableFunc, processorSupport));
     }
 
     @Test
     public void testGetAccessLevel()
     {
-        compileTestSource("fromString.pure","import meta::pure::profiles::*;\n" +
+        compileTestSource("fromString.pure", "import meta::pure::profiles::*;\n" +
                 "\n" +
                 "function <<access.private>> pkg::privateFunc(string1:String[1], string2:String[1]):String[1]\n" +
                 "{\n" +
@@ -1739,25 +1645,24 @@ public class TestAccess extends AbstractPureTestWithCoreCompiledPlatform
                 "  $s + ' (from externalizable)'\n" +
                 "}");
 
-        Function privateFunc = (Function)this.runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
+        Function<?> privateFunc = (Function<?>) runtime.getFunction("pkg::privateFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(privateFunc);
-        Assert.assertSame(AccessLevel.PRIVATE, AccessLevel.getAccessLevel(privateFunc, this.context, this.processorSupport));
+        Assert.assertSame(AccessLevel.PRIVATE, AccessLevel.getAccessLevel(privateFunc, context, processorSupport));
 
-        Function protectedFunc = (Function)this.runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
+        Function<?> protectedFunc = (Function<?>) runtime.getFunction("pkg::protectedFunc(String[1], String[1]):String[1]");
         Assert.assertNotNull(protectedFunc);
-        Assert.assertSame(AccessLevel.PROTECTED, AccessLevel.getAccessLevel(protectedFunc, this.context, this.processorSupport));
+        Assert.assertSame(AccessLevel.PROTECTED, AccessLevel.getAccessLevel(protectedFunc, context, processorSupport));
 
-        Function explicitPublicFunc = (Function)this.runtime.getFunction("pkg::explicitPublicFunc(String[1]):String[1]");
+        Function<?> explicitPublicFunc = (Function<?>) runtime.getFunction("pkg::explicitPublicFunc(String[1]):String[1]");
         Assert.assertNotNull(explicitPublicFunc);
-        Assert.assertSame(AccessLevel.PUBLIC, AccessLevel.getAccessLevel(explicitPublicFunc, this.context, this.processorSupport));
+        Assert.assertSame(AccessLevel.PUBLIC, AccessLevel.getAccessLevel(explicitPublicFunc, context, processorSupport));
 
-        Function implicitPublicFunc = (Function)this.runtime.getFunction("pkg::implicitPublicFunc(String[1]):String[1]");
+        Function<?> implicitPublicFunc = (Function<?>) runtime.getFunction("pkg::implicitPublicFunc(String[1]):String[1]");
         Assert.assertNotNull(implicitPublicFunc);
-        Assert.assertSame(AccessLevel.PUBLIC, AccessLevel.getAccessLevel(implicitPublicFunc, this.context, this.processorSupport));
+        Assert.assertSame(AccessLevel.PUBLIC, AccessLevel.getAccessLevel(implicitPublicFunc, context, processorSupport));
 
-        Function externalizableFunc = (Function)this.runtime.getFunction("pkg::externalizableFunc(String[1]):String[1]");
+        Function<?> externalizableFunc = (Function<?>) runtime.getFunction("pkg::externalizableFunc(String[1]):String[1]");
         Assert.assertNotNull(externalizableFunc);
-        Assert.assertSame(AccessLevel.EXTERNALIZABLE, AccessLevel.getAccessLevel(externalizableFunc, this.context, this.processorSupport));
+        Assert.assertSame(AccessLevel.EXTERNALIZABLE, AccessLevel.getAccessLevel(externalizableFunc, context, processorSupport));
     }
-
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/validation/TestCopy.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/validation/TestCopy.java
@@ -24,12 +24,14 @@ import org.junit.Test;
 public class TestCopy extends AbstractPureTestWithCoreCompiledPlatform
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getExtra());
+    public static void setUp()
+    {
+        setUpRuntime();
     }
 
     @After
-    public void cleanRuntime() {
+    public void cleanRuntime()
+    {
         runtime.delete("testModel.pure");
         runtime.delete("testFunc.pure");
     }
@@ -42,21 +44,14 @@ public class TestCopy extends AbstractPureTestWithCoreCompiledPlatform
                         "{\n" +
                         "    prop:String[1];\n" +
                         "}");
-        try
-        {
-            compileTestSource(
-                    "testFunc.pure",
-                    "function testFunc():A[1]\n" +
-                            "{\n" +
-                            "    let a = ^A(prop='the quick brown fox');\n" +
-                            "    ^$a(prop=1);" +
-                            "}");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Type Error: Integer not a subtype of String", "testFunc.pure", 4, 13, 4, 13, 4, 13, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "testFunc.pure",
+                "function testFunc():A[1]\n" +
+                        "{\n" +
+                        "    let a = ^A(prop='the quick brown fox');\n" +
+                        "    ^$a(prop=1);" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Type Error: Integer not a subtype of String", "testFunc.pure", 4, 13, 4, 13, 4, 13, e);
     }
 
     @Test
@@ -75,21 +70,14 @@ public class TestCopy extends AbstractPureTestWithCoreCompiledPlatform
                         "Class C\n" +
                         "{\n" +
                         "}");
-        try
-        {
-            compileTestSource(
-                    "testFunc.pure",
-                    "function testFunc():A[1]\n" +
-                            "{\n" +
-                            "    let a = ^A(prop=^B());\n" +
-                            "    ^$a(prop=^C());\n" +
-                            "}");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Type Error: C not a subtype of B", "testFunc.pure", 4, 13, 4, 13, 4, 13, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "testFunc.pure",
+                "function testFunc():A[1]\n" +
+                        "{\n" +
+                        "    let a = ^A(prop=^B());\n" +
+                        "    ^$a(prop=^C());\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Type Error: C not a subtype of B", "testFunc.pure", 4, 13, 4, 13, 4, 13, e);
     }
 
     @Test
@@ -104,21 +92,14 @@ public class TestCopy extends AbstractPureTestWithCoreCompiledPlatform
                         "Class B\n" +
                         "{\n" +
                         "}");
-        try
-        {
-            compileTestSource(
-                    "testFunc.pure",
-                    "function testFunc():A[1]\n" +
-                            "{\n" +
-                            "    let a = ^A(prop=^B());\n" +
-                            "    ^$a(prop='the quick brown fox');\n" +
-                            "}");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Type Error: String not a subtype of B", "testFunc.pure", 4, 13, 4, 13, 4, 13, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "testFunc.pure",
+                "function testFunc():A[1]\n" +
+                        "{\n" +
+                        "    let a = ^A(prop=^B());\n" +
+                        "    ^$a(prop='the quick brown fox');\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Type Error: String not a subtype of B", "testFunc.pure", 4, 13, 4, 13, 4, 13, e);
     }
 
     @Test
@@ -133,21 +114,14 @@ public class TestCopy extends AbstractPureTestWithCoreCompiledPlatform
                         "Class B\n" +
                         "{\n" +
                         "}");
-        try
-        {
-            compileTestSource(
-                    "testFunc.pure",
-                    "function testFunc():A[1]\n" +
-                            "{\n" +
-                            "    let a = ^A(prop='the quick brown fox');\n" +
-                            "    ^$a(prop=^B());\n" +
-                            "}");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Type Error: B not a subtype of String", "testFunc.pure", 4, 13, 4, 13, 4, 13, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "testFunc.pure",
+                "function testFunc():A[1]\n" +
+                        "{\n" +
+                        "    let a = ^A(prop='the quick brown fox');\n" +
+                        "    ^$a(prop=^B());\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Type Error: B not a subtype of String", "testFunc.pure", 4, 13, 4, 13, 4, 13, e);
     }
 
     @Test
@@ -158,21 +132,14 @@ public class TestCopy extends AbstractPureTestWithCoreCompiledPlatform
                         "{\n" +
                         "    prop:String[1];\n" +
                         "}\n");
-        try
-        {
-            compileTestSource(
-                    "testFunc.pure",
-                    "function testFunc():A[1]\n" +
-                            "{\n" +
-                            "    let a = ^A(prop='one string');\n" +
-                            "    ^$a(prop=['one string', 'two string', 'red string', 'blue string']);\n" +
-                            "}");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Multiplicity Error: [4] is not compatible with [1]", "testFunc.pure", 4, 13, 4, 13, 4, 13, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "testFunc.pure",
+                "function testFunc():A[1]\n" +
+                        "{\n" +
+                        "    let a = ^A(prop='one string');\n" +
+                        "    ^$a(prop=['one string', 'two string', 'red string', 'blue string']);\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Multiplicity Error: [4] is not compatible with [1]", "testFunc.pure", 4, 13, 4, 13, 4, 13, e);
     }
 
     @Test
@@ -188,21 +155,14 @@ public class TestCopy extends AbstractPureTestWithCoreCompiledPlatform
                         "{\n" +
                         "    ['one string', 'two string', 'red string', 'blue string'];\n" +
                         "}");
-        try
-        {
-            compileTestSource(
-                    "testFunc.pure",
-                    "function testFunc():A[1]\n" +
-                            "{\n" +
-                            "    let a = ^A(prop='one string');\n" +
-                            "    ^$a(prop=someStrings());\n" +
-                            "}");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Multiplicity Error: [*] is not compatible with [1]", "testFunc.pure", 4, 13, 4, 13, 4, 13, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "testFunc.pure",
+                "function testFunc():A[1]\n" +
+                        "{\n" +
+                        "    let a = ^A(prop='one string');\n" +
+                        "    ^$a(prop=someStrings());\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Multiplicity Error: [*] is not compatible with [1]", "testFunc.pure", 4, 13, 4, 13, 4, 13, e);
     }
 
     @Test
@@ -223,20 +183,13 @@ public class TestCopy extends AbstractPureTestWithCoreCompiledPlatform
                         "{\n" +
                         "    ['one string', 'two string', 'red string', 'blue string'];\n" +
                         "}");
-        try
-        {
-            compileTestSource(
-                    "testFunc.pure",
-                    "function testFunc():A[1]\n" +
-                            "{\n" +
-                            "    let a = ^A(toB=^B(prop='one string'));\n" +
-                            "    ^$a(toB.prop=someStrings());\n" +
-                            "}");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Multiplicity Error: [*] is not compatible with [1]", "testFunc.pure", 4, 17, 4, 17, 4, 17, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "testFunc.pure",
+                "function testFunc():A[1]\n" +
+                        "{\n" +
+                        "    let a = ^A(toB=^B(prop='one string'));\n" +
+                        "    ^$a(toB.prop=someStrings());\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Multiplicity Error: [*] is not compatible with [1]", "testFunc.pure", 4, 17, 4, 17, 4, 17, e);
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/validation/TestGeneralization.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/validation/TestGeneralization.java
@@ -14,8 +14,14 @@
 
 package org.finos.legend.pure.m3.tests.validation;
 
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
-import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.m4.serialization.grammar.antlr.PureParserException;
 import org.junit.After;
@@ -28,62 +34,59 @@ import java.util.regex.Pattern;
 public class TestGeneralization extends AbstractPureTestWithCoreCompiledPlatform
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getExtra());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return Lists.immutable.with(CodeRepository.newPlatformCodeRepository(),
+                GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", PlatformCodeRepository.NAME),
+                GenericCodeRepository.build("test", "test(::.*)?", PlatformCodeRepository.NAME, "system"));
     }
 
     @After
-    public void cleanRuntime() {
+    public void cleanRuntime()
+    {
         runtime.delete("testSource.pure");
         runtime.delete("fromString.pure");
         runtime.delete("/test/testModel.pure");
+        runtime.compile();
     }
 
     @Test
     public void testClassGeneralizationToEnum()
     {
-        compileTestSource("fromString.pure","Enum test::TestEnum {A, B, C}");
-        try
-        {
-            compileTestSource("testSource.pure", "Class test::TestClass extends test::TestEnum {}");
-            Assert.fail("Expected compilation error");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Invalid generalization: test::TestClass cannot extend test::TestEnum as it is not a Class", "testSource.pure", 1, 1, 1, 13, 1, 47, e);
-        }
+        compileTestSource("fromString.pure", "Enum test::TestEnum {A, B, C}");
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("testSource.pure", "Class test::TestClass extends test::TestEnum {}"));
+        assertPureException(PureCompilationException.class, "Invalid generalization: test::TestClass cannot extend test::TestEnum as it is not a Class", "testSource.pure", 1, 1, 1, 13, 1, 47, e);
     }
 
     @Test
     public void testEnumGeneralizationToEnum()
     {
-        compileTestSource("fromString.pure","Enum test::TestEnum {A, B, C}");
-        try
-        {
-            compileTestSource("testSource.pure", "Enum test::TestEnum2 extends test::TestEnum {}");
-            Assert.fail("Expected compilation error");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureParserException.class, "expected: '{' found: 'extends'", "testSource.pure", 1, 22, 1, 22, 1, 29, e);
-        }
+        compileTestSource("fromString.pure", "Enum test::TestEnum {A, B, C}");
+        PureParserException e = Assert.assertThrows(PureParserException.class, () -> compileTestSource("testSource.pure", "Enum test::TestEnum2 extends test::TestEnum {}"));
+        assertPureException(PureParserException.class, "expected: '{' found: 'extends'", "testSource.pure", 1, 22, 1, 22, 1, 29, e);
     }
 
     @Test
     public void testClassGeneralizationToPrimitiveType()
     {
-        for (String typeName : ModelRepository.PRIMITIVE_TYPE_NAMES)
+        for (String typeName : PrimitiveUtilities.getPrimitiveTypeNames())
         {
             String sourceFile = String.format("test%s.pure", typeName);
             try
             {
-                compileTestSource(sourceFile, String.format("Class test::TestClass extends %s {}", typeName));
-                Assert.fail("Expected compilation error");
-            }
-            catch (Exception e)
-            {
+                PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(sourceFile, String.format("Class test::TestClass extends %s {}", typeName)));
                 String expectedMessage = String.format("Invalid generalization: test::TestClass cannot extend %s as it is not a Class", typeName);
                 assertPureException(PureCompilationException.class, expectedMessage, sourceFile, 1, 1, 1, 13, 1, 33 + typeName.length(), e);
+            }
+            finally
+            {
+                runtime.delete(sourceFile);
+                runtime.compile();
             }
         }
     }
@@ -91,94 +94,64 @@ public class TestGeneralization extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testDiamondWithGenericIssue()
     {
-        try
-        {
-            compileTestSource("fromString.pure","Class A<T>{prop:T[1];}\n" +
-                    "Class B extends A<String>{}\n" +
-                    "Class C extends A<Integer>{}\n" +
-                    "Class D extends B,C{}\n" +
-                    "function simpleTest():D[1]\n" +
-                    "{\n" +
-                    "   ^D(prop=333);\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, Pattern.compile("^Diamond inheritance error! (('Integer' is not compatible with 'String')|('String' is not compatible with 'Integer')) going from 'D' to 'A<T>'$"), 7, 4, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "Class A<T>{prop:T[1];}\n" +
+                        "Class B extends A<String>{}\n" +
+                        "Class C extends A<Integer>{}\n" +
+                        "Class D extends B,C{}\n" +
+                        "function simpleTest():D[1]\n" +
+                        "{\n" +
+                        "   ^D(prop=333);\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, Pattern.compile("^Diamond inheritance error! (('Integer' is not compatible with 'String')|('String' is not compatible with 'Integer')) going from 'D' to 'A<T>'$"), 7, 4, e);
     }
 
     @Test
     public void testGeneralizationWithSelfReferenceInGenerics()
     {
-        try
-        {
-            compileTestSource("/test/testModel.pure",
-                    "import test::*;\n" +
-                            "Class test::A<T> {}\n" +
-                            "Class test::B extends A<B> {}\n");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Class B extends A<B> which contains a reference to B itself", "/test/testModel.pure", 3, 13, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/test/testModel.pure",
+                "import test::*;\n" +
+                        "Class test::A<T> {}\n" +
+                        "Class test::B extends A<B> {}\n"));
+        assertPureException(PureCompilationException.class, "Class B extends A<B> which contains a reference to B itself", "/test/testModel.pure", 3, 13, e);
     }
 
     @Test
     public void testGeneralizationWithNestedSelfReferenceInGenerics()
     {
-        try
-        {
-            compileTestSource("/test/testModel.pure",
-                    "import test::*;\n" +
-                            "Class test::A<T> {}\n" +
-                            "Class test::B<U> {}\n" +
-                            "Class test::C extends A<B<C>> {}\n");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Class C extends A<B<C>> which contains a reference to C itself", "/test/testModel.pure", 4, 13, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/test/testModel.pure",
+                "import test::*;\n" +
+                        "Class test::A<T> {}\n" +
+                        "Class test::B<U> {}\n" +
+                        "Class test::C extends A<B<C>> {}\n"));
+        assertPureException(PureCompilationException.class, "Class C extends A<B<C>> which contains a reference to C itself", "/test/testModel.pure", 4, 13, e);
     }
 
     @Test
     public void testGeneralizationWithSubtypeReferenceInGenerics()
     {
-        try
-        {
-            compileTestSource("/test/testModel.pure",
-                    "import test::*;\n" +
-                            "Class test::A<T> {}\n" +
-                            "Class test::B extends A<C> {}\n" +
-                            "Class test::C extends B {}\n");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Class B extends A<C> which contains a reference to C which is a subtype of B", "/test/testModel.pure", 3, 13, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/test/testModel.pure",
+                "import test::*;\n" +
+                        "Class test::A<T> {}\n" +
+                        "Class test::B extends A<C> {}\n" +
+                        "Class test::C extends B {}\n"));
+        assertPureException(PureCompilationException.class, "Class B extends A<C> which contains a reference to C which is a subtype of B", "/test/testModel.pure", 3, 13, e);
     }
 
     @Test
     public void testGeneralizationWithNestedSubtypeReferenceInGenerics()
     {
-        try
-        {
-            compileTestSource("/test/testModel.pure",
-                    "import test::*;\n" +
-                            "Class test::A<T> {}\n" +
-                            "Class test::B<U> {}\n" +
-                            "Class test::C extends A<B<D>> {}\n" +
-                            "Class test::D extends C {}\n");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Class C extends A<B<D>> which contains a reference to D which is a subtype of C", "/test/testModel.pure", 4, 13, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "/test/testModel.pure",
+                "import test::*;\n" +
+                        "Class test::A<T> {}\n" +
+                        "Class test::B<U> {}\n" +
+                        "Class test::C extends A<B<D>> {}\n" +
+                        "Class test::D extends C {}\n"));
+        assertPureException(PureCompilationException.class, "Class C extends A<B<D>> which contains a reference to D which is a subtype of C", "/test/testModel.pure", 4, 13, e);
     }
-
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tools/TestGraphPath.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tools/TestGraphPath.java
@@ -14,11 +14,16 @@
 
 package org.finos.legend.pure.m3.tools;
 
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -28,7 +33,7 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiledPlatform
     @BeforeClass
     public static void setUp()
     {
-        setUpRuntime(getExtra());
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
         compileTestSource("/test/testModel.pure",
                 "import test::domain::*;\n" +
                         "Class test::domain::ClassA\n" +
@@ -50,6 +55,13 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiledPlatform
                         "   Actus: x -> $x * 120;\n" +
                         "   Stadium: x -> $x * 625;\n" +
                         "}\n");
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return Lists.immutable.with(CodeRepository.newPlatformCodeRepository(),
+                GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", PlatformCodeRepository.NAME),
+                GenericCodeRepository.build("test", "test(::.*)?", PlatformCodeRepository.NAME, "system"));
     }
 
     @Test

--- a/legend-pure-m3-dsl-path/src/test/java/org/finos/legend/pure/m3/inlinedsl/path/inference/TestFunctionTypeInferenceInPath.java
+++ b/legend-pure-m3-dsl-path/src/test/java/org/finos/legend/pure/m3/inlinedsl/path/inference/TestFunctionTypeInferenceInPath.java
@@ -14,8 +14,14 @@
 
 package org.finos.legend.pure.m3.inlinedsl.path.inference;
 
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.exception.PureUnmatchedFunctionException;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.junit.After;
 import org.junit.Assert;
@@ -29,7 +35,12 @@ public class TestFunctionTypeInferenceInPath extends AbstractPureTestWithCoreCom
     @BeforeClass
     public static void setUp()
     {
-        setUpRuntime();
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return Lists.immutable.with(CodeRepository.newPlatformCodeRepository(), GenericCodeRepository.build("test", "((test)|(meta))(::.*)?", PlatformCodeRepository.NAME));
     }
 
     @After
@@ -80,7 +91,7 @@ public class TestFunctionTypeInferenceInPath extends AbstractPureTestWithCoreCom
                         "    $numbers->plus();\n" +
                         "}\n" +
                         "\n" +
-                        "function go():Any[*]\n" +
+                        "function test::go():Any[*]\n" +
                         "{\n" +
                         "   Trade.all()->groupBy([#/Trade/product/name#],\n" +
                         "                        ['prodName'],\n" +
@@ -131,7 +142,7 @@ public class TestFunctionTypeInferenceInPath extends AbstractPureTestWithCoreCom
                 "    $numbers->plus();\n" +
                 "}\n" +
                 "\n" +
-                "function go():Any[*]\n" +
+                "function test::go():Any[*]\n" +
                 "{\n" +
                 "   Trade.all()->groupBy([#/Trade/product/name#], ['prodName'], meta::pure::functions::collection::agg('cnt', x|$x.quantity, y|$y->sum()));\n" +
                 "   'ok';\n" +
@@ -175,7 +186,7 @@ public class TestFunctionTypeInferenceInPath extends AbstractPureTestWithCoreCom
                         "}\n" +
                         "\n" +
                         "\n" +
-                        "function go():Any[*]\n" +
+                        "function test::go():Any[*]\n" +
                         "{\n" +
                         "   Trade.all()->groupBy([#/Trade/product/name#], ['prodName'], meta::pure::functions::collection::agg('cnt', x|$x.name, y|$y->sum()));\n" +
                         "   'ok';\n" +
@@ -187,11 +198,12 @@ public class TestFunctionTypeInferenceInPath extends AbstractPureTestWithCoreCom
     public void inferTheTypeOfACollectionOfLambdaAndPath_Success()
     {
         compileTestSource(SOURCE_ID,
-                        "Class Person\n" +
+                "import test::*;\n" +
+                        "Class test::Person\n" +
                         "{\n" +
                         "   age:Integer[1];\n" +
                         "}\n" +
-                        "function a(k:FunctionExpression[1]):Any[*]\n" +
+                        "function test::a(k:FunctionExpression[1]):Any[*]\n" +
                         "{\n" +
                         "   let f = [f:Person[1]|2, #/Person/age#];\n" +
                         "   let z = $f->at(0)->eval(^Person(age=3))+4;\n" +
@@ -203,11 +215,12 @@ public class TestFunctionTypeInferenceInPath extends AbstractPureTestWithCoreCom
     {
         PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () ->
                 compileTestSource(SOURCE_ID,
-                        "Class Person\n" +
+                        "import test::*;\n" +
+                                "Class test::Person\n" +
                                 "{\n" +
                                 "   age:Integer[1];\n" +
                                 "}\n" +
-                                "function a(k:FunctionExpression[1]):Any[*]\n" +
+                                "function test::a(k:FunctionExpression[1]):Any[*]\n" +
                                 "{\n" +
                                 "   let f = [f:Person[1]|'2', #/Person/age#];\n" +
                                 "   let z = $f->at(0)->eval(^Person(age=3))+4;\n" +
@@ -219,6 +232,6 @@ public class TestFunctionTypeInferenceInPath extends AbstractPureTestWithCoreCom
                 "\tmeta::pure::functions::math::plus(Float[*]):Float[1]\n" +
                 "\tmeta::pure::functions::math::plus(Integer[*]):Integer[1]\n" +
                 "\tmeta::pure::functions::math::plus(Number[*]):Number[1]\n" +
-                "\tmeta::pure::functions::string::plus(String[*]):String[1]\n", SOURCE_ID, 8, 43, e);
+                "\tmeta::pure::functions::string::plus(String[*]):String[1]\n", SOURCE_ID, 9, 43, e);
     }
 }

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/TestIsOptionSetCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/TestIsOptionSetCompiled.java
@@ -17,20 +17,17 @@ package org.finos.legend.pure.runtime.java.compiled;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.runtime.AbstractTestIsOptionSet;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestIsOptionSetCompiled extends AbstractTestIsOptionSet
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getFunctionExecution(), getOptions());
     }
-    @After
-    public void clearRuntime() {
-        runtime.delete("fromString.pure");
-    }
-     protected static FunctionExecution getFunctionExecution()
+
+    protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();
     }

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/TestJavaStandaloneLibraryGenerator.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/TestJavaStandaloneLibraryGenerator.java
@@ -52,7 +52,7 @@ public class TestJavaStandaloneLibraryGenerator extends AbstractPureTestWithCore
         MutableCodeStorage codeStorage = new PureCodeStorage(null,
                 new ClassLoaderCodeStorage(CodeRepository.newPlatformCodeRepository()),
                 new EmptyCodeStorage(new GenericCodeRepository("test", "test::.*", PlatformCodeRepository.NAME), new GenericCodeRepository("other", "other::.*", "test")));
-        setUpRuntime(codeStorage, codeStorage.getAllRepositories(), null);
+        setUpRuntime(codeStorage);
         runtime.createInMemorySource(
                 "/test/standalone/tests.pure",
                 "import test::standalone::*;\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/TestReflectiveFunctions.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/TestReflectiveFunctions.java
@@ -24,31 +24,33 @@ import org.junit.Test;
 public class TestReflectiveFunctions extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), getCodeStorage(), getCodeRepositories());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution());
     }
 
     @After
     public void cleanRuntime()
     {
         runtime.delete("fromString.pure");
+        runtime.compile();
     }
 
     @Test
     public void testFilterSimple()
     {
-       compileTestSource("fromString.pure",
+        compileTestSource("fromString.pure",
                 "function test():Boolean[1]\n" +
-                "{\n" +
-                "   assert('test' == ['a','b','test']->filter(x|$x == 'test'), |'')\n" +
-                "}");
+                        "{\n" +
+                        "   assert('test' == ['a','b','test']->filter(x|$x == 'test'), |'')\n" +
+                        "}");
         this.compileAndExecute("test():Boolean[1]");
     }
 
     @Test
     public void testFilterReflectiveEval()
     {
-       compileTestSource("fromString.pure",
+        compileTestSource("fromString.pure",
                 "function test():Boolean[1]\n" +
                         "{\n" +
                         "   assert('test' == filter_T_MANY__Function_1__T_MANY_->eval(['a','b','test'], x:String[1]|$x == 'test'), |'')\n" +
@@ -59,7 +61,7 @@ public class TestReflectiveFunctions extends AbstractPureTestWithCoreCompiled
     @Test
     public void testFilterReflectiveEvaluate()
     {
-       compileTestSource("fromString.pure",
+        compileTestSource("fromString.pure",
                 "function test():Boolean[1]\n" +
                         "{\n" +
                         "   assert('test' == filter_T_MANY__Function_1__T_MANY_->evaluate([list(['a','b','test']), list(x:String[1]|$x == 'test')]), |'')\n" +
@@ -68,8 +70,7 @@ public class TestReflectiveFunctions extends AbstractPureTestWithCoreCompiled
 
     }
 
-
-     protected static FunctionExecution getFunctionExecution()
+    protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();
     }

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/constraints/TestConstraints.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/constraints/TestConstraints.java
@@ -14,8 +14,8 @@
 
 package org.finos.legend.pure.runtime.java.compiled.constraints;
 
-import org.finos.legend.pure.generated.CoreJavaModelFactoryRegistry;
 import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.pure.generated.CoreJavaModelFactoryRegistry;
 import org.finos.legend.pure.m3.coreinstance.CoreInstanceFactoryRegistry;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
@@ -29,13 +29,9 @@ import org.junit.Test;
 public class TestConstraints extends AbstractTestConstraints
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), getFactoryRegistryOverride());
-        runtime.createInMemorySource("employee.pure", "Class Employee" +
-                "{" +
-                "   lastName:String[1];" +
-                "}\n");
-        runtime.compile();
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage(), getFactoryRegistryOverride(), getOptions(), getExtra());
     }
 
     @After
@@ -43,8 +39,7 @@ public class TestConstraints extends AbstractTestConstraints
     {
         runtime.delete("/test/source1.pure");
         runtime.delete("/test/source2.pure");
-        runtime.delete("fromString.pure");
-        runtime.compile();
+        super.cleanRuntime();
     }
 
     @Test
@@ -77,15 +72,8 @@ public class TestConstraints extends AbstractTestConstraints
                 "}\n";
         // The two sources must be compiled together to test the issue
         runtime.createInMemoryAndCompile(Tuples.pair(source1Name, source1Code), Tuples.pair(source2Name, source2Code));
-        try
-        {
-            this.execute("test::testNew():Any[*]");
-            Assert.fail("This should fail constraint validation");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureExecutionException.class, "Constraint :[nameNotEmpty] violated in the Class SuperClass", "/test/source2.pure", 7, 3, e);
-        }
+        PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> execute("test::testNew():Any[*]"));
+        assertPureException(PureExecutionException.class, "Constraint :[nameNotEmpty] violated in the Class SuperClass", "/test/source2.pure", 7, 3, e);
     }
 
     protected static FunctionExecution getFunctionExecution()

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/TestFunctionProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/TestFunctionProcessor.java
@@ -12,76 +12,76 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.pure.runtime.java.compiled.processors;
+package org.finos.legend.pure.runtime.java.compiled.generation.processors;
 
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestFunctionProcessor extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), getCodeStorage(), getCodeRepositories());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution());
     }
 
     @Test
     public void testProcessFunctionDefinitionContent()
     {
-        this.compileTestSource("function pkg::f1():Boolean[1]\n" +
+        compileTestSource("function pkg::f1():Boolean[1]\n" +
                 "{\n" +
                 "   true;\n" +
                 "   true;\n" +
                 "}\n");
 
-        this.compileTestSource("function pkg::f2():Boolean[1]\n" +
+        compileTestSource("function pkg::f2():Boolean[1]\n" +
                 "{\n" +
                 "   1;\n" +
                 "   true;\n" +
                 "}\n");
 
-        this.compileTestSource("function pkg::f3():Boolean[1]\n" +
+        compileTestSource("function pkg::f3():Boolean[1]\n" +
                 "{\n" +
                 "   [];\n" +
                 "   true;\n" +
                 "}\n");
 
-        this.compileTestSource("function pkg::f4():String[1]\n" +
+        compileTestSource("function pkg::f4():String[1]\n" +
                 "{\n" +
                 "   [true, false];\n" +
                 "   'string';\n" +
                 "}\n");
 
-        this.compileTestSource("function pkg::f5():String[1]\n" +
+        compileTestSource("function pkg::f5():String[1]\n" +
                 "{\n" +
                 "   let a = 99;\n" +
                 "   $a;\n" +
                 "   'string';\n" +
                 "}\n");
 
-        this.compileTestSource("function pkg::f6():String[1]\n" +
+        compileTestSource("function pkg::f6():String[1]\n" +
                 "{\n" +
                 "   print('print', 1);\n" +
                 "   'string';\n" +
                 "}\n");
 
-        this.compileTestSource("function pkg::f7():Boolean[1]\n" +
+        compileTestSource("function pkg::f7():Boolean[1]\n" +
                 "{\n" +
                 "   1==1;\n" +
                 "   2==2;\n" +
                 "}\n");
 
-        this.compileTestSource("function pkg::f8():Boolean[1]\n" +
+        compileTestSource("function pkg::f8():Boolean[1]\n" +
                 "{\n" +
                 "   if(true, |true;true;, |1==2;3==4;);\n" +
                 "   if(false, |true;true;, |1==2;3==4;);\n" +
                 "   false;\n" +
                 "}\n");
 
-        this.compileTestSource("Class pkg::C{}\n" +
+        compileTestSource("Class pkg::C{}\n" +
                 "function pkg::f9():Boolean[1]\n" +
                 "{\n" +
                 "   ^pkg::C();\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/TestDynamicNew.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/TestDynamicNew.java
@@ -17,28 +17,15 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.suppor
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.AbstractTestDynamicNew;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestDynamicNew extends AbstractTestDynamicNew
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
-    }
-
-    @After
-    public void clearRuntime()
+    public static void setUp()
     {
-        runtime.delete("testSource.pure");
-        runtime.delete("/test/testModel.pure");
-        try {
-            runtime.compile();
-        } catch (PureCompilationException e) {
-            setUp();
-        }
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
     }
 
     protected static FunctionExecution getFunctionExecution()

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/lang/TestCastCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/lang/TestCastCompiled.java
@@ -29,7 +29,7 @@ public class TestCastCompiled extends AbstractTestCast
     @BeforeClass
     public static void setUp()
     {
-        setUpRuntime(getFunctionExecution());
+        setUpRuntime(getFunctionExecution(), getCodeStorage(), getExtra());
     }
 
     protected static FunctionExecution getFunctionExecution()
@@ -103,7 +103,7 @@ public class TestCastCompiled extends AbstractTestCast
     @Override
     protected void checkPrimitiveNonConcreteOneRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: Integer cannot be cast to String", "/org/finos/legend/pure/m3/cast/cast.pure", 51, 10);
+        checkException(findRootException(e), "Cast exception: Integer cannot be cast to String", "/test/cast.pure", 51, 10);
     }
 
     @Override
@@ -115,7 +115,7 @@ public class TestCastCompiled extends AbstractTestCast
     @Override
     protected void checkNonPrimitiveNonConcreteOneRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: X cannot be cast to Y", "/org/finos/legend/pure/m3/cast/cast.pure", 61, 12);
+        checkException(findRootException(e), "Cast exception: X cannot be cast to Y", "/test/cast.pure", 61, 12);
     }
 
     @Override
@@ -127,7 +127,7 @@ public class TestCastCompiled extends AbstractTestCast
     @Override
     protected void checkPrimitiveNonConcreteManyRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: String cannot be cast to Number", "/org/finos/legend/pure/m3/cast/cast.pure", 56, 13);
+        checkException(findRootException(e), "Cast exception: String cannot be cast to Number", "/test/cast.pure", 56, 13);
     }
 
     @Override
@@ -139,7 +139,7 @@ public class TestCastCompiled extends AbstractTestCast
     @Override
     protected void checkNonPrimitiveNonConcreteManyRootException(PureExecutionException e)
     {
-        checkException(findRootException(e), "Cast exception: X cannot be cast to Y", "/org/finos/legend/pure/m3/cast/cast.pure", 61, 12);
+        checkException(findRootException(e), "Cast exception: X cannot be cast to Y", "/test/cast.pure", 61, 12);
     }
 
     @Override

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/lang/TestCopyCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/lang/TestCopyCompiled.java
@@ -17,19 +17,16 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.suppor
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.lang.AbstractTestCopyAtRuntime;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestCopyCompiled extends AbstractTestCopyAtRuntime
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getFunctionExecution());
     }
-    @After
-    public void cleanRuntime() {
-        runtime.delete("fromString.pure");
-    }
+
     public static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/lang/TestNewCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/lang/TestNewCompiled.java
@@ -17,29 +17,16 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.suppor
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.lang.AbstractTestNewAtRuntime;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
+import org.junit.Assert;
 import org.junit.BeforeClass;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class TestNewCompiled extends AbstractTestNewAtRuntime
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
-    }
-    @After
-    public void cleanRuntime() {
-        runtime.delete("fromString.pure");
-        runtime.delete("/test/testModel.pure");
-        try{
-            runtime.compile();
-        } catch (PureCompilationException e) {
-            setUp();
-        }
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
     }
 
     public static FunctionExecution getFunctionExecution()
@@ -56,7 +43,7 @@ public class TestNewCompiled extends AbstractTestNewAtRuntime
     @Override
     public void testNewWithInheritenceAndOverriddenAssociationEndWithReverseOneToOneProperty()
     {
-        compileTestSource("fromString.pure","function test(): Any[*]\n" +
+        compileTestSource("fromString.pure", "function test(): Any[*]\n" +
                 "{\n" +
                 "   let car = ^test::FastCar(name='Bugatti', owner= ^test::Owner(firstName='John', lastName='Roe'));\n" +
                 "   print($car.owner.car->size()->toString(), 1);\n" +
@@ -89,20 +76,20 @@ public class TestNewCompiled extends AbstractTestNewAtRuntime
                 "}");
         try
         {
-            this.execute("test():Any[*]");
-            String result = this.functionExecution.getConsole().getLine(0);
-            assertEquals("'0'", result);
+            execute("test():Any[*]");
+            String result = functionExecution.getConsole().getLine(0);
+            Assert.assertEquals("'0'", result);
         }
         catch (Exception e)
         {
-            fail("Failed to set the reverse properties for a one-to-one association.");
+            Assert.fail("Failed to set the reverse properties for a one-to-one association.");
         }
     }
 
     @Override
     public void testNewWithInheritenceAndOverriddenAssociationEndWithReverseOneToManyProperty()
     {
-        compileTestSource("fromString.pure","function test(): Any[*]\n" +
+        compileTestSource("fromString.pure", "function test(): Any[*]\n" +
                 "{\n" +
                 "   let car = ^test::FastCar(name='Bugatti', owner= ^test::Owner(firstName='John', lastName='Roe'));\n" +
                 "   print($car.owner.cars->size()->toString(), 1);\n" +
@@ -135,13 +122,13 @@ public class TestNewCompiled extends AbstractTestNewAtRuntime
                 "}");
         try
         {
-            this.execute("test():Any[*]");
-            String result = this.functionExecution.getConsole().getLine(0);
-            assertEquals("'0'", result);
+            execute("test():Any[*]");
+            String result = functionExecution.getConsole().getLine(0);
+            Assert.assertEquals("'0'", result);
         }
         catch (Exception e)
         {
-            fail("Failed to set the reverse properties for a one-to-one association.");
+            Assert.fail("Failed to set the reverse properties for a one-to-one association.");
         }
     }
 }

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/string/TestChunk.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/string/TestChunk.java
@@ -17,19 +17,16 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.suppor
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.string.AbstractTestChunk;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestChunk extends AbstractTestChunk
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
     }
-    @After
-    public void cleanRuntime() {
-        runtime.delete("/test/testChunk.pure");
-    }
+
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/TestIncrementalCompilationCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/TestIncrementalCompilationCompiled.java
@@ -15,45 +15,21 @@
 package org.finos.legend.pure.runtime.java.compiled.incremental;
 
 import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.pure.m3.RuntimeVerifier;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.incremental.AbstractTestIncrementalCompilation;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.compiled.CompiledClassloaderStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.CompiledMetadataStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestIncrementalCompilationCompiled extends AbstractTestIncrementalCompilation
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), getCodeStorage(), getCodeRepositories());
-    }
-    @After
-    public void cleanRuntime() {
-        runtime.delete("s1.pure");
-        runtime.delete("s2.pure");
-        runtime.delete("s3.pure");
-        runtime.delete("s4.pure");
-        runtime.delete("s5.pure");
-        runtime.delete("sourceId1.pure");
-        runtime.delete("sourceId2.pure");
-        runtime.delete("sourceId3.pure");
-        runtime.delete("/model/sourceId1.pure");
-        runtime.delete("/model/domain/sourceId3.pure");
-        runtime.delete("/datamart_other/sourceId2.pure");
-        runtime.delete("/system/tests/sourceId1.pure");
-        runtime.delete("/system/tests/resources/sourceId2.pure");
-
-        try{
-            runtime.compile();
-        } catch (PureCompilationException e) {
-            setUp();
-        }
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
     }
 
     protected static FunctionExecution getFunctionExecution()
@@ -64,11 +40,6 @@ public class TestIncrementalCompilationCompiled extends AbstractTestIncrementalC
     @Override
     protected ListIterable<RuntimeVerifier.FunctionExecutionStateVerifier> getAdditionalVerifiers()
     {
-        return Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
-    }
-
-    public static Pair<String, String> getExtra()
-    {
-        return null;
+        return Lists.fixedSize.of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
     }
 }

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/TestMultipleRepoIncrementalCompilationCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/TestMultipleRepoIncrementalCompilationCompiled.java
@@ -14,9 +14,8 @@
 
 package org.finos.legend.pure.runtime.java.compiled.incremental;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.m3.RuntimeVerifier;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.incremental.TestMultipleRepoIncrementalCompilation;
@@ -29,8 +28,9 @@ import org.junit.BeforeClass;
 public class TestMultipleRepoIncrementalCompilationCompiled extends TestMultipleRepoIncrementalCompilation
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), getCodeStorage(), getCodeRepositories());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
     }
 
     protected static FunctionExecution getFunctionExecution()
@@ -41,11 +41,6 @@ public class TestMultipleRepoIncrementalCompilationCompiled extends TestMultiple
     @Override
     protected ListIterable<RuntimeVerifier.FunctionExecutionStateVerifier> getAdditionalVerifiers()
     {
-        return Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
-    }
-
-    public static Pair<String, String> getExtra()
-    {
-        return null;
+        return Lists.fixedSize.of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
     }
 }

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/_class/TestPureRuntimeClass_AsFunctionReturnCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/_class/TestPureRuntimeClass_AsFunctionReturnCompiled.java
@@ -14,17 +14,16 @@
 
 package org.finos.legend.pure.runtime.java.compiled.incremental._class;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.m3.RuntimeVerifier;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
 import org.finos.legend.pure.m3.tests.incremental._class.TestPureRuntimeClass_AsFunctionReturn;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.compiled.CompiledClassloaderStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.CompiledMetadataStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -32,25 +31,9 @@ import org.junit.Test;
 public class TestPureRuntimeClass_AsFunctionReturnCompiled extends TestPureRuntimeClass_AsFunctionReturn
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), getExtra());
-    }
-
-    @After
-    public void clearRuntime() {
-        runtime.delete("other.pure");
-        runtime.delete("userId.pure");
-        runtime.delete("sourceId.pure");
-        runtime.delete("sourceId2.pure");
-        runtime.delete("/test/testFileB.pure");
-        runtime.delete("/test/testFileA.pure");
-
-        try
-        {
-            runtime.compile();
-        } catch (PureCompilationException e) {
-            setUp();
-        }
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
     }
 
     @Test
@@ -60,7 +43,7 @@ public class TestPureRuntimeClass_AsFunctionReturnCompiled extends TestPureRunti
         testPureRuntimeClassAsQualifiedPropertyReturn();
     }
 
-     protected static FunctionExecution getFunctionExecution()
+    protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();
     }
@@ -68,8 +51,7 @@ public class TestPureRuntimeClass_AsFunctionReturnCompiled extends TestPureRunti
     @Override
     protected ListIterable<RuntimeVerifier.FunctionExecutionStateVerifier> getAdditionalVerifiers()
     {
-        return Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of(new CompiledMetadataStateVerifier(),
-                new CompiledClassloaderStateVerifier());
+        return Lists.fixedSize.of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
     }
 
     public static Pair<String, String> getExtra()

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/association/TestPureRuntimeAssociationCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/association/TestPureRuntimeAssociationCompiled.java
@@ -14,37 +14,24 @@
 
 package org.finos.legend.pure.runtime.java.compiled.incremental.association;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.m3.RuntimeVerifier;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
 import org.finos.legend.pure.m3.tests.incremental.association.TestPureRuntimeAssociation;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.compiled.CompiledClassloaderStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.CompiledMetadataStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestPureRuntimeAssociationCompiled extends TestPureRuntimeAssociation
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), getExtra());
-    }
-
-    @After
-    public void cleanRuntime() {
-        runtime.delete("userId.pure");
-        runtime.delete("sourceId.pure");
-
-        try
-        {
-            runtime.compile();
-        } catch (PureCompilationException e) {
-            setUp();
-        }
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
     }
 
     protected static FunctionExecution getFunctionExecution()
@@ -55,7 +42,7 @@ public class TestPureRuntimeAssociationCompiled extends TestPureRuntimeAssociati
     @Override
     protected ListIterable<RuntimeVerifier.FunctionExecutionStateVerifier> getAdditionalVerifiers()
     {
-        return Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
+        return Lists.fixedSize.of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
     }
 
     public static Pair<String, String> getExtra()

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/function/TestPureRuntimeFunction_AllCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/function/TestPureRuntimeFunction_AllCompiled.java
@@ -14,39 +14,24 @@
 
 package org.finos.legend.pure.runtime.java.compiled.incremental.function;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.m3.RuntimeVerifier;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
 import org.finos.legend.pure.m3.tests.incremental.function.TestPureRuntimeFunction_All;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.compiled.CompiledClassloaderStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.CompiledMetadataStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestPureRuntimeFunction_AllCompiled extends TestPureRuntimeFunction_All
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), getExtra());
-    }
-
-    @After
-    public void cleanRuntime() {
-        runtime.delete("userId.pure");
-        runtime.delete("sourceId.pure");
-        runtime.delete("/test/model.pure");
-        runtime.delete("/test/function.pure");
-
-        try
-        {
-            runtime.compile();
-        } catch (PureCompilationException e) {
-            setUp();
-        }
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
     }
 
     protected static FunctionExecution getFunctionExecution()
@@ -57,7 +42,7 @@ public class TestPureRuntimeFunction_AllCompiled extends TestPureRuntimeFunction
     @Override
     protected ListIterable<RuntimeVerifier.FunctionExecutionStateVerifier> getAdditionalVerifiers()
     {
-        return Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
+        return Lists.fixedSize.of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
     }
 
     public static Pair<String, String> getExtra()

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/milestoning/TestPureRuntimeMilestoningCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/milestoning/TestPureRuntimeMilestoningCompiled.java
@@ -14,18 +14,17 @@
 
 package org.finos.legend.pure.runtime.java.compiled.incremental.milestoning;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.m3.RuntimeVerifier;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
 import org.finos.legend.pure.m3.tests.incremental.milestoning.TestMilestoning;
 import org.finos.legend.pure.m3.tools.test.ToFix;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.compiled.CompiledClassloaderStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.CompiledMetadataStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -33,31 +32,9 @@ import org.junit.Test;
 public class TestPureRuntimeMilestoningCompiled extends TestMilestoning
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), getExtra());
-    }
-
-    @After
-    public void cleanRuntime() {
-        runtime.delete("userId.pure");
-        runtime.delete("sourceId.pure");
-        runtime.delete("sourceA.pure");
-        runtime.delete("sourceB.pure");
-        runtime.delete("classes.pure");
-        runtime.delete("classB.pure");
-        runtime.delete("association.pure");
-        runtime.delete("testFunc.pure");
-        runtime.delete("test.pure");
-        runtime.delete("trader.pure");
-        runtime.delete("/model/go.pure");
-        runtime.delete("/test/myClass.pure");
-
-        try
-        {
-            runtime.compile();
-        } catch (PureCompilationException e) {
-            setUp();
-        }
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()), getFactoryRegistryOverride(), getOptions(), getExtra());
     }
 
     protected static FunctionExecution getFunctionExecution()
@@ -68,7 +45,7 @@ public class TestPureRuntimeMilestoningCompiled extends TestMilestoning
     @Override
     protected ListIterable<RuntimeVerifier.FunctionExecutionStateVerifier> getAdditionalVerifiers()
     {
-        return Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
+        return Lists.fixedSize.of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
     }
 
     @ToFix

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/profile/TestPureRuntimeStereotypeCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/profile/TestPureRuntimeStereotypeCompiled.java
@@ -14,9 +14,8 @@
 
 package org.finos.legend.pure.runtime.java.compiled.incremental.profile;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.m3.RuntimeVerifier;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.incremental.profile.TestPureRuntimeStereotype;
@@ -30,8 +29,9 @@ import org.junit.Test;
 public class TestPureRuntimeStereotypeCompiled extends TestPureRuntimeStereotype
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), getCodeStorage(), getCodeRepositories());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
     }
 
     @Override
@@ -42,7 +42,7 @@ public class TestPureRuntimeStereotypeCompiled extends TestPureRuntimeStereotype
         super.testPureRuntimeProfileWithEnumWithReferenceToEnum();
     }
 
-     protected static FunctionExecution getFunctionExecution()
+    protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();
     }
@@ -50,11 +50,6 @@ public class TestPureRuntimeStereotypeCompiled extends TestPureRuntimeStereotype
     @Override
     protected ListIterable<RuntimeVerifier.FunctionExecutionStateVerifier> getAdditionalVerifiers()
     {
-        return Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
-    }
-
-    public static Pair<String, String> getExtra()
-    {
-        return null;
+        return Lists.fixedSize.of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
     }
 }

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/_class/TestEnumerationCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/_class/TestEnumerationCompiled.java
@@ -15,8 +15,8 @@
 package org.finos.legend.pure.runtime.java.compiled.modeling._class;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
 import org.finos.legend.pure.m3.tests.function.base.meta.AbstractTestEnumeration;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -24,22 +24,22 @@ import org.junit.BeforeClass;
 public class TestEnumerationCompiled extends AbstractTestEnumeration
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()));
     }
+
     @After
-    public void clearRuntime() {
+    public void clearRuntime()
+    {
         runtime.delete("fromString.pure");
         runtime.delete("enumDefinition.pure");
         runtime.delete("enumReference.pure");
         runtime.delete("/test/model.pure");
         runtime.delete("/test/test.pure");
-        try{
-            runtime.compile();
-        } catch (PureCompilationException e) {
-            setUp();
-        }
+        runtime.compile();
     }
+
     public static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/function/TestLambdaAsInstanceValue.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/function/TestLambdaAsInstanceValue.java
@@ -14,11 +14,16 @@
 
 package org.finos.legend.pure.runtime.java.compiled.modeling.function;
 
-import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.junit.After;
@@ -29,8 +34,9 @@ import org.junit.Test;
 public class TestLambdaAsInstanceValue extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()));
     }
 
     @After
@@ -38,11 +44,7 @@ public class TestLambdaAsInstanceValue extends AbstractPureTestWithCoreCompiled
     {
         runtime.delete("/test/testSource1.pure");
         runtime.delete("/test/testSource2.pure");
-//        try {
-//            runtime.compile();
-//        } catch(PureCompilationException e) {
-//            setUp();
-//        }
+        runtime.compile();
     }
 
     @Test
@@ -102,13 +104,19 @@ public class TestLambdaAsInstanceValue extends AbstractPureTestWithCoreCompiled
                         "{\n" +
                         "  testGetFunctionName(" + lambda + ")" +
                         "}");
-        CoreInstance test = this.runtime.getFunction("test::testFn():Any[1]");
-        CoreInstance result = this.functionExecution.start(test, Lists.immutable.<CoreInstance>empty());
+        CoreInstance test = runtime.getFunction("test::testFn():Any[1]");
+        CoreInstance result = functionExecution.start(test, Lists.immutable.empty());
         Assert.assertEquals("LAMBDA", PrimitiveUtilities.getStringValue(result.getValueForMetaPropertyToOne(M3Properties.values)));
     }
 
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return org.eclipse.collections.api.factory.Lists.immutable.with(CodeRepository.newPlatformCodeRepository(),
+                GenericCodeRepository.build("test", "test(::.*)?", PlatformCodeRepository.NAME, "system"));
     }
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/TestIsOptionSetInterpreted.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/TestIsOptionSetInterpreted.java
@@ -16,20 +16,16 @@ package org.finos.legend.pure.runtime.java.interpreted;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.runtime.AbstractTestIsOptionSet;
-import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestIsOptionSetInterpreted extends AbstractTestIsOptionSet
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getFunctionExecution(), getOptions());
     }
-    @After
-    public void cleanRuntime() {
-        runtime.delete("fromString.pure");
-    }
+
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionInterpreted();

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/constraints/TestConstraint.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/constraints/TestConstraint.java
@@ -14,28 +14,17 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.constraints;
 
-import org.finos.legend.pure.m3.tests.constraints.AbstractTestConstraints;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.tests.constraints.AbstractTestConstraints;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestConstraint extends AbstractTestConstraints
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
-        compileTestSource("employee.pure", "Class Employee" +
-                "{" +
-                "   lastName:String[1];" +
-                "}\n");
-    }
-
-    @After
-    public void cleanRuntime()
+    public static void setUp()
     {
-        runtime.delete("fromString.pure");
-        runtime.compile();
+        setUpRuntime(getFunctionExecution(), getCodeStorage(), getFactoryRegistryOverride(), getOptions(), getExtra());
     }
 
     protected static FunctionExecution getFunctionExecution()

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/TestDynamicNew.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/TestDynamicNew.java
@@ -16,32 +16,20 @@ package org.finos.legend.pure.runtime.java.interpreted.function;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.AbstractTestDynamicNew;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 
 public class TestDynamicNew extends AbstractTestDynamicNew
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
-    }
-
-    @After
-    public void cleanRuntime()
+    public static void setUp()
     {
-        runtime.delete("testSource.pure");
-        runtime.delete("/test/testModel.pure");
-        try {
-            runtime.compile();
-        } catch (PureCompilationException e) {
-            setUp();
-        }
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
     }
 
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionInterpreted();
-    }}
+    }
+}

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssert.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssert.java
@@ -22,7 +22,8 @@ import org.junit.BeforeClass;
 public class TestAssert extends AbstractTestAssert
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getFunctionExecution());
     }
 

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertContains.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertContains.java
@@ -14,52 +14,59 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.function.base.asserts;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.PureExpressionTest;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestAssertContains extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
 
     @Test
     public void testFailure()
     {
-        assertExpressionRaisesPureException("[1, 2, 5, 2, 'a', true, %2014-02-01, 'c'] does not contain false", 3, 9, "assertContains([1, 2, 5, 2, 'a', true, %2014-02-01, 'c'], false)",
-                "function meta::pure::functions::asserts::assertContains(collection:Any[*], value:Any[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assertContains($collection, $value, | format('%s does not contain %r', [$collection->map(v | $v->toRepresentation())->joinStrings('[', ', ', ']'), $value]));\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertContains(collection:Any[*], value:Any[1], message:String[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assert($collection->contains($value), $message);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertContains(collection:Any[*], value:Any[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-                "{\n" +
-                "    assert($collection->contains($value), $formatString, $formatArgs);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertContains(collection:Any[*], value:Any[1], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assert($collection->contains($value), $message);\n" +
-                "}\n" +
-                "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-                "{\n" +
-                "    assert($condition, | format($formatString, $formatArgs));\n" +
-                "}"
-        );
+        assertExpressionRaisesPureException("[1, 2, 5, 2, 'a', true, %2014-02-01, 'c'] does not contain false", 3, 9, "assertContains([1, 2, 5, 2, 'a', true, %2014-02-01, 'c'], false)");
     }
 
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionInterpreted();
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair(
+                "testAssertContains.pure",
+                "function meta::pure::functions::asserts::assertContains(collection:Any[*], value:Any[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assertContains($collection, $value, | format('%s does not contain %r', [$collection->map(v | $v->toRepresentation())->joinStrings('[', ', ', ']'), $value]));\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertContains(collection:Any[*], value:Any[1], message:String[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert($collection->contains($value), $message);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertContains(collection:Any[*], value:Any[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert($collection->contains($value), $formatString, $formatArgs);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertContains(collection:Any[*], value:Any[1], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert($collection->contains($value), $message);\n" +
+                        "}\n" +
+                        "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert($condition, | format($formatString, $formatArgs));\n" +
+                        "}\n");
     }
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertEmpty.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertEmpty.java
@@ -14,24 +14,37 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.function.base.asserts;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.PureExpressionTest;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestAssertEmpty extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
 
     @Test
     public void testFailure()
     {
-        assertExpressionRaisesPureException("[1, 2] is not empty", 3, 9, "assertEmpty([1, 2])",
+        assertExpressionRaisesPureException("[1, 2] is not empty", 3, 9, "assertEmpty([1, 2])");
+    }
+
+    protected static FunctionExecution getFunctionExecution()
+    {
+        return new FunctionExecutionInterpreted();
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair(
+                "testAssertEmpty.pure",
                 "function meta::pure::functions::asserts::assertEmpty(collection:Any[*]):Boolean[1]\n" +
                         "{\n" +
                         "    assertEmpty($collection, '%s is not empty', [^List<Any>(values=$collection)]);\n" +
@@ -54,12 +67,7 @@ public class TestAssertEmpty extends PureExpressionTest
                         "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
                         "{\n" +
                         "    assert($condition, | format($formatString, $formatArgs));\n" +
-                        "}"
+                        "}\n"
         );
-    }
-
-    protected static FunctionExecution getFunctionExecution()
-    {
-        return new FunctionExecutionInterpreted();
     }
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertEqWithinTolerance.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertEqWithinTolerance.java
@@ -14,47 +14,26 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.function.base.asserts;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.PureExpressionTest;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestAssertEqWithinTolerance extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
 
     @Test
     public void testFailure()
     {
-        assertExpressionRaisesPureException("\nexpected: 1\nactual:   0", 3, 9, "assertEqWithinTolerance(1, 0, 0)",
-                "function meta::pure::functions::asserts::assertEqWithinTolerance(expected:Number[1], actual:Number[1], delta:Number[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assertEqWithinTolerance($expected, $actual, $delta, '\\nexpected: %r\\nactual:   %r', [$expected, $actual]);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertEqWithinTolerance(expected:Number[1], actual:Number[1], delta:Number[1], message:String[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assert(abs($expected - $actual) <= abs($delta), $message);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertEqWithinTolerance(expected:Number[1], actual:Number[1], delta:Number[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-                "{\n" +
-                "    assert(abs($expected - $actual) <= abs($delta), $formatString, $formatArgs);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertEqWithinTolerance(expected:Number[1], actual:Number[1], delta:Number[1], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assert(abs($expected - $actual) <= abs($delta), $message);\n" +
-                "}" +
-                "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-                "{\n" +
-                "    assert($condition, | format($formatString, $formatArgs));\n" +
-                "}");
+        assertExpressionRaisesPureException("\nexpected: 1\nactual:   0", 3, 9, "assertEqWithinTolerance(1, 0, 0)");
         assertExpressionRaisesPureException("\nexpected: 2.718271828459045\nactual:   2.718281828459045", 3, 9, "assertEqWithinTolerance(2.718271828459045, 2.718281828459045, 0.000000001)");
         assertExpressionRaisesPureException("\nexpected: 2.718281828459045\nactual:   2.7182818284590455", 3, 9, "assertEqWithinTolerance(2.718281828459045, 2.7182818284590455, 0.0000000000000001)");
     }
@@ -62,5 +41,34 @@ public class TestAssertEqWithinTolerance extends PureExpressionTest
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionInterpreted();
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair(
+                "testAssertEqWithTolerance.pure",
+                "function meta::pure::functions::asserts::assertEqWithinTolerance(expected:Number[1], actual:Number[1], delta:Number[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assertEqWithinTolerance($expected, $actual, $delta, '\\nexpected: %r\\nactual:   %r', [$expected, $actual]);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertEqWithinTolerance(expected:Number[1], actual:Number[1], delta:Number[1], message:String[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(abs($expected - $actual) <= abs($delta), $message);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertEqWithinTolerance(expected:Number[1], actual:Number[1], delta:Number[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(abs($expected - $actual) <= abs($delta), $formatString, $formatArgs);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertEqWithinTolerance(expected:Number[1], actual:Number[1], delta:Number[1], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(abs($expected - $actual) <= abs($delta), $message);\n" +
+                        "}" +
+                        "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert($condition, | format($formatString, $formatArgs));\n" +
+                        "}");
     }
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertEquals.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertEquals.java
@@ -25,30 +25,10 @@ import org.junit.Test;
 public class TestAssertEquals extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), extra);
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
-
-    public static Pair<String, String> extra = Tuples.pair("/system/extra.pure","function meta::pure::functions::asserts::assertEquals(expected:Any[*], actual:Any[*]):Boolean[1]\n" +
-            "{\n" +
-            "    if(eq($expected->size(), 1) && eq($actual->size(), 1),\n" +
-            "       | assertEquals($expected, $actual, '\\nexpected: %r\\nactual:   %r', [$expected->toOne(), $actual->toOne()]),\n" +
-            "       | assertEquals($expected, $actual, '\\nexpected: %s\\nactual:   %s', [$expected->map(x | $x->toRepresentation())->joinStrings('[', ', ', ']'), $actual->map(x | $x->toRepresentation())->joinStrings('[', ', ', ']')]));\n" +
-            "}\n" +
-            "\n" +
-            "function meta::pure::functions::asserts::assertEquals(expected:Any[*], actual:Any[*], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-            "{\n" +
-            "    assert(equal($expected, $actual), $formatString, $formatArgs);\n" +
-            "}\n" +
-            "\n" +
-            "function meta::pure::functions::asserts::assertEquals(expected:Any[*], actual:Any[*], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
-            "{\n" +
-            "    assert(equal($expected, $actual), $message);\n" +
-            "}" +
-            "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-            "{\n" +
-            "    assert($condition, | format($formatString, $formatArgs));\n" +
-            "}");
 
     @Test
     public void testFailure()
@@ -67,5 +47,31 @@ public class TestAssertEquals extends PureExpressionTest
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionInterpreted();
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair(
+                "testAssertEquals.pure",
+                "function meta::pure::functions::asserts::assertEquals(expected:Any[*], actual:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    if(eq($expected->size(), 1) && eq($actual->size(), 1),\n" +
+                        "       | assertEquals($expected, $actual, '\\nexpected: %r\\nactual:   %r', [$expected->toOne(), $actual->toOne()]),\n" +
+                        "       | assertEquals($expected, $actual, '\\nexpected: %s\\nactual:   %s', [$expected->map(x | $x->toRepresentation())->joinStrings('[', ', ', ']'), $actual->map(x | $x->toRepresentation())->joinStrings('[', ', ', ']')]));\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertEquals(expected:Any[*], actual:Any[*], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(equal($expected, $actual), $formatString, $formatArgs);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertEquals(expected:Any[*], actual:Any[*], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(equal($expected, $actual), $message);\n" +
+                        "}" +
+                        "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert($condition, | format($formatString, $formatArgs));\n" +
+                        "}\n");
     }
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertFalse.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertFalse.java
@@ -25,37 +25,10 @@ import org.junit.Test;
 public class TestAssertFalse extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), extra);
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
-
-    public static Pair<String, String> extra = Tuples.pair("/system/extra.pure","function meta::pure::functions::asserts::assertFalse(condition:Boolean[1]):Boolean[1]\n" +
-        "{\n" +
-        "    assert(!$condition);\n" +
-        "}\n" +
-        "\n" +
-        "function meta::pure::functions::asserts::assertFalse(condition:Boolean[1], message:String[1]):Boolean[1]\n" +
-        "{\n" +
-        "    assert(!$condition, $message);\n" +
-        "}\n" +
-        "\n" +
-        "function meta::pure::functions::asserts::assertFalse(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-        "{\n" +
-        "    assert(!$condition, $formatString, $formatArgs);\n" +
-        "}\n" +
-        "\n" +
-        "function meta::pure::functions::asserts::assertFalse(condition:Boolean[1], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
-        "{\n" +
-        "    assert(!$condition, $message);\n" +
-        "}\n" +
-        "function meta::pure::functions::asserts::assert(condition:Boolean[1]):Boolean[1]\n" +
-        "{\n" +
-        "    assert($condition, 'Assert failed');\n" +
-        "}"+
-        "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-        "{\n" +
-        "    assert($condition, | format($formatString, $formatArgs));\n" +
-        "}");
 
     @Test
     public void testFailWithoutMessage()
@@ -88,5 +61,36 @@ public class TestAssertFalse extends PureExpressionTest
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionInterpreted();
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair("testAssertFalse.pure", "function meta::pure::functions::asserts::assertFalse(condition:Boolean[1]):Boolean[1]\n" +
+                "{\n" +
+                "    assert(!$condition);\n" +
+                "}\n" +
+                "\n" +
+                "function meta::pure::functions::asserts::assertFalse(condition:Boolean[1], message:String[1]):Boolean[1]\n" +
+                "{\n" +
+                "    assert(!$condition, $message);\n" +
+                "}\n" +
+                "\n" +
+                "function meta::pure::functions::asserts::assertFalse(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                "{\n" +
+                "    assert(!$condition, $formatString, $formatArgs);\n" +
+                "}\n" +
+                "\n" +
+                "function meta::pure::functions::asserts::assertFalse(condition:Boolean[1], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
+                "{\n" +
+                "    assert(!$condition, $message);\n" +
+                "}\n" +
+                "function meta::pure::functions::asserts::assert(condition:Boolean[1]):Boolean[1]\n" +
+                "{\n" +
+                "    assert($condition, 'Assert failed');\n" +
+                "}" +
+                "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                "{\n" +
+                "    assert($condition, | format($formatString, $formatArgs));\n" +
+                "}");
     }
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertInstanceOf.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertInstanceOf.java
@@ -14,24 +14,36 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.function.base.asserts;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.PureExpressionTest;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestAssertInstanceOf extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
 
     @Test
     public void testFailure()
     {
-        assertExpressionRaisesPureException("expected 3 to be an instance of Boolean, actual: Integer", 3, 9, "assertInstanceOf(3, Boolean)",
+        assertExpressionRaisesPureException("expected 3 to be an instance of Boolean, actual: Integer", 3, 9, "assertInstanceOf(3, Boolean)");
+    }
+
+    protected static FunctionExecution getFunctionExecution()
+    {
+        return new FunctionExecutionInterpreted();
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair("testAssertInstancesOf.pure",
                 "function meta::pure::functions::asserts::assertInstanceOf(instance:Any[1], type:Type[1]):Boolean[1]\n" +
                         "{\n" +
                         "    assertInstanceOf($instance, $type, | format('expected %r to be an instance of %s, actual: %s', [$instance, $type->elementToPath(), $instance->type()->toOne()->elementToPath()]));\n" +
@@ -54,12 +66,6 @@ public class TestAssertInstanceOf extends PureExpressionTest
                         "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
                         "{\n" +
                         "    assert($condition, | format($formatString, $formatArgs));\n" +
-                        "}"
-        );
-    }
-
-    protected static FunctionExecution getFunctionExecution()
-    {
-        return new FunctionExecutionInterpreted();
+                        "}");
     }
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertNotContains.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertNotContains.java
@@ -14,23 +14,36 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.function.base.asserts;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.PureExpressionTest;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestAssertNotContains extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
+
     @Test
     public void testFailure()
     {
-        assertExpressionRaisesPureException("[1, 2, 5, 2, 'a', true, %2014-02-01, 'c'] should not contain true", 3, 9, "assertNotContains([1, 2, 5, 2, 'a', true, %2014-02-01, 'c'], true)",
+        assertExpressionRaisesPureException("[1, 2, 5, 2, 'a', true, %2014-02-01, 'c'] should not contain true", 3, 9, "assertNotContains([1, 2, 5, 2, 'a', true, %2014-02-01, 'c'], true)");
+    }
+
+    protected static FunctionExecution getFunctionExecution()
+    {
+        return new FunctionExecutionInterpreted();
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair("testAssertNotContains.pure",
                 "function meta::pure::functions::asserts::assertNotContains(collection:Any[*], value:Any[1]):Boolean[1]\n" +
                         "{\n" +
                         "    assertNotContains($collection, $value, | format('%s should not contain %r', [$collection->map(v | $v->toRepresentation())->joinStrings('[', ', ', ']'), $value]));\n" +
@@ -53,11 +66,7 @@ public class TestAssertNotContains extends PureExpressionTest
                         "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
                         "{\n" +
                         "    assert($condition, | format($formatString, $formatArgs));\n" +
-                        "}");
-    }
-
-    protected static FunctionExecution getFunctionExecution()
-    {
-        return new FunctionExecutionInterpreted();
+                        "}"
+        );
     }
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertNotEmpty.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertNotEmpty.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.function.base.asserts;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.PureExpressionTest;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
@@ -23,13 +25,25 @@ import org.junit.Test;
 public class TestAssertNotEmpty extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
+
     @Test
     public void testFailure()
     {
-        assertExpressionRaisesPureException("Expected non-empty collection", 3, 9, "assertNotEmpty([1, 2, 3]->filter(x | $x == 5))",
+        assertExpressionRaisesPureException("Expected non-empty collection", 3, 9, "assertNotEmpty([1, 2, 3]->filter(x | $x == 5))");
+    }
+
+    protected static FunctionExecution getFunctionExecution()
+    {
+        return new FunctionExecutionInterpreted();
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair("testAssertNotEmpty.pure",
                 "function meta::pure::functions::asserts::assertNotEmpty(collection:Any[*]):Boolean[1]\n" +
                         "{\n" +
                         "    assertNotEmpty($collection, 'Expected non-empty collection');\n" +
@@ -76,12 +90,7 @@ public class TestAssertNotEmpty extends PureExpressionTest
                         "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
                         "{\n" +
                         "    assert($condition, | format($formatString, $formatArgs));\n" +
-                        "}");
-    }
-
-    protected static FunctionExecution getFunctionExecution()
-    {
-        return new FunctionExecutionInterpreted();
+                        "}"
+        );
     }
 }
-

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertNotEquals.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertNotEquals.java
@@ -25,36 +25,10 @@ import org.junit.Test;
 public class TestAssertNotEquals extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), extra);
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
-
-    public static Pair<String, String> extra = Tuples.pair("/system/extra.pure","function meta::pure::functions::asserts::assertNotEquals(notExpected:Any[*], actual:Any[*]):Boolean[1]\n" +
-            "{\n" +
-            "    if(eq($notExpected->size(), 1) && eq($actual->size(), 1),\n" +
-            "       | assertNotEquals($notExpected, $actual, '%r should not equal %r', [$notExpected->toOne(), $actual->toOne()]),\n" +
-            "       | assertNotEquals($notExpected, $actual, | $notExpected->map(e | $e->toRepresentation())->joinStrings('[', ', ', ']') + ' should not equal ' + $actual->map(a | $a->toRepresentation())->joinStrings('[', ', ', ']')))\n" +
-            "}\n" +
-            "\n" +
-            "function meta::pure::functions::asserts::assertNotEquals(notExpected:Any[*], actual:Any[*], message:String[1]):Boolean[1]\n" +
-            "{\n" +
-            "    assert(!equal($notExpected, $actual), $message);\n" +
-            "}\n" +
-            "\n" +
-            "function meta::pure::functions::asserts::assertNotEquals(notExpected:Any[*], actual:Any[*], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-            "{\n" +
-            "    assert(!equal($notExpected, $actual), $formatString, $formatArgs);\n" +
-            "}\n" +
-            "\n" +
-            "function meta::pure::functions::asserts::assertNotEquals(notExpected:Any[*], actual:Any[*], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
-            "{\n" +
-            "    assert(!equal($notExpected, $actual), $message);\n" +
-            "}\n" +
-            "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-            "{\n" +
-            "    assert($condition, | format($formatString, $formatArgs));\n" +
-            "}");
-    ;
 
     @Test
     public void testFailure()
@@ -73,5 +47,36 @@ public class TestAssertNotEquals extends PureExpressionTest
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionInterpreted();
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair("testAssertNotEquals.pure",
+                "function meta::pure::functions::asserts::assertNotEquals(notExpected:Any[*], actual:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    if(eq($notExpected->size(), 1) && eq($actual->size(), 1),\n" +
+                        "       | assertNotEquals($notExpected, $actual, '%r should not equal %r', [$notExpected->toOne(), $actual->toOne()]),\n" +
+                        "       | assertNotEquals($notExpected, $actual, | $notExpected->map(e | $e->toRepresentation())->joinStrings('[', ', ', ']') + ' should not equal ' + $actual->map(a | $a->toRepresentation())->joinStrings('[', ', ', ']')))\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertNotEquals(notExpected:Any[*], actual:Any[*], message:String[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(!equal($notExpected, $actual), $message);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertNotEquals(notExpected:Any[*], actual:Any[*], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(!equal($notExpected, $actual), $formatString, $formatArgs);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertNotEquals(notExpected:Any[*], actual:Any[*], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(!equal($notExpected, $actual), $message);\n" +
+                        "}\n" +
+                        "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert($condition, | format($formatString, $formatArgs));\n" +
+                        "}"
+        );
     }
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertNotSize.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertNotSize.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.function.base.asserts;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.PureExpressionTest;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
@@ -23,58 +25,67 @@ import org.junit.Test;
 public class TestAssertNotSize extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
+
     @Test
     public void testFailure()
     {
-        assertExpressionRaisesPureException("size should not equal: 2", 3, 9, "assertNotSize([1, 2], 2)", "function meta::pure::functions::asserts::assertNotSize(collection:Any[*], size:Integer[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assertNotSize($collection, $size, | format('size should not equal: %s', [$size]));\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertNotSize(collection:Any[*], size:Integer[1], message:String[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assertNotEq($size, $collection->size(), $message);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertNotSize(collection:Any[*], size:Integer[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-                "{\n" +
-                "    assertNotEq($size, $collection->size(), $formatString, $formatArgs);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertNotSize(collection:Any[*], size:Integer[1], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assertNotEq($size, $collection->size(), $message);\n" +
-                "}" +
-                "function meta::pure::functions::asserts::assertNotEq(notExpected:Any[1], actual:Any[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assertNotEq($notExpected, $actual, '%r should not equal %r', [$notExpected, $actual]);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertNotEq(notExpected:Any[1], actual:Any[1], message:String[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assert(!eq($notExpected, $actual), $message);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertNotEq(notExpected:Any[1], actual:Any[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-                "{\n" +
-                "    assert(!eq($notExpected, $actual), $formatString, $formatArgs);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertNotEq(notExpected:Any[1], actual:Any[1], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assert(!eq($notExpected, $actual), $message);\n" +
-                "}"+
-                "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-                "{\n" +
-                "    assert($condition, | format($formatString, $formatArgs));\n" +
-                "}");
+        assertExpressionRaisesPureException("size should not equal: 2", 3, 9, "assertNotSize([1, 2], 2)");
     }
 
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionInterpreted();
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair("testAssertNotEquals.pure",
+                "function meta::pure::functions::asserts::assertNotSize(collection:Any[*], size:Integer[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assertNotSize($collection, $size, | format('size should not equal: %s', [$size]));\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertNotSize(collection:Any[*], size:Integer[1], message:String[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assertNotEq($size, $collection->size(), $message);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertNotSize(collection:Any[*], size:Integer[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assertNotEq($size, $collection->size(), $formatString, $formatArgs);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertNotSize(collection:Any[*], size:Integer[1], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assertNotEq($size, $collection->size(), $message);\n" +
+                        "}" +
+                        "function meta::pure::functions::asserts::assertNotEq(notExpected:Any[1], actual:Any[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assertNotEq($notExpected, $actual, '%r should not equal %r', [$notExpected, $actual]);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertNotEq(notExpected:Any[1], actual:Any[1], message:String[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(!eq($notExpected, $actual), $message);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertNotEq(notExpected:Any[1], actual:Any[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(!eq($notExpected, $actual), $formatString, $formatArgs);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertNotEq(notExpected:Any[1], actual:Any[1], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(!eq($notExpected, $actual), $message);\n" +
+                        "}" +
+                        "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert($condition, | format($formatString, $formatArgs));\n" +
+                        "}"
+        );
     }
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertSameElements.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertSameElements.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.function.base.asserts;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.PureExpressionTest;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
@@ -23,66 +25,15 @@ import org.junit.Test;
 public class TestAssertSameElements extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
 
     @Test
     public void testFailure()
     {
-        assertExpressionRaisesPureException("\nexpected: [1, 2, 3]\nactual:   [1, 2, 4, 5]", 3, 9, "assertSameElements([1, 3, 2], [2, 4, 1, 5])", "function meta::pure::functions::asserts::assertSameElements(expected:Any[*], actual:Any[*]):Boolean[1]\n" +
-                "{\n" +
-                "    assertSameElements($expected, $actual, | $expected->sort()->map(e | $e->toRepresentation())->joinStrings('\\nexpected: [', ', ', ']') + $actual->sort()->map(a | $a->toRepresentation())->joinStrings('\\nactual:   [', ', ', ']'));\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertSameElements(expected:Any[*], actual:Any[*], message:String[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assertEquals($expected->sort(), $actual->sort(), $message);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertSameElements(expected:Any[*], actual:Any[*], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-                "{\n" +
-                "    assertEquals($expected->sort(), $actual->sort(), $formatString, $formatArgs);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertSameElements(expected:Any[*], actual:Any[*], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assertEquals($expected->sort(), $actual->sort(), $message);\n" +
-                "}" +
-                "function meta::pure::functions::collection::sort<T|m>(col:T[m], comp:Function<{T[1],T[1]->Integer[1]}>[0..1]):T[m]\n" +
-                "{\n" +
-                "    sort($col, [], $comp)\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::collection::sortBy<T,U|m>(col:T[m], key:Function<{T[1]->U[1]}>[0..1]):T[m]\n" +
-                "{\n" +
-                "    sort($col, $key, [])\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::collection::sort<T|m>(col:T[m]):T[m]\n" +
-                "{\n" +
-                "    sort($col, [], [])\n" +
-                "}" +
-                "function meta::pure::functions::asserts::assertEquals(expected:Any[*], actual:Any[*]):Boolean[1]\n" +
-                "{\n" +
-                "    if(eq($expected->size(), 1) && eq($actual->size(), 1),\n" +
-                "       | assertEquals($expected, $actual, '\\nexpected: %r\\nactual:   %r', [$expected->toOne(), $actual->toOne()]),\n" +
-                "       | assertEquals($expected, $actual, '\\nexpected: %s\\nactual:   %s', [$expected->map(x | $x->toRepresentation())->joinStrings('[', ', ', ']'), $actual->map(x | $x->toRepresentation())->joinStrings('[', ', ', ']')]));\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertEquals(expected:Any[*], actual:Any[*], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-                "{\n" +
-                "    assert(equal($expected, $actual), $formatString, $formatArgs);\n" +
-                "}\n" +
-                "\n" +
-                "function meta::pure::functions::asserts::assertEquals(expected:Any[*], actual:Any[*], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
-                "{\n" +
-                "    assert(equal($expected, $actual), $message);\n" +
-                "}" +
-                "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
-                "{\n" +
-                "    assert($condition, | format($formatString, $formatArgs));\n" +
-                "}");
+        assertExpressionRaisesPureException("\nexpected: [1, 2, 3]\nactual:   [1, 2, 4, 5]", 3, 9, "assertSameElements([1, 3, 2], [2, 4, 1, 5])");
         assertExpressionRaisesPureException("\nexpected: [1, 3, '2']\nactual:   [1, 4, 5, '2']", 3, 9, "assertSameElements([1, 3, '2'], ['2', 4, 1, 5])");
     }
 
@@ -90,5 +41,63 @@ public class TestAssertSameElements extends PureExpressionTest
     {
         return new FunctionExecutionInterpreted();
     }
-}
 
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair("testAssertSameElements.pure",
+                "function meta::pure::functions::asserts::assertSameElements(expected:Any[*], actual:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assertSameElements($expected, $actual, | $expected->sort()->map(e | $e->toRepresentation())->joinStrings('\\nexpected: [', ', ', ']') + $actual->sort()->map(a | $a->toRepresentation())->joinStrings('\\nactual:   [', ', ', ']'));\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertSameElements(expected:Any[*], actual:Any[*], message:String[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assertEquals($expected->sort(), $actual->sort(), $message);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertSameElements(expected:Any[*], actual:Any[*], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assertEquals($expected->sort(), $actual->sort(), $formatString, $formatArgs);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertSameElements(expected:Any[*], actual:Any[*], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assertEquals($expected->sort(), $actual->sort(), $message);\n" +
+                        "}" +
+                        "function meta::pure::functions::collection::sort<T|m>(col:T[m], comp:Function<{T[1],T[1]->Integer[1]}>[0..1]):T[m]\n" +
+                        "{\n" +
+                        "    sort($col, [], $comp)\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::collection::sortBy<T,U|m>(col:T[m], key:Function<{T[1]->U[1]}>[0..1]):T[m]\n" +
+                        "{\n" +
+                        "    sort($col, $key, [])\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::collection::sort<T|m>(col:T[m]):T[m]\n" +
+                        "{\n" +
+                        "    sort($col, [], [])\n" +
+                        "}" +
+                        "function meta::pure::functions::asserts::assertEquals(expected:Any[*], actual:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    if(eq($expected->size(), 1) && eq($actual->size(), 1),\n" +
+                        "       | assertEquals($expected, $actual, '\\nexpected: %r\\nactual:   %r', [$expected->toOne(), $actual->toOne()]),\n" +
+                        "       | assertEquals($expected, $actual, '\\nexpected: %s\\nactual:   %s', [$expected->map(x | $x->toRepresentation())->joinStrings('[', ', ', ']'), $actual->map(x | $x->toRepresentation())->joinStrings('[', ', ', ']')]));\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertEquals(expected:Any[*], actual:Any[*], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(equal($expected, $actual), $formatString, $formatArgs);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function meta::pure::functions::asserts::assertEquals(expected:Any[*], actual:Any[*], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(equal($expected, $actual), $message);\n" +
+                        "}" +
+                        "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert($condition, | format($formatString, $formatArgs));\n" +
+                        "}"
+        );
+    }
+}

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertSize.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestAssertSize.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.function.base.asserts;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.PureExpressionTest;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
@@ -23,14 +25,25 @@ import org.junit.Test;
 public class TestAssertSize extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
 
     @Test
     public void testFailure()
     {
-        assertExpressionRaisesPureException("expected size: 3, actual size: 2", 3, 9, "assertSize([1, 2], 3)",
+        assertExpressionRaisesPureException("expected size: 3, actual size: 2", 3, 9, "assertSize([1, 2], 3)");
+    }
+
+    protected static FunctionExecution getFunctionExecution()
+    {
+        return new FunctionExecutionInterpreted();
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair("testAssertSize.pure",
                 "function meta::pure::functions::asserts::assertSize(collection:Any[*], size:Integer[1]):Boolean[1]\n" +
                         "{\n" +
                         "    assertSize($collection, $size, 'expected size: %s, actual size: %s', [$size, $collection->size()]);\n" +
@@ -67,15 +80,11 @@ public class TestAssertSize extends PureExpressionTest
                         "function meta::pure::functions::asserts::assertEq(expected:Any[1], actual:Any[1], message:Function<{->String[1]}>[1]):Boolean[1]\n" +
                         "{\n" +
                         "    assert(eq($expected, $actual), $message);\n" +
-                        "}\n"+
+                        "}\n" +
                         "function meta::pure::functions::asserts::assert(condition:Boolean[1], formatString:String[1], formatArgs:Any[*]):Boolean[1]\n" +
                         "{\n" +
                         "    assert($condition, | format($formatString, $formatArgs));\n" +
-                        "}");
-    }
-
-    protected static FunctionExecution getFunctionExecution()
-    {
-        return new FunctionExecutionInterpreted();
+                        "}"
+        );
     }
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestFail.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/asserts/TestFail.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.function.base.asserts;
 
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.PureExpressionTest;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
@@ -23,22 +25,15 @@ import org.junit.Test;
 public class TestFail extends PureExpressionTest
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getExtra());
     }
 
     @Test
     public void testFail()
     {
-        assertExpressionRaisesPureException("Assert failed", 3, 9, "fail()",
-                "function meta::pure::functions::asserts::fail():Boolean[1]\n" +
-                "{\n" +
-                "    assert(false);\n" +
-                "}\n" +
-                        "function meta::pure::functions::asserts::assert(condition:Boolean[1]):Boolean[1]\n" +
-                        "{\n" +
-                        "    assert($condition, 'Assert failed');\n" +
-                        "}");
+        assertExpressionRaisesPureException("Assert failed", 3, 9, "fail()");
     }
 
     @Test
@@ -50,5 +45,19 @@ public class TestFail extends PureExpressionTest
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionInterpreted();
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair("testFail.pure",
+                "function meta::pure::functions::asserts::fail():Boolean[1]\n" +
+                        "{\n" +
+                        "    assert(false);\n" +
+                        "}\n" +
+                        "function meta::pure::functions::asserts::assert(condition:Boolean[1]):Boolean[1]\n" +
+                        "{\n" +
+                        "    assert($condition, 'Assert failed');\n" +
+                        "}"
+        );
     }
 }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/lang/TestCast.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/lang/TestCast.java
@@ -24,7 +24,7 @@ public class TestCast extends AbstractTestCast
     @BeforeClass
     public static void setUp()
     {
-        setUpRuntime(getFunctionExecution());
+        setUpRuntime(getFunctionExecution(), getCodeStorage(), getExtra());
     }
 
     protected static FunctionExecution getFunctionExecution()

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/lang/TestCopy.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/lang/TestCopy.java
@@ -17,19 +17,16 @@ package org.finos.legend.pure.runtime.java.interpreted.function.base.lang;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.lang.AbstractTestCopyAtRuntime;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestCopy extends AbstractTestCopyAtRuntime
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getFunctionExecution());
     }
-    @After
-    public void cleanRuntime() {
-        runtime.delete("fromString.pure");
-    }
+
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionInterpreted();

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/lang/TestNew.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/lang/TestNew.java
@@ -17,9 +17,7 @@ package org.finos.legend.pure.runtime.java.interpreted.function.base.lang;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.lang.AbstractTestNewAtRuntime;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -27,19 +25,9 @@ import org.junit.Test;
 public class TestNew extends AbstractTestNewAtRuntime
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
-    }
-    @After
-    public void cleanRuntime() {
-        runtime.delete("fromString.pure");
-        runtime.delete("/test/testModel.pure");
-
-        try{
-            runtime.compile();
-        } catch (PureCompilationException e) {
-            setUp();
-        }
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
     }
 
     @Test
@@ -62,207 +50,172 @@ public class TestNew extends AbstractTestNewAtRuntime
     @Test
     public void testNewWithMissingOneToOneProperty()
     {
-        this.compileTestSource("fromString.pure",
+        compileTestSource("fromString.pure",
                 "function test(): Any[*]\n" +
-                "{\n" +
-                "   ^test::Owner(firstName='John', lastName='Roe')\n" +
-                "}\n" +
-                "\n" +
-                "Class\n" +
-                "test::Car\n" +
-                "{\n" +
-                "   name : String[1];\n" +
-                "}\n" +
-                "\n" +
-                "Class\n" +
-                "test::Owner\n" +
-                "{\n" +
-                "   firstName: String[1];\n" +
-                "   lastName: String[1];\n" +
-                "}\n" +
-                "\n" +
-                "Association test::Car_Owner\n" +
-                "{\n" +
-                "   owner : test::Owner[1];\n" +
-                "   car  : test::Car[1];\n" +
-                "}");
-        try
-        {
-            this.execute("test():Any[*]");
-            Assert.fail("Should fail with multiplicity violation.");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureExecutionException.class, "Error instantiating class 'Owner'.  The following properties have multiplicity violations: 'car' requires 1 value, got 0", "fromString.pure", 3, 4, e);
-        }
+                        "{\n" +
+                        "   ^test::Owner(firstName='John', lastName='Roe')\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class\n" +
+                        "test::Car\n" +
+                        "{\n" +
+                        "   name : String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class\n" +
+                        "test::Owner\n" +
+                        "{\n" +
+                        "   firstName: String[1];\n" +
+                        "   lastName: String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Association test::Car_Owner\n" +
+                        "{\n" +
+                        "   owner : test::Owner[1];\n" +
+                        "   car  : test::Car[1];\n" +
+                        "}");
+        PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> execute("test():Any[*]"));
+        assertPureException(PureExecutionException.class, "Error instantiating class 'Owner'.  The following properties have multiplicity violations: 'car' requires 1 value, got 0", "fromString.pure", 3, 4, e);
     }
 
     @Test
     public void testNewWithMissingOneToManyProperty()
     {
-        this.compileTestSource("fromString.pure",
+        compileTestSource("fromString.pure",
                 "function test(): Any[*]\n" +
-                "{\n" +
-                "   ^test::Owner(firstName='John', lastName='Roe')\n" +
-                "}\n" +
-                "\n" +
-                "Class\n" +
-                "test::Car\n" +
-                "{\n" +
-                "   name : String[1];\n" +
-                "}\n" +
-                "\n" +
-                "Class\n" +
-                "test::Owner\n" +
-                "{\n" +
-                "   firstName: String[1];\n" +
-                "   lastName: String[1];\n" +
-                "}\n" +
-                "\n" +
-                "Association test::Car_Owner\n" +
-                "{\n" +
-                "   owner : test::Owner[1];\n" +
-                "   cars  : test::Car[1..*];\n" +
-                "}");
-        try
-        {
-            this.execute("test():Any[*]");
-            Assert.fail("Should fail with multiplicity violation.");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureExecutionException.class, "Error instantiating class 'Owner'.  The following properties have multiplicity violations: 'cars' requires 1..* values, got 0", "fromString.pure", 3, 4, e);
-        }
+                        "{\n" +
+                        "   ^test::Owner(firstName='John', lastName='Roe')\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class\n" +
+                        "test::Car\n" +
+                        "{\n" +
+                        "   name : String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class\n" +
+                        "test::Owner\n" +
+                        "{\n" +
+                        "   firstName: String[1];\n" +
+                        "   lastName: String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Association test::Car_Owner\n" +
+                        "{\n" +
+                        "   owner : test::Owner[1];\n" +
+                        "   cars  : test::Car[1..*];\n" +
+                        "}");
+        PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> execute("test():Any[*]"));
+        assertPureException(PureExecutionException.class, "Error instantiating class 'Owner'.  The following properties have multiplicity violations: 'cars' requires 1..* values, got 0", "fromString.pure", 3, 4, e);
     }
 
     @Test
     public void testNewWithChildWithMismatchedReverseOneToOneProperty()
     {
-        this.compileTestSource("fromString.pure",
+        compileTestSource("fromString.pure",
                 "function test(): Any[*]\n" +
-                "{\n" +
-                "   ^test::Car(name='Bugatti', owner= ^test::Owner(firstName='John', lastName='Roe', car=^test::Car(name='Audi')))\n" +
-                "}\n" +
-                "\n" +
-                "Class\n" +
-                "test::Car\n" +
-                "{\n" +
-                "   name : String[1];\n" +
-                "}\n" +
-                "\n" +
-                "Class\n" +
-                "test::Owner\n" +
-                "{\n" +
-                "   firstName: String[1];\n" +
-                "   lastName: String[1];\n" +
-                "}\n" +
-                "\n" +
-                "Association test::Car_Owner\n" +
-                "{\n" +
-                "   owner : test::Owner[1];\n" +
-                "   car  : test::Car[1];\n" +
-                "}");
-        try
-        {
-            this.execute("test():Any[*]");
-            Assert.fail("Should fail with multiplicity violation.");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureExecutionException.class, "Error instantiating the type 'Owner'. The property 'car' has a multiplicity range of [1] when the given list has a cardinality equal to 2", "fromString.pure", 3, 4, e);
-        }
+                        "{\n" +
+                        "   ^test::Car(name='Bugatti', owner= ^test::Owner(firstName='John', lastName='Roe', car=^test::Car(name='Audi')))\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class\n" +
+                        "test::Car\n" +
+                        "{\n" +
+                        "   name : String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class\n" +
+                        "test::Owner\n" +
+                        "{\n" +
+                        "   firstName: String[1];\n" +
+                        "   lastName: String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Association test::Car_Owner\n" +
+                        "{\n" +
+                        "   owner : test::Owner[1];\n" +
+                        "   car  : test::Car[1];\n" +
+                        "}");
+        PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> execute("test():Any[*]"));
+        assertPureException(PureExecutionException.class, "Error instantiating the type 'Owner'. The property 'car' has a multiplicity range of [1] when the given list has a cardinality equal to 2", "fromString.pure", 3, 4, e);
     }
 
     @Override
     public void testNewWithInheritenceAndOverriddenAssociationEndWithReverseOneToOneProperty()
     {
-        this.compileTestSource("fromString.pure",
+        compileTestSource("fromString.pure",
                 "function test(): Any[*]\n" +
-                "{\n" +
-                "   let car = ^test::FastCar(name='Bugatti', owner= ^test::Owner(firstName='John', lastName='Roe'));\n" +
-                "   print($car.owner.car->size()->toString(), 1);\n" +
-                "   $car;" +
-                "}\n" +
-                "\n" +
-                "Class\n" +
-                "test::Car\n" +
-                "{\n" +
-                "   name : String[1];\n" +
-                "}\n" +
-                "\n" +
-                "Class\n" +
-                "test::FastCar extends test::Car\n" +
-                "{\n" +
-                "   owner : test::Owner[1];\n" +
-                "}" +
-                "\n" +
-                "Class\n" +
-                "test::Owner\n" +
-                "{\n" +
-                "   firstName: String[1];\n" +
-                "   lastName: String[1];\n" +
-                "}\n" +
-                "\n" +
-                "Association test::Car_Owner\n" +
-                "{\n" +
-                "   owner : test::Owner[1];\n" +
-                "   car  : test::Car[1];\n" +
-                "}");
-        try
-        {
-            this.execute("test():Any[*]");
-            Assert.fail("Should fail with multiplicity violation.");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureExecutionException.class, "Error instantiating class 'Owner'.  The following properties have multiplicity violations: 'car' requires 1 value, got 0", "fromString.pure", 3, 14, e);
-        }
+                        "{\n" +
+                        "   let car = ^test::FastCar(name='Bugatti', owner= ^test::Owner(firstName='John', lastName='Roe'));\n" +
+                        "   print($car.owner.car->size()->toString(), 1);\n" +
+                        "   $car;" +
+                        "}\n" +
+                        "\n" +
+                        "Class\n" +
+                        "test::Car\n" +
+                        "{\n" +
+                        "   name : String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class\n" +
+                        "test::FastCar extends test::Car\n" +
+                        "{\n" +
+                        "   owner : test::Owner[1];\n" +
+                        "}" +
+                        "\n" +
+                        "Class\n" +
+                        "test::Owner\n" +
+                        "{\n" +
+                        "   firstName: String[1];\n" +
+                        "   lastName: String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Association test::Car_Owner\n" +
+                        "{\n" +
+                        "   owner : test::Owner[1];\n" +
+                        "   car  : test::Car[1];\n" +
+                        "}");
+        PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> execute("test():Any[*]"));
+        assertPureException(PureExecutionException.class, "Error instantiating class 'Owner'.  The following properties have multiplicity violations: 'car' requires 1 value, got 0", "fromString.pure", 3, 14, e);
     }
 
     @Override
     public void testNewWithInheritenceAndOverriddenAssociationEndWithReverseOneToManyProperty()
     {
-        this.compileTestSource("fromString.pure",
+        compileTestSource("fromString.pure",
                 "function test(): Any[*]\n" +
-                "{\n" +
-                "   let car = ^test::FastCar(name='Bugatti', owner= ^test::Owner(firstName='John', lastName='Roe'));\n" +
-                "   print($car.owner.cars->size()->toString(), 1);\n" +
-                "   $car;" +
-                "}\n" +
-                "\n" +
-                "Class\n" +
-                "test::Car\n" +
-                "{\n" +
-                "   name : String[1];\n" +
-                "}\n" +
-                "\n" +
-                "Class\n" +
-                "test::FastCar extends test::Car\n" +
-                "{\n" +
-                "   owner : test::Owner[1];\n" +
-                "}" +
-                "\n" +
-                "Class\n" +
-                "test::Owner\n" +
-                "{\n" +
-                "   firstName: String[1];\n" +
-                "   lastName: String[1];\n" +
-                "}\n" +
-                "\n" +
-                "Association test::Car_Owner\n" +
-                "{\n" +
-                "   owner : test::Owner[1];\n" +
-                "   cars  : test::Car[1..*];\n" +
-                "}");
-        try
-        {
-            this.execute("test():Any[*]");
-            Assert.fail("Should fail with multiplicity violation.");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureExecutionException.class, "Error instantiating class 'Owner'.  The following properties have multiplicity violations: 'cars' requires 1..* values, got 0", "fromString.pure", 3, 14, e);
-        }
+                        "{\n" +
+                        "   let car = ^test::FastCar(name='Bugatti', owner= ^test::Owner(firstName='John', lastName='Roe'));\n" +
+                        "   print($car.owner.cars->size()->toString(), 1);\n" +
+                        "   $car;" +
+                        "}\n" +
+                        "\n" +
+                        "Class\n" +
+                        "test::Car\n" +
+                        "{\n" +
+                        "   name : String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class\n" +
+                        "test::FastCar extends test::Car\n" +
+                        "{\n" +
+                        "   owner : test::Owner[1];\n" +
+                        "}" +
+                        "\n" +
+                        "Class\n" +
+                        "test::Owner\n" +
+                        "{\n" +
+                        "   firstName: String[1];\n" +
+                        "   lastName: String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Association test::Car_Owner\n" +
+                        "{\n" +
+                        "   owner : test::Owner[1];\n" +
+                        "   cars  : test::Car[1..*];\n" +
+                        "}");
+        PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> execute("test():Any[*]"));
+        assertPureException(PureExecutionException.class, "Error instantiating class 'Owner'.  The following properties have multiplicity violations: 'cars' requires 1..* values, got 0", "fromString.pure", 3, 14, e);
     }
 
     protected static FunctionExecution getFunctionExecution()

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/string/TestChunk.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/string/TestChunk.java
@@ -17,19 +17,16 @@ package org.finos.legend.pure.runtime.java.interpreted.function.base.string;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.string.AbstractTestChunk;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestChunk extends AbstractTestChunk
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
     }
-    @After
-    public void cleanRuntime() {
-        runtime.delete("/test/testChunk.pure");
-    }
+
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionInterpreted();

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/incremental/TestIncrementalCompilationInterpreted.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/incremental/TestIncrementalCompilationInterpreted.java
@@ -16,56 +16,36 @@ package org.finos.legend.pure.runtime.java.interpreted.incremental;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.incremental.AbstractTestIncrementalCompilation;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestIncrementalCompilationInterpreted extends AbstractTestIncrementalCompilation
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution(), getCodeStorage(), getCodeRepositories());
-    }
-    @After
-    public void cleanRuntime() {
-        runtime.delete("s1.pure");
-        runtime.delete("s2.pure");
-        runtime.delete("s3.pure");
-        runtime.delete("s4.pure");
-        runtime.delete("s5.pure");
-        runtime.delete("sourceId1.pure");
-        runtime.delete("sourceId2.pure");
-        runtime.delete("sourceId3.pure");
-        runtime.delete("/model/sourceId1.pure");
-        runtime.delete("/model/domain/sourceId3.pure");
-        runtime.delete("/datamart_other/sourceId2.pure");
-        runtime.delete("/system/tests/sourceId1.pure");
-        runtime.delete("/system/tests/resources/sourceId2.pure");
-
-        try{
-            runtime.compile();
-        } catch (PureCompilationException e) {
-            setUp();
-        }
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
     }
 
     @Test
     @Override
-    public void test14() {
+    public void test14()
+    {
         super.test14();
     }
 
     @Test
     @Override
-    public void test20() {
+    public void test20()
+    {
         super.test20();
     }
 
     @Test
     @Override
-    public void test21() {
+    public void test21()
+    {
         super.test21();
     }
 

--- a/legend-pure-runtime-java-extension-external-json/src/test/java/org/finos/legend/pure/runtime/java/extension/external/json/compiled/natives/test/TestToJsonCompiled.java
+++ b/legend-pure-runtime-java-extension-external-json/src/test/java/org/finos/legend/pure/runtime/java/extension/external/json/compiled/natives/test/TestToJsonCompiled.java
@@ -16,29 +16,17 @@ package org.finos.legend.pure.runtime.java.extension.external.json.compiled.nati
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.json.AbstractTestToJson;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestToJsonCompiled extends AbstractTestToJson
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage(), getExtra());
     }
-    @After
-    public void cleanRuntime() {
-        runtime.delete("fromString.pure");
-        runtime.delete("/test/testFile.pure");
-        runtime.delete("/org/finos/legend/pure/m3/toJson/toJson.pure");
-        try {
-            runtime.compile();
-        } catch (PureCompilationException e)
-        {
-            setUp();
-        }
-    }
+
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();

--- a/legend-pure-runtime-java-extension-external-json/src/test/java/org/finos/legend/pure/runtime/java/extension/external/json/interpreted/natives/test/TestToJsonInterpreted.java
+++ b/legend-pure-runtime-java-extension-external-json/src/test/java/org/finos/legend/pure/runtime/java/extension/external/json/interpreted/natives/test/TestToJsonInterpreted.java
@@ -16,31 +16,17 @@ package org.finos.legend.pure.runtime.java.extension.external.json.interpreted.n
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.json.AbstractTestToJson;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
-import org.finos.legend.pure.runtime.java.extension.external.json.interpreted.JsonExtensionInterpreted;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestToJsonInterpreted extends AbstractTestToJson
 {
     @BeforeClass
-    public static void setUp() {
-        setUpRuntime(getFunctionExecution());
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage(), getExtra());
     }
-    @After
-    public void cleanRuntime() {
-        runtime.delete("fromString.pure");
-        runtime.delete("/test/testFile.pure");
-        runtime.delete("/org/finos/legend/pure/m3/toJson/toJson.pure");
 
-        try {
-            runtime.compile();
-        } catch (PureCompilationException e)
-        {
-            setUp();
-        }
-    }
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionInterpreted();


### PR DESCRIPTION
Fix issues with sorting repositories by visibility. This ensures that visible repositories always appear earlier in the resulting list. So if A and B are repositories and A is visible to B, then A will always appear earlier than B in the list.