### PR TITLE
Replace PureRepositoriesExternal with CodeRepositorySet

### DIFF
--- a/legend-pure-ide-light/pom.xml
+++ b/legend-pure-ide-light/pom.xml
@@ -144,10 +144,6 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
-            <artifactId>legend-pure-configuration-external</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m2-dsl-diagram</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/repository/CodeRepositoryProviderHelper.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/repository/CodeRepositoryProviderHelper.java
@@ -22,19 +22,58 @@ import java.util.ServiceLoader;
 
 public class CodeRepositoryProviderHelper
 {
+    /**
+     * Find all code repositories accessible via a {@linkplain CodeRepositoryProvider}.
+     *
+     * @return all code repositories
+     */
     public static RichIterable<CodeRepository> findCodeRepositories()
     {
-        return getRepositories(ServiceLoader.load(CodeRepositoryProvider.class));
+        return findCodeRepositories(false);
     }
 
+    /**
+     * Find all code repositories accessible via a {@linkplain CodeRepositoryProvider}. If refresh is true, then any
+     * provider caches will be cleared.
+     *
+     * @param refresh whether to refresh caches
+     * @return all code repositories
+     */
+    public static RichIterable<CodeRepository> findCodeRepositories(boolean refresh)
+    {
+        return getRepositories(ServiceLoader.load(CodeRepositoryProvider.class), refresh);
+    }
+
+    /**
+     * Find all code repositories accessible via a {@linkplain CodeRepositoryProvider} in the given class loader.
+     *
+     * @param classLoader class loader
+     * @return all code repositories
+     */
     public static RichIterable<CodeRepository> findCodeRepositories(ClassLoader classLoader)
     {
-        return getRepositories(ServiceLoader.load(CodeRepositoryProvider.class, classLoader));
+        return findCodeRepositories(classLoader, false);
     }
 
-    private static RichIterable<CodeRepository> getRepositories(ServiceLoader<CodeRepositoryProvider> serviceLoader)
+    /**
+     * Find all code repositories accessible via a {@linkplain CodeRepositoryProvider} in the given class loader. If
+     * refresh is true, then any provider caches will be cleared.
+     *
+     * @param classLoader class loader
+     * @param refresh     whether to refresh caches
+     * @return all code repositories
+     */
+    public static RichIterable<CodeRepository> findCodeRepositories(ClassLoader classLoader, boolean refresh)
     {
-        serviceLoader.reload();
+        return getRepositories(ServiceLoader.load(CodeRepositoryProvider.class, classLoader), refresh);
+    }
+
+    private static RichIterable<CodeRepository> getRepositories(ServiceLoader<CodeRepositoryProvider> serviceLoader, boolean reload)
+    {
+        if (reload)
+        {
+            serviceLoader.reload();
+        }
         return Iterate.collect(serviceLoader, CodeRepositoryProvider::repository, Lists.mutable.empty());
     }
 

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/repository/CodeRepositorySet.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/repository/CodeRepositorySet.java
@@ -1,0 +1,274 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.filesystem.repository;
+
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
+import org.eclipse.collections.impl.utility.ArrayIterate;
+import org.eclipse.collections.impl.utility.Iterate;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+public class CodeRepositorySet
+{
+    private final ImmutableMap<String, CodeRepository> repositoriesByName;
+
+    private CodeRepositorySet(ImmutableMap<String, CodeRepository> repositoriesByName)
+    {
+        this.repositoriesByName = repositoriesByName;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (this == other)
+        {
+            return true;
+        }
+
+        return (other instanceof CodeRepositorySet) && this.repositoriesByName.equals(((CodeRepositorySet) other).repositoriesByName);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return this.repositoriesByName.castToMap().keySet().hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder(getClass().getSimpleName()).append('{');
+        this.repositoriesByName.keysView().appendString(builder, ", ");
+        return builder.append('}').toString();
+    }
+
+    public boolean hasRepository(String repositoryName)
+    {
+        return this.repositoriesByName.containsKey(repositoryName);
+    }
+
+    public RichIterable<String> getRepositoryNames()
+    {
+        return this.repositoriesByName.keysView();
+    }
+
+    public RichIterable<CodeRepository> getRepositories()
+    {
+        return this.repositoriesByName.valuesView();
+    }
+
+    public CodeRepository getRepository(String repositoryName)
+    {
+        CodeRepository found = this.repositoriesByName.get(repositoryName);
+        if (found == null)
+        {
+            throw new IllegalArgumentException("The code repository '" + repositoryName + "' can't be found!");
+        }
+        return found;
+    }
+
+    public Optional<CodeRepository> getOptionalRepository(String repositoryName)
+    {
+        return Optional.ofNullable(this.repositoriesByName.get(repositoryName));
+    }
+
+    public int size()
+    {
+        return this.repositoriesByName.size();
+    }
+
+    public void forEach(Consumer<? super CodeRepository> consumer)
+    {
+        this.repositoriesByName.forEachValue(consumer::accept);
+    }
+
+    /**
+     * Return the minimal subset of this CodeRepositorySet which contains all the selected repositories and is closed
+     * under repository visibility. That is, it is guaranteed to include all the selected repositories as well as all
+     * repositories from the original set which are visible to any repository in the subset. The platform repository
+     * will always be included in the subset, even if the set of selected repositories is empty.
+     *
+     * @param selectedRepositories names of repositories to include in the subset
+     * @return subset with selected repositories
+     */
+    public CodeRepositorySet subset(String... selectedRepositories)
+    {
+        return subset(ArrayAdapter.adapt(selectedRepositories));
+    }
+
+    /**
+     * Return the minimal subset of this CodeRepositorySet which contains all the selected repositories and is closed
+     * under repository visibility. That is, it is guaranteed to include all the selected repositories as well as all
+     * repositories from the original set which are visible to any repository in the subset. The platform repository
+     * will always be included in the subset, even if the set of selected repositories is empty.
+     *
+     * @param selectedRepositories names of repositories to include in the subset
+     * @return subset with selected repositories
+     */
+    public CodeRepositorySet subset(Iterable<? extends String> selectedRepositories)
+    {
+        MutableMap<String, CodeRepository> resolved = Maps.mutable.with(PlatformCodeRepository.NAME, getRepository(PlatformCodeRepository.NAME));
+        Deque<CodeRepository> deque = Iterate.collect(selectedRepositories, this::getRepository, new ArrayDeque<>(size()));
+        while (!deque.isEmpty())
+        {
+            CodeRepository repository = deque.removeLast();
+            if (resolved.put(repository.getName(), repository) == null)
+            {
+                if (repository instanceof GenericCodeRepository)
+                {
+                    ((GenericCodeRepository) repository).getDependencies().collect(this.repositoriesByName::get, deque);
+                }
+                else
+                {
+                    this.repositoriesByName.select(r -> (r != repository) && repository.isVisible(r), deque);
+                }
+            }
+        }
+        return (resolved.size() == this.repositoriesByName.size()) ? this : new CodeRepositorySet(resolved.toImmutable());
+    }
+
+    public static Builder newBuilder()
+    {
+        return new Builder();
+    }
+
+    public static Builder newBuilder(CodeRepositorySet manager)
+    {
+        return new Builder(manager);
+    }
+
+    public static class Builder
+    {
+        private final MutableMap<String, CodeRepository> repositories = Maps.mutable.empty();
+
+        private Builder()
+        {
+            addCodeRepository(CodeRepository.newPlatformCodeRepository());
+        }
+
+        private Builder(CodeRepositorySet manager)
+        {
+            this.repositories.putAll(manager.repositoriesByName.castToMap());
+        }
+
+        public void addCodeRepository(CodeRepository repository)
+        {
+            Objects.requireNonNull(repository, "repository may not be null");
+            Objects.requireNonNull(repository.getName(), "repository must have a name");
+            CodeRepository found = this.repositories.getIfAbsentPut(repository.getName(), repository);
+            if (found != repository)
+            {
+                throw new IllegalStateException("The code repository " + repository.getName() + " already exists!");
+            }
+        }
+
+        public void addCodeRepositories(Iterable<? extends CodeRepository> repositories)
+        {
+            repositories.forEach(this::addCodeRepository);
+        }
+
+        public void addCodeRepositories(CodeRepository... repositories)
+        {
+            ArrayIterate.forEach(repositories, this::addCodeRepository);
+        }
+
+        public void removeCodeRepository(String repositoryName)
+        {
+            if (PlatformCodeRepository.NAME.equals(repositoryName))
+            {
+                throw new IllegalArgumentException("The code repository " + PlatformCodeRepository.NAME + " may not be removed");
+            }
+            this.repositories.removeKey(repositoryName);
+        }
+
+        public void removeCodeRepositories(Iterable<? extends String> repositoryNames)
+        {
+            repositoryNames.forEach(this::removeCodeRepositories);
+        }
+
+        public void removeCodeRepositories(String... repositoryNames)
+        {
+            ArrayIterate.forEach(repositoryNames, this::removeCodeRepository);
+        }
+
+        public Builder withCodeRepository(CodeRepository repository)
+        {
+            addCodeRepository(repository);
+            return this;
+        }
+
+        public Builder withCodeRepositories(Iterable<? extends CodeRepository> repositories)
+        {
+            addCodeRepositories(repositories);
+            return this;
+        }
+
+        public Builder withCodeRepositories(CodeRepository... repositories)
+        {
+            addCodeRepositories(repositories);
+            return this;
+        }
+
+        public Builder withoutCodeRepository(String repositoryName)
+        {
+            removeCodeRepository(repositoryName);
+            return this;
+        }
+
+        public Builder withoutCodeRepositories(Iterable<? extends String> repositoryNames)
+        {
+            removeCodeRepositories(repositoryNames);
+            return this;
+        }
+
+        public Builder withoutCodeRepositories(String... repositoryNames)
+        {
+            removeCodeRepositories(repositoryNames);
+            return this;
+        }
+
+        public CodeRepositorySet build()
+        {
+            // validate that all dependencies are present
+            this.repositories.forEachValue(r ->
+            {
+                if (r instanceof GenericCodeRepository)
+                {
+                    MutableList<String> missingDependencies = ((GenericCodeRepository) r).getDependencies().reject(this.repositories::containsKey, Lists.mutable.empty());
+                    if (missingDependencies.notEmpty())
+                    {
+                        StringBuilder builder = new StringBuilder("The ").append((missingDependencies.size() == 1) ? "dependency" : "dependencies");
+                        missingDependencies.sortThis().appendString(builder, " '", "', '", "'");
+                        builder.append(" required by the Code Repository '").append(r.getName()).append("' can't be found!");
+                        throw new IllegalStateException(builder.toString());
+                    }
+                }
+            });
+
+            // build
+            return new CodeRepositorySet(this.repositories.toImmutable());
+        }
+    }
+}

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/filesystem/repository/TestCodeRepositorySet.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/filesystem/repository/TestCodeRepositorySet.java
@@ -1,0 +1,172 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.filesystem.repository;
+
+import org.eclipse.collections.api.factory.Sets;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestCodeRepositorySet
+{
+    @Test
+    public void testBaseRepositories()
+    {
+        CodeRepositorySet set = CodeRepositorySet.newBuilder().build();
+        Assert.assertEquals(1, set.size());
+        Assert.assertEquals("platform", set.getRepositories().getAny().getName());
+        Assert.assertTrue(set.getRepository("platform") instanceof PlatformCodeRepository);
+
+        IllegalArgumentException e = Assert.assertThrows(IllegalArgumentException.class, () -> CodeRepositorySet.newBuilder().withoutCodeRepository("platform"));
+        Assert.assertEquals("The code repository platform may not be removed", e.getMessage());
+    }
+
+    @Test
+    public void testBuilder()
+    {
+        GenericCodeRepository testRepoA = new GenericCodeRepository("test_repo_a", "test::a::.*", "platform");
+        GenericCodeRepository testRepoB = new GenericCodeRepository("test_repo_b", "test::b::.*", "platform", "test_repo_a");
+        GenericCodeRepository badDependenciesRepo = new GenericCodeRepository("test_repo_bad_deps", "test3::.*", "platform", "non_existent");
+
+        CodeRepositorySet set1 = CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA, testRepoB).build();
+        Assert.assertEquals(3, set1.size());
+        Assert.assertEquals(Sets.fixedSize.with("platform", "test_repo_a", "test_repo_b"), set1.getRepositories().collect(CodeRepository::getName, Sets.mutable.empty()));
+        Assert.assertSame(testRepoA, set1.getRepository("test_repo_a"));
+        Assert.assertSame(testRepoB, set1.getRepository("test_repo_b"));
+
+        CodeRepositorySet set2 = CodeRepositorySet.newBuilder()
+                .withCodeRepositories(testRepoA, testRepoB, badDependenciesRepo)
+                .withoutCodeRepository("test_repo_bad_deps")
+                .build();
+        Assert.assertEquals(3, set2.size());
+        Assert.assertEquals(Sets.fixedSize.with("platform", "test_repo_a", "test_repo_b"), set2.getRepositories().collect(CodeRepository::getName, Sets.mutable.empty()));
+        Assert.assertSame(testRepoA, set2.getRepository("test_repo_a"));
+        Assert.assertSame(testRepoB, set2.getRepository("test_repo_b"));
+
+        Assert.assertEquals(set1, set2);
+    }
+
+    @Test
+    public void testBuilder_NameConflict()
+    {
+        GenericCodeRepository testRepoA = new GenericCodeRepository("test_repo_a", "test::a::.*", "platform");
+        GenericCodeRepository testRepoB = new GenericCodeRepository("test_repo_b", "test::b::.*", "platform", "test_repo_a");
+        GenericCodeRepository fakePlatformRepo = new GenericCodeRepository("platform", "meta::.*");
+        GenericCodeRepository testRepoA2 = new GenericCodeRepository("test_repo_a", "test::a::.*", "platform");
+
+        // Try to add with name conflict with platform
+        IllegalStateException e1 = Assert.assertThrows(IllegalStateException.class, () -> CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA, testRepoB, fakePlatformRepo));
+        Assert.assertEquals("The code repository platform already exists!", e1.getMessage());
+
+        // Try to add with name conflict among new repos
+        IllegalStateException e2 = Assert.assertThrows(IllegalStateException.class, () -> CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA, testRepoB, testRepoA2));
+        Assert.assertEquals("The code repository test_repo_a already exists!", e2.getMessage());
+    }
+
+    @Test
+    public void testBuilder_BadDependency()
+    {
+        GenericCodeRepository testRepoA = new GenericCodeRepository("test_repo_a", "test::a::.*", "platform");
+        GenericCodeRepository testRepoB = new GenericCodeRepository("test_repo_b", "test::b::.*", "platform", "test_repo_a");
+        GenericCodeRepository badDependenciesRepo = new GenericCodeRepository("test_repo_bad_deps", "test3::.*", "platform", "non_existent");
+
+        CodeRepositorySet.Builder builder = CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA, testRepoB, badDependenciesRepo);
+        IllegalStateException e = Assert.assertThrows(IllegalStateException.class, builder::build);
+        Assert.assertEquals("The dependency 'non_existent' required by the Code Repository 'test_repo_bad_deps' can't be found!", e.getMessage());
+    }
+
+    @Test
+    public void testBuilderFromManager()
+    {
+        GenericCodeRepository testRepoA = new GenericCodeRepository("test_repo_a", "test::a::.*", "platform");
+        GenericCodeRepository testRepoB = new GenericCodeRepository("test_repo_b", "test::b::.*", "platform", "test_repo_a");
+        GenericCodeRepository testRepoC = new GenericCodeRepository("test_repo_c", "test::c::.*", "platform", "test_repo_b");
+
+        CodeRepositorySet set1 = CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA, testRepoB).build();
+        Assert.assertEquals(3, set1.size());
+        Assert.assertEquals(Sets.fixedSize.with("platform", "test_repo_a", "test_repo_b"), set1.getRepositories().collect(CodeRepository::getName, Sets.mutable.empty()));
+        Assert.assertSame(testRepoA, set1.getRepository("test_repo_a"));
+        Assert.assertSame(testRepoB, set1.getRepository("test_repo_b"));
+
+        CodeRepositorySet set2 = CodeRepositorySet.newBuilder(set1).withCodeRepository(testRepoC).build();
+        Assert.assertEquals(4, set2.size());
+        Assert.assertEquals(Sets.fixedSize.with("platform", "test_repo_a", "test_repo_b", "test_repo_c"), set2.getRepositories().collect(CodeRepository::getName, Sets.mutable.empty()));
+        Assert.assertSame(testRepoA, set2.getRepository("test_repo_a"));
+        Assert.assertSame(testRepoB, set2.getRepository("test_repo_b"));
+        Assert.assertSame(testRepoC, set2.getRepository("test_repo_c"));
+        set1.forEach(repo1 -> Assert.assertSame(repo1, set2.getRepository(repo1.getName())));
+    }
+
+    @Test
+    public void testGetRepository()
+    {
+        GenericCodeRepository testRepoA = new GenericCodeRepository("test_repo_a", "test::a::.*", "platform");
+        GenericCodeRepository testRepoB = new GenericCodeRepository("test_repo_b", "test::b::.*", "platform", "test_repo_a");
+        CodeRepositorySet set = CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA, testRepoB).build();
+
+        Assert.assertSame(testRepoA, set.getRepository("test_repo_a"));
+        Assert.assertSame(testRepoB, set.getRepository("test_repo_b"));
+
+        Assert.assertFalse(set.getOptionalRepository("test_repo_c").isPresent());
+        IllegalArgumentException e = Assert.assertThrows(IllegalArgumentException.class, () -> set.getRepository("test_repo_c"));
+        Assert.assertEquals("The code repository 'test_repo_c' can't be found!", e.getMessage());
+    }
+
+    @Test
+    public void testHasRepository()
+    {
+        GenericCodeRepository testRepoA = new GenericCodeRepository("test_repo_a", "test::a::.*", "platform");
+        GenericCodeRepository testRepoB = new GenericCodeRepository("test_repo_b", "test::b::.*", "platform", "test_repo_a");
+        CodeRepositorySet set = CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA, testRepoB).build();
+        Assert.assertTrue(set.hasRepository("platform"));
+        Assert.assertTrue(set.hasRepository("test_repo_a"));
+        Assert.assertTrue(set.hasRepository("test_repo_b"));
+        Assert.assertFalse(set.hasRepository("test_repo_c"));
+    }
+
+    @Test
+    public void testSubset()
+    {
+        GenericCodeRepository testRepoA = new GenericCodeRepository("test_repo_a", "test::a::.*", "platform");
+        GenericCodeRepository testRepoB = new GenericCodeRepository("test_repo_b", "test::b::.*", "platform", "test_repo_a");
+        GenericCodeRepository testRepoC = new GenericCodeRepository("test_repo_c", "test::c::.*", "platform", "test_repo_b");
+
+        CodeRepositorySet set = CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA, testRepoB, testRepoC).build();
+        Assert.assertEquals(4, set.size());
+        Assert.assertEquals(Sets.fixedSize.with("platform", "test_repo_a", "test_repo_b", "test_repo_c"), set.getRepositories().collect(CodeRepository::getName, Sets.mutable.empty()));
+        Assert.assertSame(testRepoA, set.getRepository("test_repo_a"));
+        Assert.assertSame(testRepoB, set.getRepository("test_repo_b"));
+        Assert.assertSame(testRepoC, set.getRepository("test_repo_c"));
+
+        // Full subset
+        Assert.assertSame(set, set.subset(set.getRepositoryNames()));
+        Assert.assertSame(set, set.subset("platform", "test_repo_a", "test_repo_b", "test_repo_c"));
+        Assert.assertSame(set, set.subset("test_repo_a", "test_repo_b", "test_repo_c"));
+        Assert.assertSame(set, set.subset("test_repo_a", "test_repo_c"));
+        Assert.assertSame(set, set.subset("test_repo_b", "test_repo_c"));
+        Assert.assertSame(set, set.subset("test_repo_c"));
+
+        // Minimal subset
+        Assert.assertEquals(CodeRepositorySet.newBuilder().build(), set.subset());
+        Assert.assertEquals(CodeRepositorySet.newBuilder().build(), set.subset("platform"));
+
+        // In between
+        Assert.assertEquals(CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA, testRepoB).build(), set.subset("platform", "test_repo_a", "test_repo_b"));
+        Assert.assertEquals(CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA, testRepoB).build(), set.subset("test_repo_a", "test_repo_b"));
+        Assert.assertEquals(CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA, testRepoB).build(), set.subset("test_repo_b"));
+
+        Assert.assertEquals(CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA).build(), set.subset("platform", "test_repo_a"));
+        Assert.assertEquals(CodeRepositorySet.newBuilder().withCodeRepositories(testRepoA).build(), set.subset("test_repo_a"));
+    }
+}

