### PR TITLE
Fix a Java generation bug with lambdas with non-concrete return types

### DIFF
--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/constraints/AbstractTestConstraintsHandler.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/constraints/AbstractTestConstraintsHandler.java
@@ -17,6 +17,7 @@ package org.finos.legend.pure.m3.tests.constraints;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.exception.PureUnmatchedFunctionException;
+import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,108 +27,93 @@ public abstract class AbstractTestConstraintsHandler extends AbstractPureTestWit
     @Test
     public void testClassDefaultConstraintHandler()
     {
-        try
-        {
-            compileTestSource("fromString.pure","Class Employee" +
-                    "[" +
-                    "   rule1 : $this.lastName->toOne()->length() < 10" +
-                    "]" +
-                    "{" +
-                    "   lastName:String[0..1];" +
-                    "}\n" +
-                    "function getterOverrideToMany(o:Any[1], property:Property<Nil,Any|*>[1]):Any[*]\n" +
-                    "{\n" +
-                    "  [];\n" +
-                    "}\n" +
-                    "\n" +
-                    "function getterOverrideToOne(o:Any[1], property:Property<Nil,Any|0..1>[1]):Any[0..1]\n" +
-                    "{\n" +
-                    "  [];\n" +
-                    "}\n" +
-                    "function testNew():Any[*] {\n" +
-                    "  let func = [];\n" +
-                    "  let r = dynamicNew(Employee,\n" +
-                    "                   [\n" +
-                    "                      ^KeyValue(key='lastName',value='1234567891000')\n" +
-                    "                   ],\n" +
-                    "                   getterOverrideToOne_Any_1__Property_1__Any_$0_1$_,\n" +
-                    "                   getterOverrideToMany_Any_1__Property_1__Any_MANY_,\n" +
-                    "                   '2'\n" +
-                    "                  )->cast(@Employee);\n" +
-                    "}\n");
-
-            this.compileAndExecute("testNew():Any[*]");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            this.assertOriginatingPureException(PureExecutionException.class, "Constraint :[rule1] violated in the Class Employee", 13, 11, e);
-        }
+        compileTestSource("fromString.pure", "Class Employee\n" +
+                "[\n" +
+                "   rule1 : $this.lastName->toOne()->length() < 10\n" +
+                "]\n" +
+                "{\n" +
+                "   lastName:String[0..1];\n" +
+                "}\n" +
+                "function getterOverrideToMany(o:Any[1], property:Property<Nil,Any|*>[1]):Any[*]\n" +
+                "{\n" +
+                "  [];\n" +
+                "}\n" +
+                "\n" +
+                "function getterOverrideToOne(o:Any[1], property:Property<Nil,Any|0..1>[1]):Any[0..1]\n" +
+                "{\n" +
+                "  [];\n" +
+                "}\n" +
+                "function testNew():Any[*] {\n" +
+                "  let func = [];\n" +
+                "  let r = dynamicNew(Employee,\n" +
+                "                   [\n" +
+                "                      ^KeyValue(key='lastName',value='1234567891000')\n" +
+                "                   ],\n" +
+                "                   getterOverrideToOne_Any_1__Property_1__Any_$0_1$_,\n" +
+                "                   getterOverrideToMany_Any_1__Property_1__Any_MANY_,\n" +
+                "                   '2'\n" +
+                "                  )->cast(@Employee);\n" +
+                "}\n");
+        PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> compileAndExecute("testNew():Any[*]"));
+        assertOriginatingPureException(PureExecutionException.class, "Constraint :[rule1] violated in the Class Employee", 19, 11, e);
     }
 
     @Test
     public void testClassInvalidConstraintHandler()
     {
-        try
-        {
-            compileTestSource("fromString.pure","Class Employee" +
-                    "[" +
-                    "   rule1 : $this.lastName->toOne()->length() < 10" +
-                    "]" +
-                    "{" +
-                    "   lastName:String[0..1];" +
-                    "}\n" +
-                    "function getterOverrideToMany(o:Any[1], property:Property<Nil,Any|*>[1]):Any[*]\n" +
-                    "{\n" +
-                    "  [];\n" +
-                    "}\n" +
-                    "\n" +
-                    "function getterOverrideToOne(o:Any[1], property:Property<Nil,Any|0..1>[1]):Any[0..1]\n" +
-                    "{\n" +
-                    "  [];\n" +
-                    "}\n" +
-                    "function constraintsManager(o:Any[1]):Any[*]\n" +
-                    "{\n" +
-                    "  [$o,$o];\n" +
-                    "}\n" +
-                    "function testNew():Any[*] {\n" +
-                    "  let r = dynamicNew(Employee,\n" +
-                    "                   [\n" +
-                    "                      ^KeyValue(key='lastName',value='1234567891000')\n" +
-                    "                   ],\n" +
-                    "                   getterOverrideToOne_Any_1__Property_1__Any_$0_1$_,\n" +
-                    "                   getterOverrideToMany_Any_1__Property_1__Any_MANY_,\n" +
-                    "                   '2',\n" +
-                    "                   constraintsManager_Any_1__Any_MANY_\n" +
-                    "                  )->cast(@Employee);\n" +
-                    "}\n");
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "Class Employee\n" +
+                        "[\n" +
+                        "   rule1 : $this.lastName->toOne()->length() < 10\n" +
+                        "]\n" +
+                        "{\n" +
+                        "   lastName:String[0..1];\n" +
+                        "}\n" +
+                        "function getterOverrideToMany(o:Any[1], property:Property<Nil,Any|*>[1]):Any[*]\n" +
+                        "{\n" +
+                        "  [];\n" +
+                        "}\n" +
+                        "\n" +
+                        "function getterOverrideToOne(o:Any[1], property:Property<Nil,Any|0..1>[1]):Any[0..1]\n" +
+                        "{\n" +
+                        "  [];\n" +
+                        "}\n" +
+                        "function constraintsManager(o:Any[1]):Any[*]\n" +
+                        "{\n" +
+                        "  [$o,$o];\n" +
+                        "}\n" +
+                        "function testNew():Any[*] {\n" +
+                        "  let r = dynamicNew(Employee,\n" +
+                        "                   [\n" +
+                        "                      ^KeyValue(key='lastName',value='1234567891000')\n" +
+                        "                   ],\n" +
+                        "                   getterOverrideToOne_Any_1__Property_1__Any_$0_1$_,\n" +
+                        "                   getterOverrideToMany_Any_1__Property_1__Any_MANY_,\n" +
+                        "                   '2',\n" +
+                        "                   constraintsManager_Any_1__Any_MANY_\n" +
+                        "                  )->cast(@Employee);\n" +
+                        "}\n"));
 
