### PR TITLE
Update for compiled mode so that evaluation of lambdas where the expressionSequence has modified is in sync / matches

### DIFF
--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/AbstractTestFunctionDefinitionModify.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/AbstractTestFunctionDefinitionModify.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2022 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/AbstractTestFunctionDefinitionModify.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/AbstractTestFunctionDefinitionModify.java
@@ -98,7 +98,6 @@ public abstract class AbstractTestFunctionDefinitionModify extends AbstractPureT
     public void cleanRuntime()
     {
         runtime.delete("testSource.pure");
-//        runtime.delete("/test/testModel.pure");
         runtime.compile();
     }
 

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/AbstractTestFunctionDefinitionModify.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/AbstractTestFunctionDefinitionModify.java
@@ -1,0 +1,259 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.tests.function;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.TestCodeRepositoryWithDependencies;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public abstract class AbstractTestFunctionDefinitionModify extends AbstractPureTestWithCoreCompiled
+{
+    private static final String DECLARATION = "" +
+            "function performCompare(origLambda : FunctionDefinition<{String[1]->String[1]}>[1], \n" +
+            "                   mutator : FunctionDefinition<{FunctionDefinition<{String[1]->String[1]}>[1],\n" +
+            "                                                 FunctionDefinition<{String[1]->String[1]}>[1]\n" +
+            "                                                 ->FunctionDefinition<{String[1]->String[1]}>[1]\n" +
+            "                                               }>[1],\n" +
+            "                   expectedLambda : FunctionDefinition<{String[1]->String[1]}>[1]):Boolean[1]\n" +
+            "{ \n" +
+            "    if($origLambda->openVariableValues()->keyValues()->isEmpty(), " +
+            "         | ''," +
+            "         | print('WARNING: Copy/clone of lambdas with open variables fully supported, failures may occur', 1)" +
+            "         );\n" +
+            "  \n" +
+            "  let newLambda = $mutator->eval($origLambda, $expectedLambda);\n" +
+            "  \n" +
+            "  let inputVal = 'hello';\n" +
+            "\n" +
+            "  print('Evaluating $origLambda\\n', 1);\n" +
+            "  let resultOrigLambda = $origLambda->eval($inputVal);\n" +
+            "  print('Evaluating $expectedLambda\\n', 1);\n" +
+            "  let resultExpectedLambda = $expectedLambda->eval($inputVal);\n" +
+            "  print('Evaluating $newLambda\\n', 1);\n" +
+            "  let resultNewLambda = $newLambda->eval($inputVal);\n" +
+            "\n" +
+            "  print('$resultOrigLambda: ' + $resultOrigLambda + '\\n', 1);\n" +
+            "  print('$resultExpectedLambda: ' + $resultExpectedLambda + '\\n', 1);\n" +
+            "  print('$resultNewLambda: ' + $resultNewLambda + '\\n', 1);\n" +
+            "  print('$resultOrigLambda sourceInformation: ', 1);\n" +
+            "  print($resultOrigLambda->sourceInformation(), 1);\n" +
+            "  print('$resultNewLambda sourceInformation: ', 1);\n" +
+            "  print($resultNewLambda->sourceInformation(), 1);\n" +
+            "\n" +
+            "  //if($resultNewLambda == $resultOrigLambda,\n" +
+            "  //     | fail('Modified lambda result not changed, got original: \\'' + $resultOrigLambda +  '\\''),\n" +
+            "  //     | true);\n" +
+            "\n" +
+            "  if($resultNewLambda != $resultExpectedLambda,\n" +
+            "       | fail('Modified lambda result not as expected, expected: \\'' + $resultExpectedLambda +  '\\' got: \\'' + $resultNewLambda +  '\\''),\n" +
+            "       | true);\n" +
+            "}\n" +
+            "\n" +
+            "\n" +
+            "function test::hierarchicalProperties(class:Class<Any>[1]):Property<Nil,Any|*>[*]\n" +
+            "{\n" +
+            "   if($class==Any,\n" +
+            "      | [],\n" +
+            "      | $class.properties->concatenate($class.generalizations->map(g| test::hierarchicalProperties($g.general.rawType->cast(@Class<Any>)->toOne())))->removeDuplicates()\n" +
+            "   );\n" +
+            "}\n" +
+            "\n" +
+            "function modifyExpressionSequenceWithDynamicNew<T>(fd:FunctionDefinition<T>[1], es : ValueSpecification[1..*]) : FunctionDefinition<T>[1]\n" +
+            "{\n" +
+            "    let genericType = ^KeyValue(key='classifierGenericType', value= $fd.classifierGenericType);\n" +
+            "\n" +
+            "    let fdClass = $fd->type()->cast(@Class<Any>);\n" +
+            "    let properties = $fdClass->test::hierarchicalProperties()->map(p|\n" +
+            "      if($p.name == 'expressionSequence', \n" +
+            "        | ^KeyValue(key=$p.name->toOne(), value= $es), \n" +
+            "        | ^KeyValue(key=$p.name->toOne(), value= $p->eval($fd))\n" +
+            "        );\n" +
+            "      );\n" +
+            "\n" +
+            "    dynamicNew($fd.classifierGenericType->toOne(), $properties->concatenate($genericType))->cast($fd);\n" +
+            "}\n" +
+            "\n";
+
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete("testSource.pure");
+//        runtime.delete("/test/testModel.pure");
+        runtime.compile();
+    }
+
+    @Test
+    public void testConcreteFunctionDefinitionModifyWithCopyConstructor()
+    {
+        compileTestSource("testSource.pure",
+                DECLARATION
+                        + "function xx::myFunc(s : String[1]) : String[1] { 'answer: ' + $s; }\n"
+                        + "\n"
+                        + "function test():Any[*] \n{"
+                        + "\n"
+                        + "  let origFunc = xx::myFunc_String_1__String_1_;\n" +
+                        "  let replacementLambda = {s:String[1]|'not your input:' + $s};\n" +
+                        "  let replacementLambda2 = {s:String[1]|'not your input2:' + $s};\n" +
+                        "  \n" +
+                        "  let mutator = {f:FunctionDefinition<{String[1]->String[1]}>[1], f2:FunctionDefinition<{String[1]->String[1]}>[1]|\n" +
+                        "    ^$f(expressionSequence = $f2->evaluateAndDeactivate().expressionSequence)\n" +
+                        "    };\n" +
+                        "\n" +
+                        "  performCompare($origFunc, $mutator, $replacementLambda);\n" +
+                        "  performCompare($origFunc, $mutator, $replacementLambda2);\n" +
+                        "\n"
+                        + "}\n");
+
+        CoreInstance func = runtime.getFunction("test():Any[*]");
+        functionExecution.start(func, Lists.immutable.empty());
+    }
+
+    @Test
+    public void testConcreteFunctionDefinitionModifyWithDynamicNew()
+    {
+        compileTestSource("testSource.pure",
+                DECLARATION
+                        + "function xx::myFunc(s : String[1]) : String[1] { 'answer: ' + $s; }\n"
+                        + "\n"
+                        + "function test():Any[*] \n{"
+                        + "\n"
+                        + "  let origFunc = xx::myFunc_String_1__String_1_;\n" +
+                        "  let replacementLambda = {s:String[1]|'not your input:' + $s};\n" +
+                        "  let replacementLambda2 = {s:String[1]|'not your input2:' + $s};\n" +
+                        "  \n" +
+                        "  let mutator = {f:FunctionDefinition<{String[1]->String[1]}>[1], f2:FunctionDefinition<{String[1]->String[1]}>[1]|\n" +
+                        "    $f->modifyExpressionSequenceWithDynamicNew($f2.expressionSequence)\n" +
+                        "    };\n" +
+                        "\n" +
+                        "  performCompare($origFunc, $mutator, $replacementLambda);\n" +
+                        "  performCompare($origFunc, $mutator, $replacementLambda2);\n" +
+                        "\n"
+                        + "}\n");
+
+        CoreInstance func = runtime.getFunction("test():Any[*]");
+        functionExecution.start(func, Lists.immutable.empty());
+    }
+
+    @Test
+    public void testLambdaModifyWithCopyConstructor()
+    {
+        compileTestSource("testSource.pure",
+                DECLARATION
+                        + "function test():Any[*] \n{"
+                        + "\n"
+                        + "  let origLambda = {s:String[1]|'answer: ' + $s};\n" +
+                        "  let replacementLambda = {s:String[1]|'not your input:' + $s};\n" +
+                        "  let replacementLambda2 = {s:String[1]|'not your input2:' + $s};\n" +
+                        "  \n" +
+                        "  let mutator = {f:FunctionDefinition<{String[1]->String[1]}>[1], f2:FunctionDefinition<{String[1]->String[1]}>[1]|\n" +
+                        "    ^$f(expressionSequence = $f2->evaluateAndDeactivate().expressionSequence)\n" +
+                        "    };\n" +
+                        "\n" +
+                        "  performCompare($origLambda, $mutator, $replacementLambda);\n" +
+                        "  performCompare($origLambda, $mutator, $replacementLambda2);\n" +
+                        "\n"
+                        + "}\n");
+
+        CoreInstance func = runtime.getFunction("test():Any[*]");
+        functionExecution.start(func, Lists.immutable.empty());
+    }
+
+    @Test
+    @Ignore(value = "This is not supported (Dynamic new can't pass in the variable context / values for open variables)")
+    public void testLambdaCloneWithDynamicNew()
+    {
+        compileTestSource("testSource.pure",
+                DECLARATION
+                        + "function test():Any[*] \n{"
+                        + "\n" +
+                        "  let openVarValue = 'xyz';\n" +
+                        "  \n" +
+                        "  let origLambda = {s:String[1]|'answer: ' + $openVarValue + '/' + $s};\n" +
+                        "  \n" +
+                        "  let mutator = {f:FunctionDefinition<{String[1]->String[1]}>[1], f2:FunctionDefinition<{String[1]->String[1]}>[1]|\n" +
+                        "    $f->modifyExpressionSequenceWithDynamicNew($f.expressionSequence)\n" +
+                        "    };\n" +
+                        "\n" +
+                        "  performCompare($origLambda, $mutator, $origLambda);\n" +
+                        "\n"
+                        + "}\n");
+
+        CoreInstance func = runtime.getFunction("test():Any[*]");
+        functionExecution.start(func, Lists.immutable.empty());
+    }
+
+    @Test
+    @Ignore(value = "This is not supported (copy doesn't in the variable context / values for open variables)")
+    public void testLambdaCloneWithCopyConstructor()
+    {
+        compileTestSource("testSource.pure",
+                DECLARATION
+                        + "function test():Any[*] \n{"
+                        + "\n" +
+                        "  let openVarValue = 'xyz';\n" +
+                        "  \n" +
+                        "  let origLambda = {s:String[1]|'answer: ' + $openVarValue + '/' + $s};\n" +
+                        "  \n" +
+                        "  let mutator = {f:FunctionDefinition<{String[1]->String[1]}>[1], f2:FunctionDefinition<{String[1]->String[1]}>[1]|\n" +
+                        "    ^$f()\n" +
+                        "    };\n" +
+                        "\n" +
+                        "  performCompare($origLambda, $mutator, $origLambda);\n" +
+                        "\n"
+                        + "}\n");
+
+        CoreInstance func = runtime.getFunction("test():Any[*]");
+        functionExecution.start(func, Lists.immutable.empty());
+    }
+
+    @Test
+    public void testLambdaModifyWithDynamicNew()
+    {
+        compileTestSource("testSource.pure",
+                DECLARATION
+                        + "function test():Any[*] \n{"
+                        + "\n"
+                        + "  let origLambda = {s:String[1]|'answer: ' + $s};\n" +
+                        "  let replacementLambda = {s:String[1]|'not your input:' + $s};\n" +
+                        "  let replacementLambda2 = {s:String[1]|'not your input2:' + $s};\n" +
+                        "  \n" +
+                        "  let mutator = {f:FunctionDefinition<{String[1]->String[1]}>[1], f2:FunctionDefinition<{String[1]->String[1]}>[1]|\n" +
+                        "    $f->modifyExpressionSequenceWithDynamicNew($f2.expressionSequence)\n" +
+                        "    };\n" +
+                        "\n" +
+                        "  performCompare($origLambda, $mutator, $replacementLambda);\n" +
+                        "  performCompare($origLambda, $mutator, $replacementLambda2);\n" +
+                        "\n"
+                        + "}\n");
+
+        CoreInstance func = runtime.getFunction("test():Any[*]");
+        functionExecution.start(func, Lists.immutable.empty());
+    }
+
+    protected static MutableCodeStorage getCodeStorage()
+    {
+        CodeRepository platform = CodeRepository.newPlatformCodeRepository();
+        CodeRepository test = new TestCodeRepositoryWithDependencies("test", null, platform);
+        return new PureCodeStorage(null, new ClassLoaderCodeStorage(platform, test));
+    }
+}

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
@@ -58,8 +58,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-public final class JavaSourceCodeGenerator
-{
+public final class JavaSourceCodeGenerator {
     public static final String EXTERNAL_FUNCTIONS_CLASS_NAME = "PureExternal";
 
     public static final String imports =
@@ -153,8 +152,7 @@ public final class JavaSourceCodeGenerator
 
     private final String name;
 
-    public JavaSourceCodeGenerator(ProcessorSupport processorSupport, IdBuilder idBuilder, CodeStorage codeStorage, boolean writeFilesToDisk, Path directoryToWriteFilesTo, boolean includePureStackTrace, Iterable<? extends CompiledExtension> extensions, String name, String externalAPIPackage, boolean generateCompilerExtensionCode)
-    {
+    public JavaSourceCodeGenerator(ProcessorSupport processorSupport, IdBuilder idBuilder, CodeStorage codeStorage, boolean writeFilesToDisk, Path directoryToWriteFilesTo, boolean includePureStackTrace, Iterable<? extends CompiledExtension> extensions, String name, String externalAPIPackage, boolean generateCompilerExtensionCode) {
         this.name = name;
         this.processorSupport = processorSupport;
         this.idBuilder = (idBuilder == null) ? IdBuilder.newIdBuilder(this.processorSupport) : idBuilder;
@@ -164,55 +162,44 @@ public final class JavaSourceCodeGenerator
         this.includePureStackTrace = includePureStackTrace;
         this.extensions = Lists.mutable.with(CoreExtensionCompiled.extension()).withAll(extensions);
         this.externalAPIPackage = externalAPIPackage;
-        if (this.directoryToWriteFilesTo != null && generateCompilerExtensionCode)
-        {
+        if (this.directoryToWriteFilesTo != null && generateCompilerExtensionCode) {
             this.javaClassesToDisk(this.extensions.flatCollect(CompiledExtension::getExtraJavaSources));
         }
     }
 
-    public JavaSourceCodeGenerator(ProcessorSupport processorSupport, CodeStorage codeStorage, boolean writeFilesToDisk, Path directoryToWriteFilesTo, boolean includePureStackTrace, Iterable<? extends CompiledExtension> extensions, String name, String externalAPIPackage, boolean generateCompilerExtensionCode)
-    {
+    public JavaSourceCodeGenerator(ProcessorSupport processorSupport, CodeStorage codeStorage, boolean writeFilesToDisk, Path directoryToWriteFilesTo, boolean includePureStackTrace, Iterable<? extends CompiledExtension> extensions, String name, String externalAPIPackage, boolean generateCompilerExtensionCode) {
         this(processorSupport, null, codeStorage, writeFilesToDisk, directoryToWriteFilesTo, includePureStackTrace, extensions, name, externalAPIPackage, generateCompilerExtensionCode);
     }
 
-    public ProcessorSupport getProcessorSupport()
-    {
+    public ProcessorSupport getProcessorSupport() {
         return this.processorSupport;
     }
 
-    ListIterable<StringJavaSource> generateCode(Source source)
-    {
-        if (source.getNewInstances() == null)
-        {
+    ListIterable<StringJavaSource> generateCode(Source source) {
+        if (source.getNewInstances() == null) {
             return Lists.fixedSize.empty();
         }
-        try
-        {
+        try {
             ProcessorContext processorContext = new ProcessorContext(this.processorSupport, this.extensions, this.idBuilder, this.includePureStackTrace);
             source.getNewInstances().forEach(coreInstance ->
             {
-                if (!Instance.instanceOf(coreInstance, M3Paths.Package, this.processorSupport))
-                {
+                if (!Instance.instanceOf(coreInstance, M3Paths.Package, this.processorSupport)) {
                     this.toJava(coreInstance, processorContext);
                 }
             });
 
             MutableList<StringJavaSource> javaClasses = buildJavaClasses(processorContext);
-            if (this.writeFilesToDisk)
-            {
+            if (this.writeFilesToDisk) {
                 this.javaClassesToDisk(javaClasses);
             }
 
             return javaClasses;
-        }
-        catch (Throwable t)
-        {
+        } catch (Throwable t) {
             throw new RuntimeException("Error generating Java code for " + source.getId(), t);
         }
     }
 
-    ListIterable<StringJavaSource> generateCode()
-    {
+    ListIterable<StringJavaSource> generateCode() {
         CoreInstance root = this.processorSupport.package_getByUserPath("::");
 
         ProcessorContext processorContext = new ProcessorContext(this.processorSupport, this.extensions, this.idBuilder, this.includePureStackTrace);
@@ -221,8 +208,7 @@ public final class JavaSourceCodeGenerator
 
         MutableList<StringJavaSource> javaClasses = Lists.mutable.empty();
         javaClasses.addAll(this.buildJavaClasses(processorContext));
-        if (this.writeFilesToDisk)
-        {
+        if (this.writeFilesToDisk) {
             this.javaClassesToDisk(javaClasses);
         }
 
@@ -230,8 +216,7 @@ public final class JavaSourceCodeGenerator
         return javaClasses;
     }
 
-    ListIterable<StringJavaSource> generatePureCoreHelperClasses(ProcessorContext processorContext)
-    {
+    ListIterable<StringJavaSource> generatePureCoreHelperClasses(ProcessorContext processorContext) {
         String platform = "import " + JavaPackageAndImportBuilder.platformJavaPackage() + ".*;\n";
         MutableList<StringJavaSource> coreJavaSources = Lists.mutable.with(
                 StringJavaSource.newStringJavaSource(JavaPackageAndImportBuilder.platformJavaPackage(), "PureCompiledLambda", imports + platform + this.buildPureCompiledLambda(processorContext)),
@@ -239,34 +224,28 @@ public final class JavaSourceCodeGenerator
                 StringJavaSource.newStringJavaSource(JavaPackageAndImportBuilder.platformJavaPackage(), getFactoryRegistryName(), this.buildFactoryRegistry()),
                 EnumProcessor.processEnum(),
                 EnumProcessor.processEnumLazy());
-        if (this.writeFilesToDisk)
-        {
+        if (this.writeFilesToDisk) {
             this.javaClassesToDisk(coreJavaSources);
         }
         return coreJavaSources;
     }
 
-    void collectClassesToSerialize()
-    {
+    void collectClassesToSerialize() {
         AccessLevel.EXTERNALIZABLE.getStereotype(this.processorSupport).getValueForMetaPropertyToMany(M3Properties.modelElements).forEach(element ->
         {
-            if (Instance.instanceOf(element, M3Paths.Function, this.processorSupport))
-            {
+            if (Instance.instanceOf(element, M3Paths.Function, this.processorSupport)) {
                 CoreInstance functionType = this.processorSupport.function_getFunctionType(element);
                 functionType.getValueForMetaPropertyToMany(M3Properties.parameters).forEach(parameter ->
                 {
                     CoreInstance type = Instance.getValueForMetaPropertyToOneResolved(parameter, M3Properties.genericType, this.processorSupport);
                     CoreInstance rawType = Instance.getValueForMetaPropertyToOneResolved(type, M3Properties.rawType, this.processorSupport);
-                    if (M3Paths.Map.equals(PackageableElement.getUserPathForPackageableElement(rawType)))
-                    {
+                    if (M3Paths.Map.equals(PackageableElement.getUserPathForPackageableElement(rawType))) {
                         CoreInstance mapKey = Instance.getValueForMetaPropertyToOneResolved(Instance.getValueForMetaPropertyToManyResolved(type, M3Properties.typeArguments, this.processorSupport).get(0), M3Properties.rawType, this.processorSupport);
-                        if (Instance.instanceOf(mapKey, M3Paths.Class, this.processorSupport))
-                        {
+                        if (Instance.instanceOf(mapKey, M3Paths.Class, this.processorSupport)) {
                             this.addClassToSerialize(mapKey, this.javaSerializedClasses);
                         }
                         CoreInstance mapValue = Instance.getValueForMetaPropertyToOneResolved(Instance.getValueForMetaPropertyToManyResolved(type, M3Properties.typeArguments, this.processorSupport).get(1), M3Properties.rawType, this.processorSupport);
-                        if (Instance.instanceOf(mapValue, M3Paths.Class, this.processorSupport))
-                        {
+                        if (Instance.instanceOf(mapValue, M3Paths.Class, this.processorSupport)) {
                             this.addClassToSerialize(mapValue, this.javaSerializedClasses);
                         }
                     }
@@ -275,36 +254,28 @@ public final class JavaSourceCodeGenerator
         });
     }
 
-    private void addClassToSerialize(CoreInstance coreInstanceClass, MutableSet<CoreInstance> set)
-    {
-        if (!set.add(coreInstanceClass))
-        {
+    private void addClassToSerialize(CoreInstance coreInstanceClass, MutableSet<CoreInstance> set) {
+        if (!set.add(coreInstanceClass)) {
             return;
         }
 
         boolean isInherit = !coreInstanceClass.getValueForMetaPropertyToMany(M3Properties.generalizations).isEmpty();
 
-        if (isInherit)
-        {
-            for (CoreInstance superClass : coreInstanceClass.getValueForMetaPropertyToMany(M3Properties.generalizations))
-            {
+        if (isInherit) {
+            for (CoreInstance superClass : coreInstanceClass.getValueForMetaPropertyToMany(M3Properties.generalizations)) {
                 CoreInstance generalGenericType = Instance.getValueForMetaPropertyToOneResolved(superClass, M3Properties.general, this.processorSupport);
                 CoreInstance rawType = Instance.getValueForMetaPropertyToOneResolved(generalGenericType, M3Properties.rawType, this.processorSupport);
-                if (rawType != null && Instance.instanceOf(rawType, M3Paths.Class, this.processorSupport))
-                {
+                if (rawType != null && Instance.instanceOf(rawType, M3Paths.Class, this.processorSupport)) {
                     this.addClassToSerialize(rawType, set);
                 }
             }
         }
 
         boolean isInherited = !coreInstanceClass.getValueForMetaPropertyToMany(M3Properties.specializations).isEmpty();
-        if (isInherited)
-        {
-            for (CoreInstance subClass : coreInstanceClass.getValueForMetaPropertyToMany(M3Properties.specializations))
-            {
+        if (isInherited) {
+            for (CoreInstance subClass : coreInstanceClass.getValueForMetaPropertyToMany(M3Properties.specializations)) {
                 CoreInstance specificType = Instance.getValueForMetaPropertyToOneResolved(subClass, M3Properties.specific, this.processorSupport);
-                if (Instance.instanceOf(specificType, M3Paths.Class, this.processorSupport))
-                {
+                if (Instance.instanceOf(specificType, M3Paths.Class, this.processorSupport)) {
                     this.addClassToSerialize(specificType, set);
                 }
             }
@@ -315,22 +286,19 @@ public final class JavaSourceCodeGenerator
         {
             CoreInstance type = Instance.getValueForMetaPropertyToOneResolved(coreInstance, M3Properties.genericType, this.processorSupport);
             CoreInstance rawType = Instance.getValueForMetaPropertyToOneResolved(type, M3Properties.rawType, this.processorSupport);
-            if (rawType != null && Instance.instanceOf(rawType, M3Paths.Class, this.processorSupport))
-            {
+            if (rawType != null && Instance.instanceOf(rawType, M3Paths.Class, this.processorSupport)) {
                 addClassToSerialize(rawType, set);
             }
         });
     }
 
-    ListIterable<StringJavaSource> generateExternalizableAPI(String pack)
-    {
+    ListIterable<StringJavaSource> generateExternalizableAPI(String pack) {
         MutableList<String> externalizableFunctionCode = Lists.mutable.empty();
         CoreInstance functionClass = this.processorSupport.package_getByUserPath(M3Paths.Function);
         ProcessorContext processorContext = new ProcessorContext(this.processorSupport, this.extensions, this.idBuilder, this.includePureStackTrace);
         AccessLevel.EXTERNALIZABLE.getStereotype(this.processorSupport).getValueForMetaPropertyToMany(M3Properties.modelElements).forEach(element ->
         {
-            if (Instance.instanceOf(element, functionClass, this.processorSupport))
-            {
+            if (Instance.instanceOf(element, functionClass, this.processorSupport)) {
                 externalizableFunctionCode.add(FunctionProcessor.buildExternalizableFunction(element, processorContext));
             }
         });
@@ -338,52 +306,41 @@ public final class JavaSourceCodeGenerator
         return Lists.immutable.with(StringJavaSource.newStringJavaSource(pack, EXTERNAL_FUNCTIONS_CLASS_NAME, text));
     }
 
-    private void javaClassesToDisk(Iterable<? extends StringJavaSource> javaClasses)
-    {
-        try
-        {
+    private void javaClassesToDisk(Iterable<? extends StringJavaSource> javaClasses) {
+        try {
             Files.createDirectories(this.directoryToWriteFilesTo);
-            for (StringJavaSource source : javaClasses)
-            {
+            for (StringJavaSource source : javaClasses) {
                 //String fileUri = "file://" + source.toUri().getPath();
                 Path file = Paths.get(this.directoryToWriteFilesTo + source.toUri().getPath());
                 Files.createDirectories(file.getParent());
                 Files.write(file, source.getCode().getBytes(StandardCharsets.UTF_8));
             }
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private MutableList<StringJavaSource> buildJavaClasses(ProcessorContext processorContext)
-    {
+    private MutableList<StringJavaSource> buildJavaClasses(ProcessorContext processorContext) {
         MutableList<StringJavaSource> javaClasses = Lists.mutable.empty();
         javaClasses.addAll(processorContext.getClasses());
 
         MutableSet<String> processedSources = Sets.mutable.empty();
         String functionImports = processorContext.getNativeFunctionProcessor().getImports().makeString("");
-        for (String sourceId : processorContext.getSourcesWithFunctionDefinitions())
-        {
+        for (String sourceId : processorContext.getSourcesWithFunctionDefinitions()) {
             processedSources.add(sourceId);
             javaClasses.add(StringJavaSource.newStringJavaSource(this.getFunctionPackageName(sourceId), sourceId, functionImports +
                     this.buildFunctionClass(sourceId, processorContext.getFunctionDefinitionsForSource(sourceId), processorContext.getLambdaFunctionsForSource(sourceId), processorContext.getNativeLambdaFunctionsForSource(sourceId))));
         }
 
-        for (String sourceId : processorContext.getSourcesWithLambdaFunctions())
-        {
-            if (processedSources.add(sourceId))
-            {
+        for (String sourceId : processorContext.getSourcesWithLambdaFunctions()) {
+            if (processedSources.add(sourceId)) {
                 javaClasses.add(StringJavaSource.newStringJavaSource(this.getFunctionPackageName(sourceId), sourceId, functionImports +
                         this.buildFunctionClass(sourceId, null, processorContext.getLambdaFunctionsForSource(sourceId), processorContext.getNativeLambdaFunctionsForSource(sourceId))));
             }
         }
 
-        for (String sourceId : processorContext.getSourcesWithNativeLambdaFunctions())
-        {
-            if (processedSources.add(sourceId))
-            {
+        for (String sourceId : processorContext.getSourcesWithNativeLambdaFunctions()) {
+            if (processedSources.add(sourceId)) {
                 javaClasses.add(StringJavaSource.newStringJavaSource(this.getFunctionPackageName(sourceId), sourceId, functionImports +
                         this.buildFunctionClass(sourceId, null, null, processorContext.getNativeLambdaFunctionsForSource(sourceId))));
             }
@@ -392,24 +349,18 @@ public final class JavaSourceCodeGenerator
         return javaClasses;
     }
 
-    private String getFunctionPackageName(String sourceId)
-    {
+    private String getFunctionPackageName(String sourceId) {
         return JavaPackageAndImportBuilder.rootPackage();
     }
 
-    private void toJava(CoreInstance coreInstance, ProcessorContext processorContext) throws PureCompilationException
-    {
-        try
-        {
-            if (Instance.instanceOf(coreInstance, M3Paths.Package, this.processorSupport))
-            {
-                for (CoreInstance element : coreInstance.getValueForMetaPropertyToMany(M3Properties.children))
-                {
+    private void toJava(CoreInstance coreInstance, ProcessorContext processorContext) throws PureCompilationException {
+        try {
+            if (Instance.instanceOf(coreInstance, M3Paths.Package, this.processorSupport)) {
+                for (CoreInstance element : coreInstance.getValueForMetaPropertyToMany(M3Properties.children)) {
                     this.toJava(element, processorContext);
                 }
             }
-            if (Instance.instanceOf(coreInstance, M3Paths.Class, this.processorSupport))
-            {
+            if (Instance.instanceOf(coreInstance, M3Paths.Class, this.processorSupport)) {
                 CoreInstance genericType = Type.wrapGenericType(coreInstance, null, this.processorSupport);
                 Instance.addValueToProperty(genericType, M3Properties.typeArguments, coreInstance.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToOne(M3Properties.typeArguments).getValueForMetaPropertyToMany(M3Properties.typeArguments), this.processorSupport);
                 Instance.addValueToProperty(genericType, M3Properties.multiplicityArguments, coreInstance.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToOne(M3Properties.typeArguments).getValueForMetaPropertyToMany(M3Properties.multiplicityArguments), this.processorSupport);
@@ -419,83 +370,65 @@ public final class JavaSourceCodeGenerator
 
                 ClassJsonFactoryProcessor.processClass(genericType, processorContext);
             }
-            if (Instance.instanceOf(coreInstance, M3Paths.Enumeration, this.processorSupport) && ClassProcessor.isPlatformClass(coreInstance))
-            {
+            if (Instance.instanceOf(coreInstance, M3Paths.Enumeration, this.processorSupport) && ClassProcessor.isPlatformClass(coreInstance)) {
                 this.platformEnumerations.add(coreInstance);
             }
-            if (Instance.instanceOf(coreInstance, M3Paths.ConcreteFunctionDefinition, this.processorSupport))
-            {
+            if (Instance.instanceOf(coreInstance, M3Paths.ConcreteFunctionDefinition, this.processorSupport)) {
                 FunctionProcessor.processFunctionDefinition(coreInstance, processorContext, this.processorSupport);
             }
-            if (Instance.instanceOf(coreInstance, M3Paths.NativeFunction, this.processorSupport))
-            {
+            if (Instance.instanceOf(coreInstance, M3Paths.NativeFunction, this.processorSupport)) {
                 processorContext.getNativeFunctionProcessor().buildNativeLambdaFunction(coreInstance, processorContext);
             }
-            if (Instance.instanceOf(coreInstance, M3Paths.Measure, this.processorSupport))
-            {
+            if (Instance.instanceOf(coreInstance, M3Paths.Measure, this.processorSupport)) {
                 RichIterable<CoreInstance> processedMeasure = MeasureProcessor.processMeasure(coreInstance, processorContext);
                 this.processedMeasures.addAllIterable(processedMeasure);
             }
-            if (Instance.instanceOf(coreInstance, M3Paths.Unit, this.processorSupport))
-            {
+            if (Instance.instanceOf(coreInstance, M3Paths.Unit, this.processorSupport)) {
                 RichIterable<CoreInstance> processedUnit = UnitProcessor.processUnit(coreInstance, processorContext);
                 this.processedUnits.addAllIterable(processedUnit);
             }
             LazyIterate.flatCollect(this.extensions, CompiledExtension::getExtraPackageableElementProcessors).forEach(e -> e.value(coreInstance, this, processorContext));
-        }
-        catch (PureCompilationException e)
-        {
+        } catch (PureCompilationException e) {
             throw e;
-        }
-        catch (Throwable t)
-        {
+        } catch (Throwable t) {
             PureException pe = PureException.findPureException(t);
-            if (pe == null)
-            {
+            if (pe == null) {
                 throw new PureCompilationException(coreInstance.getSourceInformation(), "Error generating Java code for " + coreInstance, t);
-            }
-            else
-            {
+            } else {
                 String info = pe.getInfo();
                 throw new PureCompilationException(coreInstance.getSourceInformation(), info == null ? "Error generating Java code for " + coreInstance : info, pe);
             }
         }
     }
 
-    private String buildFunctionClass(String name, RichIterable<String> functionDefinitions, MapIterable<String, String> lambdaFunctions, MapIterable<String, String> nativeFunctions)
-    {
+    private String buildFunctionClass(String name, RichIterable<String> functionDefinitions, MapIterable<String, String> lambdaFunctions, MapIterable<String, String> nativeFunctions) {
         return
                 "public class " + name + "\n" +
                         "{\n" +
                         ((lambdaFunctions != null || nativeFunctions != null) ?
-                        "    public static MutableMap<String, SharedPureFunction<?>> __functions = Maps.mutable.empty();\n" +
-                        "    static\n" +
-                        "    {\n" +
-                        (lambdaFunctions == null ? "" : lambdaFunctions.keyValuesView().collect(keyValuePair -> "        __functions.put(\"" + keyValuePair.getOne() + "\", " + keyValuePair.getTwo() + ");\n").makeString("")) +
-                        (nativeFunctions == null ? "" : nativeFunctions.keyValuesView().collect(keyValuePair -> "        __functions.put(\"" + keyValuePair.getOne() + "\", " + keyValuePair.getTwo() + ");\n").makeString("")) +
-                        "    }\n" :
-                        "    public static MutableMap<String, SharedPureFunction<?>> __functions = Maps.fixedSize.empty();\n"
+                                "    public static MutableMap<String, SharedPureFunction<?>> __functions = Maps.mutable.empty();\n" +
+                                        "    static\n" +
+                                        "    {\n" +
+                                        (lambdaFunctions == null ? "" : lambdaFunctions.keyValuesView().collect(keyValuePair -> "        __functions.put(\"" + keyValuePair.getOne() + "\", " + keyValuePair.getTwo() + ");\n").makeString("")) +
+                                        (nativeFunctions == null ? "" : nativeFunctions.keyValuesView().collect(keyValuePair -> "        __functions.put(\"" + keyValuePair.getOne() + "\", " + keyValuePair.getTwo() + ");\n").makeString("")) +
+                                        "    }\n" :
+                                "    public static MutableMap<String, SharedPureFunction<?>> __functions = Maps.fixedSize.empty();\n"
                         ) +
                         (functionDefinitions == null || functionDefinitions.isEmpty() ? "" : functionDefinitions.makeString("\n", "\n\n", "\n")) +
                         "}";
     }
 
-    private String buildExternalizableFunctionClass(RichIterable<String> functionDefinitions)
-    {
-        try
-        {
+    private String buildExternalizableFunctionClass(RichIterable<String> functionDefinitions) {
+        try {
             java.lang.Class<?> externalClass = Thread.currentThread().getContextClassLoader().loadClass("org.finos.legend.pure.runtime.java.compiled.generation.ExternalClassBuilder");
             Method method = externalClass.getMethod("buildExternalizableFunctionClass", RichIterable.class, String.class, RichIterable.class);
             return (String) method.invoke(null, functionDefinitions, EXTERNAL_FUNCTIONS_CLASS_NAME, this.codeStorage.getAllRepoNames());
-        }
-        catch (ReflectiveOperationException e)
-        {
+        } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private String buildPureCompiledLambda(ProcessorContext processorContext)
-    {
+    private String buildPureCompiledLambda(ProcessorContext processorContext) {
         return "import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.*;\n" +
                 "import org.finos.legend.pure.m4.coreinstance.AbstractCoreInstance;\n" +
                 "public class PureCompiledLambda extends ReflectiveCoreInstance implements LambdaFunction<Object>, org.finos.legend.pure.runtime.java.compiled.generation.processors.support.LambdaCompiledExtended\n" +
@@ -513,17 +446,12 @@ public final class JavaSourceCodeGenerator
                 "        super(id);\n" +
                 "    }\n" +
                 "\n" +
-                "     public PureCompiledLambda lambdaFunction(LambdaFunction lambdaFunction)\n" +
-                "     {\n" +
-                "         this.lambdaFunction = (LambdaFunction)lambdaFunction;\n" +
-                "         return this;\n" +
-                "     }\n" +
-                "\n" +
-                "     public PureCompiledLambda pureFunction(SharedPureFunction pureFunction)\n" +
-                "     {\n" +
-                "         this.pureFunction = pureFunction;\n" +
-                "         return this;\n" +
-                "     }\n" +
+                "    public PureCompiledLambda(LambdaFunction lambdaFunction, SharedPureFunction pureFunction)\n" +
+                "    {\n" +
+                "        this();\n" +
+                "        this.lambdaFunction = (LambdaFunction)lambdaFunction;\n" +
+                "        this.pureFunction = pureFunction;\n" +
+                "    }" +
                 "\n" +
                 "    public SharedPureFunction pureFunction()" +
                 "    {" +
@@ -532,10 +460,10 @@ public final class JavaSourceCodeGenerator
                 "    public String __id(){return this.lambdaFunction == null ? \"Anonymous_Lambda\" : this.lambdaFunction.getName();}\n" +
                 "    public PureCompiledLambda copy()\n" +
                 "    {\n" +
-                "        PureCompiledLambda p =  new PureCompiledLambda();\n" +
-                "        p.lambdaFunction = (LambdaFunction)((AbstractCoreInstance)this.lambdaFunction).copy();\n" +
-                "        p.pureFunction = this.pureFunction;\n" +
-                "        return p;\n" +
+                "        return new PureCompiledLambda(" +
+                "                   (LambdaFunction)((AbstractCoreInstance)this.lambdaFunction).copy(),\n" +
+                "                   this.pureFunction" +
+                "                   );\n" +
                 "    }\n" +
                 "\n" +
                 "    public static SharedPureFunction getPureFunction(final org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function<?> function, ExecutionSupport es)\n" +
@@ -557,7 +485,7 @@ public final class JavaSourceCodeGenerator
                     CoreInstance returnType = GenericType.isGenericTypeConcrete(unresolvedReturnType) ? unresolvedReturnType : Type.wrapGenericType(this.processorSupport.package_getByUserPath(M3Paths.Any), this.processorSupport);
                     String name = Instance.getValueForMetaPropertyToOneResolved(coreInstance, M3Properties.name, this.processorSupport).getName();
                     CoreInstance multiplicity = Instance.getValueForMetaPropertyToOneResolved(coreInstance, M3Properties.multiplicity, this.processorSupport);
-                    return buildDelegationReadProperty(coreInstance, "LambdaFunction", "this.lambdaFunction", "", name, returnType, unresolvedReturnType, multiplicity, this.processorSupport, processorContext);
+                    return buildDelegationReadProperty(coreInstance, "LambdaFunction", "this.lambdaFunction", true, "", name, returnType, unresolvedReturnType, multiplicity, this.processorSupport, processorContext);
 
                 }).makeString("", "\n", "\n") +
                 "\n" +
@@ -568,13 +496,20 @@ public final class JavaSourceCodeGenerator
                 "}";
     }
 
-    public static String buildDelegationReadProperty(CoreInstance property, String className, String owner, String classOwnerFullId, String name, CoreInstance returnType, CoreInstance unresolvedReturnType, CoreInstance multiplicity, ProcessorSupport processorSupport, ProcessorContext processorContext)
+    public static String buildDelegationReadProperty(CoreInstance property, String className, String owner, String classOwnerFullId, String name, CoreInstance returnType,
+                                                     CoreInstance unresolvedReturnType, CoreInstance multiplicity, ProcessorSupport processorSupport, ProcessorContext processorContext)
+    {
+        return buildDelegationReadProperty(property, className, owner, false, classOwnerFullId, name, returnType, unresolvedReturnType, multiplicity, processorSupport, processorContext);
+    }
+
+    public static String buildDelegationReadProperty(CoreInstance property, String className, String owner, boolean returnOwnerOnModify, String classOwnerFullId, String name, CoreInstance returnType, CoreInstance unresolvedReturnType, CoreInstance multiplicity, ProcessorSupport processorSupport, ProcessorContext processorContext)
     {
         CoreInstance rawType = Instance.getValueForMetaPropertyToOneResolved(returnType, M3Properties.rawType, processorSupport);
         boolean isPrimitive = rawType != null && Instance.instanceOf(rawType, M3Paths.PrimitiveType, processorSupport);
         boolean makePrimitiveIfPossible = GenericType.isGenericTypeConcrete(unresolvedReturnType) && Multiplicity.isToOne(multiplicity, true);
         String typePrimitive = TypeProcessor.pureTypeToJava(returnType, true, makePrimitiveIfPossible, processorSupport);
         String typeObject = TypeProcessor.pureTypeToJava(returnType, true, false, processorSupport);
+        String returnRef = returnOwnerOnModify ? owner : "this";
 
         if (Multiplicity.isToOne(multiplicity, false))
         {
@@ -596,13 +531,13 @@ public final class JavaSourceCodeGenerator
                     "    public " + className + " _" + name + "(" + typePrimitive + " val)\n" +
                     "    {\n" +
                     "        " + owner + "._" + name + "(val);" +
-                    "        return this;\n" +
+                    "        return " + returnRef + ";\n" +
                     "    }\n" +
                     "\n" +
                     "    public " + className + " _" + name + "Remove()\n" +
                     "    {\n" +
                     "        " + owner + "._" + name + "Remove();\n" +
-                    "        return this;\n" +
+                    "        return " + returnRef + ";\n" +
                     "    }\n" +
                     "\n" +
                     "    public " + typePrimitive + " _" + name + "()\n" +
@@ -631,29 +566,29 @@ public final class JavaSourceCodeGenerator
                     "    public " + className + " _" + name + "(RichIterable<? extends " + typeObject + "> val)\n" +
                     "    {\n" +
                     "        " + owner + "._" + name + "(val);\n" +
-                    "        return this;\n" +
+                    "        return " + returnRef + ";\n" +
                     "    }\n" +
                     "\n" +
                     "    public " + className + " _" + name + "Add(" + typeObject + " val)\n" +
                     "    {\n" +
                     "        " + owner + "._" + name + "Add(val);\n" +
-                    "        return this;\n" +
+                    "        return " + returnRef + ";\n" +
                     "    }\n" +
                     "\n" +
                     "    public " + className + " _" + name + "AddAll(RichIterable<? extends " + typeObject + "> val)\n" +
                     "    {\n" +
                     "        " + owner + "._" + name + "AddAll(val);\n" +
-                    "        return this;\n" +
+                    "        return " + returnRef + ";\n" +
                     "    }\n" +
                     "    public " + className + " _" + name + "Remove(" + typeObject + " val)\n" +
                     "    {\n" +
                     "        " + owner + "._" + name + "Remove(val);\n" +
-                    "        return this;\n" +
+                    "        return " + returnRef + ";\n" +
                     "    }\n" +
                     "    public " + className + " _" + name + "Remove()\n" +
                     "    {\n" +
                     "        " + owner + "._" + name + "Remove();\n" +
-                    "        return this;\n" +
+                    "        return " + returnRef + ";\n" +
                     "    }\n" +
                     "    public RichIterable<? extends " + typeObject + "> _" + name + "()\n" +
                     "    {\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
@@ -460,9 +460,9 @@ public final class JavaSourceCodeGenerator {
                 "    public String __id(){return this.lambdaFunction == null ? \"Anonymous_Lambda\" : this.lambdaFunction.getName();}\n" +
                 "    public PureCompiledLambda copy()\n" +
                 "    {\n" +
-                "        return new PureCompiledLambda(" +
+                "        return new PureCompiledLambda(\n" +
                 "                   (LambdaFunction)((AbstractCoreInstance)this.lambdaFunction).copy(),\n" +
-                "                   this.pureFunction" +
+                "                   this.pureFunction\n" +
                 "                   );\n" +
                 "    }\n" +
                 "\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Bridge.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Bridge.java
@@ -19,8 +19,10 @@ import org.eclipse.collections.api.block.function.Function2;
 import org.eclipse.collections.api.block.function.Function3;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.List;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.SharedPureFunction;
 
 public interface Bridge
 {
@@ -48,15 +50,10 @@ public interface Bridge
         return this::elementToPath;
     }
 
-    @Deprecated
-    default Function0<LambdaCompiledExtended> lambdaBuilder()
-    {
-        return this::buildLambda;
-    }
-
     <T> List<T> buildList();
     boolean hasToOneUpperBound(Multiplicity multiplicity, ExecutionSupport executionSupport);
     boolean isToOne(Multiplicity multiplicity, ExecutionSupport executionSupport);
     String elementToPath(PackageableElement element, String separator, ExecutionSupport executionSupport);
-    LambdaCompiledExtended buildLambda();
+
+    LambdaCompiledExtended buildLambda(LambdaFunction<Object> lambdaFunction, SharedPureFunction<Object> pureFunction);
 }

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/CoreExtensionCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/CoreExtensionCompiled.java
@@ -296,9 +296,8 @@ public class CoreExtensionCompiled extends BaseCompiledExtension
                                 "        }\n" +
                                 "\n" +
                                 "        @Override\n" +
-                                "        public LambdaCompiledExtended buildLambda()\n" +
-                                "        {\n" +
-                                "            return new PureCompiledLambda();\n" +
+                                "        public LambdaCompiledExtended buildLambda(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> lambdaFunction, SharedPureFunction<Object> pureFunction) {\n" +
+                                "            return new PureCompiledLambda(lambdaFunction, pureFunction);\n" +
                                 "        }\n" +
                                 "    }\n" +
                                 "}\n")),

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/CoreExtensionCompiled.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/CoreExtensionCompiled.java
@@ -296,7 +296,8 @@ public class CoreExtensionCompiled extends BaseCompiledExtension
                                 "        }\n" +
                                 "\n" +
                                 "        @Override\n" +
-                                "        public LambdaCompiledExtended buildLambda(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> lambdaFunction, SharedPureFunction<Object> pureFunction) {\n" +
+                                "        public LambdaCompiledExtended buildLambda(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<Object> lambdaFunction, SharedPureFunction<Object> pureFunction)\n" +
+                                "{\n" +
                                 "            return new PureCompiledLambda(lambdaFunction, pureFunction);\n" +
                                 "        }\n" +
                                 "    }\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/DynamicPureFunctionImpl.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/DynamicPureFunctionImpl.java
@@ -98,13 +98,10 @@ public class DynamicPureFunctionImpl<T> implements SharedPureFunction<T> {
         return getClass().getSimpleName() + "{func=" + this.func + ", openVariables=" + this.openVariables + "}";
     }
 
-    public static SharedPureFunction<Object> createPureFunction(FunctionDefinition<?> func, MutableMap<String, Object> openVariables, Bridge bridge) {
+    public static SharedPureFunction<Object> createPureFunction(FunctionDefinition<?> func, MutableMap<String, Object> openVariables, Bridge bridge)
+    {
         DynamicPureFunctionImpl<Object> impl = new DynamicPureFunctionImpl<>(func, openVariables, bridge);
-        if (func instanceof LambdaFunction) {
-            return createPureLambdaFunctionWrapper(impl);
-        } else {
-            return impl;
-        }
+        return (func instanceof LambdaFunction) ? createPureLambdaFunctionWrapper(impl) : impl;
     }
 
     private static <X> PureLambdaFunction<X> createPureLambdaFunctionWrapper(DynamicPureFunctionImpl<X> inner) {

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/DynamicPureFunctionImpl.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/DynamicPureFunctionImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.List;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.NativeFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
@@ -29,43 +30,34 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecificat
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
 import org.finos.legend.pure.m3.tools.ListHelper;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.PureLambdaFunction;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.PureLambdaFunction0;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.PureLambdaFunction1;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.PureLambdaFunction2;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.PureLambdaFunction3;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.*;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.map.PureMap;
 
 import java.util.Objects;
 
 /*
-An implementation of PureLambdaFunction that implements the execution by dynamically
+An implementation of SharedPureFunction that implements the execution by dynamically
 looking at the expression sequence and reactivates / evaluates them individually to compose
 the overall result of the function.
  */
-public class DynamicPureLambdaFunctionImpl<T> implements PureLambdaFunction<T>
-{
+public class DynamicPureFunctionImpl<T> implements SharedPureFunction<T> {
     private final MutableMap<String, Object> openVariables;
-    private final LambdaFunction<?> func;
+    private final FunctionDefinition<?> func;
     private final Bridge bridge;
 
-    public DynamicPureLambdaFunctionImpl(LambdaFunction<?> func, MutableMap<String, Object> openVariables, Bridge bridge)
-    {
+    public DynamicPureFunctionImpl(FunctionDefinition<?> func, MutableMap<String, Object> openVariables, Bridge bridge) {
         this.func = Objects.requireNonNull(func, "func");
         this.openVariables = Objects.requireNonNull(openVariables, "openVariables").asUnmodifiable();
         this.bridge = Objects.requireNonNull(bridge, "bridge");
     }
 
-    @Override
-    public MutableMap<String, Object> getOpenVariables()
-    {
+    public MutableMap<String, Object> getOpenVariables() {
         return this.openVariables;
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public T execute(ListIterable<?> vars, ExecutionSupport es)
-    {
+    public T execute(ListIterable<?> vars, ExecutionSupport es) {
         Objects.requireNonNull(vars, "vars");
         Objects.requireNonNull(es, "es");
 
@@ -79,12 +71,10 @@ public class DynamicPureLambdaFunctionImpl<T> implements PureLambdaFunction<T>
         return (T) this.func._expressionSequence().injectInto(null, (previousResult, expression) ->
         {
             Object result = Reactivator.reactivateWithoutJavaCompilation(this.bridge, expression, executionOpenVarsPureMap, es);
-            if (expression instanceof SimpleFunctionExpression)
-            {
+            if (expression instanceof SimpleFunctionExpression) {
                 SimpleFunctionExpression sfe = (SimpleFunctionExpression) expression;
                 Function<?> sfeFunc = sfe._func();
-                if ((sfeFunc instanceof NativeFunction) && "letFunction_String_1__T_m__T_m_".equals(sfeFunc._name()))
-                {
+                if ((sfeFunc instanceof NativeFunction) && "letFunction_String_1__T_m__T_m_".equals(sfeFunc._name())) {
                     String varName = (String) ((InstanceValue) sfe._parametersValues().getFirst())._values().getFirst();
                     executionOpenVars.put(varName, toPureList(result));
                 }
@@ -93,154 +83,138 @@ public class DynamicPureLambdaFunctionImpl<T> implements PureLambdaFunction<T>
         });
     }
 
-    private List<Object> toPureList(Object value)
-    {
+    private List<Object> toPureList(Object value) {
         List<Object> list = this.bridge.buildList();
-        if (value instanceof Iterable)
-        {
+        if (value instanceof Iterable) {
             list._values(Lists.mutable.withAll((Iterable<?>) value));
-        }
-        else if (value != null)
-        {
+        } else if (value != null) {
             list._values(Lists.immutable.with(value));
         }
         return list;
     }
 
     @Override
-    public String toString()
-    {
+    public String toString() {
         return getClass().getSimpleName() + "{func=" + this.func + ", openVariables=" + this.openVariables + "}";
     }
 
-    public static PureLambdaFunction<Object> createPureLambdaFunction(LambdaFunction<?> func, MutableMap<String, Object> openVariables, Bridge bridge)
-    {
-        return createPureLambdaFunctionWrapper(new DynamicPureLambdaFunctionImpl<>(func, openVariables, bridge));
+    public static SharedPureFunction<Object> createPureFunction(FunctionDefinition<?> func, MutableMap<String, Object> openVariables, Bridge bridge) {
+        DynamicPureFunctionImpl<Object> impl = new DynamicPureFunctionImpl<>(func, openVariables, bridge);
+        if (func instanceof LambdaFunction) {
+            return createPureLambdaFunctionWrapper(impl);
+        } else {
+            return impl;
+        }
     }
 
-    public static <X> PureLambdaFunction<X> createPureLambdaFunctionWrapper(DynamicPureLambdaFunctionImpl<X> inner)
-    {
+    private static <X> PureLambdaFunction<X> createPureLambdaFunctionWrapper(DynamicPureFunctionImpl<X> inner) {
         RichIterable<? extends VariableExpression> params = ((FunctionType) inner.func._classifierGenericType()._typeArguments().getFirst()._rawType())._parameters();
-        switch (params.size())
-        {
-            case 0:
-            {
-                return new PureLambdaFunction0<X>()
-                {
+        switch (params.size()) {
+            case 0: {
+                return new PureLambdaFunction0<X>() {
                     @Override
-                    public MutableMap<String, Object> getOpenVariables()
-                    {
+                    public MutableMap<String, Object> getOpenVariables() {
                         return inner.getOpenVariables();
                     }
 
                     @Override
-                    public X valueOf(ExecutionSupport executionSupport)
-                    {
+                    public X valueOf(ExecutionSupport executionSupport) {
                         return execute(Lists.immutable.empty(), executionSupport);
                     }
 
                     @Override
-                    public X execute(ListIterable<?> vars, ExecutionSupport es)
-                    {
+                    public X execute(ListIterable<?> vars, ExecutionSupport es) {
                         return inner.execute(vars, es);
                     }
 
                     @Override
-                    public String toString()
-                    {
+                    public String toString() {
                         return getClass().getSimpleName() + "{inner=" + inner + "}";
                     }
                 };
             }
-            case 1:
-            {
-                return new PureLambdaFunction1<Object, X>()
-                {
+            case 1: {
+                return new PureLambdaFunction1<Object, X>() {
                     @Override
-                    public MutableMap<String, Object> getOpenVariables()
-                    {
+                    public MutableMap<String, Object> getOpenVariables() {
                         return inner.getOpenVariables();
                     }
 
                     @Override
-                    public X value(Object o, ExecutionSupport executionSupport)
-                    {
+                    public X value(Object o, ExecutionSupport executionSupport) {
                         return execute(Lists.immutable.with(o), executionSupport);
                     }
 
                     @Override
-                    public X execute(ListIterable<?> vars, ExecutionSupport es)
-                    {
+                    public X execute(ListIterable<?> vars, ExecutionSupport es) {
                         return inner.execute(vars, es);
                     }
 
                     @Override
-                    public String toString()
-                    {
+                    public String toString() {
                         return getClass().getSimpleName() + "{inner=" + inner + "}";
                     }
                 };
             }
-            case 2:
-            {
-                return new PureLambdaFunction2<Object, Object, X>()
-                {
+            case 2: {
+                return new PureLambdaFunction2<Object, Object, X>() {
                     @Override
-                    public MutableMap<String, Object> getOpenVariables()
-                    {
+                    public MutableMap<String, Object> getOpenVariables() {
                         return inner.getOpenVariables();
                     }
 
                     @Override
-                    public X value(Object o, Object o2, ExecutionSupport executionSupport)
-                    {
+                    public X value(Object o, Object o2, ExecutionSupport executionSupport) {
                         return execute(Lists.immutable.with(o, o2), executionSupport);
                     }
 
                     @Override
-                    public X execute(ListIterable<?> vars, ExecutionSupport es)
-                    {
+                    public X execute(ListIterable<?> vars, ExecutionSupport es) {
                         return inner.execute(vars, es);
                     }
 
                     @Override
-                    public String toString()
-                    {
+                    public String toString() {
                         return getClass().getSimpleName() + "{inner=" + inner + "}";
                     }
                 };
             }
-            case 3:
-            {
-                return new PureLambdaFunction3<Object, Object, Object, X>()
-                {
+            case 3: {
+                return new PureLambdaFunction3<Object, Object, Object, X>() {
                     @Override
-                    public MutableMap<String, Object> getOpenVariables()
-                    {
+                    public MutableMap<String, Object> getOpenVariables() {
                         return inner.getOpenVariables();
                     }
 
                     @Override
-                    public X value(Object o, Object o2, Object o3, ExecutionSupport executionSupport)
-                    {
+                    public X value(Object o, Object o2, Object o3, ExecutionSupport executionSupport) {
                         return execute(Lists.immutable.with(o, o2, o3), executionSupport);
                     }
 
                     @Override
-                    public X execute(ListIterable<?> vars, ExecutionSupport es)
-                    {
+                    public X execute(ListIterable<?> vars, ExecutionSupport es) {
                         return inner.execute(vars, es);
                     }
 
-                    public String toString()
-                    {
+                    public String toString() {
                         return getClass().getSimpleName() + "{inner=" + inner + "}";
                     }
                 };
             }
-            default:
-            {
-                return inner;
+            default: {
+                return new PureLambdaFunction<X>() {
+
+                    @Override
+                    public X execute(ListIterable<?> vars, ExecutionSupport es) {
+                        return inner.execute(vars, es);
+                    }
+
+                    @Override
+                    public MutableMap<String, Object> getOpenVariables() {
+                        return inner.getOpenVariables();
+                    }
+                }
+                        ;
             }
         }
     }

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/DynamicPureFunctionImpl.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/DynamicPureFunctionImpl.java
@@ -201,20 +201,22 @@ public class DynamicPureFunctionImpl<T> implements SharedPureFunction<T> {
                     }
                 };
             }
-            default: {
-                return new PureLambdaFunction<X>() {
-
+            default:
+             {
+                return new PureLambdaFunction<X>()
+                {
                     @Override
-                    public X execute(ListIterable<?> vars, ExecutionSupport es) {
+                    public X execute(ListIterable<?> vars, ExecutionSupport es)
+                    {
                         return inner.execute(vars, es);
                     }
 
                     @Override
-                    public MutableMap<String, Object> getOpenVariables() {
+                    public MutableMap<String, Object> getOpenVariables()
+                    {
                         return inner.getOpenVariables();
                     }
-                }
-                        ;
+                };
             }
         }
     }

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/LambdaCompiledExtended.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/LambdaCompiledExtended.java
@@ -20,7 +20,4 @@ import org.finos.legend.pure.runtime.java.compiled.generation.processors.support
 public interface LambdaCompiledExtended extends LambdaFunction<Object>
 {
     SharedPureFunction<Object> pureFunction();
-    LambdaCompiledExtended lambdaFunction(LambdaFunction<Object> l);
-    LambdaCompiledExtended pureFunction(SharedPureFunction<Object> l);
-
 }

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Reactivator.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Reactivator.java
@@ -23,10 +23,7 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.List;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.functions.lang.KeyExpression;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.NativeFunction;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.*;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
@@ -136,6 +133,10 @@ public class Reactivator
         {
             return true;
         }
+        if (func instanceof ConcreteFunctionDefinition)
+        {
+            return true;
+        }
         if (func instanceof FunctionDefinition || func instanceof Property)
         {
             return Pure.findSharedPureFunction(func, bridge, es) != null;
@@ -213,9 +214,7 @@ public class Reactivator
                 MutableMap<String, Object> openVariables = Maps.mutable.empty();
                 lambdaOpenVariablesMap.getMap().forEachKeyValue((key, values) -> openVariables.put((String) key, ((List<?>) values)._values()));
                 Pure.getOpenVariables(lambdaFunction, bridge).getMap().forEachKeyValue((key, values) -> openVariables.put((String) key, ((List<?>) values)._values()));
-                results.add(bridge.buildLambda()
-                        .lambdaFunction(lambdaFunction)
-                        .pureFunction(DynamicPureLambdaFunctionImpl.createPureLambdaFunction(lambdaFunction, openVariables, bridge)));
+                results.add(bridge.buildLambda(lambdaFunction, DynamicPureFunctionImpl.createPureFunction(lambdaFunction, openVariables, bridge)));
             }
             else if (value instanceof Iterable)
             {

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/UnitImplProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/UnitImplProcessor.java
@@ -78,11 +78,11 @@ public class UnitImplProcessor
 
                 "public org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction<? extends java.lang.Object> _conversionFunction(final ExecutionSupport es)\n" +
                 "    {\n" +
-                "        return new PureCompiledLambda().lambdaFunction(\n" +
+                "        return new PureCompiledLambda((\n" +
                 "((CompiledExecutionSupport)es).getMetadataAccessor().getLambdaFunction(\"" + processorContext.getIdBuilder().buildId(func) + "\")\n" +
-                ").pureFunction(\n" +
+                "), (\n" +
                 ValueSpecificationProcessor.createFunctionForLambda(unit, func, true, processorSupport, processorContext) + "\n" +
-                ")\n" +
+                "))\n" +
                 ";\n" +
                 "    }\n";
     }

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/valuespecification/ValueSpecificationProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/valuespecification/ValueSpecificationProcessor.java
@@ -281,7 +281,7 @@ public class ValueSpecificationProcessor
                 "(" + FullJavaPaths.LambdaFunction + ")localLambdas.get(" + System.identityHashCode(function) + ")" :
                 "((CompiledExecutionSupport)es).getMetadataAccessor().getLambdaFunction(\"" + processorContext.getIdBuilder().buildId(function) + "\")");
 
-        return "new PureCompiledLambda().lambdaFunction(\n" + lambdaFunctionString + "\n).pureFunction(\n" + pureFunctionString + "\n)\n";
+        return "new PureCompiledLambda(\n(" + lambdaFunctionString + "\n), (\n" + pureFunctionString + "\n))\n";
     }
 
     public static String createFunctionForLambda(CoreInstance topLevelElement, CoreInstance function, ProcessorSupport processorSupport, ProcessorContext processorContext)

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/JavaMethodWithParamsSharedPureFunction.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/JavaMethodWithParamsSharedPureFunction.java
@@ -41,8 +41,7 @@ public final class JavaMethodWithParamsSharedPureFunction<R> implements SharedPu
         this.method = method;
         this.paramClasses = paramClasses;
         this.sourceInformation = sourceInformation;
-
-        appendExecutionSupportParameter = (this.paramClasses.length > 0 && (this.paramClasses[paramClasses.length - 1] == ExecutionSupport.class));
+        this.appendExecutionSupportParameter = (this.paramClasses.length > 0 && (this.paramClasses[paramClasses.length - 1] == ExecutionSupport.class));
     }
 
     public Class<?>[] getParametersTypes()

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/JavaMethodWithParamsSharedPureFunction.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/JavaMethodWithParamsSharedPureFunction.java
@@ -56,18 +56,7 @@ public final class JavaMethodWithParamsSharedPureFunction<R> implements SharedPu
     {
         try
         {
-            ListIterable<Object> argValues;
-            if(!appendExecutionSupportParameter)
-            {
-                argValues = (ListIterable<Object>) vars;
-            }
-            else
-            {
-                MutableList<Object> x2 = Lists.mutable.empty();
-                x2.addAll((Collection<?>) vars);
-                x2.add(es);
-                argValues = x2;
-            }
+            ListIterable<?> argValues = this.appendExecutionSupportParameter ? Lists.mutable.<Object>withAll(vars).with(es) : vars;
             return (R) this.method.invoke(null, argValues.toArray());
         }
         catch (IllegalArgumentException e)

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/TestFunctionDefinitionModify.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/TestFunctionDefinitionModify.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2022 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/TestFunctionDefinitionModify.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/TestFunctionDefinitionModify.java
@@ -1,0 +1,47 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function;
+
+
+import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.tests.function.AbstractTestDynamicNew;
+import org.finos.legend.pure.m3.tests.function.AbstractTestFunctionDefinitionModify;
+import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestFunctionDefinitionModify extends AbstractTestFunctionDefinitionModify
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
+    }
+
+    protected static FunctionExecution getFunctionExecution()
+    {
+        return new FunctionExecutionCompiledBuilder().build();
+    }
+
+    @Test
+    @Ignore(value = "Further fixes needed for clone as source information is copied over currently")
+    @Override
+    public void testConcreteFunctionDefinitionModifyWithCopyConstructor()
+    {
+        super.testConcreteFunctionDefinitionModifyWithCopyConstructor();
+    }
+
+}

--- a/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/core/lang/Copy.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/core/lang/Copy.java
@@ -23,24 +23,17 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
-import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.*;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.compiler.Context;
-import org.finos.legend.pure.m3.navigation.Instance;
-import org.finos.legend.pure.m3.navigation.ValueSpecificationBootstrap;
 import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.navigation.type.Type;
 import org.finos.legend.pure.m3.navigation.valuespecification.ValueSpecification;
-import org.finos.legend.pure.m3.navigation.ProcessorSupport;
-import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
-import org.finos.legend.pure.runtime.java.interpreted.ExecutionSupport;
-import org.finos.legend.pure.runtime.java.interpreted.Executor;
-import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.finos.legend.pure.runtime.java.interpreted.VariableContext;
+import org.finos.legend.pure.runtime.java.interpreted.*;
 import org.finos.legend.pure.runtime.java.interpreted.natives.core.InstantiationContext;
 import org.finos.legend.pure.runtime.java.interpreted.natives.core.NativeFunction;
 import org.finos.legend.pure.runtime.java.interpreted.natives.core.constraints.DefaultConstraintHandler;
@@ -73,7 +66,7 @@ public class Copy extends NativeFunction
         instantiationContext.push(sourceClassifier);
 
         // TODO should we start a repository transaction here?
-        final CoreInstance newInstance = this.repository.newEphemeralAnonymousCoreInstance(null, sourceClassifier);
+        CoreInstance newInstance = this.repository.newEphemeralAnonymousCoreInstance(null, sourceClassifier);
 
         ListIterable<? extends CoreInstance> keyValues = (params.size() > 2) ? Instance.getValueForMetaPropertyToManyResolved(params.get(2), M3Properties.values, processorSupport) : Lists.immutable.<CoreInstance>with();
 

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/TestFunctionDefinitionModify.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/TestFunctionDefinitionModify.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2022 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/TestFunctionDefinitionModify.java
+++ b/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/TestFunctionDefinitionModify.java
@@ -1,0 +1,36 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.interpreted.function;
+
+import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.tests.function.AbstractTestDynamicNew;
+import org.finos.legend.pure.m3.tests.function.AbstractTestFunctionDefinitionModify;
+import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
+import org.junit.BeforeClass;
+
+
+public class TestFunctionDefinitionModify extends AbstractTestFunctionDefinitionModify
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
+    }
+
+    protected static FunctionExecution getFunctionExecution()
+    {
+        return new FunctionExecutionInterpreted();
+    }
+}


### PR DESCRIPTION
Previously modifying the expression sequence and then invoking eval caused the (original pre-compiled) pureFunction, with logic corresponding to the original expression sequence, to executed giving incorrect / unexpected results.

Primary change is to make PureCompiledLambda immutable.  It is essentially a wrapper around a LambdaFunction that pairs it with a pre-compiled / generated implementation of SharedPureFunction.  This change modifies this wrapper class so that on any modifications it unwraps / returns the LambdaFunction, which will then be routed to DynamicPureFunctionImpl to be handled dynamically.