### PR TITLE
Add post-processing observers and improve variable context handling

### DIFF
--- a/legend-pure-m2-dsl-mapping/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/processor/AggregationAwareProcessor.java
+++ b/legend-pure-m2-dsl-mapping/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/processor/AggregationAwareProcessor.java
@@ -14,21 +14,16 @@
 
 package org.finos.legend.pure.m2.dsl.mapping.serialization.grammar.v1.processor;
 
-import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.m2.dsl.mapping.M2MappingPaths;
-import org.finos.legend.pure.m2.dsl.mapping.serialization.grammar.v1.processor.SetImplementationProcessor;
-import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.compiler.postprocessing.PostProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState;
+import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState.VariableContextScope;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.Processor;
-import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
-import org.finos.legend.pure.m3.navigation.type.Type;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.InstanceSetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMapping;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.aggregationAware.AggregateSetImplementationContainer;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.aggregationAware.AggregateSpecification;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.aggregationAware.AggregateSpecificationValueSpecificationContext;
@@ -38,20 +33,22 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.aggregationAware.
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.aggregationAware.GroupByFunctionSpecification;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PropertyOwner;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.ClassInstance;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpressionInstance;
+import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
+import org.finos.legend.pure.m3.navigation.type.Type;
 import org.finos.legend.pure.m3.tools.matcher.Matcher;
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 
 public class AggregationAwareProcessor extends Processor<AggregationAwareSetImplementation>
 {
-
     @Override
     public String getClassName()
     {
@@ -61,8 +58,8 @@ public class AggregationAwareProcessor extends Processor<AggregationAwareSetImpl
     @Override
     public void process(AggregationAwareSetImplementation instance, ProcessorState state, Matcher matcher, ModelRepository repository, Context context, ProcessorSupport processorSupport)
     {
-        PropertyOwner _class = (PropertyOwner)ImportStub.withImportStubByPass(instance._classCoreInstance(), processorSupport);
-        if (!(_class instanceof ClassInstance))
+        PropertyOwner _class = (PropertyOwner) ImportStub.withImportStubByPass(instance._classCoreInstance(), processorSupport);
+        if (!(_class instanceof Class))
         {
             throw new PureCompilationException(instance.getSourceInformation(), "AggregationAware mappings are allowed only for class mappings");
         }
@@ -71,14 +68,10 @@ public class AggregationAwareProcessor extends Processor<AggregationAwareSetImpl
 
         for (AggregateSetImplementationContainer container : instance._aggregateSetImplementations())
         {
-            SetImplementation setImplementation = container._setImplementation();
+            InstanceSetImplementation setImplementation = container._setImplementation();
             setImplementation._id(instance._id() + "_Aggregate_" + container._index());
-            if (!(setImplementation instanceof InstanceSetImplementation))
-            {
-                throw new PureCompilationException(setImplementation.getSourceInformation(), "Mappings for an aggregate specification must be an InstanceSetImplementation");
-            }
-            this.processAggregateSpecification(container._aggregateSpecification(), (InstanceSetImplementation)setImplementation, (ClassInstance)_class, state, matcher, repository, context, processorSupport);
-            ((InstanceSetImplementation)setImplementation)._aggregateSpecification(container._aggregateSpecification());
+            processAggregateSpecification(container._aggregateSpecification(), setImplementation, (Class<?>) _class, state, matcher, repository, processorSupport);
+            setImplementation._aggregateSpecification(container._aggregateSpecification());
             PostProcessor.processElement(matcher, setImplementation, state, processorSupport);
         }
 
@@ -86,14 +79,11 @@ public class AggregationAwareProcessor extends Processor<AggregationAwareSetImpl
         mainSetImplementation._id(instance._id() + "_Main");
         PostProcessor.processElement(matcher, mainSetImplementation, state, processorSupport);
 
-        MutableList<PropertyMapping> newPropertyMappings = Lists.mutable.empty();
-        for (PropertyMapping propertyMapping : mainSetImplementation._propertyMappings())
-        {
-            PropertyMapping newPropertyMapping = AggregationAwarePropertyMappingInstance.createPersistent(repository, null, propertyMapping._sourceSetImplementationId(), propertyMapping._targetSetImplementationId());
-            newPropertyMapping._propertyCoreInstance(propertyMapping._propertyCoreInstance());
-            newPropertyMapping._owner(instance);
-            newPropertyMappings.add(newPropertyMapping);
-        }
+        MutableList<PropertyMapping> newPropertyMappings = mainSetImplementation._propertyMappings().collect(propertyMapping ->
+                AggregationAwarePropertyMappingInstance.createPersistent(repository, null, propertyMapping._sourceSetImplementationId(), propertyMapping._targetSetImplementationId())
+                        ._propertyCoreInstance(propertyMapping._propertyCoreInstance())
+                        ._owner(instance),
+                Lists.mutable.empty());
         instance._propertyMappings(newPropertyMappings);
     }
 
@@ -103,58 +93,57 @@ public class AggregationAwareProcessor extends Processor<AggregationAwareSetImpl
 
     }
 
-    private void processAggregateSpecification(AggregateSpecification aggregateSpecification, InstanceSetImplementation setImplementation, ClassInstance _class, ProcessorState state, Matcher matcher, ModelRepository repository, Context context, ProcessorSupport processorSupport)
+    private void processAggregateSpecification(AggregateSpecification aggregateSpecification, InstanceSetImplementation setImplementation, Class<?> _class, ProcessorState state, Matcher matcher, ModelRepository repository, ProcessorSupport processorSupport)
     {
         int i = 0;
         for (GroupByFunctionSpecification groupByFunctionSpecification : aggregateSpecification._groupByFunctions())
         {
-            state.pushVariableContext();
-            VariableExpression thisParam = VariableExpressionInstance.createPersistent(repository, aggregateSpecification.getSourceInformation(), (GenericType) Type.wrapGenericType(_class, processorSupport), (Multiplicity) processorSupport.package_getByUserPath(M3Paths.PureOne), "this");
-            FunctionType functionType = (FunctionType) ImportStub.withImportStubByPass(groupByFunctionSpecification._groupByFn()._classifierGenericType()._typeArguments().toList().get(0)._rawTypeCoreInstance(), processorSupport);
-            functionType._parameters(((ImmutableList<VariableExpression>)Lists.immutable.withAll(functionType._parameters())).newWithAll(Lists.immutable.with(thisParam)));
-            matcher.fullMatch(groupByFunctionSpecification._groupByFn(), state);
+            try (VariableContextScope ignore = state.withNewVariableContext())
+            {
+                VariableExpression thisParam = VariableExpressionInstance.createPersistent(repository, aggregateSpecification.getSourceInformation(), (GenericType) Type.wrapGenericType(_class, processorSupport), (Multiplicity) processorSupport.package_getByUserPath(M3Paths.PureOne), "this");
+                FunctionType functionType = (FunctionType) ImportStub.withImportStubByPass(groupByFunctionSpecification._groupByFn()._classifierGenericType()._typeArguments().toList().get(0)._rawTypeCoreInstance(), processorSupport);
+                functionType._parameters(Lists.mutable.<VariableExpression>withAll(functionType._parameters()).with(thisParam));
+                matcher.fullMatch(groupByFunctionSpecification._groupByFn(), state);
 
-            ValueSpecification groupByFnExpressionSequence = groupByFunctionSpecification._groupByFn()._expressionSequence().toList().getFirst();
-            this.addAggregateSpecificationUsageContext(groupByFnExpressionSequence, setImplementation, i, processorSupport);
-            i++;
-
-            state.popVariableContext();
+                ValueSpecification groupByFnExpressionSequence = groupByFunctionSpecification._groupByFn()._expressionSequence().toList().getFirst();
+                this.addAggregateSpecificationUsageContext(groupByFnExpressionSequence, setImplementation, i, processorSupport);
+                i++;
+            }
         }
 
         for (AggregationFunctionSpecification aggregationFunctionSpecification : aggregateSpecification._aggregateValues())
         {
-            state.pushVariableContext();
             VariableExpression thisParam = VariableExpressionInstance.createPersistent(repository, aggregateSpecification.getSourceInformation(), (GenericType) Type.wrapGenericType(_class, processorSupport), (Multiplicity) processorSupport.package_getByUserPath(M3Paths.PureOne), "this");
             FunctionType mapFnType = (FunctionType) ImportStub.withImportStubByPass(aggregationFunctionSpecification._mapFn()._classifierGenericType()._typeArguments().toList().get(0)._rawTypeCoreInstance(), processorSupport);
-            mapFnType._parameters(((ImmutableList<VariableExpression>)Lists.immutable.withAll(mapFnType._parameters())).newWithAll(Lists.immutable.with(thisParam)));
-            matcher.fullMatch(aggregationFunctionSpecification._mapFn(), state);
+            mapFnType._parameters(Lists.mutable.<VariableExpression>withAll(mapFnType._parameters()).with(thisParam));
+            try (VariableContextScope ignore = state.withNewVariableContext())
+            {
+                matcher.fullMatch(aggregationFunctionSpecification._mapFn(), state);
 
-            ValueSpecification mapFnExpressionSequence = aggregationFunctionSpecification._mapFn()._expressionSequence().toList().getFirst();
-            this.addAggregateSpecificationUsageContext(mapFnExpressionSequence, setImplementation, i, processorSupport);
-            i++;
+                ValueSpecification mapFnExpressionSequence = aggregationFunctionSpecification._mapFn()._expressionSequence().toList().getFirst();
+                this.addAggregateSpecificationUsageContext(mapFnExpressionSequence, setImplementation, i, processorSupport);
+                i++;
+            }
 
-            state.popVariableContext();
-
-            state.pushVariableContext();
             VariableExpression mappedParam = VariableExpressionInstance.createPersistent(repository, aggregateSpecification.getSourceInformation(), mapFnType._returnType(), (Multiplicity) processorSupport.package_getByUserPath(M3Paths.ZeroMany), "mapped");
             FunctionType aggregateFnType = (FunctionType) ImportStub.withImportStubByPass(aggregationFunctionSpecification._aggregateFn()._classifierGenericType()._typeArguments().toList().get(0)._rawTypeCoreInstance(), processorSupport);
-            aggregateFnType._parameters(((ImmutableList<VariableExpression>)Lists.immutable.withAll(aggregateFnType._parameters())).newWithAll(Lists.immutable.with(mappedParam)));
-            matcher.fullMatch(aggregationFunctionSpecification._aggregateFn(), state);
+            aggregateFnType._parameters(Lists.mutable.<VariableExpression>withAll(aggregateFnType._parameters()).with(mappedParam));
+            try (VariableContextScope ignore = state.withNewVariableContext())
+            {
+                matcher.fullMatch(aggregationFunctionSpecification._aggregateFn(), state);
 
-            ValueSpecification aggregateFnExpressionSequence = aggregationFunctionSpecification._aggregateFn()._expressionSequence().toList().getFirst();
-            this.addAggregateSpecificationUsageContext(aggregateFnExpressionSequence, setImplementation, i, processorSupport);
-            i++;
-
-            state.popVariableContext();
+                ValueSpecification aggregateFnExpressionSequence = aggregationFunctionSpecification._aggregateFn()._expressionSequence().toList().getFirst();
+                this.addAggregateSpecificationUsageContext(aggregateFnExpressionSequence, setImplementation, i, processorSupport);
+                i++;
+            }
         }
-
     }
 
     private void addAggregateSpecificationUsageContext(ValueSpecification expressionSequence, InstanceSetImplementation setImplementation, int offset, ProcessorSupport processorSupport)
     {
         if (expressionSequence != null)
         {
-            AggregateSpecificationValueSpecificationContext usageContext = (AggregateSpecificationValueSpecificationContext)processorSupport.newAnonymousCoreInstance(null, M2MappingPaths.AggregateSpecificationValueSpecificationContext);
+            AggregateSpecificationValueSpecificationContext usageContext = (AggregateSpecificationValueSpecificationContext) processorSupport.newAnonymousCoreInstance(null, M2MappingPaths.AggregateSpecificationValueSpecificationContext);
             usageContext._offset(offset);
             usageContext._aggregateSetImplementation(setImplementation);
             expressionSequence._usageContext(usageContext);

--- a/legend-pure-m2-dsl-mapping/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/processor/PureInstanceSetImplementationProcessor.java
+++ b/legend-pure-m2-dsl-mapping/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/processor/PureInstanceSetImplementationProcessor.java
@@ -19,6 +19,7 @@ import org.finos.legend.pure.m2.dsl.mapping.M2MappingPaths;
 import org.finos.legend.pure.m2.dsl.mapping.M2MappingProperties;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState;
+import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState.VariableContextScope;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.Processor;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMappingValueSpecificationContext;
@@ -56,46 +57,46 @@ public class PureInstanceSetImplementationProcessor extends Processor<PureInstan
         LambdaFunction<?> filter = classMapping._filter();
         if (filter != null)
         {
-            state.pushVariableContext();
-            if (srcClass != null)
+            try (VariableContextScope ignore = state.withNewVariableContext())
             {
-                FunctionType fType = getFunctionType(filter, processorSupport);
-                fType._parameters(Lists.mutable.<VariableExpression>withAll(fType._parameters()).with(createSrcParameter(srcClass, srcGenericTypeSourceInfo, filter.getSourceInformation(), processorSupport)));
+                if (srcClass != null)
+                {
+                    FunctionType fType = getFunctionType(filter, processorSupport);
+                    fType._parameters(Lists.mutable.<VariableExpression>withAll(fType._parameters()).with(createSrcParameter(srcClass, srcGenericTypeSourceInfo, filter.getSourceInformation(), processorSupport)));
+                }
+                matcher.fullMatch(filter, state);
             }
-            matcher.fullMatch(filter, state);
-            state.popVariableContext();
         }
 
         int i = 0;
         for (PropertyMapping propertyMapping : classMapping._propertyMappings())
         {
-            state.pushVariableContext();
-
-            if (((PurePropertyMapping) propertyMapping)._transformerCoreInstance() != null)
+            try (VariableContextScope ignore = state.withNewVariableContext())
             {
-                GrammarInfoStub transformerStub = (GrammarInfoStub) ((PurePropertyMapping) propertyMapping)._transformerCoreInstance();
-                EnumerationMappingProcessor.processsEnumerationTransformer(transformerStub, propertyMapping, processorSupport);
-            }
+                if (((PurePropertyMapping) propertyMapping)._transformerCoreInstance() != null)
+                {
+                    GrammarInfoStub transformerStub = (GrammarInfoStub) ((PurePropertyMapping) propertyMapping)._transformerCoreInstance();
+                    EnumerationMappingProcessor.processsEnumerationTransformer(transformerStub, propertyMapping, processorSupport);
+                }
 
-            LambdaFunction<?> transform = ((PurePropertyMapping) propertyMapping)._transform();
-            if (srcClass != null)
-            {
-                FunctionType fType = getFunctionType(transform, processorSupport);
-                fType._parameters(Lists.mutable.<VariableExpression>withAll(fType._parameters()).with(createSrcParameter(srcClass, srcGenericTypeSourceInfo, propertyMapping.getSourceInformation(), processorSupport)));
-            }
-            matcher.fullMatch(transform, state);
+                LambdaFunction<?> transform = ((PurePropertyMapping) propertyMapping)._transform();
+                if (srcClass != null)
+                {
+                    FunctionType fType = getFunctionType(transform, processorSupport);
+                    fType._parameters(Lists.mutable.<VariableExpression>withAll(fType._parameters()).with(createSrcParameter(srcClass, srcGenericTypeSourceInfo, propertyMapping.getSourceInformation(), processorSupport)));
+                }
+                matcher.fullMatch(transform, state);
 
-            ValueSpecification expressionSequence = transform._expressionSequence().getFirst();
-            if (expressionSequence != null)
-            {
-                PropertyMappingValueSpecificationContext usageContext = (PropertyMappingValueSpecificationContext) processorSupport.newAnonymousCoreInstance(null, M2MappingPaths.PropertyMappingValueSpecificationContext);
-                usageContext._offset(i);
-                usageContext._propertyMapping(propertyMapping);
-                expressionSequence._usageContext(usageContext);
+                ValueSpecification expression = transform._expressionSequence().getAny();
+                if (expression != null)
+                {
+                    PropertyMappingValueSpecificationContext usageContext = (PropertyMappingValueSpecificationContext) processorSupport.newAnonymousCoreInstance(null, M2MappingPaths.PropertyMappingValueSpecificationContext);
+                    usageContext._offset(i);
+                    usageContext._propertyMapping(propertyMapping);
+                    expression._usageContext(usageContext);
+                }
+                i++;
             }
-            i++;
-
-            state.popVariableContext();
         }
     }
 

--- a/legend-pure-m2-dsl-mapping/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/processor/XStoreProcessor.java
+++ b/legend-pure-m2-dsl-mapping/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/processor/XStoreProcessor.java
@@ -14,22 +14,18 @@
 
 package org.finos.legend.pure.m2.dsl.mapping.serialization.grammar.v1.processor;
 
-import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.map.MapIterable;
-import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.m2.dsl.mapping.M2MappingPaths;
-import org.finos.legend.pure.m2.dsl.mapping.serialization.grammar.v1.processor.PropertyMappingProcessor;
 import org.finos.legend.pure.m2.dsl.mapping.serialization.grammar.v1.validator.MappingValidator;
-import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState;
+import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState.VariableContextScope;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.Processor;
-import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.InstanceSetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.MappingClass;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMappingValueSpecificationContext;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.xStore.XStoreAssociationImplementation;
@@ -41,9 +37,10 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionTy
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
+import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
 import org.finos.legend.pure.m3.tools.matcher.Matcher;
-import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.ModelRepository;
 
 public class XStoreProcessor extends Processor<XStoreAssociationImplementation>
@@ -62,52 +59,43 @@ public class XStoreProcessor extends Processor<XStoreAssociationImplementation>
         MapIterable<String, SetImplementation> setImpl = org.finos.legend.pure.m2.dsl.mapping.Mapping.getClassMappingsByIdIncludeEmbedded(mapping, processorSupport);
 
         int i = 0;
-        for (XStorePropertyMapping propertyMapping : (RichIterable<XStorePropertyMapping>) instance._propertyMappings())
+        for (PropertyMapping pm : instance._propertyMappings())
         {
+            XStorePropertyMapping propertyMapping = (XStorePropertyMapping) pm;
             PropertyMappingProcessor.processPropertyMapping(propertyMapping, repository, processorSupport, association, instance);
-            state.pushVariableContext();
-
-            InstanceSetImplementation sourceSetImpl = (InstanceSetImplementation) MappingValidator.validateId(instance, propertyMapping, setImpl, propertyMapping._sourceSetImplementationId(), "source", processorSupport);
-            InstanceSetImplementation targetSetImpl = (InstanceSetImplementation) MappingValidator.validateId(instance, propertyMapping, setImpl, propertyMapping._targetSetImplementationId(), "target", processorSupport);
-
-            Class srcClass = getSetImplementationClass(sourceSetImpl, processorSupport);
-            Class targetClass = getSetImplementationClass(targetSetImpl, processorSupport);
-            VariableExpression thisParam = this.buildParam("this", srcClass, repository, processorSupport);
-            VariableExpression thatParam = this.buildParam("that", targetClass, repository, processorSupport);
-            FunctionType fType = (FunctionType) ImportStub.withImportStubByPass(
-                    propertyMapping._crossExpression()._classifierGenericType()._typeArguments().collect(new Function<GenericType, CoreInstance>()
+            try (VariableContextScope ignore = state.withNewVariableContext())
             {
-                @Override
-                public CoreInstance valueOf(GenericType genericType)
+                InstanceSetImplementation sourceSetImpl = (InstanceSetImplementation) MappingValidator.validateId(instance, propertyMapping, setImpl, propertyMapping._sourceSetImplementationId(), "source", processorSupport);
+                InstanceSetImplementation targetSetImpl = (InstanceSetImplementation) MappingValidator.validateId(instance, propertyMapping, setImpl, propertyMapping._targetSetImplementationId(), "target", processorSupport);
+
+                Class<?> srcClass = getSetImplementationClass(sourceSetImpl, processorSupport);
+                Class<?> targetClass = getSetImplementationClass(targetSetImpl, processorSupport);
+                VariableExpression thisParam = buildParam("this", srcClass, repository, processorSupport);
+                VariableExpression thatParam = buildParam("that", targetClass, repository, processorSupport);
+                FunctionType fType = (FunctionType) ImportStub.withImportStubByPass(propertyMapping._crossExpression()._classifierGenericType()._typeArguments().getOnly()._rawTypeCoreInstance(), processorSupport);
+                fType._parametersAddAll(Lists.immutable.with(thisParam, thatParam));
+                matcher.fullMatch(propertyMapping._crossExpression(), state);
+
+                ValueSpecification expressionSequence = propertyMapping._crossExpression()._expressionSequence().toList().getFirst();
+                if (expressionSequence != null)
                 {
-                    return genericType._rawTypeCoreInstance();
+                    PropertyMappingValueSpecificationContext usageContext = (PropertyMappingValueSpecificationContext) processorSupport.newAnonymousCoreInstance(null, M2MappingPaths.PropertyMappingValueSpecificationContext);
+                    usageContext._offset(i);
+                    usageContext._propertyMapping(propertyMapping);
+                    expressionSequence._usageContext(usageContext);
                 }
-            }).toList().get(0), processorSupport);
-            fType._parameters(Lists.immutable.withAll((ImmutableList<VariableExpression>)fType._parameters()).newWithAll(Lists.immutable.with(thisParam)));
-            fType._parameters(Lists.immutable.withAll((ImmutableList<VariableExpression>)fType._parameters()).newWithAll(Lists.immutable.with(thatParam)));
-            matcher.fullMatch(propertyMapping._crossExpression(), state);
-
-            ValueSpecification expressionSequence = propertyMapping._crossExpression()._expressionSequence().toList().getFirst();
-            if (expressionSequence != null)
-            {
-                PropertyMappingValueSpecificationContext usageContext = (PropertyMappingValueSpecificationContext)processorSupport.newAnonymousCoreInstance(null, M2MappingPaths.PropertyMappingValueSpecificationContext);
-                usageContext._offset(i);
-                usageContext._propertyMapping(propertyMapping);
-                expressionSequence._usageContext(usageContext);
+                i++;
             }
-            i++;
-
-            state.popVariableContext();
         }
     }
 
-    private Class getSetImplementationClass(InstanceSetImplementation setImplementation, ProcessorSupport processorSupport)
+    private Class<?> getSetImplementationClass(InstanceSetImplementation setImplementation, ProcessorSupport processorSupport)
     {
-        MappingClass mappingClass = setImplementation._mappingClass();
-        return mappingClass == null ? (Class) ImportStub.withImportStubByPass(setImplementation._classCoreInstance(),processorSupport) : mappingClass;
+        MappingClass<?> mappingClass = setImplementation._mappingClass();
+        return mappingClass == null ? (Class<?>) ImportStub.withImportStubByPass(setImplementation._classCoreInstance(), processorSupport) : mappingClass;
     }
 
-    private VariableExpression buildParam(String name, Class type, ModelRepository repository, ProcessorSupport processorSupport)
+    private VariableExpression buildParam(String name, Class<?> type, ModelRepository repository, ProcessorSupport processorSupport)
     {
         GenericType genericType = (GenericType) repository.newAnonymousCoreInstance(null, processorSupport.package_getByUserPath(M3Paths.GenericType));
         genericType._rawTypeCoreInstance(type);

--- a/legend-pure-m2-dsl-mapping/src/test/java/org/finos/legend/pure/m2/ds/mapping/test/TestXStoreMapping.java
+++ b/legend-pure-m2-dsl-mapping/src/test/java/org/finos/legend/pure/m2/ds/mapping/test/TestXStoreMapping.java
@@ -22,7 +22,8 @@ import org.junit.Test;
 public class TestXStoreMapping extends AbstractPureMappingTestWithCoreCompiled
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime();
     }
 
@@ -84,8 +85,8 @@ public class TestXStoreMapping extends AbstractPureMappingTestWithCoreCompiled
                 "      employees[f1, e] : $this.id == $that.firmId\n" +
                 "   }\n" +
                 ")\n";
-        this.runtime.createInMemorySource("mapping.pure", source);
-        this.runtime.compile();
+        runtime.createInMemorySource("mapping.pure", source);
+        runtime.compile();
         assertSetSourceInformation(source, "Firm");
         assertSetSourceInformation(source, "Person");
         assertSetSourceInformation(source, "Firm_Person");
@@ -94,7 +95,7 @@ public class TestXStoreMapping extends AbstractPureMappingTestWithCoreCompiled
     @Test
     public void testXStoreMappingTypeError()
     {
-        this.runtime.createInMemorySource("mapping.pure",
+        runtime.createInMemorySource("mapping.pure",
                 "Class Firm\n" +
                         "{\n" +
                         "   legalName : String[1];\n" +
@@ -146,7 +147,7 @@ public class TestXStoreMapping extends AbstractPureMappingTestWithCoreCompiled
                         ")\n");
         try
         {
-            this.runtime.compile();
+            runtime.compile();
             Assert.fail();
         }
         catch (Exception e)
@@ -207,8 +208,8 @@ public class TestXStoreMapping extends AbstractPureMappingTestWithCoreCompiled
                 "      employees[f1, e] : $this.id->toOne() == $that.firmId\n" +
                 "   }\n" +
                 ")\n";
-        this.runtime.createInMemorySource("mapping.pure", source);
-        this.runtime.compile();
+        runtime.createInMemorySource("mapping.pure", source);
+        runtime.compile();
         assertSetSourceInformation(source, "Firm");
         assertSetSourceInformation(source, "Person");
         assertSetSourceInformation(source, "Firm_Person");
@@ -277,8 +278,8 @@ public class TestXStoreMapping extends AbstractPureMappingTestWithCoreCompiled
                 "      employees[f1, MyPerson] : $this.id->toOne() == $that.firmId\n" +
                 "   }\n" +
                 ")\n";
-        this.runtime.createInMemorySource("mapping.pure", source);
-        this.runtime.compile();
+        runtime.createInMemorySource("mapping.pure", source);
+        runtime.compile();
         assertSetSourceInformation(source, "Firm");
         assertSetSourceInformation(source, "Person");
         assertSetSourceInformation(source, "Firm_MyPerson");

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/inference/PrintTypeInferenceObserver.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/inference/PrintTypeInferenceObserver.java
@@ -30,38 +30,55 @@ import org.finos.legend.pure.m4.tools.SafeAppendable;
 public class PrintTypeInferenceObserver implements TypeInferenceObserver
 {
     private final SafeAppendable appendable;
-    private int tab;
-    private final ProcessorSupport processorSupport;
+    private int tabCount;
+    private final String tab;
     private final ProcessorState processorState;
 
-    public PrintTypeInferenceObserver(Appendable appendable, ProcessorSupport processorSupport, ProcessorState processorState)
+    public PrintTypeInferenceObserver(Appendable appendable, String tab, ProcessorState processorState)
     {
         this.appendable = SafeAppendable.wrap(appendable);
-        this.processorSupport = processorSupport;
+        this.tab = tab;
         this.processorState = processorState;
     }
 
+    public PrintTypeInferenceObserver(Appendable appendable, ProcessorState processorState)
+    {
+        this(appendable, "  ", processorState);
+    }
+
+    public PrintTypeInferenceObserver(ProcessorState processorState)
+    {
+        this(System.out, processorState);
+    }
+
+    @Deprecated
+    public PrintTypeInferenceObserver(Appendable appendable, ProcessorSupport processorSupport, ProcessorState processorState)
+    {
+        this(appendable, processorState);
+    }
+
+    @Deprecated
     public PrintTypeInferenceObserver(ProcessorSupport processorSupport, ProcessorState processorState)
     {
-        this(System.out, processorSupport, processorState);
+        this(processorState);
     }
 
     @Override
     public void resetTab()
     {
-        this.tab = 0;
+        this.tabCount = 0;
     }
 
     @Override
     public void shiftTab()
     {
-        this.tab += 2;
+        this.tabCount++;
     }
 
     @Override
     public void unShiftTab()
     {
-        this.tab = Math.max(0, this.tab - 2);
+        this.tabCount = Math.max(0, this.tabCount - 1);
     }
 
     @Override
@@ -74,7 +91,7 @@ public class PrintTypeInferenceObserver implements TypeInferenceObserver
             sourceInfo.appendM4String(this.appendable);
         }
         print(" '(");
-        FunctionType.print(this.appendable, functionType, this.processorSupport);
+        FunctionType.print(this.appendable, functionType, this.processorState.getProcessorSupport());
         print(')').printNewline();
     }
 
@@ -94,7 +111,7 @@ public class PrintTypeInferenceObserver implements TypeInferenceObserver
     public void finishedProcessingFunction(CoreInstance functionType)
     {
         printTab().print("Finished processing function / ");
-        FunctionType.print(this.appendable, functionType, this.processorSupport);
+        FunctionType.print(this.appendable, functionType, this.processorState.getProcessorSupport());
         printNewline();
     }
 
@@ -143,7 +160,7 @@ public class PrintTypeInferenceObserver implements TypeInferenceObserver
     public void functionMatched(CoreInstance foundFunction, CoreInstance foundFunctionType)
     {
         printTab().print("- Function matched: name:'").print(foundFunction.getName()).print("'  signature:'");
-        FunctionType.print(this.appendable, foundFunctionType, this.processorSupport);
+        FunctionType.print(this.appendable, foundFunctionType, this.processorState.getProcessorSupport());
         print('\'').printNewline();
     }
 
@@ -163,9 +180,9 @@ public class PrintTypeInferenceObserver implements TypeInferenceObserver
     public void register(CoreInstance templateGenType, CoreInstance valueForMetaPropertyToOne, TypeInferenceContext context, TypeInferenceContext targetGenericsContext)
     {
         printTab().print(". Register ");
-        GenericType.print(this.appendable, templateGenType, this.processorSupport);
+        GenericType.print(this.appendable, templateGenType, this.processorState.getProcessorSupport());
         print(" / ");
-        GenericType.print(this.appendable, valueForMetaPropertyToOne, this.processorSupport);
+        GenericType.print(this.appendable, valueForMetaPropertyToOne, this.processorState.getProcessorSupport());
         print(" in ").print(context.getId()).print("/").print(targetGenericsContext.getId()).print("   ");
         printTypeInferenceContext().printNewline();
     }
@@ -210,7 +227,7 @@ public class PrintTypeInferenceObserver implements TypeInferenceObserver
     public void returnType(CoreInstance returnGenericType)
     {
         printTab().print("Return type '");
-        GenericType.print(this.appendable, returnGenericType, this.processorSupport);
+        GenericType.print(this.appendable, returnGenericType, this.processorState.getProcessorSupport());
         print('\'').printNewline();
     }
 
@@ -236,7 +253,7 @@ public class PrintTypeInferenceObserver implements TypeInferenceObserver
     public void newReturnType(CoreInstance returnGenericType)
     {
         printTab().print("New return type '");
-        GenericType.print(this.appendable, returnGenericType, this.processorSupport);
+        GenericType.print(this.appendable, returnGenericType, this.processorState.getProcessorSupport());
         print('\'').printNewline();
     }
 
@@ -266,9 +283,9 @@ public class PrintTypeInferenceObserver implements TypeInferenceObserver
 
     private PrintTypeInferenceObserver printTab()
     {
-        for (int i = 0; i < this.tab; i++)
+        for (int i = 0; i < this.tabCount; i++)
         {
-            this.appendable.append(' ');
+            this.appendable.append(this.tab);
         }
         return this;
     }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/inference/TestTypeInferenceObserver.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/inference/TestTypeInferenceObserver.java
@@ -14,37 +14,41 @@
 
 package org.finos.legend.pure.m3.compiler.postprocessing.inference;
 
+import org.eclipse.collections.api.factory.Stacks;
+import org.eclipse.collections.api.stack.MutableStack;
 import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 
-import java.util.Stack;
-
 public class TestTypeInferenceObserver implements TypeInferenceObserver
 {
-    private static final TypeInferenceObserver VOID_OBSERVER = new VoidTypeInferenceObserver();
-
     private final TypeInferenceObserver printObserver;
-    private final Stack<TypeInferenceObserver> stack = new Stack<>();
+    private final MutableStack<TypeInferenceObserver> stack = Stacks.mutable.empty();
 
+    public TestTypeInferenceObserver(ProcessorState processorState)
+    {
+        this.printObserver = new PrintTypeInferenceObserver(processorState);
+        this.stack.push(new VoidTypeInferenceObserver());
+    }
+
+    @Deprecated
     public TestTypeInferenceObserver(ProcessorSupport processorSupport, ProcessorState processorState)
     {
-        this.printObserver = new PrintTypeInferenceObserver(processorSupport, processorState);
-        this.stack.push(VOID_OBSERVER);
+        this(processorState);
     }
 
     private TypeInferenceObserver activeObserver()
     {
-        return stack.peek();
+        return this.stack.peek();
     }
 
     @Override
     public void startProcessingFunction(CoreInstance functionDefinition, CoreInstance functionType)
     {
         SourceInformation sourceInfo = functionDefinition.getSourceInformation();
-        stack.push(sourceInfo != null && sourceInfo.getSourceId().equals("inferenceTest.pure") ? printObserver : stack.peek());
+        this.stack.push(((sourceInfo != null) && "inferenceTest.pure".equals(sourceInfo.getSourceId())) ? this.printObserver : this.stack.peek());
         activeObserver().startProcessingFunction(functionDefinition, functionType);
     }
 
@@ -52,37 +56,161 @@ public class TestTypeInferenceObserver implements TypeInferenceObserver
     public void finishedProcessingFunction(CoreInstance functionType)
     {
         activeObserver().finishedProcessingFunction(functionType);
-        stack.pop();
+        this.stack.pop();
     }
 
     public boolean isInATest()
     {
-        return stack.peek() == printObserver;
+        return this.stack.peek() == this.printObserver;
     }
 
-    @Override public void resetTab() { activeObserver().resetTab(); }
-    @Override public void shiftTab() { activeObserver().shiftTab(); }
-    @Override public void unShiftTab() { activeObserver(). unShiftTab(); }
-    @Override public void startProcessingFunctionBody() { activeObserver().startProcessingFunctionBody(); }
-    @Override public void finishedProcessingFunctionBody() { activeObserver().finishedProcessingFunctionBody(); }
-    @Override public void startProcessingFunctionExpression(CoreInstance functionExpression) { activeObserver().startProcessingFunctionExpression(functionExpression); }
-    @Override public void startFirstPassParametersProcessing() { activeObserver().startFirstPassParametersProcessing(); }
-    @Override public void processingParameter(CoreInstance functionExpression, int i, ValueSpecification value) { activeObserver().processingParameter(functionExpression, i, value); }
-    @Override public void inferenceResult(boolean success) { activeObserver().inferenceResult(success);  }
-    @Override public void functionMatched(CoreInstance foundFunction, CoreInstance foundFunctionType) { activeObserver().functionMatched(foundFunction, foundFunctionType); }
-    @Override public void firstPassInferenceFailed() { activeObserver().firstPassInferenceFailed(); }
-    @Override public void matchTypeParamsFromFoundFunction(CoreInstance foundFunction) { activeObserver().matchTypeParamsFromFoundFunction(foundFunction); }
-    @Override public void register(CoreInstance templateGenType, CoreInstance valueForMetaPropertyToOne, TypeInferenceContext context, TypeInferenceContext targetGenericsContext) { activeObserver().register(templateGenType, valueForMetaPropertyToOne, context, targetGenericsContext); }
-    @Override public void registerMul(CoreInstance templateMul, CoreInstance valueMul, TypeInferenceContext context, TypeInferenceContext targetGenericsContext) { activeObserver().registerMul(templateMul, valueMul, context, targetGenericsContext); }
-    @Override public void matchParam(int z) { activeObserver().matchParam(z); }
-    @Override public void paramInferenceFailed(int z) { activeObserver().paramInferenceFailed(z); }
-    @Override public void reverseMatching() { activeObserver().reverseMatching(); }
-    @Override public void parameterInferenceSucceeded() { activeObserver().parameterInferenceSucceeded(); }
-    @Override public void returnType(CoreInstance returnGenericType) { activeObserver().returnType(returnGenericType); }
-    @Override public void returnTypeNotConcrete() { activeObserver().returnTypeNotConcrete(); }
-    @Override public void reprocessingTheParameter() { activeObserver().reprocessingTheParameter(); }
-    @Override public void finishedProcessParameter() { activeObserver().finishedProcessParameter(); }
-    @Override public void newReturnType(CoreInstance returnGenericType) { activeObserver().newReturnType(returnGenericType); }
-    @Override public void finishedRegisteringParametersAndMultiplicities() { activeObserver().finishedRegisteringParametersAndMultiplicities(); }
-    @Override public void finishedProcessingFunctionExpression(CoreInstance functionExpression) { activeObserver().finishedProcessingFunctionExpression(functionExpression); }
+    @Override
+    public void resetTab()
+    {
+        activeObserver().resetTab();
+    }
+
+    @Override
+    public void shiftTab()
+    {
+        activeObserver().shiftTab();
+    }
+
+    @Override
+    public void unShiftTab()
+    {
+        activeObserver().unShiftTab();
+    }
+
+    @Override
+    public void startProcessingFunctionBody()
+    {
+        activeObserver().startProcessingFunctionBody();
+    }
+
+    @Override
+    public void finishedProcessingFunctionBody()
+    {
+        activeObserver().finishedProcessingFunctionBody();
+    }
+
+    @Override
+    public void startProcessingFunctionExpression(CoreInstance functionExpression)
+    {
+        activeObserver().startProcessingFunctionExpression(functionExpression);
+    }
+
+    @Override
+    public void startFirstPassParametersProcessing()
+    {
+        activeObserver().startFirstPassParametersProcessing();
+    }
+
+    @Override
+    public void processingParameter(CoreInstance functionExpression, int i, ValueSpecification value)
+    {
+        activeObserver().processingParameter(functionExpression, i, value);
+    }
+
+    @Override
+    public void inferenceResult(boolean success)
+    {
+        activeObserver().inferenceResult(success);
+    }
+
+    @Override
+    public void functionMatched(CoreInstance foundFunction, CoreInstance foundFunctionType)
+    {
+        activeObserver().functionMatched(foundFunction, foundFunctionType);
+    }
+
+    @Override
+    public void firstPassInferenceFailed()
+    {
+        activeObserver().firstPassInferenceFailed();
+    }
+
+    @Override
+    public void matchTypeParamsFromFoundFunction(CoreInstance foundFunction)
+    {
+        activeObserver().matchTypeParamsFromFoundFunction(foundFunction);
+    }
+
+    @Override
+    public void register(CoreInstance templateGenType, CoreInstance valueForMetaPropertyToOne, TypeInferenceContext context, TypeInferenceContext targetGenericsContext)
+    {
+        activeObserver().register(templateGenType, valueForMetaPropertyToOne, context, targetGenericsContext);
+    }
+
+    @Override
+    public void registerMul(CoreInstance templateMul, CoreInstance valueMul, TypeInferenceContext context, TypeInferenceContext targetGenericsContext)
+    {
+        activeObserver().registerMul(templateMul, valueMul, context, targetGenericsContext);
+    }
+
+    @Override
+    public void matchParam(int z)
+    {
+        activeObserver().matchParam(z);
+    }
+
+    @Override
+    public void paramInferenceFailed(int z)
+    {
+        activeObserver().paramInferenceFailed(z);
+    }
+
+    @Override
+    public void reverseMatching()
+    {
+        activeObserver().reverseMatching();
+    }
+
+    @Override
+    public void parameterInferenceSucceeded()
+    {
+        activeObserver().parameterInferenceSucceeded();
+    }
+
+    @Override
+    public void returnType(CoreInstance returnGenericType)
+    {
+        activeObserver().returnType(returnGenericType);
+    }
+
+    @Override
+    public void returnTypeNotConcrete()
+    {
+        activeObserver().returnTypeNotConcrete();
+    }
+
+    @Override
+    public void reprocessingTheParameter()
+    {
+        activeObserver().reprocessingTheParameter();
+    }
+
+    @Override
+    public void finishedProcessParameter()
+    {
+        activeObserver().finishedProcessParameter();
+    }
+
+    @Override
+    public void newReturnType(CoreInstance returnGenericType)
+    {
+        activeObserver().newReturnType(returnGenericType);
+    }
+
+    @Override
+    public void finishedRegisteringParametersAndMultiplicities()
+    {
+        activeObserver().finishedRegisteringParametersAndMultiplicities();
+    }
+
+    @Override
+    public void finishedProcessingFunctionExpression(CoreInstance functionExpression)
+    {
+        activeObserver().finishedProcessingFunctionExpression(functionExpression);
+    }
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/inference/TypeInference.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/inference/TypeInference.java
@@ -24,6 +24,7 @@ import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState;
+import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState.VariableContextScope;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.FunctionDefinitionProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.LambdaFunctionProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.valuespecification.InstanceValueProcessor;
@@ -141,10 +142,11 @@ public class TypeInference
                     param._multiplicity((Multiplicity) org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.copyMultiplicity(multiplicity, param.getSourceInformation(), processorSupport));
                 }
             }
-            state.pushVariableContext();
-            FunctionDefinitionProcessor.process(lambdaFunction, state, matcher, repository);
-            LambdaFunctionProcessor.process(lambdaFunction, state, matcher, repository);
-            state.popVariableContext();
+            try (VariableContextScope ignore = state.withNewVariableContext())
+            {
+                FunctionDefinitionProcessor.process(lambdaFunction, state, matcher, repository);
+                LambdaFunctionProcessor.process(lambdaFunction, state, matcher, repository);
+            }
         }
         else
         {

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/CombinedPostProcessorObserver.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/CombinedPostProcessorObserver.java
@@ -1,0 +1,128 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.compiler.postprocessing.observer;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+public class CombinedPostProcessorObserver implements PostProcessorObserver
+{
+    private final ImmutableList<PostProcessorObserver> observers;
+
+    private CombinedPostProcessorObserver(ImmutableList<PostProcessorObserver> observers)
+    {
+        this.observers = observers;
+    }
+
+    @Override
+    public void startProcessing(CoreInstance instance)
+    {
+        forEachObserver(o -> o.startProcessing(instance));
+    }
+
+    @Override
+    public void finishProcessing(CoreInstance instance)
+    {
+        forEachObserver(o -> o.finishProcessing(instance));
+    }
+
+    @Override
+    public void finishProcessing(CoreInstance instance, Exception e)
+    {
+        forEachObserver(o -> o.finishProcessing(instance, e));
+    }
+
+    private void forEachObserver(Consumer<? super PostProcessorObserver> consumer)
+    {
+        RuntimeException exception = null;
+        for (PostProcessorObserver observer : this.observers)
+        {
+            try
+            {
+                consumer.accept(observer);
+            }
+            catch (RuntimeException e)
+            {
+                if (exception == null)
+                {
+                    exception = e;
+                }
+                else
+                {
+                    exception.addSuppressed(e);
+                }
+            }
+        }
+        if (exception != null)
+        {
+            throw exception;
+        }
+    }
+
+    public static PostProcessorObserver combine(PostProcessorObserver... observers)
+    {
+        switch (observers.length)
+        {
+            case 0:
+            {
+                return new VoidPostProcessorObserver();
+            }
+            case 1:
+            {
+                return (observers[0] == null) ? new VoidPostProcessorObserver() : observers[0];
+            }
+            default:
+            {
+                return combine(Arrays.asList(observers));
+            }
+        }
+    }
+
+    public static PostProcessorObserver combine(Iterable<? extends PostProcessorObserver> observers)
+    {
+        MutableList<PostProcessorObserver> list = Lists.mutable.empty();
+        observers.forEach(o ->
+        {
+            if (o instanceof CombinedPostProcessorObserver)
+            {
+                list.addAllIterable(((CombinedPostProcessorObserver) o).observers);
+            }
+            else if ((o != null) && !(o instanceof VoidPostProcessorObserver))
+            {
+                list.add(o);
+            }
+        });
+        switch (list.size())
+        {
+            case 0:
+            {
+                return new VoidPostProcessorObserver();
+            }
+            case 1:
+            {
+                return list.get(0);
+            }
+            default:
+            {
+                return new CombinedPostProcessorObserver(list.toImmutable());
+            }
+        }
+    }
+}

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/FilterPostProcessorObserver.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/FilterPostProcessorObserver.java
@@ -1,0 +1,79 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.compiler.postprocessing.observer;
+
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+import java.util.function.Predicate;
+
+public class FilterPostProcessorObserver<T extends PostProcessorObserver> implements PostProcessorObserver
+{
+    private final T observer;
+    private final Predicate<? super CoreInstance> filter;
+
+    private FilterPostProcessorObserver(T observer, Predicate<? super CoreInstance> filter)
+    {
+        this.observer = observer;
+        this.filter = filter;
+    }
+
+    @Override
+    public void startProcessing(CoreInstance instance)
+    {
+        if (this.filter.test(instance))
+        {
+            this.observer.startProcessing(instance);
+        }
+    }
+
+    @Override
+    public void finishProcessing(CoreInstance instance)
+    {
+        if (this.filter.test(instance))
+        {
+            this.observer.finishProcessing(instance);
+        }
+    }
+
+    @Override
+    public void finishProcessing(CoreInstance instance, Exception e)
+    {
+        if (this.filter.test(instance))
+        {
+            this.observer.finishProcessing(instance, e);
+        }
+    }
+
+    public T getObserver()
+    {
+        return this.observer;
+    }
+
+    public Predicate<? super CoreInstance> getFilter()
+    {
+        return this.filter;
+    }
+
+    public static <T extends PostProcessorObserver> FilterPostProcessorObserver<T> filter(T observer, Predicate<? super CoreInstance> filter)
+    {
+        return new FilterPostProcessorObserver<>(observer, filter);
+    }
+
+    public static <T extends PostProcessorObserver> FilterPostProcessorObserver<T> onlyPackagedElements(T observer)
+    {
+        return filter(observer, e -> (e instanceof PackageableElement) && (((PackageableElement) e)._package() != null));
+    }
+}

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/NetTimingPostProcessorObserver.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/NetTimingPostProcessorObserver.java
@@ -1,0 +1,84 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.compiler.postprocessing.observer;
+
+import org.eclipse.collections.api.factory.Stacks;
+import org.eclipse.collections.api.stack.MutableStack;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+class NetTimingPostProcessorObserver extends TimingPostProcessorObserver
+{
+    private final MutableStack<InstanceWithStartTime> stack = Stacks.mutable.empty();
+
+    NetTimingPostProcessorObserver()
+    {
+    }
+
+    @Override
+    protected void noteProcessingStart(CoreInstance instance, long startNanoTime)
+    {
+        if (this.stack.notEmpty())
+        {
+            InstanceWithStartTime previous = this.stack.peek();
+            recordDuration(previous.instance, startNanoTime - previous.startNanoTime);
+        }
+        this.stack.push(new InstanceWithStartTime(instance, startNanoTime));
+    }
+
+    @Override
+    protected long noteProcessingEnd(CoreInstance instance, long endNanoTime)
+    {
+        if (this.stack.isEmpty())
+        {
+            return 0L;
+        }
+
+        InstanceWithStartTime current = this.stack.pop();
+        if (current.instance != instance)
+        {
+            // Something has gone wrong: try to recover
+            if (this.stack.noneSatisfy(iwst -> iwst.instance == instance))
+            {
+                // Can't find this instance in the stack: set things back the way they were and return 0 duration
+                this.stack.push(current);
+                return 0L;
+            }
+
+            // Pop the stack until we find the current instance
+            while (current.instance != instance)
+            {
+                current = this.stack.pop();
+            }
+        }
+
+        if (this.stack.notEmpty())
+        {
+            this.stack.peek().startNanoTime = endNanoTime;
+        }
+        return endNanoTime - current.startNanoTime;
+    }
+
+    private static class InstanceWithStartTime
+    {
+        private final CoreInstance instance;
+        private long startNanoTime;
+
+        private InstanceWithStartTime(CoreInstance instance, long startNanoTime)
+        {
+            this.instance = instance;
+            this.startNanoTime = startNanoTime;
+        }
+    }
+}

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/PostProcessorObserver.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/PostProcessorObserver.java
@@ -1,0 +1,35 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.compiler.postprocessing.observer;
+
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+public interface PostProcessorObserver
+{
+    default void startProcessing(CoreInstance instance)
+    {
+        // Do nothing by default
+    }
+
+    default void finishProcessing(CoreInstance instance)
+    {
+        finishProcessing(instance, null);
+    }
+
+    default void finishProcessing(CoreInstance instance, Exception e)
+    {
+        // Do nothing by default
+    }
+}

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/SimpleTimingPostProcessorObserver.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/SimpleTimingPostProcessorObserver.java
@@ -1,0 +1,42 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.compiler.postprocessing.observer;
+
+import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
+import org.eclipse.collections.impl.block.factory.HashingStrategies;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMapWithHashingStrategy;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+class SimpleTimingPostProcessorObserver extends TimingPostProcessorObserver
+{
+    private final MutableObjectLongMap<CoreInstance> starts = ObjectLongHashMapWithHashingStrategy.newMap(HashingStrategies.identityStrategy());
+
+    SimpleTimingPostProcessorObserver()
+    {
+    }
+
+    @Override
+    protected void noteProcessingStart(CoreInstance instance, long startNanoTime)
+    {
+        this.starts.put(instance, startNanoTime);
+    }
+
+    @Override
+    protected long noteProcessingEnd(CoreInstance instance, long endNanoTime)
+    {
+        long startNanoTime = this.starts.removeKeyIfAbsent(instance, endNanoTime);
+        return endNanoTime - startNanoTime;
+    }
+}

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/TimingPostProcessorObserver.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/TimingPostProcessorObserver.java
@@ -1,0 +1,391 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.compiler.postprocessing.observer;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
+import org.eclipse.collections.impl.block.factory.HashingStrategies;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMapWithHashingStrategy;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+public abstract class TimingPostProcessorObserver implements PostProcessorObserver
+{
+    private final MutableObjectLongMap<CoreInstance> durations = ObjectLongHashMapWithHashingStrategy.newMap(HashingStrategies.identityStrategy());
+
+    protected TimingPostProcessorObserver()
+    {
+    }
+
+    @Override
+    public final void startProcessing(CoreInstance instance)
+    {
+        long startNanoTime = System.nanoTime();
+        noteProcessingStart(instance, startNanoTime);
+    }
+
+    @Override
+    public final void finishProcessing(CoreInstance instance)
+    {
+        long endNanoTime = System.nanoTime();
+        long duration = noteProcessingEnd(instance, endNanoTime);
+        recordDuration(instance, duration);
+    }
+
+    @Override
+    public final void finishProcessing(CoreInstance instance, Exception e)
+    {
+        long endNanoTime = System.nanoTime();
+        long duration = noteProcessingEnd(instance, endNanoTime);
+        recordDuration(instance, duration);
+    }
+
+    /**
+     * Note the start of processing for an instance.
+     *
+     * @param instance      instance to be processed
+     * @param startNanoTime start nano-time
+     */
+    protected abstract void noteProcessingStart(CoreInstance instance, long startNanoTime);
+
+    /**
+     * Note the end of processing for an instance, and return the duration in nanoseconds. Positive values will be added
+     * to any duration that has already been recorded. Non-positive values will be ignored.
+     *
+     * @param instance    processed instance
+     * @param endNanoTime end nano-time
+     * @return duration in nanoseconds
+     */
+    protected abstract long noteProcessingEnd(CoreInstance instance, long endNanoTime);
+
+    /**
+     * Record a processing duration for an instance. Positive values are added to any duration that has already been
+     * recorded. Non-positive values are ignored.
+     *
+     * @param instance      processed instance
+     * @param durationNanos duration in nanoseconds
+     */
+    protected void recordDuration(CoreInstance instance, long durationNanos)
+    {
+        if (durationNanos > 0)
+        {
+            this.durations.addToValue(instance, durationNanos);
+        }
+    }
+
+    /**
+     * Get the duration in nanoseconds spent processing an instance. Returns -1 if the instance was not observed.
+     *
+     * @param instance instance
+     * @return duration in nanoseconds or -1 if not present
+     */
+    public long getDurationInNanos(CoreInstance instance)
+    {
+        return this.durations.getIfAbsent(instance, -1L);
+    }
+
+    /**
+     * Get all observed durations. The result is not sorted.
+     *
+     * @return all durations (unsorted)
+     */
+    public MutableList<Duration> getAllDurations()
+    {
+        MutableList<Duration> list = Lists.mutable.ofInitialCapacity(this.durations.size());
+        forEachDuration(list::add);
+        return list;
+    }
+
+    /**
+     * Get the longest duration. If there is more than one, one is selected arbitrarily. If there are no durations,
+     * null is returned.
+     *
+     * @return longest duration or null
+     */
+    public Duration getLongestDuration()
+    {
+        DurationBuilder builder = new DurationBuilder();
+        this.durations.forEachKeyValue((instance, duration) ->
+        {
+            if (builder.isUnset() || (duration > builder.durationNanos))
+            {
+                builder.set(instance, duration);
+            }
+        });
+        return builder.build();
+    }
+
+    /**
+     * Get the n longest durations, sorted from longest to shortest. If there are fewer than n durations in total, all
+     * durations will be returned. In case of multiple instances with the same duration, ordering is arbitrary. If such
+     * ties occur around the nth place, it is arbitrary which will be included in the result.
+     *
+     * @param n number of durations
+     * @return n longest durations
+     */
+    public MutableList<Duration> getLongestDurations(int n)
+    {
+        return getTopDurations(n, true);
+    }
+
+    /**
+     * Get the shortest duration. If there is more than one, one is selected arbitrarily. If there are no durations,
+     * null is returned.
+     *
+     * @return shortest duration or null
+     */
+    public Duration getShortestDuration()
+    {
+        DurationBuilder builder = new DurationBuilder();
+        this.durations.forEachKeyValue((instance, duration) ->
+        {
+            if (builder.isUnset() || (duration < builder.durationNanos))
+            {
+                builder.set(instance, duration);
+            }
+        });
+        return builder.build();
+    }
+
+    /**
+     * Get the n shortest durations, sorted from shortest to longest. If there are fewer than n durations in total, all
+     * durations will be returned. In case of multiple instances with the same duration, ordering is arbitrary. If such
+     * ties occur around the nth place, it is arbitrary which will be included in the result.
+     *
+     * @param n number of durations
+     * @return n shortest durations
+     */
+    public MutableList<Duration> getShortestDurations(int n)
+    {
+        return getTopDurations(n, false);
+    }
+
+    /**
+     * Get all durations at least as long as minDurationNanos. The result is not sorted.
+     *
+     * @param minDurationNanos minimum duration in nanoseconds
+     * @return all durations at least minDurationNanos
+     */
+    public MutableList<Duration> getDurationsAtLeast(long minDurationNanos)
+    {
+        MutableList<Duration> list = Lists.mutable.empty();
+        this.durations.forEachKeyValue((instance, duration) ->
+        {
+            if (duration >= minDurationNanos)
+            {
+                list.add(new Duration(instance, duration));
+            }
+        });
+        return list;
+    }
+
+    /**
+     * Get all durations no longer than maxDurationNanos. The result is not sorted.
+     *
+     * @param maxDurationNanos maximum duration in nanoseconds
+     * @return all durations at most maxDurationNanos
+     */
+    public MutableList<Duration> getDurationsAtMost(long maxDurationNanos)
+    {
+        MutableList<Duration> list = Lists.mutable.empty();
+        this.durations.forEachKeyValue((instance, durationNanos) ->
+        {
+            if (durationNanos <= maxDurationNanos)
+            {
+                list.add(new Duration(instance, durationNanos));
+            }
+        });
+        return list;
+    }
+
+    /**
+     * Filter durations by the given predicate.
+     *
+     * @param predicate filter predicate
+     * @return filtered durations
+     */
+    public MutableList<Duration> filterDurations(Predicate<? super Duration> predicate)
+    {
+        MutableList<Duration> list = Lists.mutable.empty();
+        this.durations.forEachKeyValue((instance, durationNanos) ->
+        {
+            Duration duration = new Duration(instance, durationNanos);
+            if (predicate.test(duration))
+            {
+                list.add(duration);
+            }
+        });
+        return list;
+    }
+
+    private MutableList<Duration> getTopDurations(int n, boolean longerFirst)
+    {
+        if ((n == 0) || this.durations.isEmpty())
+        {
+            return Lists.mutable.empty();
+        }
+
+        if (n == 1)
+        {
+            Duration top = longerFirst ? getLongestDuration() : getShortestDuration();
+            return Lists.mutable.with(top);
+        }
+
+        Comparator<Duration> comparator = longerFirst ? TimingPostProcessorObserver::compareLongerFirst : TimingPostProcessorObserver::compareShorterFirst;
+        if ((n < 0) || (n >= this.durations.size()))
+        {
+            return getAllDurations().sortThis(comparator);
+        }
+
+        MutableList<Duration> list = Lists.mutable.ofInitialCapacity(n);
+        this.durations.forEachKeyValue((instance, durationNanos) ->
+        {
+            Duration duration = new Duration(instance, durationNanos);
+            if (list.size() < n)
+            {
+                list.add(duration);
+                if (list.size() == n)
+                {
+                    list.sort(comparator);
+                }
+            }
+            else if (comparator.compare(duration, list.get(n - 1)) < 0)
+            {
+                int search = Collections.binarySearch(list, duration, comparator);
+                int index = (search < 0) ? (-search - 1) : search;
+                list.remove(n - 1);
+                list.add(index, duration);
+            }
+        });
+        return list;
+    }
+
+    public void forEachDuration(Consumer<? super Duration> consumer)
+    {
+        this.durations.forEachKeyValue((instance, durationNanos) -> consumer.accept(new Duration(instance, durationNanos)));
+    }
+
+    public void forEachDuration(boolean longestFirst, Consumer<? super Duration> consumer)
+    {
+        forEachDuration(longestFirst, -1, consumer);
+    }
+
+    public void forEachDuration(boolean longestFirst, int limit, Consumer<? super Duration> consumer)
+    {
+        if ((limit == 0) || this.durations.isEmpty())
+        {
+            return;
+        }
+
+        if (limit == 1)
+        {
+            Duration duration = longestFirst ? getLongestDuration() : getShortestDuration();
+            consumer.accept(duration);
+            return;
+        }
+
+        getTopDurations(limit, longestFirst).forEach(consumer);
+    }
+
+    public static TimingPostProcessorObserver newObserver()
+    {
+        return newObserver(false);
+    }
+
+    public static TimingPostProcessorObserver newObserver(boolean net)
+    {
+        return net ? new NetTimingPostProcessorObserver() : new SimpleTimingPostProcessorObserver();
+    }
+
+    private static int compareLongerFirst(Duration one, Duration two)
+    {
+        return Long.compare(two.durationNanos, one.durationNanos);
+    }
+
+    private static int compareShorterFirst(Duration one, Duration two)
+    {
+        return Long.compare(one.durationNanos, two.durationNanos);
+    }
+
+    private static class DurationBuilder
+    {
+        private CoreInstance instance;
+        private long durationNanos;
+
+        private boolean isUnset()
+        {
+            return this.instance == null;
+        }
+
+        private void set(CoreInstance instance, long durationNanos)
+        {
+            this.instance = instance;
+            this.durationNanos = durationNanos;
+        }
+
+        private Duration build()
+        {
+            return isUnset() ? null : new Duration(this.instance, this.durationNanos);
+        }
+    }
+
+    public static class Duration
+    {
+        private final CoreInstance instance;
+        private final long durationNanos;
+
+        private Duration(CoreInstance instance, long durationNanos)
+        {
+            this.instance = instance;
+            this.durationNanos = durationNanos;
+        }
+
+        public CoreInstance getInstance()
+        {
+            return this.instance;
+        }
+
+        public long getDurationNanos()
+        {
+            return this.durationNanos;
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (this == other)
+            {
+                return true;
+            }
+            if (!(other instanceof Duration))
+            {
+                return false;
+            }
+            Duration that = (Duration) other;
+            return (this.instance == that.instance) && (this.durationNanos == that.durationNanos);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return System.identityHashCode(this.instance) ^ Long.hashCode(this.durationNanos);
+        }
+    }
+}

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/TracingPostProcessorObserver.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/TracingPostProcessorObserver.java
@@ -1,0 +1,181 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.compiler.postprocessing.observer;
+
+import org.eclipse.collections.api.factory.Stacks;
+import org.eclipse.collections.api.stack.MutableStack;
+import org.eclipse.collections.api.tuple.primitive.ObjectLongPair;
+import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+import org.finos.legend.pure.m4.tools.SafeAppendable;
+
+import java.util.Arrays;
+
+public class TracingPostProcessorObserver implements PostProcessorObserver
+{
+    private final SafeAppendable appendable;
+    private final MutableStack<ObjectLongPair<CoreInstance>> startTimeStack = Stacks.mutable.empty();
+
+    private TracingPostProcessorObserver(Appendable appendable)
+    {
+        this.appendable = SafeAppendable.wrap(appendable);
+    }
+
+    @Override
+    public void startProcessing(CoreInstance instance)
+    {
+        long start = System.nanoTime();
+        this.startTimeStack.push(PrimitiveTuples.pair(instance, start));
+        int level = this.startTimeStack.size() - 1;
+        String indent = spaces(level);
+        String levelLabel = (level + 1) + ": ";
+        String moreIndent = spaces(levelLabel.length());
+        print(indent).print(levelLabel).print("START ").printInstance(instance).printLineBreak();
+        print(indent).print(moreIndent).print("classifier: ").printClassifier(instance.getClassifier()).printLineBreak();
+        print(indent).print(moreIndent).print("source info: ").printSourceInfo(instance.getSourceInformation()).printLineBreak();
+    }
+
+    @Override
+    public void finishProcessing(CoreInstance instance, Exception e)
+    {
+        long end = System.nanoTime();
+        if (this.startTimeStack.isEmpty())
+        {
+            return;
+        }
+
+        ObjectLongPair<CoreInstance> previous = this.startTimeStack.pop();
+        if (previous.getOne() != instance)
+        {
+            this.startTimeStack.push(previous);
+            return;
+        }
+
+        long start = previous.getTwo();
+        int level = this.startTimeStack.size();
+        String indent = spaces(level);
+        String levelLabel = (level + 1) + ": ";
+        String moreIndent = spaces(levelLabel.length());
+        print(indent).print(levelLabel).print("END ").printDuration(end - start).print("s ").printInstance(instance).printLineBreak();
+        if (e != null)
+        {
+            print(indent).print(moreIndent).print("exception class: ").print(e.getClass().toString()).printLineBreak();
+            print(indent).print(moreIndent).print("exception message: ").print(e.getMessage()).printLineBreak();
+        }
+    }
+
+    private TracingPostProcessorObserver print(String string)
+    {
+        this.appendable.append(string);
+        return this;
+    }
+
+    private void printLineBreak()
+    {
+        print(System.lineSeparator());
+    }
+
+    private TracingPostProcessorObserver printInstance(CoreInstance instance)
+    {
+        return (instance instanceof PackageableElement) ? printPackageableElementPath(instance) : print(instance.getName());
+    }
+
+    private TracingPostProcessorObserver printClassifier(CoreInstance classifier)
+    {
+        return (classifier == null) ? print("null") : printPackageableElementPath(classifier);
+    }
+
+    private TracingPostProcessorObserver printPackageableElementPath(CoreInstance instance)
+    {
+        org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.writeUserPathForPackageableElement(this.appendable, instance);
+        return this;
+    }
+
+    private TracingPostProcessorObserver printSourceInfo(SourceInformation sourceInfo)
+    {
+        if (sourceInfo == null)
+        {
+            return print("null");
+        }
+
+        sourceInfo.appendMessage(this.appendable);
+        return this;
+    }
+
+    private TracingPostProcessorObserver printDuration(long durationInNanos)
+    {
+        this.appendable.append(getDurationString(durationInNanos));
+        return this;
+    }
+
+    private static String getDurationString(long durationInNanos)
+    {
+        if (durationInNanos == 0)
+        {
+            return "0.000000000";
+        }
+
+        boolean negative = durationInNanos < 0;
+        String string = Long.toString(durationInNanos);
+        int secondsCharCount = string.length() - (negative ? 10 : 9);
+        if (secondsCharCount <= 0)
+        {
+            int expectedLen = negative ? 12 : 11;
+            StringBuilder builder = new StringBuilder(expectedLen);
+            builder.append(negative ? "-0." : "0.");
+            for (int i = secondsCharCount; i < 0; i++)
+            {
+                builder.append('0');
+            }
+            if (negative)
+            {
+                builder.append(string, 1, string.length());
+            }
+            else
+            {
+                builder.append(string);
+            }
+            return builder.toString();
+        }
+
+        StringBuilder builder = new StringBuilder(string.length() + 1 + ((secondsCharCount - 1) / 3));
+        int firstSeparatorIndex = ((secondsCharCount - 1) % 3) + 1 + (negative ? 1 : 0);
+        builder.append(string, 0, firstSeparatorIndex);
+        for (int i = firstSeparatorIndex; i < secondsCharCount; i += 3)
+        {
+            builder.append(',').append(string, i, i + 3);
+        }
+        return builder.append('.').append(string, string.length() - 9, string.length()).toString();
+    }
+
+    private String spaces(int len)
+    {
+        if (len == 0)
+        {
+            return "";
+        }
+
+        char[] chars = new char[len];
+        Arrays.fill(chars, ' ');
+        return new String(chars);
+    }
+
+    public static TracingPostProcessorObserver newObserver(Appendable appendable)
+    {
+        return new TracingPostProcessorObserver(appendable);
+    }
+}

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/VoidPostProcessorObserver.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/observer/VoidPostProcessorObserver.java
@@ -1,0 +1,19 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.compiler.postprocessing.observer;
+
+public class VoidPostProcessorObserver implements PostProcessorObserver
+{
+}

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/UnitProcessor.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/UnitProcessor.java
@@ -14,11 +14,12 @@
 
 package org.finos.legend.pure.m3.compiler.postprocessing.processor;
 
-import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
+import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState.VariableContextScope;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
+import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.tools.matcher.Matcher;
 import org.finos.legend.pure.m4.ModelRepository;
@@ -29,24 +30,26 @@ import org.finos.legend.pure.m4.ModelRepository;
 public class UnitProcessor extends Processor<Unit>
 {
     @Override
+    public String getClassName()
+    {
+        return M3Paths.Unit;
+    }
+
+    @Override
     public void process(Unit instance, ProcessorState state, Matcher matcher, ModelRepository repository, Context context, ProcessorSupport processorSupport)
     {
-        if (null != instance._conversionFunction())
+        FunctionDefinition<?> conversionFunction = instance._conversionFunction();
+        if (conversionFunction != null)
         {
-            state.pushVariableContext();
-            FunctionDefinitionProcessor.process((LambdaFunction)instance._conversionFunction(), state, matcher, repository);
-            state.popVariableContext();
+            try (VariableContextScope ignore = state.withNewVariableContext())
+            {
+                FunctionDefinitionProcessor.process(conversionFunction, state, matcher, repository);
+            }
         }
     }
 
     @Override
     public void populateReferenceUsages(Unit unit, ModelRepository repository, ProcessorSupport processorSupport)
     {
-    }
-
-    @Override
-    public String getClassName()
-    {
-        return M3Paths.Unit;
     }
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/inlinedsl/treepath/RootRouteNodePostProcessor.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/inlinedsl/treepath/RootRouteNodePostProcessor.java
@@ -33,6 +33,7 @@ import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.compiler.postprocessing.GenericTypeTraceability;
 import org.finos.legend.pure.m3.compiler.postprocessing.PostProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState;
+import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState.VariableContextScope;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.Processor;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.PropertyStub;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.AbstractProperty;
@@ -325,23 +326,24 @@ public class RootRouteNodePostProcessor extends Processor<RootRouteNode>
 
     private static void processDerivedPropertyExpressions(NewPropertyRouteNodeAccessor treePathNode, Type type, RichIterable<? extends ValueSpecification> expressions, Matcher matcher, ProcessorState processorState, ProcessorSupport processorSupport)
     {
-        processorState.pushVariableContext();
-        processorState.getVariableContext().buildAndRegister("this", (GenericType) org.finos.legend.pure.m3.navigation.type.Type.wrapGenericType(type, processorSupport), (Multiplicity) processorSupport.package_getByUserPath(M3Paths.PureOne), processorSupport);
-        int i = 0;
-        for (ValueSpecification expression : expressions)
+        try (VariableContextScope ignore = processorState.withNewVariableContext())
         {
-            if (expression._usageContext() == null)
+            processorState.getVariableContext().buildAndRegister("this", (GenericType) org.finos.legend.pure.m3.navigation.type.Type.wrapGenericType(type, processorSupport), (Multiplicity) processorSupport.package_getByUserPath(M3Paths.PureOne), processorSupport);
+            int i = 0;
+            for (ValueSpecification expression : expressions)
             {
-                ExpressionSequenceValueSpecificationContext usageContext = (ExpressionSequenceValueSpecificationContext) processorSupport.newAnonymousCoreInstance(null, M3Paths.ExpressionSequenceValueSpecificationContext);
+                if (expression._usageContext() == null)
+                {
+                    ExpressionSequenceValueSpecificationContext usageContext = (ExpressionSequenceValueSpecificationContext) processorSupport.newAnonymousCoreInstance(null, M3Paths.ExpressionSequenceValueSpecificationContext);
 
-                usageContext._offset(i);
-                usageContext._functionDefinition(treePathNode._functionDefinition());
-                expression._usageContext(usageContext);
+                    usageContext._offset(i);
+                    usageContext._functionDefinition(treePathNode._functionDefinition());
+                    expression._usageContext(usageContext);
+                }
+                processorState.resetVariables();
+                PostProcessor.processElement(matcher, expression, processorState, processorSupport);
+                i++;
             }
-            processorState.resetVariables();
-            PostProcessor.processElement(matcher, expression, processorState, processorSupport);
-            i++;
         }
-        processorState.popVariableContext();
     }
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/IncrementalCompiler.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/IncrementalCompiler.java
@@ -31,6 +31,7 @@ import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;
 import org.finos.legend.pure.m3.SourceMutation;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.compiler.postprocessing.PostProcessor;
+import org.finos.legend.pure.m3.compiler.postprocessing.observer.PostProcessorObserver;
 import org.finos.legend.pure.m3.compiler.validation.ValidationType;
 import org.finos.legend.pure.m3.compiler.validation.Validator;
 import org.finos.legend.pure.m3.coreinstance.CoreInstanceFactoryRegistry;
@@ -181,21 +182,31 @@ public abstract class IncrementalCompiler implements SourceEventHandler
 
     public SourceMutation compileInCurrentTransaction(RichIterable<? extends Source> sources)
     {
+        return compileInCurrentTransaction(sources, null);
+    }
+
+    public SourceMutation compileInCurrentTransaction(RichIterable<? extends Source> sources, PostProcessorObserver postProcessorObserver)
+    {
         IncrementalCompilerTransaction transaction = this.transactionManager.getThreadLocalTransaction();
         if (transaction == null)
         {
             throw new IllegalStateException("No current transaction");
         }
         // TODO should we use this.compilerEventHandlers?
-        return this.compile(sources, Lists.immutable.empty());
+        return this.compile(sources, Lists.immutable.empty(), postProcessorObserver);
     }
 
     SourceMutation compile(RichIterable<? extends Source> sources) throws PureCompilationException, PureParserException
     {
-        return this.compile(sources, this.compilerEventHandlers);
+        return compile(sources, null);
     }
 
-    abstract SourceMutation compile(RichIterable<? extends Source> sources, Iterable<? extends CompilerEventHandler> compilerEventHandlers) throws PureCompilationException, PureParserException;
+    SourceMutation compile(RichIterable<? extends Source> sources, PostProcessorObserver postProcessorObserver) throws PureCompilationException, PureParserException
+    {
+        return this.compile(sources, this.compilerEventHandlers, postProcessorObserver);
+    }
+
+    abstract SourceMutation compile(RichIterable<? extends Source> sources, Iterable<? extends CompilerEventHandler> compilerEventHandlers, PostProcessorObserver postProcessorObserver) throws PureCompilationException, PureParserException;
 
     void runEventHandlers(Iterable<? extends CompilerEventHandler> compilerEventHandlers, SetIterable<CoreInstance> copyToProcess, Multimap<String, ? extends Source> compiledSourcesByRepo)
     {
@@ -213,7 +224,7 @@ public abstract class IncrementalCompiler implements SourceEventHandler
         return toProcess.reject(instance -> (instance.getSourceInformation() == null) || excludedSourceIds.contains(instance.getSourceInformation().getSourceId()));
     }
 
-    SourceMutation finishRepoCompilation(String repoName, MutableList<CoreInstance> newInstancesConsolidated, ValidationType validationType) throws PureCompilationException
+    SourceMutation finishRepoCompilation(String repoName, MutableList<CoreInstance> newInstancesConsolidated, ValidationType validationType, PostProcessorObserver postProcessorObserver) throws PureCompilationException
     {
         Procedure<CoreInstance> registerInContext = instance ->
         {
@@ -233,7 +244,7 @@ public abstract class IncrementalCompiler implements SourceEventHandler
             newInstancesConsolidated.forEach(registerInContext);
         }
 
-        SourceMutation sourceMutation = PostProcessor.process(newInstancesConsolidated, this.modelRepository, this.library, this.dslLibrary, this.codeStorage, this.context, this.processorSupport, this.urlPatternLibrary, this.message);
+        SourceMutation sourceMutation = PostProcessor.process(newInstancesConsolidated, this.modelRepository, this.library, this.dslLibrary, this.codeStorage, this.context, this.processorSupport, this.urlPatternLibrary, this.message, postProcessorObserver);
 
         if (validationType == ValidationType.DEEP)
         {

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/IncrementalCompiler_New.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/IncrementalCompiler_New.java
@@ -15,8 +15,6 @@
 package org.finos.legend.pure.m3.serialization.runtime;
 
 import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
@@ -29,6 +27,7 @@ import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.factory.Multimaps;
 import org.finos.legend.pure.m3.SourceMutation;
 import org.finos.legend.pure.m3.compiler.postprocessing.PostProcessor;
+import org.finos.legend.pure.m3.compiler.postprocessing.observer.PostProcessorObserver;
 import org.finos.legend.pure.m3.compiler.unload.Unbinder;
 import org.finos.legend.pure.m3.compiler.unload.unbind.UnbindState;
 import org.finos.legend.pure.m3.compiler.unload.walk.WalkerState;
@@ -60,30 +59,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class IncrementalCompiler_New extends IncrementalCompiler
 {
-    private static final Function<SourceState, String> GET_SOURCE_STATE_REPO = object ->
-    {
-        String repo = PureCodeStorage.getSourceRepoName(object.getSource().getId());
-        if (repo == null)
-        {
-            return null;
-        }
-        return repo.startsWith("model") ? "model-all" : repo;
-    };
-
-    private static final Predicate2<CoreInstance, String> CORE_INSTANCE_IS_FROM_REPO = (instance, repoName) ->
-    {
-        String instanceRepository = PureCodeStorage.getSourceRepoName(instance.getSourceInformation().getSourceId());
-        if ("Pure".equals(repoName))
-        {
-            return true;
-        }
-        if (instanceRepository == null)
-        {
-            return repoName == null;
-        }
-        return repoName != null && ("model-all".equals(repoName) ? instanceRepository.startsWith("model") : instanceRepository.equals(repoName));
-    };
-
     private final MutableSet<SourceState> oldSourceStates = Sets.mutable.with();
     private final MutableSet<CoreInstance> toUnbind = Sets.mutable.with();
     private final MutableSet<CoreInstance> processed = Sets.mutable.with();
@@ -98,7 +73,7 @@ public class IncrementalCompiler_New extends IncrementalCompiler
     //----------
 
     @Override
-    SourceMutation compile(RichIterable<? extends Source> sources, Iterable<? extends CompilerEventHandler> compilerEventHandlers) throws PureCompilationException, PureParserException
+    SourceMutation compile(RichIterable<? extends Source> sources, Iterable<? extends CompilerEventHandler> compilerEventHandlers, PostProcessorObserver postProcessorObserver) throws PureCompilationException, PureParserException
     {
         MutableSet<CoreInstance> potentialToProcess = this.walkTheGraphForUnload(this.toUnload).withAll(this.toProcess).withAll(this.toUnbind);
 
@@ -117,7 +92,7 @@ public class IncrementalCompiler_New extends IncrementalCompiler
             MutableSet<CoreInstance> repoTransactionInstances = Sets.mutable.empty();
             try
             {
-                result = this.compileRepoSources(repoTransaction, "Pure", 1, 1, sources, this.toProcess.toImmutable(), this.toUnbind.toImmutable(), Lists.mutable.<SourceState>with(), repoTransactionInstances);
+                result = this.compileRepoSources(repoTransaction, "Pure", 1, 1, sources, this.toProcess.toImmutable(), this.toUnbind.toImmutable(), Lists.mutable.<SourceState>with(), repoTransactionInstances, postProcessorObserver);
                 if (shouldCreateNewRepoTransaction)
                 {
                     repoTransaction.commit();
@@ -138,7 +113,7 @@ public class IncrementalCompiler_New extends IncrementalCompiler
 
             Multimap<String, ? extends Source> sourcesByRepo = sources.groupBy(s -> PureCodeStorage.getSourceRepoName(s.getId()));
             Multimap<String, ? extends Source> sourcesByRepoNew = sources.groupBy(PureCodeStorage.GET_SOURCE_REPO);
-            Multimap<String, SourceState> sourceStatesByRepo = this.oldSourceStates.groupBy(GET_SOURCE_STATE_REPO);
+            Multimap<String, SourceState> sourceStatesByRepo = this.oldSourceStates.groupBy(IncrementalCompiler_New::getSourceStateRepo);
             Multimap<String, CoreInstance> potentialRepos = potentialToProcess.groupBy(GET_COREINSTANCE_REPO_NAME);
 
             MutableSet<String> allReposToCompile = Sets.mutable.withAll(sourcesByRepo.keysView()).withAll(potentialRepos.keysView());
@@ -166,14 +141,14 @@ public class IncrementalCompiler_New extends IncrementalCompiler
             {
                 IncrementalCompilerTransaction repoTransaction = shouldCreateNewRepoTransactions ? this.newTransaction(true) : threadLocalTransaction;
                 RichIterable<? extends Source> repoSources = sourcesByRepoNew.get(repo);
-                RichIterable<CoreInstance> toProcessThisRepo = this.toProcess.selectWith(CORE_INSTANCE_IS_FROM_REPO, repo).toImmutable();
-                RichIterable<CoreInstance> toUnbindThisRepo = this.toUnbind.selectWith(CORE_INSTANCE_IS_FROM_REPO, repo).toImmutable();
+                RichIterable<CoreInstance> toProcessThisRepo = this.toProcess.selectWith(IncrementalCompiler_New::coreInstanceIsFromRepo, repo).toImmutable();
+                RichIterable<CoreInstance> toUnbindThisRepo = this.toUnbind.selectWith(IncrementalCompiler_New::coreInstanceIsFromRepo, repo).toImmutable();
                 MutableSet<CoreInstance> repoTransactionInstances = Sets.mutable.empty();
 
                 SourceMutation repoResult;
                 try
                 {
-                    repoResult = this.compileRepoSources(repoTransaction, repo, i + 1, repoCount, repoSources, toProcessThisRepo, toUnbindThisRepo, sourceStatesByRepo.get(repo), repoTransactionInstances);
+                    repoResult = this.compileRepoSources(repoTransaction, repo, i + 1, repoCount, repoSources, toProcessThisRepo, toUnbindThisRepo, sourceStatesByRepo.get(repo), repoTransactionInstances, postProcessorObserver);
                     if (shouldCreateNewRepoTransactions)
                     {
                         repoTransaction.commit();
@@ -208,7 +183,7 @@ public class IncrementalCompiler_New extends IncrementalCompiler
         return result;
     }
 
-    private SourceMutation compileRepoSources(IncrementalCompilerTransaction transaction, String repoName, int repoNum, int repoTotalCount, RichIterable<? extends Source> sources, RichIterable<CoreInstance> instancesToProcess, RichIterable<CoreInstance> instancesToUnbind, RichIterable<SourceState> sourceStates, MutableSet<CoreInstance> repoTransactionInstances) throws PureCompilationException, PureParserException
+    private SourceMutation compileRepoSources(IncrementalCompilerTransaction transaction, String repoName, int repoNum, int repoTotalCount, RichIterable<? extends Source> sources, RichIterable<CoreInstance> instancesToProcess, RichIterable<CoreInstance> instancesToUnbind, RichIterable<SourceState> sourceStates, MutableSet<CoreInstance> repoTransactionInstances, PostProcessorObserver observer) throws PureCompilationException, PureParserException
     {
         String repoDisplayName = repoName == null ? "non-repository" : repoName;
         try (ThreadLocalTransactionContext ignored = transaction != null ? transaction.openInCurrentThread() : null)
@@ -275,7 +250,7 @@ public class IncrementalCompiler_New extends IncrementalCompiler
             MutableSet<CoreInstance> toUnbindGenerated = this.walkTheGraphForUnload(oldButNotNew);
 
             // Filter the instances which are within the repo
-            MutableSet<CoreInstance> toUnbindWithinRepo = toUnbindGenerated.selectWith(CORE_INSTANCE_IS_FROM_REPO, repoName);
+            MutableSet<CoreInstance> toUnbindWithinRepo = toUnbindGenerated.selectWith(IncrementalCompiler_New::coreInstanceIsFromRepo, repoName);
 
             // Total Unbind set is ( generated here + obtained through call - non retained )
             MutableSet<CoreInstance> hereUnbind = toUnbindWithinRepo.union(oldButNotNew).union(instancesToUnbind.toSet());
@@ -291,7 +266,7 @@ public class IncrementalCompiler_New extends IncrementalCompiler
             MutableSet<CoreInstance> toProcessGenerated = toUnbindGenerated.select(each -> !sourcesInScope.contains(each.getSourceInformation().getSourceId()) || newInstances.contains(each));
 
             // Filter the instances which are within this repo
-            MutableSet<CoreInstance> toProcessWithinRepoGenerated = toProcessGenerated.selectWith(CORE_INSTANCE_IS_FROM_REPO, repoName);
+            MutableSet<CoreInstance> toProcessWithinRepoGenerated = toProcessGenerated.selectWith(IncrementalCompiler_New::coreInstanceIsFromRepo, repoName);
 
             // ToProcess from call is filtered for the existence in new instances if source is within the sourcesInScope
             MutableSet<CoreInstance> instancesToProcessFiltered = instancesToProcess.select(each -> !sourcesInScope.contains(each.getSourceInformation().getSourceId()) || newInstances.contains(each)).toSet();
@@ -313,7 +288,7 @@ public class IncrementalCompiler_New extends IncrementalCompiler
             repoTransactionInstances.addAllIterable(newInstancesConsolidated);
 
             // Do postprocessing, validation - can throw an error
-            SourceMutation result = this.finishRepoCompilation(repoDisplayName, allInstances, newInstancesConsolidated, ValidationType.SHALLOW);
+            SourceMutation result = this.finishRepoCompilation(repoDisplayName, allInstances, newInstancesConsolidated, ValidationType.SHALLOW, observer);
 
             // Repo compilation Successful
 
@@ -342,7 +317,7 @@ public class IncrementalCompiler_New extends IncrementalCompiler
     }
 
 
-    private SourceMutation finishRepoCompilation(String repoName, MutableList<CoreInstance> allInstances, MutableList<CoreInstance> newInstancesConsolidated, ValidationType validationType) throws PureCompilationException
+    private SourceMutation finishRepoCompilation(String repoName, MutableList<CoreInstance> allInstances, MutableList<CoreInstance> newInstancesConsolidated, ValidationType validationType, PostProcessorObserver observer) throws PureCompilationException
     {
         Procedure<CoreInstance> registerInContext = instance ->
         {
@@ -362,7 +337,7 @@ public class IncrementalCompiler_New extends IncrementalCompiler
             allInstances.forEach(registerInContext);
         }
 
-        SourceMutation sourceMutation = PostProcessor.process(newInstancesConsolidated, this.modelRepository, this.library, this.dslLibrary, this.codeStorage, this.context, this.processorSupport, this.urlPatternLibrary, this.message);
+        SourceMutation sourceMutation = PostProcessor.process(newInstancesConsolidated, this.modelRepository, this.library, this.dslLibrary, this.codeStorage, this.context, this.processorSupport, this.urlPatternLibrary, this.message, observer);
 
         if (validationType == ValidationType.DEEP)
         {
@@ -494,5 +469,29 @@ public class IncrementalCompiler_New extends IncrementalCompiler
             this.oldSourceStates.add(new SourceState(source, oldContent, source.getNewInstances().toSet(), this.collectImportGroups(source.getId())));
         }
         super.updateSource(source, oldContent);
+    }
+
+    private static String getSourceStateRepo(SourceState sourceState)
+    {
+        String repo = PureCodeStorage.getSourceRepoName(sourceState.getSource().getId());
+        if (repo == null)
+        {
+            return null;
+        }
+        return repo.startsWith("model") ? "model-all" : repo;
+    }
+
+    private static boolean coreInstanceIsFromRepo(CoreInstance instance, String repoName)
+    {
+        String instanceRepository = PureCodeStorage.getSourceRepoName(instance.getSourceInformation().getSourceId());
+        if ("Pure".equals(repoName))
+        {
+            return true;
+        }
+        if (instanceRepository == null)
+        {
+            return repoName == null;
+        }
+        return repoName != null && ("model-all".equals(repoName) ? instanceRepository.startsWith("model") : instanceRepository.equals(repoName));
     }
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/PureRuntime.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/PureRuntime.java
@@ -31,6 +31,7 @@ import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.finos.legend.pure.m3.SourceMutation;
 import org.finos.legend.pure.m3.compiler.Context;
+import org.finos.legend.pure.m3.compiler.postprocessing.observer.PostProcessorObserver;
 import org.finos.legend.pure.m3.coreinstance.CoreInstanceFactoryRegistry;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
@@ -185,6 +186,11 @@ public class PureRuntime
 
     public RichIterable<Source> loadAndCompileCore(Message message)
     {
+        return loadAndCompileCore(message, null);
+    }
+
+    public RichIterable<Source> loadAndCompileCore(Message message, PostProcessorObserver postProcessorObserver)
+    {
         this.pureRuntimeStatus.startLoadingAndCompilingCore();
 
         try
@@ -215,7 +221,7 @@ public class PureRuntime
             this.getIncrementalCompiler().preCompileM3(newInstances);
             ////END READ and Serialize m3.pure
 
-            this.compile(sources.reject(s -> M3_PURE.equals(s.getId())));
+            this.compile(sources.reject(s -> M3_PURE.equals(s.getId())), postProcessorObserver);
 
             this.getIncrementalCompiler().finishedCompilingCore(sources);
             return sources;
@@ -241,6 +247,11 @@ public class PureRuntime
 
     public RichIterable<Source> loadAndCompileSystem(Message message)
     {
+        return loadAndCompileSystem(message, null);
+    }
+
+    public RichIterable<Source> loadAndCompileSystem(Message message, PostProcessorObserver postProcessorObserver)
+    {
         this.pureRuntimeStatus.startLoadingAndCompilingSystemFiles();
         try
         {
@@ -250,7 +261,7 @@ public class PureRuntime
                 message.setMessage("Loading "+sourcePaths.size()+" sources...");
             }
             MutableList<Source> sources = sourcePaths.collect(this::getOrLoadSource).reject(Source.IS_COMPILED).toList();
-            compile(sources);
+            compile(sources, postProcessorObserver);
             return sources;
         }
         finally
@@ -313,7 +324,12 @@ public class PureRuntime
 
     private SourceMutation compile(RichIterable<? extends Source> sources)
     {
-        SourceMutation sourceMutation = this.incrementalCompiler.compile(sources);
+        return compile(sources, null);
+    }
+
+    private SourceMutation compile(RichIterable<? extends Source> sources, PostProcessorObserver postProcessorObserver)
+    {
+        SourceMutation sourceMutation = this.incrementalCompiler.compile(sources, postProcessorObserver);
         if (sourceMutation != null)
         {
             try


### PR DESCRIPTION
Add post-processing observers, that can allow better information about what post-processing is doing. For example, this can allow timing of instance processing or tracing of how instances are processed.

Also, improve variable context handling so that it can be done with try-with-resources. This should ensure that whenever a new context is pushed, it is always popped.