### PR TITLE
Support loading code repos from classpath when configuring IDE light

### DIFF
--- a/legend-pure-ide-light/pom.xml
+++ b/legend-pure-ide-light/pom.xml
@@ -142,7 +142,10 @@
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-runtime-java-engine-interpreted</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-configuration-external</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m2-dsl-diagram</artifactId>


### PR DESCRIPTION
This will allow developers to just configure the repos they need to actually edit, and the others are sourced from classpath.

This can be useful when working on 3rd party projects, where the focus its to edit the local files, and the pure dependencies can be read only.  On this same scenario, this can avoid needing to checkout the legend-pure and legend-engine to make the IDE work.