### PR TITLE
Ensure repository sorting does not depend on input order

### DIFF
--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/filesystem/repository/TestCodeRepository.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/filesystem/repository/TestCodeRepository.java
@@ -19,73 +19,73 @@ public class TestCodeRepository
     public void testToSortedRepositoriesList_Single()
     {
         CodeRepository platformRepo = CodeRepository.newPlatformCodeRepository();
-        CodeRepository repo1 = GenericCodeRepository.build("repo_one", "meta::pure::\\.*", "platform");
-        CodeRepository repo2 = GenericCodeRepository.build("repo_two", "meta::pure::\\.*", "platform");
-        CodeRepository repo3 = GenericCodeRepository.build("repo_three", "meta::pure::\\.*", "platform", "repo_one");
-        CodeRepository repo4 = GenericCodeRepository.build("repo_four", "meta::pure::\\.*", "platform", "repo_one", "repo_two");
+        CodeRepository repoA = GenericCodeRepository.build("repo_a", "meta::pure::\\.*", "platform");
+        CodeRepository repoB = GenericCodeRepository.build("repo_b", "meta::pure::\\.*", "platform");
+        CodeRepository repoC = GenericCodeRepository.build("repo_c", "meta::pure::\\.*", "platform", "repo_a");
+        CodeRepository repoD = GenericCodeRepository.build("repo_d", "meta::pure::\\.*", "platform", "repo_a", "repo_b");
 
         assertSort(Lists.fixedSize.with(platformRepo), platformRepo);
-        assertSort(Lists.fixedSize.with(repo1), repo1);
-        assertSort(Lists.fixedSize.with(repo2), repo2);
-        assertSort(Lists.fixedSize.with(repo3), repo3);
-        assertSort(Lists.fixedSize.with(repo4), repo4);
+        assertSort(Lists.fixedSize.with(repoA), repoA);
+        assertSort(Lists.fixedSize.with(repoB), repoB);
+        assertSort(Lists.fixedSize.with(repoC), repoC);
+        assertSort(Lists.fixedSize.with(repoD), repoD);
     }
 
     @Test
     public void testToSortedRepositoriesList_General()
     {
         CodeRepository platformRepo = CodeRepository.newPlatformCodeRepository();
-        CodeRepository repo1 = GenericCodeRepository.build("repo_one", "meta::pure::\\.*", "platform");
-        CodeRepository repo2 = GenericCodeRepository.build("repo_two", "meta::pure::\\.*", "platform");
-        CodeRepository repo3 = GenericCodeRepository.build("repo_three", "meta::pure::\\.*", "platform", "repo_one");
-        CodeRepository repo4 = GenericCodeRepository.build("repo_four", "meta::pure::\\.*", "platform", "repo_one", "repo_two");
-        CodeRepository repo5 = GenericCodeRepository.build("repo_five", "meta::pure::\\.*", "platform", "repo_two");
+        CodeRepository repoA = GenericCodeRepository.build("repo_a", "meta::pure::\\.*", "platform");
+        CodeRepository repoB = GenericCodeRepository.build("repo_b", "meta::pure::\\.*", "platform");
+        CodeRepository repoC = GenericCodeRepository.build("repo_c", "meta::pure::\\.*", "platform", "repo_a");
+        CodeRepository repoD = GenericCodeRepository.build("repo_d", "meta::pure::\\.*", "platform", "repo_a", "repo_b");
+        CodeRepository repoE = GenericCodeRepository.build("repo_e", "meta::pure::\\.*", "platform", "repo_b");
 
-        assertSort(Lists.fixedSize.with(platformRepo, repo1), repo1, platformRepo);
-        assertSort(Lists.fixedSize.with(platformRepo, repo1), platformRepo, repo1);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA), repoA, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA), platformRepo, repoA);
 
-        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2), repo1, repo2, platformRepo);
-        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2), repo1, platformRepo, repo2);
-        assertSort(Lists.fixedSize.with(platformRepo, repo2, repo1), repo2, platformRepo, repo1);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoB), repoA, repoB, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoB), repoA, platformRepo, repoB);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoB), repoB, platformRepo, repoA);
 
-        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2, repo3, repo4), repo3, repo4, repo1, repo2, platformRepo);
-        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2, repo3, repo4), repo3, repo1, repo4, repo2, platformRepo);
-        assertSort(Lists.fixedSize.with(platformRepo, repo2, repo1, repo4, repo3), repo4, repo3, repo2, repo1, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoB, repoC, repoD), repoC, repoD, repoA, repoB, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoB, repoC, repoD), repoC, repoA, repoD, repoB, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoB, repoC, repoD), repoD, repoC, repoB, repoA, platformRepo);
 
-        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo5, repo4, repo3), repo4, repo3, repo1, repo5, platformRepo);
-        assertSort(Lists.fixedSize.with(platformRepo, repo5, repo1, repo4, repo3), repo4, repo3, repo5, repo1, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoE, repoC, repoD), repoD, repoC, repoA, repoE, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoE, repoC, repoD), repoD, repoC, repoE, repoA, platformRepo);
 
