### PR TITLE
Index repositories by name in a thread local to avoid thread conflicts

### DIFF
--- a/legend-pure-configuration-external/pom.xml
+++ b/legend-pure-configuration-external/pom.xml
@@ -55,5 +55,11 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-pure-configuration-external/src/test/java/org/finos/legend/pure/configuration/TestPureRepositoriesExternal.java
+++ b/legend-pure-configuration-external/src/test/java/org/finos/legend/pure/configuration/TestPureRepositoriesExternal.java
@@ -1,0 +1,104 @@
+package org.finos.legend.pure.configuration;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class TestPureRepositoriesExternal
+{
+    @Before
+    public void setUp()
+    {
+        PureRepositoriesExternal.refresh();
+    }
+
+    @After
+    public void cleanUp()
+    {
+        PureRepositoriesExternal.refresh();
+    }
+
+    @Test
+    public void testBaseRepositories()
+    {
+        assertRepoNames("platform");
+        Assert.assertNotNull(PureRepositoriesExternal.getRepository("platform"));
+        Assert.assertTrue(PureRepositoriesExternal.getRepository("platform") instanceof PlatformCodeRepository);
+    }
+
+    @Test
+    public void testAddRepositories()
+    {
+        GenericCodeRepository testRepoA = new GenericCodeRepository("test_repo_a", "test::a::.*", "platform");
+        GenericCodeRepository testRepoB = new GenericCodeRepository("test_repo_b", "test::b::.*", "platform", "test_repo_a");
+        GenericCodeRepository badDependenciesRepo = new GenericCodeRepository("test_repo_bad_deps", "test3::.*", "platform", "non_existent");
+        GenericCodeRepository fakePlatformRepo = new GenericCodeRepository("platform", "meta::.*");
+        GenericCodeRepository testRepoA2 = new GenericCodeRepository("test_repo_a", "test::a::.*", "platform");
+
+        assertRepoNames("platform");
+
+        // Try to add with name conflict with platform
+        RuntimeException e1 = Assert.assertThrows(RuntimeException.class, () -> PureRepositoriesExternal.addRepositories(Lists.fixedSize.with(testRepoA, testRepoB, fakePlatformRepo)));
+        Assert.assertEquals("The code repository platform already exists!", e1.getMessage());
+        assertRepoNames("platform");
+
+        // Try to add with name conflict among new repos
+        RuntimeException e2 = Assert.assertThrows(RuntimeException.class, () -> PureRepositoriesExternal.addRepositories(Lists.fixedSize.with(testRepoA, testRepoB, testRepoA2)));
+        Assert.assertEquals("The code repository test_repo_a already exists!", e2.getMessage());
+        assertRepoNames("platform");
+
+        // Try to add with a bad dependency
+        RuntimeException e3 = Assert.assertThrows(RuntimeException.class, () -> PureRepositoriesExternal.addRepositories(Lists.fixedSize.with(testRepoA, testRepoB, badDependenciesRepo)));
+        Assert.assertEquals("The dependency 'non_existent' required by the Code Repository 'test_repo_bad_deps' can't be found!", e3.getMessage());
+        assertRepoNames("platform");
+
+        // Add valid
+        PureRepositoriesExternal.addRepositories(Lists.fixedSize.with(testRepoA, testRepoB));
+        assertRepoNames("platform", "test_repo_a", "test_repo_b");
+
+        // Refresh
+        PureRepositoriesExternal.refresh();
+        assertRepoNames("platform");
+    }
+
+    @Test
+    public void testThreadLocality() throws Exception
+    {
+        GenericCodeRepository testRepoA = new GenericCodeRepository("test_repo_a", "test::a::.*", "platform");
+        GenericCodeRepository testRepoB = new GenericCodeRepository("test_repo_b", "test::b::.*", "platform", "test_repo_a");
+
+        assertRepoNames("platform");
+        PureRepositoriesExternal.addRepositories(Lists.fixedSize.with(testRepoA, testRepoB));
+        assertRepoNames("platform", "test_repo_a", "test_repo_b");
+
+        MutableList<String> threadRepoNames = Lists.mutable.<String>empty().asSynchronized();
+        Thread thread = new Thread(() ->
+        {
+            PureRepositoriesExternal.repositories().collect(CodeRepository::getName, threadRepoNames);
+            PureRepositoriesExternal.refresh();
+        });
+        thread.start();
+        thread.join();
+
+        // Test that addRepositories does not affect the other thread
+        Assert.assertEquals(Lists.fixedSize.with("platform"), threadRepoNames.sortThis());
+
+        // Test that refresh in the other thread does not affect this thread
+        assertRepoNames("platform", "test_repo_a", "test_repo_b");
+    }
+
+    private void assertRepoNames(String... expectedRepoNames)
+    {
+        Arrays.sort(expectedRepoNames);
+        Assert.assertEquals(ArrayAdapter.adapt(expectedRepoNames), PureRepositoriesExternal.repositories().collect(CodeRepository::getName, Lists.mutable.empty()).sortThis());
+    }
+}

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/repository/CodeRepositoryProviderHelper.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/repository/CodeRepositoryProviderHelper.java
@@ -16,7 +16,7 @@ package org.finos.legend.pure.m3.serialization.filesystem.repository;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.utility.Iterate;
 
 import java.util.ServiceLoader;
 
@@ -24,14 +24,18 @@ public class CodeRepositoryProviderHelper
 {
     public static RichIterable<CodeRepository> findCodeRepositories()
     {
-        MutableList<CodeRepository> repositories = Lists.mutable.empty();
-        ServiceLoader<CodeRepositoryProvider> serviceLoader = ServiceLoader.load(CodeRepositoryProvider.class);
+        return getRepositories(ServiceLoader.load(CodeRepositoryProvider.class));
+    }
+
+    public static RichIterable<CodeRepository> findCodeRepositories(ClassLoader classLoader)
+    {
+        return getRepositories(ServiceLoader.load(CodeRepositoryProvider.class, classLoader));
+    }
+
+    private static RichIterable<CodeRepository> getRepositories(ServiceLoader<CodeRepositoryProvider> serviceLoader)
+    {
         serviceLoader.reload();
-        for (CodeRepositoryProvider codeRepositoryProvider : serviceLoader)
-        {
-            repositories.add(codeRepositoryProvider.repository());
-        }
-        return repositories;
+        return Iterate.collect(serviceLoader, CodeRepositoryProvider::repository, Lists.mutable.empty());
     }
 
     public static boolean isCoreRepository(CodeRepository codeRepository)


### PR DESCRIPTION
Index repositories by name in a thread local to avoid conflicts where compilation steps in concurrent threads are clearing and recomputing the sets of available repositories.