### PR TITLE
Handle properties with type parameters defined on supertype

### DIFF
--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/bootstrap/generator/M3CoreInstanceGenerator.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/bootstrap/generator/M3CoreInstanceGenerator.java
@@ -20,6 +20,7 @@ import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
 import org.eclipse.collections.impl.utility.StringIterate;
 import org.finos.legend.pure.m3.compiler.Context;
+import org.finos.legend.pure.m3.coreinstance.helper.PropertyTypeHelper;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3ProcessorSupport;
 import org.finos.legend.pure.m3.navigation.M3Properties;
@@ -93,7 +94,7 @@ public class M3CoreInstanceGenerator
         @Override
         public CoreInstance getPropertyReturnType(CoreInstance classGenericType, CoreInstance property)
         {
-            return getPropertyResolvedReturnType(classGenericType, property, this.processorSupport);
+            return PropertyTypeHelper.getPropertyResolvedReturnType(classGenericType, property, this.processorSupport);
         }
 
         @Override
@@ -104,18 +105,5 @@ public class M3CoreInstanceGenerator
             Instance.addValueToProperty(genericType, M3Properties.multiplicityArguments, coreInstance.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToOne(M3Properties.typeArguments).getValueForMetaPropertyToMany(M3Properties.multiplicityArguments), this.processorSupport);
             return genericType;
         }
-    }
-
-    static CoreInstance getPropertyResolvedReturnType(CoreInstance classGenericType, CoreInstance property, ProcessorSupport processorSupport)
-    {
-        CoreInstance functionType = processorSupport.function_getFunctionType(property);
-        CoreInstance returnType = Instance.getValueForMetaPropertyToOneResolved(functionType, M3Properties.returnType, processorSupport);
-        CoreInstance propertyOwner = functionType.getValueForMetaPropertyToMany(M3Properties.parameters).getFirst().getValueForMetaPropertyToOne(M3Properties.genericType);
-        if (!GenericType.isGenericTypeConcrete(returnType, processorSupport) && Instance.getValueForMetaPropertyToOneResolved(classGenericType, M3Properties.rawType, processorSupport) != Instance.getValueForMetaPropertyToOneResolved(propertyOwner, M3Properties.rawType, processorSupport))
-        {
-            GenericTypeWithXArguments res = GenericType.resolveClassTypeParameterUsingInheritance(classGenericType, propertyOwner, processorSupport);
-            returnType = GenericType.makeTypeArgumentAsConcreteAsPossible(returnType, res.getArgumentsByParameterName(), Maps.immutable.empty(), processorSupport);
-        }
-        return returnType;
     }
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/coreinstance/helper/PropertyTypeHelper.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/coreinstance/helper/PropertyTypeHelper.java
@@ -1,0 +1,45 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.coreinstance.helper;
+
+import org.eclipse.collections.impl.factory.Maps;
+import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.generictype.GenericType;
+import org.finos.legend.pure.m3.navigation.generictype.GenericTypeWithXArguments;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+public final class PropertyTypeHelper
+{
+    private PropertyTypeHelper()
+    {
+
+    }
+
+    public static CoreInstance getPropertyResolvedReturnType(CoreInstance classGenericType, CoreInstance property, ProcessorSupport processorSupport)
+    {
+        CoreInstance functionType = processorSupport.function_getFunctionType(property);
+        CoreInstance returnType = Instance.getValueForMetaPropertyToOneResolved(functionType, M3Properties.returnType, processorSupport);
+        CoreInstance propertyOwner = functionType.getValueForMetaPropertyToMany(M3Properties.parameters).getFirst().getValueForMetaPropertyToOne(M3Properties.genericType);
+        if (!GenericType.isGenericTypeFullyConcrete(returnType, true, processorSupport)
+                && Instance.getValueForMetaPropertyToOneResolved(classGenericType, M3Properties.rawType, processorSupport) != Instance.getValueForMetaPropertyToOneResolved(propertyOwner, M3Properties.rawType, processorSupport))
+        {
+            GenericTypeWithXArguments res = GenericType.resolveClassTypeParameterUsingInheritance(classGenericType, propertyOwner, processorSupport);
+            returnType = GenericType.makeTypeArgumentAsConcreteAsPossible(returnType, res.getArgumentsByParameterName(), Maps.immutable.empty(), processorSupport);
+        }
+        return returnType;
+    }
+}

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/ClassJsonFactoryProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/ClassJsonFactoryProcessor.java
@@ -18,8 +18,8 @@ import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.factory.Maps;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.milestoning.MilestoningFunctions;
+import org.finos.legend.pure.m3.coreinstance.helper.PropertyTypeHelper;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
@@ -228,15 +228,7 @@ public class ClassJsonFactoryProcessor
 
     private static CoreInstance getPropertyResolvedReturnType(CoreInstance classGenericType, CoreInstance property, ProcessorSupport processorSupport)
     {
-        CoreInstance functionType = processorSupport.function_getFunctionType(property);
-        CoreInstance returnType = Instance.getValueForMetaPropertyToOneResolved(functionType, M3Properties.returnType, processorSupport);
-        CoreInstance propertyOwner = functionType.getValueForMetaPropertyToMany(M3Properties.parameters).getFirst().getValueForMetaPropertyToOne(M3Properties.genericType);
-        if (!GenericType.isGenericTypeConcrete(returnType, processorSupport) && Instance.getValueForMetaPropertyToOneResolved(classGenericType, M3Properties.rawType, processorSupport) != Instance.getValueForMetaPropertyToOneResolved(propertyOwner, M3Properties.rawType, processorSupport))
-        {
-            GenericTypeWithXArguments res = GenericType.resolveClassTypeParameterUsingInheritance(classGenericType, propertyOwner, processorSupport);
-            returnType = GenericType.makeTypeArgumentAsConcreteAsPossible(returnType, res.getArgumentsByParameterName(), Maps.immutable.<String, CoreInstance>empty(), processorSupport);
-        }
-        return returnType;
+        return PropertyTypeHelper.getPropertyResolvedReturnType(classGenericType, property, processorSupport);
     }
 
     private static String typeParameters(CoreInstance _class)

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassProcessor.java
@@ -21,16 +21,14 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.SetIterable;
 import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Maps;
 import org.eclipse.collections.impl.factory.Sets;