-        assertSort(Lists.fixedSize.with(platformRepo, repo2, repo1, repo5, repo4, repo3), repo4, repo3, repo2, repo1, repo5, platformRepo);
-        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2, repo5, repo4, repo3), repo4, repo3, repo1, repo2, repo5, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoB, repoC, repoD, repoE), repoD, repoC, repoB, repoA, repoE, platformRepo);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoB, repoC, repoD, repoE), repoD, repoC, repoA, repoB, repoE, platformRepo);
     }
 
     @Test
     public void testToSortedRepositoriesList_Loop()
     {
         CodeRepository platformRepo = CodeRepository.newPlatformCodeRepository();
-        CodeRepository repo1 = GenericCodeRepository.build("repo_one", "meta::pure::\\.*", "platform");
-        CodeRepository repo2 = GenericCodeRepository.build("repo_two", "meta::pure::\\.*", "platform", "repo_one");
-        CodeRepository repo3 = GenericCodeRepository.build("repo_three", "meta::pure::\\.*", "platform", "repo_two", "repo_five");
-        CodeRepository repo4 = GenericCodeRepository.build("repo_four", "meta::pure::\\.*", "platform", "repo_one", "repo_three");
-        CodeRepository repo5 = GenericCodeRepository.build("repo_five", "meta::pure::\\.*", "platform", "repo_four", "repo_two");
+        CodeRepository repoA = GenericCodeRepository.build("repo_a", "meta::pure::\\.*", "platform");
+        CodeRepository repoB = GenericCodeRepository.build("repo_b", "meta::pure::\\.*", "platform", "repo_a");
+        CodeRepository repoC = GenericCodeRepository.build("repo_c", "meta::pure::\\.*", "platform", "repo_b", "repo_e");
+        CodeRepository repoD = GenericCodeRepository.build("repo_d", "meta::pure::\\.*", "platform", "repo_a", "repo_c");
+        CodeRepository repoE = GenericCodeRepository.build("repo_e", "meta::pure::\\.*", "platform", "repo_d", "repo_b");
 
         // No loops
-        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2, repo3, repo4), platformRepo, repo1, repo2, repo3, repo4);
-        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2, repo5, repo3), platformRepo, repo1, repo2, repo3, repo5);
-        assertSort(Lists.fixedSize.with(platformRepo, repo1, repo2, repo4, repo5), platformRepo, repo1, repo2, repo4, repo5);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoB, repoC, repoD), platformRepo, repoA, repoB, repoC, repoD);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoB, repoE, repoC), platformRepo, repoA, repoB, repoC, repoE);
+        assertSort(Lists.fixedSize.with(platformRepo, repoA, repoB, repoD, repoE), platformRepo, repoA, repoB, repoD, repoE);
 
         // Loops
-        RuntimeException e1 = Assert.assertThrows(RuntimeException.class, () -> CodeRepository.toSortedRepositoryList(Lists.fixedSize.with(platformRepo, repo1, repo2, repo3, repo4, repo5)));
-        Assert.assertEquals("Could not consistently order the following repositories: repo_three (visible: repo_five), repo_four (visible: repo_three), repo_five (visible: repo_four)", e1.getMessage());
+        RuntimeException e1 = Assert.assertThrows(RuntimeException.class, () -> CodeRepository.toSortedRepositoryList(Lists.fixedSize.with(platformRepo, repoA, repoB, repoC, repoD, repoE)));
+        Assert.assertEquals("Could not consistently order the following repositories: repo_c (visible: repo_e), repo_d (visible: repo_c), repo_e (visible: repo_d)", e1.getMessage());
 
-        RuntimeException e2 = Assert.assertThrows(RuntimeException.class, () -> CodeRepository.toSortedRepositoryList(Lists.fixedSize.with(platformRepo, repo2, repo3, repo4, repo5)));
-        Assert.assertEquals("Could not consistently order the following repositories: repo_three (visible: repo_five), repo_four (visible: repo_three), repo_five (visible: repo_four)", e2.getMessage());
+        RuntimeException e2 = Assert.assertThrows(RuntimeException.class, () -> CodeRepository.toSortedRepositoryList(Lists.fixedSize.with(platformRepo, repoB, repoC, repoD, repoE)));
+        Assert.assertEquals("Could not consistently order the following repositories: repo_c (visible: repo_e), repo_d (visible: repo_c), repo_e (visible: repo_d)", e2.getMessage());
 
-        RuntimeException e3 = Assert.assertThrows(RuntimeException.class, () -> CodeRepository.toSortedRepositoryList(Lists.fixedSize.with(platformRepo, repo3, repo4, repo5)));
-        Assert.assertEquals("Could not consistently order the following repositories: repo_three (visible: repo_five), repo_four (visible: repo_three), repo_five (visible: repo_four)", e3.getMessage());
+        RuntimeException e3 = Assert.assertThrows(RuntimeException.class, () -> CodeRepository.toSortedRepositoryList(Lists.fixedSize.with(platformRepo, repoC, repoD, repoE)));
+        Assert.assertEquals("Could not consistently order the following repositories: repo_c (visible: repo_e), repo_d (visible: repo_c), repo_e (visible: repo_d)", e3.getMessage());
 
-        RuntimeException e4 = Assert.assertThrows(RuntimeException.class, () -> CodeRepository.toSortedRepositoryList(Lists.fixedSize.with(repo3, repo4, repo5)));
-        Assert.assertEquals("Could not consistently order the following repositories: repo_three (visible: repo_five), repo_four (visible: repo_three), repo_five (visible: repo_four)", e4.getMessage());
+        RuntimeException e4 = Assert.assertThrows(RuntimeException.class, () -> CodeRepository.toSortedRepositoryList(Lists.fixedSize.with(repoC, repoD, repoE)));
+        Assert.assertEquals("Could not consistently order the following repositories: repo_c (visible: repo_e), repo_d (visible: repo_c), repo_e (visible: repo_d)", e4.getMessage());
     }
 
     private void assertSort(ListIterable<? extends CodeRepository> expected, CodeRepository... repositories)


### PR DESCRIPTION
Previously, sorting always respected visibility, but the ordering of repositories which were not visible to each other might depend on the order of the repositories in the input. This change ensures that the final order is independent of the input order.