### PR TITLE
Support Any properties for primitive values on fromJson

### DIFF
--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/json/AbstractTestFromJson.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/json/AbstractTestFromJson.java
@@ -83,7 +83,7 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
         }
     }
 
-    private void runShouldPassTestCase(String testName, String expectedType, String actualJson, String additionalPureCode)
+    private void runShouldPassTestCase(String testName, String expectedType, String actualJson, String additionalPureCode, String result)
     {
         String[] rawSource = {
                 "import meta::json::*;\nimport meta::pure::functions::json::tests::*;",
@@ -92,7 +92,9 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
                 "{\n  testField : " + expectedType + ";\n}",
                 "function " + testName + "():Any[*]",
                 "{\n  let json = '{\"testField\": " + actualJson + "}';",
-                "  $json -> fromJson(" + testName + ", ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));\n}"
+                "     let jsonAsPure = $json -> fromJson(" + testName + ", ^JSONDeserializationConfig(typeKeyName='@type', failOnUnknownProperties=false));",
+                "     assertEquals(" + result + ", $jsonAsPure.testField, 'Output does match expected');",
+                "\n}"
         };
         String source = StringUtils.join(rawSource, "\n") + "\n";
 
@@ -124,9 +126,9 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
     }
 
     @Test
-    public void typeCheck_JsonLongToIntegerProperty()
+    public void typeCheck_JsonFloatToIntegerProperty()
     {
-        this.runShouldFailTestCase("IntegerToFloat", "Integer[1]", "3.0",
+        this.runShouldFailTestCase("FloatToInteger", "Integer[1]", "3.0",
                 "Expected Integer, found Float");
     }
 
@@ -167,7 +169,9 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
     {
         this.runShouldPassTestCase("IntegerToObject", "meta::pure::functions::json::tests::someClass[1]",
                 "3",
-                "Class meta::pure::functions::json::tests::someClass {  } ");
+                "Class meta::pure::functions::json::tests::someClass {  } ",
+                "[]"
+        );
     }
 
     @Test
@@ -182,21 +186,56 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
     public void typeCheck_JsonIntegerToFloatProperty()
     {
         this.runShouldPassTestCase("IntegerToFloat", "Float[1]",
-                "1", "");
+                "1", "", "1.0");
+    }
+
+    @Test
+    public void typeCheck_JsonIntegerToAnyProperty()
+    {
+        this.runShouldPassTestCase("IntegerToAny", "Any[1]",
+                "1", "", "1");
+    }
+
+    @Test
+    public void typeCheck_JsonFloatToAnyProperty()
+    {
+        this.runShouldPassTestCase("FloatToAny", "Any[1]",
+                "2.0", "", "2.0");
+    }
+
+    @Test
+    public void typeCheck_JsonStringToAnyProperty()
+    {
+        this.runShouldPassTestCase("StringToAny", "Any[1]",
+                "\"Hello\"", "", "'Hello'");
+    }
+
+    @Test
+    public void typeCheck_JsonBooleanToAnyProperty()
+    {
+        this.runShouldPassTestCase("BooleanToAny", "Any[1]",
+                "true", "", "true");
+    }
+
+    @Test
+    public void typeCheck_JsonObjectToAnyProperty()
+    {
+        this.runShouldFailTestCase("ObjectToAny", "Any[1]",
+                "{}", "Deserialization of Any currently only supported on primitive values!");
     }
 
     @Test
     public void typeCheck_JsonFloatToDecimalProperty()
     {
         this.runShouldPassTestCase("FloatToDecimal", "Decimal[1]",
-                "3.14", "");
+                "3.14", "", "3.14D");
     }
 
     @Test
     public void typeCheck_JsonIntegerToDecimalProperty()
     {
         this.runShouldPassTestCase("IntegerToDecimal", "Decimal[1]",
-                "3", "");
+                "3", "", "3D");
     }
 
     @Test
