### PR TITLE
Java factory: box primitive number branches to fix type inference

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/java/metamodel_factories.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/java/metamodel_factories.pure
@@ -1828,15 +1828,25 @@ function meta::external::language::java::factory::j_instanceof(expression:Code[1
 function meta::external::language::java::factory::j_conditional(test:Code[1], then:Code[1], else:Code[1]):Code[1]
 {
    // TODO common interface inference
-   let thenType = if($then->instanceOf(Null) && $then.type == javaVoid(), |$else.type, |$then.type);
-   let elseType = if($else->instanceOf(Null) && $else.type == javaVoid(), |$then.type, |$else.type);
+   let thenBoxed = if($then.type->isPrimitiveNumber() && $else.type->isBoxedNumberType(), | $then->j_box(), | []);
+   let elseBoxed = if($else.type->isPrimitiveNumber() && $then.type->isBoxedNumberType(), | $else->j_box(), | []);
+
+   let thenType = if($thenBoxed->isEmpty(), 
+                    | if($then->instanceOf(Null) && $then.type == javaVoid(), |$else.type, |$then.type),
+                    | $thenBoxed->toOne().type
+                  );
+
+   let elseType = if($elseBoxed->isEmpty(), 
+                    | if($else->instanceOf(Null) && $else.type == javaVoid(), |$then.type, |$else.type),
+                    | $elseBoxed->toOne().type
+                  );
+
    assert($thenType == $elseType, 'Type not inferred: then: '+$thenType->typeToString()+' else: '+$elseType->typeToString());
    
    if($test->instanceOf(InfixExpression),
-      | optimizeEqualityComparison($test->cast(@InfixExpression), $then, $else, $thenType),
-      | ^Conditional(test=$test, then=$then, else=$else, type=$thenType)
-   );
-   
+      | optimizeEqualityComparison($test->cast(@InfixExpression), $thenBoxed->orElse($then), $elseBoxed->orElse($else), $thenType),
+      | ^Conditional(test=$test, then=$thenBoxed->orElse($then), else=$elseBoxed->orElse($else), type=$thenType)
+   );   
 }
 
 function meta::external::language::java::factory::optimizeEqualityComparison(expr:InfixExpression[1], then:Code[1], else:Code[1], type:meta::external::language::java::metamodel::Type[1]): Code[1]

--- a/legend-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/langExtension.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/pure/corefunctions/tests/langExtension.pure
@@ -17,6 +17,7 @@ function <<test.Test>> meta::pure::functions::lang::tests::orElse::testOrElse():
 {
    assertEquals('A', ['A']->orElse('B'));
    assertEquals('B', []->cast(@String)->orElse('B'));
+   assertEquals(1, []->cast(@Integer)->orElse(1));
 }
 
 


### PR DESCRIPTION
Both branches in a Java conditional need to be of the same type: in the case that one branch is a primitive type, but the other branch is the equivalent boxed type this change boxes the primitive type so that both branches are consistent in their return value type.