### PR TITLE
Support scheme (http, https) on URL

### DIFF
--- a/legend-pure-m3-platform/src/main/resources/platform/pure/corefunctions/io.pure
+++ b/legend-pure-m3-platform/src/main/resources/platform/pure/corefunctions/io.pure
@@ -20,9 +20,16 @@ native function meta::pure::functions::io::readFile(file:String[1]):String[0..1]
 
 Class meta::pure::functions::io::http::URL
 {
+    scheme: URLScheme[0..1];
     host : String[1];
     port : Integer[1];
     path : String[1];
+}
+
+Enum meta::pure::functions::io::http::URLScheme
+{
+    http,
+    https
 }
 
 Enum meta::pure::functions::io::http::HTTPMethod

--- a/legend-pure-runtime-java-engine-compiled/pom.xml
+++ b/legend-pure-runtime-java-engine-compiled/pom.xml
@@ -257,6 +257,11 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/CompiledSupport.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/CompiledSupport.java
@@ -109,6 +109,7 @@ import org.finos.legend.pure.runtime.java.compiled.metadata.JavaMethodWithParams
 import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataAccessor;
 import org.finos.legend.pure.runtime.java.shared.cipher.AESCipherUtil;
 import org.finos.legend.pure.runtime.java.shared.http.HttpMethod;
+import org.finos.legend.pure.runtime.java.shared.http.URLScheme;
 import org.finos.legend.pure.runtime.java.shared.http.HttpRawHelper;
 import org.finos.legend.pure.runtime.java.shared.identity.IdentityManager;
 import org.json.simple.JSONValue;