--- a/legend-pure-maven-compilation-par/pom.xml
+++ b/legend-pure-maven-compilation-par/pom.xml
@@ -91,11 +91,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.finos.legend.pure</groupId>
-            <artifactId>legend-pure-configuration-external</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>

--- a/legend-pure-maven-compilation-par/src/main/java/org/finos/legend/pure/maven/par/PureJarMojo.java
+++ b/legend-pure-maven-compilation-par/src/main/java/org/finos/legend/pure/maven/par/PureJarMojo.java
@@ -18,16 +18,11 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.utility.Iterate;
-import org.finos.legend.pure.configuration.PureRepositoriesExternal;
-import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositorySet;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
 
 import java.io.File;
-import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Set;
@@ -63,17 +58,11 @@ public class PureJarMojo extends AbstractMojo
             getLog().info("  Requested repositories: " + this.repositories);
             getLog().info("  Excluded repositories: " + this.excludedRepositories);
             getLog().info("  Extra repositories: " + this.extraRepositories);
-            ListIterable<CodeRepository> resolvedRepositories = resolveRepositories();
-            getLog().info("  Repositories with resolved dependencies: " + resolvedRepositories);
+            CodeRepositorySet resolvedRepositories = resolveRepositories();
+            getLog().info("  Repositories with resolved dependencies: " + resolvedRepositories.getRepositories());
             getLog().info("  Pure platform version: " + this.purePlatformVersion);
             getLog().info("  Pure source directory: " + this.sourceDirectory);
             getLog().info("  Output directory: " + this.outputDirectory);