-            this.compileAndExecute("testNew():Any[*]");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            this.assertOriginatingPureException(PureUnmatchedFunctionException.class, PureUnmatchedFunctionException.FUNCTION_UNMATCHED_MESSAGE + "dynamicNew(_:Class<Employee>[1],_:KeyValue[1],_:ConcreteFunctionDefinition<{Any[1], Property<Nil, Any|0..1>[1]->Any[0..1]}>[1],_:ConcreteFunctionDefinition<{Any[1], Property<Nil, Any|*>[1]->Any[*]}>[1],_:String[1],_:ConcreteFunctionDefinition<{Any[1]->Any[*]}>[1])\n" +
-                    PureUnmatchedFunctionException.EMPTY_CANDIDATES_WITH_PACKAGE_IMPORTED_MESSAGE +
-                    PureUnmatchedFunctionException.NONEMPTY_CANDIDATES_WITH_PACKAGE_NOT_IMPORTED_MESSAGE +
-                    "\tmeta::pure::functions::lang::dynamicNew(Class[1], KeyValue[*]):Any[1]\n" +
-                    "\tmeta::pure::functions::lang::dynamicNew(Class[1], KeyValue[*], Function[0..1], Function[0..1], Any[0..1]):Any[1]\n" +
-                    "\tmeta::pure::functions::lang::dynamicNew(Class[1], KeyValue[*], Function[0..1], Function[0..1], Any[0..1], Function[0..1]):Any[1]\n" +
-                    "\tmeta::pure::functions::lang::dynamicNew(GenericType[1], KeyValue[*]):Any[1]\n" +
-                    "\tmeta::pure::functions::lang::dynamicNew(GenericType[1], KeyValue[*], Function[0..1], Function[0..1], Any[0..1]):Any[1]\n" +
-                    "\tmeta::pure::functions::lang::dynamicNew(GenericType[1], KeyValue[*], Function[0..1], Function[0..1], Any[0..1], Function[0..1]):Any[1]\n", 16, 11, e);
-        }
+        assertOriginatingPureException(PureUnmatchedFunctionException.class, PureUnmatchedFunctionException.FUNCTION_UNMATCHED_MESSAGE + "dynamicNew(_:Class<Employee>[1],_:KeyValue[1],_:ConcreteFunctionDefinition<{Any[1], Property<Nil, Any|0..1>[1]->Any[0..1]}>[1],_:ConcreteFunctionDefinition<{Any[1], Property<Nil, Any|*>[1]->Any[*]}>[1],_:String[1],_:ConcreteFunctionDefinition<{Any[1]->Any[*]}>[1])\n" +
+                PureUnmatchedFunctionException.EMPTY_CANDIDATES_WITH_PACKAGE_IMPORTED_MESSAGE +
+                PureUnmatchedFunctionException.NONEMPTY_CANDIDATES_WITH_PACKAGE_NOT_IMPORTED_MESSAGE +
+                "\tmeta::pure::functions::lang::dynamicNew(Class[1], KeyValue[*]):Any[1]\n" +
+                "\tmeta::pure::functions::lang::dynamicNew(Class[1], KeyValue[*], Function[0..1], Function[0..1], Any[0..1]):Any[1]\n" +
+                "\tmeta::pure::functions::lang::dynamicNew(Class[1], KeyValue[*], Function[0..1], Function[0..1], Any[0..1], Function[0..1]):Any[1]\n" +
+                "\tmeta::pure::functions::lang::dynamicNew(GenericType[1], KeyValue[*]):Any[1]\n" +
+                "\tmeta::pure::functions::lang::dynamicNew(GenericType[1], KeyValue[*], Function[0..1], Function[0..1], Any[0..1]):Any[1]\n" +
+                "\tmeta::pure::functions::lang::dynamicNew(GenericType[1], KeyValue[*], Function[0..1], Function[0..1], Any[0..1], Function[0..1]):Any[1]\n", 22, 11, e);
     }
 
     @Test
     public void testClassConstraintHandler()
     {
-        compileTestSource("fromString.pure","Class Employee" +
-                "[" +
-                "   rule1 : $this.lastName->toOne()->length() < 10" +
-                "]" +
-                "{" +
-                "   lastName:String[0..1];" +
+        compileTestSource("fromString.pure", "Class Employee\n" +
+                "[\n" +
+                "   rule1 : $this.lastName->toOne()->length() < 10\n" +
+                "]\n" +
+                "{\n" +
+                "   lastName:String[0..1];\n" +
                 "}\n" +
                 "function getterOverrideToMany(o:Any[1], property:Property<Nil,Any|*>[1]):Any[*]\n" +
                 "{\n" +
@@ -161,12 +147,12 @@ public abstract class AbstractTestConstraintsHandler extends AbstractPureTestWit
     @Test
     public void testClassConstraintHandlerSignature()
     {
-        compileTestSource("fromString.pure","Class Employee" +
-                "[" +
-                "   rule1 : $this.lastName->toOne()->length() < 10" +
-                "]" +
-                "{" +
-                "   lastName:String[0..1];" +
+        compileTestSource("fromString.pure", "Class Employee\n" +
+                "[\n" +
+                "   rule1 : $this.lastName->toOne()->length() < 10\n" +
+                "]\n" +
+                "{\n" +
+                "   lastName:String[0..1];\n" +
                 "}\n" +
                 "function getterOverrideToMany(o:Any[1], property:Property<Nil,Any|*>[1]):Any[*]\n" +
                 "{\n" +
@@ -194,12 +180,12 @@ public abstract class AbstractTestConstraintsHandler extends AbstractPureTestWit
     @Test
     public void testClassConstraintHandlerNoException()
     {
-        compileTestSource("fromString.pure","Class Employee" +
-                "[" +
-                "   rule1 : $this.lastName->toOne()->length() < 10" +
-                "]" +
-                "{" +
-                "   lastName:String[0..1];" +
+        compileTestSource("fromString.pure", "Class Employee\n" +
+                "[\n" +
+                "   rule1 : $this.lastName->toOne()->length() < 10\n" +
+                "]\n" +
+                "{\n" +
+                "   lastName:String[0..1];\n" +
                 "}\n" +
                 "Class ConstraintResult" +
                 "{" +
@@ -249,15 +235,15 @@ public abstract class AbstractTestConstraintsHandler extends AbstractPureTestWit
     @Test
     public void testGenericTypeConstraintHandlerNoException()
     {
-        compileTestSource("fromString.pure","Class Employee" +
-                "[" +
-                "   rule1 : $this.lastName->toOne()->length() < 10," +
-                "   rule2: $this.lastName->toOne()->length() > 3" +
-                "]" +
-                "{" +
-                "   lastName:String[0..1];" +
+        compileTestSource("fromString.pure", "Class Employee\n" +
+                "[\n" +
+                "   rule1 : $this.lastName->toOne()->length() < 10,\n" +
+                "   rule2: $this.lastName->toOne()->length() > 3\n" +
+                "]\n" +
+                "{\n" +
+                "   lastName:String[0..1];\n" +
                 "}\n" +
-                "Class ConstraintResult" +
+                "Class ConstraintResult\n" +
                 "{" +
                 "   instance:Any[1];\n" +
                 "}\n" +
@@ -303,15 +289,15 @@ public abstract class AbstractTestConstraintsHandler extends AbstractPureTestWit
     @Test
     public void testGenericTypeConstraintHandlerCopyAfterDynamicNew()
     {
-        compileTestSource("fromString.pure","Class Employee" +
-                "[" +
-                "   rule1 : $this.lastName->toOne()->length() < 10" +
-                "]" +
-                "{" +
-                "   lastName:String[0..1];" +
+        compileTestSource("fromString.pure", "Class Employee\n" +
+                "[\n" +
+                "   rule1 : $this.lastName->toOne()->length() < 10\n" +
+                "]\n" +
+                "{\n" +
+                "   lastName:String[0..1];\n" +
                 "}\n" +
-                "Class ConstraintResult" +
-                "{" +
+                "Class ConstraintResult\n" +
+                "{\n" +
                 "   instance:Any[1];\n" +
                 "}\n" +
                 "function getterOverrideToMany(o:Any[1], property:Property<Nil,Any|*>[1]):Any[*]\n" +
@@ -352,15 +338,15 @@ public abstract class AbstractTestConstraintsHandler extends AbstractPureTestWit
     @Test
     public void testClassConstraintHandlerCopyAfterDynamicNew()
     {
-        compileTestSource("fromString.pure","Class Employee" +
-                "[" +
-                "   rule1 : $this.lastName->toOne()->length() < 10" +
-                "]" +
-                "{" +
-                "   lastName:String[0..1];" +
+        compileTestSource("fromString.pure", "Class Employee\n" +
+                "[\n" +
+                "   rule1 : $this.lastName->toOne()->length() < 10\n" +
+                "]\n" +
+                "{\n" +
+                "   lastName:String[0..1];\n" +
                 "}\n" +
-                "Class ConstraintResult" +
-                "{" +
+                "Class ConstraintResult\n" +
+                "{\n" +
                 "   instance:Any[1];\n" +
                 "}\n" +
                 "function getterOverrideToMany(o:Any[1], property:Property<Nil,Any|*>[1]):Any[*]\n" +
@@ -398,12 +384,12 @@ public abstract class AbstractTestConstraintsHandler extends AbstractPureTestWit
     @Test
     public void testEvaluateConstraint()
     {
-        compileTestSource("fromString.pure","Class Employee" +
-                "[" +
-                "   rule1 : $this.lastName->toOne()->length() < 10" +
-                "]" +
-                "{" +
-                "   lastName:String[0..1];" +
+        compileTestSource("fromString.pure", "Class Employee\n" +
+                "[\n" +
+                "   rule1 : $this.lastName->toOne()->length() < 10\n" +
+                "]\n" +
+                "{\n" +
+                "   lastName:String[0..1];\n" +
                 "}\n" +
                 "function getterOverrideToMany(o:Any[1], property:Property<Nil,Any|*>[1]):Any[*]\n" +
                 "{\n" +
@@ -439,7 +425,7 @@ public abstract class AbstractTestConstraintsHandler extends AbstractPureTestWit
     @Test
     public void testConstraintManagerWithExtendedConstraintGrammar()
     {
-        compileTestSource("fromString.pure","Class Position\n" +
+        compileTestSource("fromString.pure", "Class Position\n" +
                 "[\n" +
                 "   c1\n" +
                 "   (\n" +
@@ -501,7 +487,7 @@ public abstract class AbstractTestConstraintsHandler extends AbstractPureTestWit
     @Test
     public void testConstraintManager2WithExtendedConstraintGrammar()
     {
-        compileTestSource("fromString.pure","Class Position\n" +
+        compileTestSource("fromString.pure", "Class Position\n" +
                 "[\n" +
                 "   c1\n" +
                 "   (\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
@@ -562,11 +562,11 @@ public class Pure
                         builder.append("'").append(name).append("'");
                     }
                     builder.append(" id: '").append(func.getName()).append("' yet");
-                    throw new PureExecutionException(builder.toString());
+                    throw new PureExecutionException(func.getSourceInformation(), builder.toString());
                 }
                 return foundFunc.execute(Lists.mutable.with(paramInstances), es);
             }
-            throw new PureExecutionException("Unknown function type:" + func.getClass().getName());
+            throw new PureExecutionException(func.getSourceInformation(), "Unknown function type:" + func.getClass().getName());
         }
         catch (RuntimeException e)
         {

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/function/TestLambdasWithTypeParameters.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/function/TestLambdasWithTypeParameters.java
@@ -1,0 +1,86 @@
+package org.finos.legend.pure.runtime.java.compiled.modeling.function;
+
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiled;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
+import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.serialization.filesystem.PureCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.PlatformCodeRepository;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestLambdasWithTypeParameters extends AbstractPureTestWithCoreCompiled
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), PureCodeStorage.createCodeStorage(getCodeStorageRoot(), getCodeRepositories()));
+    }
+
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete("/test/testSource1.pure");
+        runtime.compile();
+    }
+
+    @Test
+    public void testLambdaWithNotFullyConcreteReturnType()
+    {
+        compileTestSource(
+                "/test/testSource1.pure",
+                "import test::*;\n" +
+                        "\n" +
+                        "Class test::Result<T|m>\n" +
+                        "{\n" +
+                        "  values:T[m];\n" +
+                        "  other:Any[*];\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test::singleOther<T>(other:Any[1], object:T[0..1]):Result<T|0..1>[1]\n" +
+                        "{\n" +
+                        "  ^Result<T|0..1>(other=$other)\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test::singleValue<T>(value:T[1]):Result<T|0..1>[1]\n" +
+                        "{\n" +
+                        "  ^Result<T|0..1>(values=$value)\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test::expand<T>(result:Result<T|*>[1]):Result<T|0..1>[*]\n" +
+                        "{\n" +
+                        "  if($result.values->isEmpty(),\n" +
+                        "     | $result.other->map(o | singleOther($o, @T)),\n" +
+                        "     | $result.values->map(v | singleValue($v)))\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test::test():Any[*]\n" +
+                        "{\n" +
+                        "  expand(^Result<String|0>(other=[1, 2, 3, 4]))\n" +
+                        "}\n");
+        CoreInstance test = runtime.getFunction("test::test():Any[*]");
+        Assert.assertNotNull(test);
+        CoreInstance result = functionExecution.start(test, Lists.immutable.empty());
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result instanceof InstanceValue);
+        Assert.assertEquals(4, ((InstanceValue) result)._values().size());
+    }
+
+    protected static FunctionExecution getFunctionExecution()
+    {
+        return new FunctionExecutionCompiledBuilder().build();
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return org.eclipse.collections.api.factory.Lists.immutable.with(CodeRepository.newPlatformCodeRepository(),
+                GenericCodeRepository.build("test", "test(::.*)?", PlatformCodeRepository.NAME, "system"));
+    }
+}


### PR DESCRIPTION
Fix a Java generation bug with a lambda with a not fully concrete return type. Specifically, the issue occurred when the return type was concrete at the top level but had nested type or multiplicity parameters.