+import org.finos.legend.pure.m3.coreinstance.helper.PropertyTypeHelper;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation._class._Class;
-import org.finos.legend.pure.m3.navigation.generictype.GenericType;
-import org.finos.legend.pure.m3.navigation.generictype.GenericTypeWithXArguments;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 import org.finos.legend.pure.runtime.java.compiled.compiler.StringJavaSource;
@@ -126,15 +124,7 @@ public class ClassProcessor
 
     static CoreInstance getPropertyResolvedReturnType(CoreInstance classGenericType, CoreInstance property, ProcessorSupport processorSupport)
     {
-        CoreInstance functionType = processorSupport.function_getFunctionType(property);
-        CoreInstance returnType = Instance.getValueForMetaPropertyToOneResolved(functionType, M3Properties.returnType, processorSupport);
-        CoreInstance propertyOwner = functionType.getValueForMetaPropertyToMany(M3Properties.parameters).getFirst().getValueForMetaPropertyToOne(M3Properties.genericType);
-        if (!GenericType.isGenericTypeConcrete(returnType, processorSupport) && Instance.getValueForMetaPropertyToOneResolved(classGenericType, M3Properties.rawType, processorSupport) != Instance.getValueForMetaPropertyToOneResolved(propertyOwner, M3Properties.rawType, processorSupport))
-        {
-            GenericTypeWithXArguments res = GenericType.resolveClassTypeParameterUsingInheritance(classGenericType, propertyOwner, processorSupport);
-            returnType = GenericType.makeTypeArgumentAsConcreteAsPossible(returnType, res.getArgumentsByParameterName(), Maps.immutable.<String, CoreInstance>empty(), processorSupport);
-        }
-        return returnType;
+        return PropertyTypeHelper.getPropertyResolvedReturnType(classGenericType, property, processorSupport);
     }
 
     static String typeParameters(CoreInstance _class)

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/TestClassWithParamSuperType.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/TestClassWithParamSuperType.java
@@ -35,6 +35,42 @@ public class TestClassWithParamSuperType extends AbstractPureTestWithCoreCompile
     }
 
     @Test
+    public void testPropertiesWithTypeParamsAndExtends()
+    {
+        compileTestSource("fromString.pure",
+                // class with concrete field that has type arguments - i.e Pair
+                "Class A<K,V | m>\n" +
+                "{\n" +
+                "    test : Pair<K, V>[1];\n" +
+                "    withMult: String[m];\n" +
+                "}\n" +
+                "\n" +
+                // class that binds ALL type arguments of generalization
+                "Class B extends A<Integer, String | 0..1>" +
+                "{\n" +
+                "}\n" +
+                "\n" +
+                // class that binds SOME type arguments of generalization
+                "Class C<X|k> extends A<String, X | k>" +
+                "{\n" +
+                "}\n" +
+                "\n" +
+                // class that have multiple generalizations with type arguments bind at diff levels
+                "Class D extends C<String | 1>" +
+                "{\n" +
+                "}\n" +
+                "\n" +
+                "function test():Any[*]\n" +
+                "{\n" +
+                "  ^D(test = pair('eeee', 'ffff'), withMult = 'aaaa');\n" +
+                "  ^C<Float|*>(test = pair('eeee', 1.2), withMult = ['aaaa', 'aaaa']);\n" +
+                "  ^B(test = pair(2, 'eeee'),  withMult = []);\n" +
+                "  ^A<Integer, String|1>(test = pair(2, 'eeee'), withMult = 'aaaa');\n" +
+                "}\n");
+        this.compileAndExecute("test():Any[*]");
+    }
+
+    @Test
     public void testTypeParamsAndExtends()
     {
         compileTestSource("fromString.pure","Class A<P>\n" +


### PR DESCRIPTION
This ensure we generate proper java code when a property contains type arguments, and these type arguments are then defined on a subclass of it.  