### PR TITLE
Attempt to fix error with partially loaded enum metadata

### DIFF
--- a/legend-pure-m2-dsl-mapping/src/main/resources/platform/pure/mapping.pure
+++ b/legend-pure-m2-dsl-mapping/src/main/resources/platform/pure/mapping.pure
@@ -147,7 +147,9 @@ Class meta::pure::mapping::EnumerationMapping<T> extends meta::pure::mapping::Va
 
     toSourceValues(domainValue: Any[1])
     {
-        $this.enumValueMappings->filter( m | $m.enum == $domainValue )->toOne().sourceValues;
+        let enumValueMapping = $this.enumValueMappings->filter( m | $m.enum == $domainValue );
+        assertEquals(1, $enumValueMapping->size(), 'The system can\'t find source values in the enumMapping \''+$this.name+'\' for the enum \''+$this.enumeration->enumName()+ '.' +$domainValue->toString()+'\'');
+        $enumValueMapping->toOne().sourceValues;
     }:Any[*];
 
 }

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
@@ -119,14 +119,10 @@ public class MetadataLazy implements Metadata
         }
 
         ConcurrentMutableMap<String, CoreInstance> cache = getClassifierInstanceCache(enumerationName);
-        if (cache.isEmpty())
-        {
-            loadAllClassifierInstances(enumerationName);
-        }
         CoreInstance result = cache.get(enumName);
         if (result == null)
         {
-            //might have only been partially loaded so try again:
+            //might not have loaded yet, so request full load and try again:
             loadAllClassifierInstances(enumerationName);
             result = cache.get(enumName);
             if (result == null) {

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
@@ -126,16 +126,21 @@ public class MetadataLazy implements Metadata
         CoreInstance result = cache.get(enumName);
         if (result == null)
         {
-            StringBuilder builder = new StringBuilder("Cannot find enum '").append(enumName).append("' in enumeration '").append(enumerationName).append("' unknown enum value");
-            if (cache.isEmpty())
-            {
-                builder.append(" (no known values)");
+            //might have only been partially loaded so try again:
+            loadAllClassifierInstances(enumerationName);
+            result = cache.get(enumName);
+            if (result == null) {
+                StringBuilder builder = new StringBuilder("Cannot find enum '").append(enumName).append("' in enumeration '").append(enumerationName).append("' unknown enum value");
+                if (cache.isEmpty())
+                {
+                    builder.append(" (no known values)");
+                }
+                else
+                {
+                    cache.keysView().appendString(builder, " (known values: '", "', '", "')");
+                }
+                throw new RuntimeException(builder.toString());
             }
-            else
-            {
-                cache.keysView().appendString(builder, " (known values: '", "', '", "')");
-            }
-            throw new RuntimeException(builder.toString());
         }
         return result;
     }


### PR DESCRIPTION
When running our PURE compiled jar with multiple threads, we occasionally (at the start of the run) get errors like this:
"Cannot find enum 'A' in enumeration 'a::s::d::f' unknown enum value (known values: 'A','B','C','D')

Which implies that the enum is valid but couldn't be found.  Looking at the code behind this, it appears it's possible that there is an edge case where the enum is being populated at the same time as it's being looked up. (and the population code explicitly caters for this partially populated scenario).  Since this is a transient error I'm going to try applying this fix to my local codebase to see if it actually fixes the error - but in the meantime any thoughts would be greatly appreciated.

- monica