### PR TITLE
Allow extraRepositories to be resource names in PureJarMojo

### DIFF
--- a/legend-pure-maven-compilation-par/pom.xml
+++ b/legend-pure-maven-compilation-par/pom.xml
@@ -54,11 +54,6 @@
     <dependencies>
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
-            <artifactId>legend-pure-m4</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
         </dependency>
 

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
@@ -125,7 +125,8 @@ public class MetadataLazy implements Metadata
             //might not have loaded yet, so request full load and try again:
             loadAllClassifierInstances(enumerationName);
             result = cache.get(enumName);
-            if (result == null) {
+            if (result == null)
+            {
                 StringBuilder builder = new StringBuilder("Cannot find enum '").append(enumName).append("' in enumeration '").append(enumerationName).append("' unknown enum value");
                 if (cache.isEmpty())
                 {

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/serialization/binary/DistributedBinaryGraphDeserializer.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/serialization/binary/DistributedBinaryGraphDeserializer.java
@@ -499,14 +499,14 @@ public abstract class DistributedBinaryGraphDeserializer
             for (String instanceId : instanceIds)
             {
                 SourceCoordinates sourceCoordinates = classifierIndex.getSourceCoordinates(instanceId);
-                if (sourceCoordinates == null && throwIfNotFound)
-                {
-                    throw new UnknownInstanceException(classifierId, instanceId);
-                }
                 if (sourceCoordinates != null)
                 {
                     sourceCoordinatesByFile.getIfAbsentPut(sourceCoordinates.getFilePath(), Lists.mutable::empty).add(sourceCoordinates);
                     size++;
+                }
+                else if (throwIfNotFound)
+                {
+                    throw new UnknownInstanceException(classifierId, instanceId);
                 }
             }
             if (size == 0)


### PR DESCRIPTION
Currently, PureJaraMojo requires extra repositories to be specified as file paths. This allows it alternately to be specified as resource names.