### PR TITLE
Java Gen: Improve performance of statement generation

### DIFF
--- a/legend-pure-code-compiled-core/src/main/resources/core/java/generation/expressionGeneration.pure
+++ b/legend-pure-code-compiled-core/src/main/resources/core/java/generation/expressionGeneration.pure
@@ -37,11 +37,11 @@ function meta::external::language::java::transform::generateJavaMethodBody(vses:
 
 function <<access.private>> meta::external::language::java::transform::statementsForBlock(vses:ValueSpecification[*], conventions: Conventions[1], debug: DebugContext[1]):Code[*]
 {
-   $vses->toIndexed()
-      ->map(z| print(if($debug.debug,|$debug.space+'statementsForBlock - processing expression '+$z.first->toString()+'\n',|''));
-               let x = $z.second;
-               $x->generateJavaInternal($conventions, $debug);)
-      ->match([
+   let generated = $vses->toIndexed()
+      			->map(z| print(if($debug.debug,|$debug.space+'statementsForBlock - processing expression '+$z.first->toString()+'\n',|''));
+               			let x = $z.second;
+               			$x->generateJavaInternal($conventions, $debug););
+   $generated->match([
          {c0: Code[0] | []},
          {cs: Code[*] | 
             let toLast = $cs->init();


### PR DESCRIPTION
This change avoids an issue in legend-pure Java generation: in this case the map is essentially inlined into each match statement. Hence we end up doing Java generation for the same statement multiple times are each clause of the match statement is evaluated. 
By assigning to a variable, we perform the Java generation first, then match on the *results* of the Java generation. 