@@ -260,56 +299,56 @@ public abstract class AbstractTestFromJson extends AbstractPureTestWithCoreCompi
     public void multiplicityIsInRange_SingleValueToSingletonProperty()
     {
         this.runShouldPassTestCase("SingleToSingleton", "Float[1]",
-                "3.0", "");
+                "3.0", "", "3.0");
     }
 
     @Test
     public void multiplicityIsInRange_SingleArrayToSingletonProperty()
     {
         this.runShouldPassTestCase("SingleArrayToSingleton", "Float[1]",
-                "[3.0]", "");
+                "[3.0]", "", "3.0");
     }
 
     @Test
     public void multiplicityIsInRange_NullToOptionalProperty()
     {
         this.runShouldPassTestCase("NullToOptional", "Float[0..1]",
-                "null", "");
+                "null", "", "[]");
     }
 
     @Test
     public void multiplicityIsInRange_EmptyArrayToOptionalProperty()
     {
         this.runShouldPassTestCase("EmptyToOptional", "Float[0..1]",
-                "[]", "");
+                "[]", "", "[]");
     }
 
     @Test
     public void multiplicityIsInRange_NullToManyProperty()
     {
         this.runShouldPassTestCase("NullToMany", "Float[*]",
-                "null", "");
+                "null", "", "[]");
     }
 
     @Test
     public void multiplicityIsInRange_EmptyArrayToManyProperty()
     {
         this.runShouldPassTestCase("EmptyToMany", "Float[*]",
-                "[]", "");
+                "[]", "", "[]");
     }
 
     @Test
     public void multiplicityIsInRange_SingleValueToManyProperty()
     {
         this.runShouldPassTestCase("SingleToMany", "Float[*]",
-                "3.0", "");
+                "3.0", "", "[3.0]");
     }
 
     @Test
     public void multiplicityIsInRange_SingleArrayToManyProperty()
     {
         this.runShouldPassTestCase("SingleArrayToMany", "Float[*]",
-                "[3.0]", "");
+                "[3.0]", "", "[3.0]");
     }
 
 

--- a/legend-pure-runtime-java-extension-external-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/shared/JsonAnyTypeDeserialization.java
+++ b/legend-pure-runtime-java-extension-external-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/shared/JsonAnyTypeDeserialization.java
@@ -1,0 +1,48 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.extension.external.json.shared;
+
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.PrimitiveType;
+import org.finos.legend.pure.m3.exception.PureExecutionException;
+import org.finos.legend.pure.runtime.java.extension.external.shared.conversion.Conversion;
+import org.finos.legend.pure.runtime.java.extension.external.shared.conversion.ConversionContext;
+import org.finos.legend.pure.runtime.java.extension.external.shared.conversion.PrimitiveConversion;
+
+public class JsonAnyTypeDeserialization implements Conversion<Object, Object>
+{
+    static final JsonAnyTypeDeserialization JSON_ANY_TYPE_DESERIALIZATION = new JsonAnyTypeDeserialization();
+
+    @Override
+    public Object apply(Object value, ConversionContext context)
+    {
+        try
+        {
+            String primitiveTypeName = PrimitiveConversion.toPurePrimitiveName(value.getClass());
+            PrimitiveType primitiveType = (PrimitiveType) context.getProcessorSupport().repository_getTopLevel(primitiveTypeName);
+            Conversion conversion = context.getConversionCache().getConversion(primitiveType, context);
+            return conversion.apply(value, context);
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw new PureExecutionException("Deserialization of Any currently only supported on primitive values!", e);
+        }
+    }
+
+    @Override
+    public String pureTypeAsString()
+    {
+        return "Any";
+    }
+}

--- a/legend-pure-runtime-java-extension-external-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/shared/JsonDeserializationCache.java
+++ b/legend-pure-runtime-java-extension-external-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/shared/JsonDeserializationCache.java
@@ -158,8 +158,15 @@ public class JsonDeserializationCache extends ConversionCache
     }
 
     @Override