@@ -3233,6 +3234,11 @@ public class CompiledSupport
 
     public static HTTPResponse executeHttpRaw(URL url, Object method, String mimeType, String body, ExecutionSupport executionSupport)
     {
-        return (HTTPResponse)HttpRawHelper.toHttpResponseInstance(HttpRawHelper.executeHttpService(url._host(), (int)url._port(), url._path(), HttpMethod.valueOf(((Enum)method)._name()), mimeType, body), ((CompiledExecutionSupport)executionSupport).getProcessorSupport());
+        URLScheme scheme = URLScheme.http;
+        if (url._scheme() != null)
+        {
+            scheme = URLScheme.valueOf(url._scheme()._name());
+        }
+        return (HTTPResponse)HttpRawHelper.toHttpResponseInstance(HttpRawHelper.executeHttpService(scheme, url._host(), (int)url._port(), url._path(), HttpMethod.valueOf(((Enum)method)._name()), mimeType, body), ((CompiledExecutionSupport)executionSupport).getProcessorSupport());
     }
 }

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/io/TestHttpCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/io/TestHttpCompiled.java
@@ -17,12 +17,8 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.suppor
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.io.AbstractTestHttp;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.junit.After;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 
-//Remove Ignore when we have an available HTTP server for tests
-@Ignore
 public class TestHttpCompiled extends AbstractTestHttp
 {
     @BeforeClass

--- a/legend-pure-runtime-java-engine-interpreted/pom.xml
+++ b/legend-pure-runtime-java-engine-interpreted/pom.xml
@@ -92,6 +92,10 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/core/io/Http.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/core/io/Http.java
@@ -14,11 +14,8 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.natives.core.io;
 
-import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Properties;
@@ -33,6 +30,7 @@ import org.finos.legend.pure.runtime.java.interpreted.natives.core.Instantiation
 import org.finos.legend.pure.runtime.java.interpreted.natives.core.NativeFunction;
 import org.finos.legend.pure.runtime.java.interpreted.profiler.Profiler;
 import org.finos.legend.pure.runtime.java.shared.http.HttpMethod;
+import org.finos.legend.pure.runtime.java.shared.http.URLScheme;
 import org.finos.legend.pure.runtime.java.shared.http.HttpRawHelper;
 import org.finos.legend.pure.runtime.java.shared.http.SimpleHttpResponse;
 
@@ -53,6 +51,12 @@ public class Http extends NativeFunction
         // URL: param 0
         CoreInstance urlInstance = Instance.getValueForMetaPropertyToOneResolved(params.get(0), M3Properties.values, processorSupport);
 
+        URLScheme urlScheme = URLScheme.http;
+        CoreInstance scheme = Instance.getValueForMetaPropertyToOneResolved(urlInstance, "scheme", processorSupport);
+        if (scheme != null)
+        {
+            urlScheme = URLScheme.valueOf(scheme.getName());
+        }
         String host = PrimitiveUtilities.getStringValue(Instance.getValueForMetaPropertyToOneResolved(urlInstance, M3Properties.host, processorSupport));
         Integer port = (Integer)PrimitiveUtilities.getIntegerValue(Instance.getValueForMetaPropertyToOneResolved(urlInstance, M3Properties.port, processorSupport));
         String path = PrimitiveUtilities.getStringValue(Instance.getValueForMetaPropertyToOneResolved(urlInstance, M3Properties.path, processorSupport));
@@ -70,7 +74,7 @@ public class Http extends NativeFunction
         CoreInstance bodyInstance = Instance.getValueForMetaPropertyToOneResolved(params.get(3), M3Properties.values, processorSupport);
         String body = bodyInstance == null ? null : PrimitiveUtilities.getStringValue(bodyInstance);
 
-        SimpleHttpResponse response = HttpRawHelper.executeHttpService(host, port, path, httpMethod, mimeType, body);
+        SimpleHttpResponse response = HttpRawHelper.executeHttpService(urlScheme, host, port, path, httpMethod, mimeType, body);
 
         return ValueSpecificationBootstrap.wrapValueSpecification(HttpRawHelper.toHttpResponseInstance(response, processorSupport), true, processorSupport);
     }

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/io/TestHttp.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/io/TestHttp.java
@@ -17,12 +17,8 @@ package org.finos.legend.pure.runtime.java.interpreted.function.base.io;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.io.AbstractTestHttp;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 
-//Remove Ignore when we have an available HTTP server for tests
-@Ignore
 public class TestHttp extends AbstractTestHttp
 {
     @BeforeClass

--- a/legend-pure-runtime-java-engine-shared/src/main/java/org/finos/legend/pure/runtime/java/shared/http/HttpRawHelper.java
+++ b/legend-pure-runtime-java-engine-shared/src/main/java/org/finos/legend/pure/runtime/java/shared/http/HttpRawHelper.java
@@ -43,11 +43,15 @@ import java.nio.charset.StandardCharsets;
 
 public class HttpRawHelper
 {
-
     public static SimpleHttpResponse executeHttpService(String host, int port, String path, HttpMethod httpMethod, String mimeType, String body)
     {
+        return executeHttpService(URLScheme.http, host, port, path, httpMethod, mimeType, body);
+    }
+
+    public static SimpleHttpResponse executeHttpService(URLScheme scheme, String host, int port, String path, HttpMethod httpMethod, String mimeType, String body)
+    {
         final URIBuilder uriBuilder = new URIBuilder()
-                .setScheme("http")
+                .setScheme(scheme.name())
                 .setHost(host)
                 .setPort(port)
                 .setPath(path);

--- a/legend-pure-runtime-java-engine-shared/src/main/java/org/finos/legend/pure/runtime/java/shared/http/URLScheme.java
+++ b/legend-pure-runtime-java-engine-shared/src/main/java/org/finos/legend/pure/runtime/java/shared/http/URLScheme.java
@@ -1,0 +1,20 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.shared.http;
+
+public enum URLScheme
+{
+    http, https
+}


### PR DESCRIPTION
This PR enhance the URL, and the execute raw HTTP request to support a provided url scheme: http, or https.

The change is fully backward compatible, assuming http when the scheme is not provided, and keeping the existing method signatures.