-
-            if (resolvedRepositories.isEmpty())
-            {
-                getLog().info("   -> No repositories to serialize: nothing to do");
-                return;
-            }
 
             getLog().info("  Starting compilation and generation of Pure PAR file(s)");
             PureJarSerializer.writePureRepositoryJars(this.outputDirectory.toPath(), (this.sourceDirectory == null) ? null : this.sourceDirectory.toPath(), this.purePlatformVersion, resolvedRepositories, getLog());
@@ -81,29 +70,27 @@ public class PureJarMojo extends AbstractMojo
         catch (Exception e)
         {
             getLog().error(String.format("  -> Pure PAR generation failed (%.9fs)", durationSinceInSeconds(start)), e);
-            throw new MojoExecutionException("Error serializing Pure PAR", e);
+            String baseMessage = "Error serializing Pure PAR";
+            String eMessage = e.getMessage();
+            throw new MojoExecutionException((eMessage == null) ? baseMessage : (baseMessage + ": " + eMessage), e);
         }
         getLog().info(String.format("  -> Finished Pure PAR generation in %.9fs", durationSinceInSeconds(start)));
     }
 
-    private ListIterable<CodeRepository> resolveRepositories()
+    private CodeRepositorySet resolveRepositories()
     {
-        PureRepositoriesExternal.refresh();
-
-        if ((this.extraRepositories != null) && !this.extraRepositories.isEmpty())
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        CodeRepositorySet.Builder builder = CodeRepositorySet.newBuilder().withCodeRepositories(CodeRepositoryProviderHelper.findCodeRepositories(classLoader, true));
+        if (this.extraRepositories != null)
         {
-            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-            PureRepositoriesExternal.addRepositories(Iterate.collect(this.extraRepositories, r -> getExtraRepository(classLoader, r), Lists.mutable.withInitialCapacity(this.extraRepositories.size())));
+            this.extraRepositories.forEach(r -> builder.addCodeRepository(getExtraRepository(classLoader, r)));
         }
-
-        MutableList<CodeRepository> selectedRepos = (this.repositories == null) ?
-                PureRepositoriesExternal.repositories().toList() :
-                Iterate.collect(this.repositories, PureRepositoriesExternal::getRepository, Lists.mutable.withInitialCapacity(this.repositories.size()));
-        if ((this.excludedRepositories != null) && !this.excludedRepositories.isEmpty())
+        if (this.excludedRepositories != null)
         {
-            selectedRepos.removeIf(r -> this.excludedRepositories.contains(r.getName()));
+            builder.withoutCodeRepositories(this.excludedRepositories);
         }
-        return selectedRepos;
+        CodeRepositorySet repositories = builder.build();
+        return ((this.repositories == null) || this.repositories.isEmpty()) ? repositories : repositories.subset(this.repositories);
     }
 
     private GenericCodeRepository getExtraRepository(ClassLoader classLoader, String extraRepository)
@@ -112,9 +99,9 @@ public class PureJarMojo extends AbstractMojo
         URL url = classLoader.getResource(extraRepository);
         if (url != null)
         {
-            try (InputStream stream = url.openStream())
+            try
             {
-                return GenericCodeRepository.build(stream);
+                return GenericCodeRepository.build(url);
             }
             catch (Exception e)
             {

--- a/legend-pure-maven-java-compiled/pom.xml
+++ b/legend-pure-maven-java-compiled/pom.xml
@@ -83,11 +83,6 @@
 
         <dependency>
             <groupId>org.finos.legend.pure</groupId>
-            <artifactId>legend-pure-configuration-external</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-runtime-java-engine-compiled</artifactId>
         </dependency>
 


### PR DESCRIPTION
Since repositories are found through the Java service loader framework, a static cache of them makes little sense. This deprecates that static cache (PureRepositoriesExternal) and replaces it with a non-static class (CodeRepositorySet) which guarantees the same integrity, but is more flexible and eliminates concurrency issues.