-    protected Conversion<?, ?> newGenericAndAnyTypeConversion(ConversionContext context)
+    protected Conversion<?, ?> newGenericAndAnyTypeConversion(boolean isExplicitAny, ConversionContext context)
     {
-        return GenericAndAnyTypeNotSupportedConversion.GENERIC_AND_ANY_TYPE_NOT_SUPPORTED_CONVERSION;
+        if (isExplicitAny)
+        {
+            return JsonAnyTypeDeserialization.JSON_ANY_TYPE_DESERIALIZATION;
+        }
+        else
+        {
+            return GenericAndAnyTypeNotSupportedConversion.GENERIC_AND_ANY_TYPE_NOT_SUPPORTED_CONVERSION;
+        }
     }
 }

--- a/legend-pure-runtime-java-extension-external-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/shared/JsonSerializationCache.java
+++ b/legend-pure-runtime-java-extension-external-json/src/main/java/org/finos/legend/pure/runtime/java/extension/external/json/shared/JsonSerializationCache.java
@@ -156,7 +156,7 @@ public class JsonSerializationCache extends ConversionCache
     }
 
     @Override
-    protected Conversion<?, ?> newGenericAndAnyTypeConversion(ConversionContext context)
+    protected Conversion<?, ?> newGenericAndAnyTypeConversion(boolean isExplicitAny, ConversionContext context)
     {
         return JsonGenericAndAnyTypeSerialization.JSON_GENERIC_AND_ANY_TYPE_SERIALIZATION;
     }

--- a/legend-pure-runtime-java-extension-external-shared/src/main/java/org/finos/legend/pure/runtime/java/extension/external/shared/conversion/ConversionCache.java
+++ b/legend-pure-runtime-java-extension-external-shared/src/main/java/org/finos/legend/pure/runtime/java/extension/external/shared/conversion/ConversionCache.java
@@ -55,6 +55,12 @@ public abstract class ConversionCache
                 this.cache.put(type, mapConversion);
                 return mapConversion;
             }
+            else if (type.getName().equals("Any"))
+            {
+                Conversion<?, ?> anyTypeConversion = this.newGenericAndAnyTypeConversion(true, context);
+                this.cache.put(type, anyTypeConversion);
+                return anyTypeConversion;
+            }
             else
             {
                 ClassConversion<?, ?> classConversion = this.newClassConversion((Class)type, context);
@@ -81,7 +87,7 @@ public abstract class ConversionCache
         }
         if (type == null)
         {
-            return this.newGenericAndAnyTypeConversion(context);
+            return this.newGenericAndAnyTypeConversion(false, context);
         }
         throw new IllegalArgumentException("Unknown type.");
     }
@@ -101,5 +107,5 @@ public abstract class ConversionCache
 
     protected abstract UnitConversion<?, ?> newUnitConversion(CoreInstance type, ConversionContext context);
 
-    protected abstract Conversion<?, ?> newGenericAndAnyTypeConversion(ConversionContext context);
+    protected abstract Conversion<?, ?> newGenericAndAnyTypeConversion(boolean isExplicitAny, ConversionContext context);
 }


### PR DESCRIPTION
This will allow to parse json values into properties of type Any.  This will only work for values that are primitive types (integer, float, string, boolean)

The rational - Im currently trying to parse the Elastic Search specification json, and one of their types (literal_value) have a property that can be any primitive type, and without this enhancement, I not able to get the proper value.

Sample json from ES spec:

```json
       [ {
          "name": "model",
          "required": true,
          "type": {
            "kind": "literal_value",
            "value": "linear"
          }
        },
        {
          "name": "managed",
          "required": true,
          "type": {
            "kind": "literal_value",
            "value": true
          }
        }]
```

The `type` field are mapped into this Pure Type, where value is Any to be able to contain Boolean and String:

```legend
Class meta::external::store::elasticsearch::metamodel::spec::property::LiteralValueType extends PropertyType
{
	kind(){ 'literal_value' }: String[1];
	value: Any[1];
}
```
