### PR TITLE
Stabilize compiled mode metadata ids for Path instances

### DIFF
--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/inlinedsl/InlineDSL.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/inlinedsl/InlineDSL.java
@@ -25,32 +25,9 @@ import org.finos.legend.pure.m4.ModelRepository;
 
 public interface InlineDSL extends CoreInstanceFactoriesRegistry
 {
-    Function<InlineDSL, RichIterable<MatchRunner>> GET_PROCESSORS = new Function<InlineDSL, RichIterable<MatchRunner>>()
-    {
-        @Override
-        public RichIterable<MatchRunner> valueOf(InlineDSL inlineDSL)
-        {
-            return inlineDSL.getProcessors();
-        }
-    };
-
-    Function<InlineDSL, RichIterable<MatchRunner>> GET_UNLOAD_WALKERS = new Function<InlineDSL, RichIterable<MatchRunner>>()
-    {
-        @Override
-        public RichIterable<MatchRunner> valueOf(InlineDSL inlineDSL)
-        {
-            return inlineDSL.getUnLoadWalkers();
-        }
-    };
-
-    Function<InlineDSL, RichIterable<MatchRunner>> GET_UNLOAD_UNBINDERS = new Function<InlineDSL, RichIterable<MatchRunner>>()
-    {
-        @Override
-        public RichIterable<MatchRunner> valueOf(InlineDSL inlineDSL)
-        {
-            return inlineDSL.getUnLoadUnbinders();
-        }
-    };
+    Function<InlineDSL, RichIterable<MatchRunner>> GET_PROCESSORS = InlineDSL::getProcessors;
+    Function<InlineDSL, RichIterable<MatchRunner>> GET_UNLOAD_WALKERS = InlineDSL::getUnLoadWalkers;
+    Function<InlineDSL, RichIterable<MatchRunner>> GET_UNLOAD_UNBINDERS = InlineDSL::getUnLoadUnbinders;
 
     String getName();
     boolean match(String code);

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/AbstractCompiledStateIntegrityTest.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/AbstractCompiledStateIntegrityTest.java
@@ -178,16 +178,14 @@ public abstract class AbstractCompiledStateIntegrityTest
     @Test
     public void testPackageableElementsHaveSourceInfo()
     {
-        CoreInstance functionTypeClass = runtime.getCoreInstance(M3Paths.FunctionType);
         CoreInstance importGroupClass = runtime.getCoreInstance(M3Paths.ImportGroup);
         CoreInstance packageClass = runtime.getCoreInstance(M3Paths.Package);
         CoreInstance packageableElementClass = runtime.getCoreInstance(M3Paths.PackageableElement);
-        Assert.assertNotNull(functionTypeClass);
         Assert.assertNotNull(importGroupClass);
         Assert.assertNotNull(packageClass);
         Assert.assertNotNull(packageableElementClass);
 
-        ImmutableSet<CoreInstance> exceptionClasses = Sets.immutable.with(importGroupClass, packageClass, functionTypeClass);
+        ImmutableSet<CoreInstance> exceptionClasses = Sets.immutable.with(importGroupClass, packageClass);
 
         MutableList<CoreInstance> noSourceInfo = selectNodes(instance -> (instance.getSourceInformation() == null) &&
                 !exceptionClasses.contains(instance.getClassifier()) &&
@@ -197,11 +195,8 @@ public abstract class AbstractCompiledStateIntegrityTest
             StringBuilder message = new StringBuilder("The following packageable elements have no source information:");
             noSourceInfo.forEach(instance ->
             {
-                message.append("\n\t");
-                PackageableElement.writeUserPathForPackageableElement(message, instance);
-                message.append(" (");
-                PackageableElement.writeUserPathForPackageableElement(message, instance.getClassifier());
-                message.append(')');
+                PackageableElement.writeUserPathForPackageableElement(message.append("\n\t"), instance);
+                PackageableElement.writeUserPathForPackageableElement(message.append(" ("), instance.getClassifier()).append(')');
             });
             Assert.fail(message.toString());
         }

--- a/legend-pure-m3-dsl-graph/src/main/java/org/finos/legend/pure/m3/inlinedsl/graph/antlr/GraphDSL.java
+++ b/legend-pure-m3-dsl-graph/src/main/java/org/finos/legend/pure/m3/inlinedsl/graph/antlr/GraphDSL.java
@@ -15,7 +15,7 @@
 package org.finos.legend.pure.m3.inlinedsl.graph.antlr;
 
 import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.pure.m3.inlinedsl.graph.processor.RootGraphFetchTreeProcessor;
 import org.finos.legend.pure.m3.inlinedsl.graph.unbinder.RootGraphFetchTreeUnbind;
 import org.finos.legend.pure.m3.inlinedsl.graph.validator.RootGraphFetchTreeValidator;
@@ -52,25 +52,25 @@ public class GraphDSL implements InlineDSL
     @Override
     public RichIterable<MatchRunner> getProcessors()
     {
-        return Lists.immutable.<MatchRunner>with(new RootGraphFetchTreeProcessor());
+        return Lists.immutable.with(new RootGraphFetchTreeProcessor());
     }
 
     @Override
     public RichIterable<MatchRunner> getValidators()
     {
-        return Lists.immutable.<MatchRunner>with(new RootGraphFetchTreeValidator());
+        return Lists.immutable.with(new RootGraphFetchTreeValidator());
     }
 
     @Override
     public RichIterable<MatchRunner> getUnLoadWalkers()
     {
-        return Lists.immutable.<MatchRunner>with(new RootGraphFetchTreeUnloaderWalk());
+        return Lists.immutable.with(new RootGraphFetchTreeUnloaderWalk());
     }
 
     @Override
     public RichIterable<MatchRunner> getUnLoadUnbinders()
     {
-        return Lists.immutable.<MatchRunner>with(new RootGraphFetchTreeUnbind());
+        return Lists.immutable.with(new RootGraphFetchTreeUnbind());
     }
 
     @Override

--- a/legend-pure-m3-dsl-path/src/main/java/org/finos/legend/pure/m3/inlinedsl/path/NavigationPath.java
+++ b/legend-pure-m3-dsl-path/src/main/java/org/finos/legend/pure/m3/inlinedsl/path/NavigationPath.java
@@ -15,29 +15,23 @@
 package org.finos.legend.pure.m3.inlinedsl.path;
 
 import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.pure.m3.compiler.Context;
+import org.finos.legend.pure.m3.coreinstance.CoreInstanceFactoryRegistry;
+import org.finos.legend.pure.m3.coreinstance.PathCoreInstanceFactoryRegistry;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportGroup;
 import org.finos.legend.pure.m3.inlinedsl.path.parser.NavigationParser;
 import org.finos.legend.pure.m3.inlinedsl.path.processor.PathProcessor;
 import org.finos.legend.pure.m3.inlinedsl.path.unloader.PathUnbind;
 import org.finos.legend.pure.m3.inlinedsl.path.validation.PathValidator;
 import org.finos.legend.pure.m3.inlinedsl.path.walker.PathWalk;
-import org.finos.legend.pure.m3.compiler.Context;
-import org.finos.legend.pure.m3.coreinstance.CoreInstanceFactoryRegistry;
-import org.finos.legend.pure.m3.coreinstance.PathCoreInstanceFactoryRegistry;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportGroup;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.inlinedsl.InlineDSL;
 import org.finos.legend.pure.m3.tools.matcher.MatchRunner;
-import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
 public class NavigationPath implements InlineDSL
 {
-    private final ImmutableList<MatchRunner> processors = Lists.immutable.<MatchRunner>with(new PathProcessor());
-    private final ImmutableList<MatchRunner> unbind = Lists.immutable.<MatchRunner>with(new PathUnbind());
-    private final ImmutableList<MatchRunner> walk = Lists.immutable.<MatchRunner>with(new PathWalk());
-    private final ImmutableList<MatchRunner> validators = Lists.immutable.<MatchRunner>with(new PathValidator());
-
     @Override
     public String getName()
     {
@@ -59,25 +53,25 @@ public class NavigationPath implements InlineDSL
     @Override
     public RichIterable<MatchRunner> getValidators()
     {
-        return this.validators;
+        return Lists.immutable.with(new PathValidator());
     }
 
     @Override
     public RichIterable<MatchRunner> getProcessors()
     {
-        return this.processors;
+        return Lists.immutable.with(new PathProcessor());
     }
 
     @Override
     public RichIterable<MatchRunner> getUnLoadWalkers()
     {
-        return this.walk;
+        return Lists.immutable.with(new PathWalk());
     }
 
     @Override
     public RichIterable<MatchRunner> getUnLoadUnbinders()
     {
-        return this.unbind;
+        return Lists.immutable.with(new PathUnbind());
     }
 
     @Override

--- a/legend-pure-m3-dsl-path/src/main/java/org/finos/legend/pure/m3/inlinedsl/path/parser/NavigationParser.java
+++ b/legend-pure-m3-dsl-path/src/main/java/org/finos/legend/pure/m3/inlinedsl/path/parser/NavigationParser.java
@@ -14,21 +14,19 @@
 
 package org.finos.legend.pure.m3.inlinedsl.path.parser;
 
-import org.finos.legend.pure.m3.inlinedsl.path.serialization.grammar.NavigationLexer;
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.atn.PredictionMode;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportGroup;
-import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m3.inlinedsl.path.serialization.grammar.NavigationLexer;
+import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.ParsingUtils;
 import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.serialization.grammar.antlr.AntlrDescriptiveErrorListener;
 import org.finos.legend.pure.m4.serialization.grammar.antlr.AntlrSourceInformation;
 import org.finos.legend.pure.m4.serialization.grammar.antlr.PureAntlrErrorStrategy;
 import org.finos.legend.pure.m4.serialization.grammar.antlr.PureParserException;
-import org.antlr.v4.runtime.ANTLRInputStream;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.atn.PredictionMode;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-
-import static org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.ParsingUtils.isAntlrRecognitionExceptionUsingFastParser;
 
 public class NavigationParser
 {
@@ -49,15 +47,11 @@ public class NavigationParser
         }
         catch (Exception e)
         {
-            if (isAntlrRecognitionExceptionUsingFastParser(useFastParser, e))
+            if (ParsingUtils.isAntlrRecognitionExceptionUsingFastParser(useFastParser, e))
             {
-                //System.err.println("Error using fast Antlr Parser: " + ExceptionUtils.getStackTrace(e));
                 return this.parseDefinition(false, code, sourceName, false, offsetLine, offsetColumn, repository, context, importId);
             }
-            else
-            {
-                throw e;
-            }
+            throw e;
         }
     }
 

--- a/legend-pure-m3-dsl-path/src/main/java/org/finos/legend/pure/m3/inlinedsl/path/walker/PathWalk.java
+++ b/legend-pure-m3-dsl-path/src/main/java/org/finos/legend/pure/m3/inlinedsl/path/walker/PathWalk.java
@@ -14,17 +14,16 @@
 
 package org.finos.legend.pure.m3.inlinedsl.path.walker;
 
-import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.compiler.Context;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.ReferenceUsage;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.path.Path;
+import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.tools.matcher.MatchRunner;
 import org.finos.legend.pure.m3.tools.matcher.Matcher;
 import org.finos.legend.pure.m3.tools.matcher.MatcherState;
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 
-public class PathWalk implements MatchRunner<Path>
+public class PathWalk implements MatchRunner<Path<?, ?>>
 {
     @Override
     public String getClassName()
@@ -33,11 +32,8 @@ public class PathWalk implements MatchRunner<Path>
     }
 
     @Override
-    public void run(Path path, MatcherState state, Matcher matcher, ModelRepository modelRepository, Context context) throws PureCompilationException
+    public void run(Path<?, ?> path, MatcherState state, Matcher matcher, ModelRepository modelRepository, Context context) throws PureCompilationException
     {
-        for (ReferenceUsage referenceUsage : path._referenceUsages())
-        {
-            matcher.fullMatch(referenceUsage._ownerCoreInstance(), state);
-        }
+        path._referenceUsages().forEach(refUsage -> matcher.fullMatch(refUsage._ownerCoreInstance(), state));
     }
 }

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/IdBuilder.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/IdBuilder.java
@@ -148,6 +148,14 @@ public class IdBuilder
         return ModelRepository.isAnonymousInstanceName(name) ? null : name;
     }
 
+    // Path
+
+    private static String buildIdForPath(CoreInstance path)
+    {
+        SourceInformation sourceInfo = path.getSourceInformation();
+        return sourceInfo.getMessage();
+    }
+
     // Annotation
 
     private static String buildIdForAnnotation(CoreInstance annotation)
@@ -324,6 +332,7 @@ public class IdBuilder
             addIdBuilder(M3Paths.Enum, CoreInstance::getName);
             addIdBuilder(M3Paths.LambdaFunction, IdBuilder::buildIdForLambdaFunction);
             addIdBuilder(M3Paths.PackageableElement, IdBuilder::buildIdForPackageableElement);
+            addIdBuilder(M3Paths.Path, IdBuilder::buildIdForPath);
             addIdBuilder(M3Paths.Property, IdBuilder::buildIdForProperty);
             addIdBuilder(M3Paths.QualifiedProperty, IdBuilder::buildIdForQualifiedProperty);
         }


### PR DESCRIPTION
Stabilize compiled mode metadata ids for Path instances. In passing, clean up some of the code in the Path DSL.