### PR TITLE
Fix typo in PureCompiledJarMojo

### DIFF
--- a/legend-pure-maven-java-compiled/src/main/java/org/finos/legend/pure/maven/javaCompiled/PureCompiledJarMojo.java
+++ b/legend-pure-maven-java-compiled/src/main/java/org/finos/legend/pure/maven/javaCompiled/PureCompiledJarMojo.java
@@ -173,7 +173,7 @@ public class PureCompiledJarMojo extends AbstractMojo
         if ((this.extraRepositories != null) && !this.extraRepositories.isEmpty())
         {
             ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-            PureRepositoriesExternal.addRepositories(Iterate.collect(this.extraRepositories, r -> GenericCodeRepository.build(classLoader, r), Lists.mutable.withInitialCapacity(excludedRepositories.size())));
+            PureRepositoriesExternal.addRepositories(Iterate.collect(this.extraRepositories, r -> GenericCodeRepository.build(classLoader, r), Lists.mutable.withInitialCapacity(this.extraRepositories.size())));
         }
 
         MutableList<CodeRepository> selectedRepos = (this.repositories == null) ?


### PR DESCRIPTION
Fix a typo in PureCompiledJarMojo that can cause a NullPointerException under certain circumstances.