### PR TITLE
Validate function definitions and message functions in constraints

### DIFF
--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/ElementWithConstraintsProcessor.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/ElementWithConstraintsProcessor.java
@@ -18,19 +18,18 @@ import org.eclipse.collections.api.RichIterable;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.compiler.postprocessing.PostProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState;
+import org.finos.legend.pure.m3.compiler.postprocessing.VariableContext;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.constraint.Constraint;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.ElementWithConstraints;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ClassConstraintValueSpecificationContext;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
-import org.finos.legend.pure.m3.navigation.type.Type;
 import org.finos.legend.pure.m3.tools.matcher.Matcher;
 import org.finos.legend.pure.m4.ModelRepository;
-
+import org.finos.legend.pure.m4.exception.PureCompilationException;
 
 public class ElementWithConstraintsProcessor extends Processor<ElementWithConstraints>
 {
@@ -43,32 +42,31 @@ public class ElementWithConstraintsProcessor extends Processor<ElementWithConstr
     @Override
     public void process(ElementWithConstraints instance, ProcessorState state, Matcher matcher, ModelRepository repository, Context context, ProcessorSupport processorSupport)
     {
-        this.processConstraints(instance, state, matcher, processorSupport);
-    }
-
-    private void processConstraints(ElementWithConstraints cls, ProcessorState state, Matcher matcher, ProcessorSupport processorSupport)
-    {
-
-        RichIterable<? extends Constraint> constraints = cls._constraints();
+        RichIterable<? extends Constraint> constraints = instance._constraints();
         if (constraints.notEmpty())
         {
-            state.getVariableContext().buildAndRegister("this", (GenericType) Type.wrapGenericType(cls, processorSupport), (Multiplicity) processorSupport.package_getByUserPath(M3Paths.PureOne), processorSupport);
             int i = 0;
             for (Constraint constraint : constraints)
             {
                 FunctionDefinition<?> constraintFn = constraint._functionDefinition();
-                ValueSpecification constraintFnExpressionSequence = constraintFn._expressionSequence().toList().getFirst();
-                PostProcessor.processElement(matcher, constraintFnExpressionSequence, state, processorSupport);
-                this.addConstraintUsageContext(constraintFnExpressionSequence, cls, i, processorSupport);
-                i++;
+                try (ProcessorState.VariableContextScope ignore = state.withNewVariableContext())
+                {
+                    registerParams(constraintFn, state.getVariableContext(), processorSupport);
+                    ValueSpecification constraintFnExpressionSequence = constraintFn._expressionSequence().getOnly();
+                    PostProcessor.processElement(matcher, constraintFnExpressionSequence, state, processorSupport);
+                    addConstraintUsageContext(constraintFnExpressionSequence, instance, i++, processorSupport);
+                }
 
                 if (constraint._messageFunction() != null)
                 {
                     FunctionDefinition<?> constraintMessage = constraint._messageFunction();
-                    ValueSpecification constraintMessageExpressionSequence = constraintMessage._expressionSequence().toList().getFirst();
-                    PostProcessor.processElement(matcher, constraintMessageExpressionSequence, state, processorSupport);
-                    this.addConstraintUsageContext(constraintMessageExpressionSequence, cls, i, processorSupport);
-                    i++;
+                    try (ProcessorState.VariableContextScope ignore = state.withNewVariableContext())
+                    {
+                        registerParams(constraintFn, state.getVariableContext(), processorSupport);
+                        ValueSpecification constraintMessageExpressionSequence = constraintMessage._expressionSequence().getOnly();
+                        PostProcessor.processElement(matcher, constraintMessageExpressionSequence, state, processorSupport);
+                        addConstraintUsageContext(constraintMessageExpressionSequence, instance, i++, processorSupport);
+                    }
                 }
             }
         }
@@ -83,6 +81,22 @@ public class ElementWithConstraintsProcessor extends Processor<ElementWithConstr
             usageContext._classCoreInstance(cls);
             expressionSequence._usageContext(usageContext);
         }
+    }
+
+    private void registerParams(FunctionDefinition<?> functionDefinition, VariableContext variableContext, ProcessorSupport processorSupport)
+    {
+        FunctionType functionType = (FunctionType) processorSupport.function_getFunctionType(functionDefinition);
+        functionType._parameters().forEach(var ->
+        {
+            try
+            {
+                variableContext.registerValue(var._name(), var);
+            }
+            catch (VariableContext.VariableNameConflictException e)
+            {
+                throw new PureCompilationException(functionDefinition.getSourceInformation(), e.getMessage());
+            }
+        });
     }
 
     @Override

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/valuespecification/FunctionExpressionProcessor.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/valuespecification/FunctionExpressionProcessor.java
@@ -46,14 +46,15 @@ import org.finos.legend.pure.m3.compiler.unload.unbind.UnbindState;
 import org.finos.legend.pure.m3.compiler.visibility.Visibility;
 import org.finos.legend.pure.m3.coreinstance.Package;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.functions.lang.KeyExpression;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.PackageableFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportAccessor;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportGroup;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunctionInstance;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.PackageableFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.AbstractProperty;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.ClassInstance;
@@ -73,6 +74,7 @@ import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation.ValueSpecificationBootstrap;
 import org.finos.legend.pure.m3.navigation._class._Class;
@@ -402,7 +404,10 @@ public class FunctionExpressionProcessor extends Processor<FunctionExpression>
 
                 if (!org.finos.legend.pure.m3.navigation.generictype.GenericType.isGenericTypeConcrete(returnGenericType) && !state.getTypeInferenceContext().isTop(org.finos.legend.pure.m3.navigation.generictype.GenericType.getTypeParameterName(returnGenericType)))
                 {
-                    throw new PureCompilationException(functionExpression.getSourceInformation(), "The system is not capable of inferring the return type of the function '" + functionExpression.getValueForMetaPropertyToOne(M3Properties.func).getValueForMetaPropertyToOne(M3Properties.functionName).getName() + "'. Check your signatures!");
+                    CoreInstance func = functionExpression.getValueForMetaPropertyToOne(M3Properties.func);
+                    String funcType = (func instanceof Property) ? "property" : ((func instanceof QualifiedProperty) ? "qualified property" : "function");
+                    CoreInstance funcName = func.getValueForMetaPropertyToOne("property".equals(funcType) ? M3Properties.name : M3Properties.functionName);
+                    throw new PureCompilationException(functionExpression.getSourceInformation(), "The system is not capable of inferring the return type of the " + funcType + " '" + PrimitiveUtilities.getStringValue(funcName) + "'. Check your signatures!");
                 }
 
                 // Update the type

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/validator/ElementWithConstraintsValidator.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/validator/ElementWithConstraintsValidator.java
@@ -15,26 +15,26 @@
 package org.finos.legend.pure.m3.compiler.validation.validator;
 
 import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.set.MutableSet;
 import org.finos.legend.pure.m3.compiler.Context;
-import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
-import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
+import org.finos.legend.pure.m3.compiler.validation.Validator;
 import org.finos.legend.pure.m3.compiler.validation.ValidatorState;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.ModelElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.constraint.Constraint;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.ElementWithConstraints;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
+import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.tools.matcher.MatchRunner;
 import org.finos.legend.pure.m3.tools.matcher.Matcher;
 import org.finos.legend.pure.m3.tools.matcher.MatcherState;
-import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
-
 
 public class ElementWithConstraintsValidator implements MatchRunner<ElementWithConstraints>
 {
@@ -48,46 +48,46 @@ public class ElementWithConstraintsValidator implements MatchRunner<ElementWithC
     @Override
     public void run(ElementWithConstraints instance, MatcherState state, Matcher matcher, ModelRepository modelRepository, Context context) throws PureCompilationException
     {
-        validateConstraints((ModelElement)instance, instance._constraints(), state);
+        validateConstraints((ModelElement) instance, instance._constraints(), state, matcher);
     }
 
-    static void validateConstraints(ModelElement instance, RichIterable<? extends Constraint> constraints, MatcherState state) throws PureCompilationException
+    static void validateConstraints(ModelElement instance, RichIterable<? extends Constraint> constraints, MatcherState state, Matcher matcher) throws PureCompilationException
     {
-        ValidatorState validatorState = (ValidatorState)state;
-        ProcessorSupport processorSupport = validatorState.getProcessorSupport();
-        MutableList<String> ruleNames = FastList.newList();
-        if (constraints.notEmpty())
+        if (constraints.isEmpty())
         {
-            CoreInstance booleanType = processorSupport.package_getByUserPath(M3Paths.Boolean);
-            CoreInstance stringType = processorSupport.package_getByUserPath(M3Paths.String);
-            for (Constraint constraint : constraints)
+            return;
+        }
+
+        ValidatorState validatorState = (ValidatorState) state;
+        ProcessorSupport processorSupport = validatorState.getProcessorSupport();
+        CoreInstance booleanType = processorSupport.package_getByUserPath(M3Paths.Boolean);
+        CoreInstance stringType = processorSupport.package_getByUserPath(M3Paths.String);
+        MutableSet<String> ruleNames = Sets.mutable.empty();
+        for (Constraint constraint : constraints)
+        {
+            String ruleName = constraint._name();
+            if (!ruleNames.add(ruleName))
             {
-                String ruleName = constraint._name();
-                if (ruleNames.contains(ruleName))
-                {
-                    String instanceName = instance._name();
-                    throw new PureCompilationException(constraint.getSourceInformation(), "Constraints for " + instanceName + " must be unique, [" + ruleName + "] is duplicated");
-                }
-                ruleNames.add(ruleName);
+                String instanceName = instance._name();
+                throw new PureCompilationException(constraint.getSourceInformation(), "Constraints for " + instanceName + " must be unique, [" + ruleName + "] is duplicated");
+            }
 
-                ValueSpecification definition = constraint._functionDefinition()._expressionSequence().getFirst();
-                Type type = (Type)ImportStub.withImportStubByPass(definition._genericType()._rawTypeCoreInstance(), processorSupport);
-                if (type != booleanType || !Multiplicity.isToOne(definition._multiplicity(), true))
-                {
-                    throw new PureCompilationException(constraint._functionDefinition().getSourceInformation(), "A constraint must be of type Boolean and multiplicity one");
-                }
+            ValueSpecification definition = constraint._functionDefinition()._expressionSequence().getFirst();
+            Validator.validate(definition, validatorState, matcher, processorSupport);
+            Type type = (Type) ImportStub.withImportStubByPass(definition._genericType()._rawTypeCoreInstance(), processorSupport);
+            if (type != booleanType || !Multiplicity.isToOne(definition._multiplicity(), true))
+            {
+                throw new PureCompilationException(constraint._functionDefinition().getSourceInformation(), "A constraint must be of type Boolean and multiplicity one");
+            }
 
-                if(processorSupport.instance_instanceOf(instance, M3Paths.ElementWithConstraints))
+            if (constraint._messageFunction() != null)
+            {
+                ValueSpecification message = constraint._messageFunction()._expressionSequence().getFirst();
+                Validator.validate(message, validatorState, matcher, processorSupport);
+                Type messageType = (Type) ImportStub.withImportStubByPass(message._genericType()._rawTypeCoreInstance(), processorSupport);
+                if (messageType != stringType || !Multiplicity.isToOne(message._multiplicity(), true))
                 {
-                    if(constraint._messageFunction() != null)
-                    {
-                        ValueSpecification message = constraint._messageFunction()._expressionSequence().getFirst();
-                        Type messageType = (Type)ImportStub.withImportStubByPass(message._genericType()._rawTypeCoreInstance(), processorSupport);
-                        if (messageType != stringType || !Multiplicity.isToOne(message._multiplicity(), true))
-                        {
-                            throw new PureCompilationException(constraint._messageFunction().getSourceInformation(), "A constraint message must be of type String and multiplicity one");
-                        }
-                    }
+                    throw new PureCompilationException(constraint._messageFunction().getSourceInformation(), "A constraint message must be of type String and multiplicity one");
                 }
             }
         }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/validator/PackageableFunctionValidator.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/validator/PackageableFunctionValidator.java
@@ -15,7 +15,6 @@
 package org.finos.legend.pure.m3.compiler.validation.validator;
 
 import org.finos.legend.pure.m3.compiler.Context;
-import org.finos.legend.pure.m3.compiler.validation.ValidatorState;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.PackageableFunction;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.tools.matcher.MatchRunner;
@@ -36,7 +35,7 @@ public class PackageableFunctionValidator implements MatchRunner<PackageableFunc
     @Override
     public void run(PackageableFunction<CoreInstance> functionDefinition, MatcherState state, Matcher matcher, ModelRepository modelRepository, Context context) throws PureCompilationException
     {
-        ElementWithConstraintsValidator.validateConstraints(functionDefinition, functionDefinition._preConstraints(), state);
-        ElementWithConstraintsValidator.validateConstraints(functionDefinition, functionDefinition._postConstraints(), state);
+        ElementWithConstraintsValidator.validateConstraints(functionDefinition, functionDefinition._preConstraints(), state, matcher);
+        ElementWithConstraintsValidator.validateConstraints(functionDefinition, functionDefinition._postConstraints(), state, matcher);
     }
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/multiplicity/Multiplicity.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/multiplicity/Multiplicity.java
@@ -351,8 +351,7 @@ public class Multiplicity
     }
 
     /**
-     * Create a new non-concrete multiplicity instance with the given
-     * parameter name.
+     * Create a new non-concrete multiplicity instance with the given parameter name.
      *
      * @param parameterName    multiplicity parameter name
      * @param processorSupport processor support
@@ -360,7 +359,20 @@ public class Multiplicity
      */
     public static CoreInstance newMultiplicity(String parameterName, ProcessorSupport processorSupport)
     {
-        CoreInstance newMultiplicity = processorSupport.newAnonymousCoreInstance(null, M3Paths.Multiplicity);
+        return newMultiplicity(parameterName, null, processorSupport);
+    }
+
+    /**
+     * Create a new non-concrete multiplicity instance with the given parameter name.
+     *
+     * @param parameterName     multiplicity parameter name
+     * @param sourceInformation source information
+     * @param processorSupport  processor support
+     * @return new non-concrete multiplicity
+     */
+    public static CoreInstance newMultiplicity(String parameterName, SourceInformation sourceInformation, ProcessorSupport processorSupport)
+    {
+        CoreInstance newMultiplicity = processorSupport.newAnonymousCoreInstance(sourceInformation, M3Paths.Multiplicity);
         Instance.addValueToProperty(newMultiplicity, M3Properties.multiplicityParameter, processorSupport.newCoreInstance(parameterName, M3Paths.String, null), processorSupport);
         return newMultiplicity;
     }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
@@ -2416,7 +2416,7 @@ public class AntlrContextToM3CoreInstance
                     multParameters.add(mult);
 
                 }
-                classInstance._multiplicityParameters(this.processMultiplicityParametersInstance(multiplicityParameterNames));
+                classInstance._multiplicityParameters(this.multParamsToInstanceValues(multiplicityParameterNames));
                 classifierGTTA._multiplicityArguments(multParameters);
             }
 
@@ -2523,13 +2523,16 @@ public class AntlrContextToM3CoreInstance
                     GenericType thisParamType = (GenericType) org.finos.legend.pure.m3.navigation.type.Type.wrapGenericType(owner, this.processorSupport);
                     if (typeParameterNames.notEmpty())
                     {
-                        MutableList<GenericType> typeArgs = typeParameterNames.collect(n -> GenericTypeInstance.createPersistent(this.repository)._typeParameter(TypeParameterInstance.createPersistent(this.repository, n)));
+                        MutableList<TypeParameter> typeParameters = typeParameterNames.collect(n -> TypeParameterInstance.createPersistent(this.repository, n));
+                        Instance.setValuesForProperty(messageFunctionType, M3Properties.typeParameters, typeParameters, this.processorSupport);
+                        MutableList<GenericType> typeArgs = typeParameters.collect(tp -> GenericTypeInstance.createPersistent(this.repository)._typeParameter(tp));
                         thisParamType._typeArguments(typeArgs);
                     }
                     if (multiplicityParameterNames.notEmpty())
                     {
-                        MutableList<Multiplicity> multParameters = multiplicityParameterNames.collect(n -> MultiplicityInstance.createPersistent(this.repository, null, null)._multiplicityParameter(n));
-                        thisParamType._multiplicityArguments(multParameters);
+                        Instance.setValuesForProperty(messageFunctionType, M3Properties.multiplicityParameters, multParamsToInstanceValues(multiplicityParameterNames), this.processorSupport);
+                        MutableList<Multiplicity> multArgs = multiplicityParameterNames.collect(n -> MultiplicityInstance.createPersistent(this.repository, null, null)._multiplicityParameter(n));
+                        thisParamType._multiplicityArguments(multArgs);
                     }
 
                     CoreInstance param = VariableExpressionInstance.createPersistent(this.repository, messageSourceInformation, thisParamType, this.pureOne, "this");
@@ -2562,11 +2565,14 @@ public class AntlrContextToM3CoreInstance
             GenericType thisParamType = (GenericType) org.finos.legend.pure.m3.navigation.type.Type.wrapGenericType(owner, this.processorSupport);
             if (typeParameterNames.notEmpty())
             {
-                MutableList<GenericType> typeArgs = typeParameterNames.collect(n -> GenericTypeInstance.createPersistent(this.repository)._typeParameter(TypeParameterInstance.createPersistent(this.repository, n)));
+                MutableList<TypeParameter> typeParameters = typeParameterNames.collect(n -> TypeParameterInstance.createPersistent(this.repository, n));
+                Instance.setValuesForProperty(functionType, M3Properties.typeParameters, typeParameters, this.processorSupport);
+                MutableList<GenericType> typeArgs = typeParameters.collect(tp -> GenericTypeInstance.createPersistent(this.repository)._typeParameter(tp));
                 thisParamType._typeArguments(typeArgs);
             }
             if (multiplicityParameterNames.notEmpty())
             {
+                Instance.setValuesForProperty(functionType, M3Properties.multiplicityParameters, multParamsToInstanceValues(multiplicityParameterNames), this.processorSupport);
                 MutableList<Multiplicity> multParameters = multiplicityParameterNames.collect(n -> MultiplicityInstance.createPersistent(this.repository, null, null)._multiplicityParameter(n));
                 thisParamType._multiplicityArguments(multParameters);
             }
@@ -3134,7 +3140,7 @@ public class AntlrContextToM3CoreInstance
         }
         if (multiplicityParametersNames.notEmpty())
         {
-            ft._multiplicityParameters(this.processMultiplicityParametersInstance(multiplicityParametersNames));
+            ft._multiplicityParameters(this.multParamsToInstanceValues(multiplicityParametersNames));
         }
         if (vars.notEmpty())
         {
@@ -3143,21 +3149,11 @@ public class AntlrContextToM3CoreInstance
         return ft;
     }
 
-    private ListIterable<InstanceValue> processMultiplicityParametersInstance(MutableList<String> multParameters)
+    private ListIterable<InstanceValue> multParamsToInstanceValues(ListIterable<String> multParameters)
     {
-        MutableList<InstanceValue> result = Lists.mutable.of();
-        for (String multParameter : multParameters)
-        {
-            InstanceValueInstance iv = InstanceValueInstance.createPersistent(this.repository, null, null);
-            iv._values(Lists.mutable.of(this.repository.newStringCoreInstance_cached(multParameter)));
-            GenericTypeInstance gt = GenericTypeInstance.createPersistent(this.repository);
-            Type ti = (Type) this.processorSupport.package_getByUserPath("String");
-            gt._rawTypeCoreInstance(ti);
-            iv._genericType(gt);
-            iv._multiplicity(this.getPureOne());
-            result.add(iv);
-        }
-        return result;
+        Type stringType = (Type) this.processorSupport.package_getByUserPath(M3Paths.String);
+        Multiplicity pureOne = getPureOne();
+        return multParameters.collect(multParameter -> InstanceValueInstance.createPersistent(this.repository, GenericTypeInstance.createPersistent(this.repository)._rawTypeCoreInstance(stringType), pureOne)._values(Lists.mutable.of(this.repository.newStringCoreInstance_cached(multParameter))));
     }
 
     private ListIterable<TypeParameter> processTypeParametersInstance(ModelRepository repository, MutableList<String> typeParameters)

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
@@ -33,7 +33,6 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.list.mutable.ListAdapter;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
@@ -387,7 +386,7 @@ public class AntlrContextToM3CoreInstance
             {
                 if (this.hasImportChanged)
                 {
-                    result = this.measureParser(dCtx, importId, this.addLines);
+                    result = this.measureParser(dCtx, importId);
                 }
                 else
                 {
@@ -441,12 +440,12 @@ public class AntlrContextToM3CoreInstance
                         }
                         else
                         {
-                            result = this.measureParser(dCtx, importId, this.addLines);
+                            result = this.measureParser(dCtx, importId);
                         }
                     }
                     else
                     {
-                        result = this.measureParser(dCtx, importId, this.addLines);
+                        result = this.measureParser(dCtx, importId);
                     }
                 }
                 MeasureInstance mI = (MeasureInstance) result;
@@ -2065,7 +2064,7 @@ public class AntlrContextToM3CoreInstance
      * Parses the measure given its definition context.
      * Returns the parsed measure as a CoreInstance.
      */
-    private CoreInstance measureParser(org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.MeasureDefinitionContext ctx, ImportGroup importId, boolean addLines) throws PureParserException
+    private CoreInstance measureParser(org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.MeasureDefinitionContext ctx, ImportGroup importId) throws PureParserException
     {
         UnitInstance canonicalUnit;
         MutableList<UnitInstance> nonCanonicalUnits;
@@ -2083,8 +2082,6 @@ public class AntlrContextToM3CoreInstance
         PackageInstance packageInstance = this.buildPackage(ctx.qualifiedName().packagePath());
         measureInstance._package(packageInstance);
         packageInstance._childrenAdd(measureInstance);
-
-        String fullName = this.getQualifiedNameString(ctx.qualifiedName());
 
         measureInstance.setSourceInformation(this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.qualifiedName().identifier().getStart(), ctx.getStop()));
 
@@ -2172,7 +2169,7 @@ public class AntlrContextToM3CoreInstance
             MutableList<UnitInstance> nonConvertibleUnits = Lists.mutable.empty();
             for (org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.NonConvertibleMeasureExprContext ncctx : ctx.measureBody().nonConvertibleMeasureExpr())
             {
-                UnitInstance currentUnit = this.nonConvertibleUnitParser(ncctx, importId, measureInstance, ctx);
+                UnitInstance currentUnit = this.nonConvertibleUnitParser(ncctx, measureInstance, ctx);
                 nonConvertibleUnits.add(currentUnit);
             }
             measureInstance._canonicalUnit(nonConvertibleUnits.get(0));
@@ -2272,7 +2269,7 @@ public class AntlrContextToM3CoreInstance
         lambdaFunctionInstance._classifierGenericType(genericTypeInstance);
         signature._functionAdd(lambdaFunctionInstance);
 
-        ListIterable<ValueSpecification> block = this.codeBlock(ctx.unitExpr().codeBlock(), typeParametersNames, importId, lambdaContext, addLines, tabs(6));
+        ListIterable<ValueSpecification> block = this.codeBlock(ctx.unitExpr().codeBlock(), typeParametersNames, importId, lambdaContext, this.addLines, tabs(6));
         lambdaFunctionInstance._expressionSequence(block);
 
         unitInstance._conversionFunction(lambdaFunctionInstance);
@@ -2280,7 +2277,7 @@ public class AntlrContextToM3CoreInstance
         return unitInstance;
     }
 
-    private UnitInstance nonConvertibleUnitParser(org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.NonConvertibleMeasureExprContext ctx, ImportGroup importId, MeasureInstance measureInstance, org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.MeasureDefinitionContext mctx) throws PureParserException
+    private UnitInstance nonConvertibleUnitParser(org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.NonConvertibleMeasureExprContext ctx, MeasureInstance measureInstance, org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.MeasureDefinitionContext mctx) throws PureParserException
     {
         UnitInstance unitInstance;
         MutableList<GenericType> superTypesGenericTypes = Lists.mutable.empty();
@@ -2366,7 +2363,7 @@ public class AntlrContextToM3CoreInstance
             ownerType = ImportStubInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.qualifiedName().identifier().getStart()), fullName, importId);
 
             LambdaContext lambdaContext = new LambdaContext(fullName.replace("::", "_"));
-            MutableList<Constraint> constraints = this.constraints(classInstance, ctx.constraints(), importId, lambdaContext, addLines);
+            MutableList<Constraint> constraints = constraints(classInstance, ctx.constraints(), typeParameterNames, multiplicityParameterNames, importId, lambdaContext, addLines);
             this.propertyParser(ctx.classBody().properties(), properties, qualifiedProperties, typeParameterNames, multiplicityParameterNames, ownerType, importId, 0);
             classInstance.setSourceInformation(this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.qualifiedName().identifier().getStart(), ctx.getStop()));
 
@@ -2464,23 +2461,17 @@ public class AntlrContextToM3CoreInstance
     }
 
 
-    private MutableList<Constraint> constraints(CoreInstance owner, ConstraintsContext ctx, ImportGroup importId, LambdaContext lambdaContext, boolean addLines)
+    private MutableList<Constraint> constraints(CoreInstance owner, ConstraintsContext ctx, MutableList<String> typeParameterNames, MutableList<String> multParameterNames, ImportGroup importId, LambdaContext lambdaContext, boolean addLines)
     {
         MutableList<Constraint> constraints = Lists.mutable.empty();
         if (ctx != null)
         {
-            int i = 0;
-
-            for (ConstraintContext cCtx : ctx.constraint())
-            {
-                constraints.add(this.constraint(owner, cCtx, i, importId, lambdaContext, addLines, false));
-                i++;
-            }
+            ListIterate.forEachWithIndex(ctx.constraint(), (cCtx, i) -> constraints.add(constraint(owner, cCtx, i, typeParameterNames, multParameterNames, importId, lambdaContext, addLines, false)));
         }
         return constraints;
     }
 
-    private Constraint constraint(CoreInstance owner, ConstraintContext ctx, int position, ImportGroup importId, LambdaContext lambdaContext, boolean addLines, boolean postConstraint)
+    private Constraint constraint(CoreInstance owner, ConstraintContext ctx, int position, MutableList<String> typeParameterNames, MutableList<String> multiplicityParameterNames, ImportGroup importId, LambdaContext lambdaContext, boolean addLines, boolean postConstraint)
     {
         String constraintName;
         String constraintOwner = null;
@@ -2529,7 +2520,19 @@ public class AntlrContextToM3CoreInstance
                     SourceInformation messageSourceInformation = messageFunction.getSourceInformation();
 
                     CoreInstance messageFunctionType = this.repository.newAnonymousCoreInstance(messageSourceInformation, this.processorSupport.package_getByUserPath(M3Paths.FunctionType), true);
-                    CoreInstance param = VariableExpressionInstance.createPersistent(this.repository, messageSourceInformation, (GenericType) org.finos.legend.pure.m3.navigation.type.Type.wrapGenericType(owner, this.processorSupport), this.pureOne, "this");
+                    GenericType thisParamType = (GenericType) org.finos.legend.pure.m3.navigation.type.Type.wrapGenericType(owner, this.processorSupport);
+                    if (typeParameterNames.notEmpty())
+                    {
+                        MutableList<GenericType> typeArgs = typeParameterNames.collect(n -> GenericTypeInstance.createPersistent(this.repository)._typeParameter(TypeParameterInstance.createPersistent(this.repository, n)));
+                        thisParamType._typeArguments(typeArgs);
+                    }
+                    if (multiplicityParameterNames.notEmpty())
+                    {
+                        MutableList<Multiplicity> multParameters = multiplicityParameterNames.collect(n -> MultiplicityInstance.createPersistent(this.repository, null, null)._multiplicityParameter(n));
+                        thisParamType._multiplicityArguments(multParameters);
+                    }
+
+                    CoreInstance param = VariableExpressionInstance.createPersistent(this.repository, messageSourceInformation, thisParamType, this.pureOne, "this");
                     Instance.addValueToProperty(messageFunctionType, M3Properties.parameters, param, this.processorSupport);
                     Instance.setValueForProperty(messageFunctionType, M3Properties.returnMultiplicity, this.getPureOne(), this.processorSupport);
                     Instance.setValueForProperty(messageFunctionType, M3Properties.returnType, org.finos.legend.pure.m3.navigation.type.Type.wrapGenericType(this.processorSupport.package_getByUserPath(M3Paths.String), this.processorSupport), this.processorSupport);
@@ -2556,7 +2559,18 @@ public class AntlrContextToM3CoreInstance
         CoreInstance functionType = this.repository.newAnonymousCoreInstance(functionSourceInformation, this.processorSupport.package_getByUserPath(M3Paths.FunctionType), true);
         if (this.processorSupport.instance_instanceOf(owner, M3Paths.ElementWithConstraints))
         {
-            CoreInstance param = VariableExpressionInstance.createPersistent(this.repository, functionSourceInformation, (GenericType) org.finos.legend.pure.m3.navigation.type.Type.wrapGenericType(owner, this.processorSupport), this.pureOne, "this");
+            GenericType thisParamType = (GenericType) org.finos.legend.pure.m3.navigation.type.Type.wrapGenericType(owner, this.processorSupport);
+            if (typeParameterNames.notEmpty())
+            {
+                MutableList<GenericType> typeArgs = typeParameterNames.collect(n -> GenericTypeInstance.createPersistent(this.repository)._typeParameter(TypeParameterInstance.createPersistent(this.repository, n)));
+                thisParamType._typeArguments(typeArgs);
+            }
+            if (multiplicityParameterNames.notEmpty())
+            {
+                MutableList<Multiplicity> multParameters = multiplicityParameterNames.collect(n -> MultiplicityInstance.createPersistent(this.repository, null, null)._multiplicityParameter(n));
+                thisParamType._multiplicityArguments(multParameters);
+            }
+            CoreInstance param = VariableExpressionInstance.createPersistent(this.repository, functionSourceInformation, thisParamType, this.pureOne, "this");
             Instance.addValueToProperty(functionType, M3Properties.parameters, param, this.processorSupport);
         }
 
@@ -2564,7 +2578,7 @@ public class AntlrContextToM3CoreInstance
         {
             FunctionType ft = (FunctionType) this.processorSupport.function_getFunctionType(owner);
             MutableList<CoreInstance> params = Lists.mutable.empty();
-            params.addAll(Instance.getValueForMetaPropertyToManyResolved(ft, M3Properties.parameters, this.processorSupport).toList());
+            params.addAllIterable(Instance.getValueForMetaPropertyToManyResolved(ft, M3Properties.parameters, this.processorSupport));
             if (postConstraint)
             {
                 CoreInstance returnParam = VariableExpressionInstance.createPersistent(this.repository, functionSourceInformation, (GenericType) ft.getValueForMetaPropertyToOne(M3Properties.returnType), (Multiplicity) ft.getValueForMetaPropertyToOne(M3Properties.returnMultiplicity), "return");
@@ -2644,7 +2658,7 @@ public class AntlrContextToM3CoreInstance
         GeneralizationInstance generalizationInstance = GeneralizationInstance.createPersistent(this.repository, superType, projection);
         projection._generalizations(Lists.mutable.<Generalization>of(generalizationInstance));
         String fullName = this.getQualifiedNameString(ctx.qualifiedName());
-        MutableList<Constraint> constraints = this.constraints(projection, ctx.constraints(), importId, new LambdaContext(fullName.replace("::", "_")), addLines);
+        MutableList<Constraint> constraints = constraints(projection, ctx.constraints(), Lists.fixedSize.empty(), Lists.fixedSize.empty(), importId, new LambdaContext(fullName.replace("::", "_")), addLines);
 
         if (Iterate.notEmpty(stereotypes))
         {
@@ -3042,11 +3056,11 @@ public class AntlrContextToM3CoreInstance
                 }
                 if (cCtx.simpleConstraint().combinedExpression().getText().contains("$return"))
                 {
-                    postConstraints.add(this.constraint(functionDefinition, cCtx, i, importId, lambdaContext, addLines, true));
+                    postConstraints.add(this.constraint(functionDefinition, cCtx, i, Lists.fixedSize.empty(), Lists.fixedSize.empty(), importId, lambdaContext, addLines, true));
                 }
                 else
                 {
-                    preConstraints.add(this.constraint(functionDefinition, cCtx, i, importId, lambdaContext, addLines, false));
+                    preConstraints.add(this.constraint(functionDefinition, cCtx, i, Lists.fixedSize.empty(), Lists.fixedSize.empty(), importId, lambdaContext, addLines, false));
                 }
             });
         }
@@ -3146,7 +3160,7 @@ public class AntlrContextToM3CoreInstance
         return result;
     }
 
-    private ListIterable<TypeParameter> processTypeParametersInstance(final ModelRepository repository, MutableList<String> typeParameters)
+    private ListIterable<TypeParameter> processTypeParametersInstance(ModelRepository repository, MutableList<String> typeParameters)
     {
         return typeParameters.collect(tp -> TypeParameterInstance.createPersistent(repository, tp));
     }
@@ -3275,9 +3289,7 @@ public class AntlrContextToM3CoreInstance
     {
         LambdaFunction<?> defaultValueFunctionLambda = null;
 
-        DefaultValueExpressionContext expression = ctx.defaultValueExpression();
-
-        ++this.functionCounter;
+        this.functionCounter++;
         LambdaContext lambdaContext = new LambdaContext(propertyName + "_defaultValue_" + this.functionCounter);
 
         DefaultValueInstance defaultValueInstance = DefaultValueInstance.createPersistent(this.repository,
@@ -3608,10 +3620,8 @@ public class AntlrContextToM3CoreInstance
 
     public TemporaryPurePropertyMapping mappingLine(MappingLineContext ctx, LambdaContext lambdaContext, String cl, ImportGroup importId)
     {
-        String sourceMappingId = null;
-        String targetMappingId = null;
-        Pair<String, SourceInformation> enumerationMappingInformation = null;
-
+        String sourceMappingId;
+        String targetMappingId;
         if (ctx.sourceAndTargetMappingId() != null)
         {
             SourceAndTargetMappingIdContext sctx = ctx.sourceAndTargetMappingId();
@@ -3622,16 +3632,27 @@ public class AntlrContextToM3CoreInstance
             }
             else
             {
+                sourceMappingId = null;
                 targetMappingId = sctx.sourceId().qualifiedName().getText();
             }
         }
+        else
+        {
+            sourceMappingId = null;
+            targetMappingId = null;
+        }
 
+        Pair<String, SourceInformation> enumerationMappingInformation;
         if (ctx.ENUMERATION_MAPPING() != null)
         {
             IdentifierContext identifier = ctx.identifier();
             String enumerationMappingName = identifier.getText();
             SourceInformation enumerationMappingReferenceSourceInformation = this.sourceInformation.getPureSourceInformation(identifier.getStart(), identifier.getStart(), identifier.getStop());
             enumerationMappingInformation = Tuples.pair(enumerationMappingName, enumerationMappingReferenceSourceInformation);
+        }
+        else
+        {
+            enumerationMappingInformation = null;
         }
 
         return TemporaryPurePropertyMapping.build(
@@ -3717,7 +3738,7 @@ public class AntlrContextToM3CoreInstance
 
     public TemporaryPureMergeOperationFunctionSpecification mergeOperationSpecification(CombinedExpressionContext ctx, LambdaContext lambdaContext, ImportGroup importId)
     {
-        CoreInstance expression = this.combinedExpression(ctx, "", FastList.<String>newList(), lambdaContext, "", true, importId, true);
+        CoreInstance expression = this.combinedExpression(ctx, "", Lists.mutable.empty(), lambdaContext, "", true, importId, true);
         return TemporaryPureMergeOperationFunctionSpecification.build(
                 this.sourceInformation.getPureSourceInformation(ctx.getStart()),
                 expression);

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/constraints/AbstractTestConstraints.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/constraints/AbstractTestConstraints.java
@@ -1531,6 +1531,67 @@ public abstract class AbstractTestConstraints extends AbstractPureTestWithCoreCo
         assertPureException(PureExecutionException.class, "Constraint :[superPeopleHaveNoDuplicates] violated in the Class SuperPeople, Message: test", "/test/repro.pure", 45, 4, 45, 4, 45, 128, e);
     }
 
+    @Test
+    public void testConstraintInClassWithTypeParameters()
+    {
+        compileTestSource("/test/repro.pure",
+                "Class ClassWrapper<T|m>\n" +
+                        "[\n" +
+                        "   notAny: $this.classes->forAll(c | $c != Any)\n" +
+                        "]\n" +
+                        "{\n" +
+                        "   classes: Class<T>[m];\n" +
+                        "}\n" +
+                        "\n" +
+                        "function testSucceed():Any[*]\n" +
+                        "{\n" +
+                        "    ^ClassWrapper<Type|1>(classes=Type);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function testFail():Any[*]\n" +
+                        "{\n" +
+                        "    ^ClassWrapper<Any|2>(classes=[Type, Any]);\n" +
+                        "}\n"
+        );
+        execute("testSucceed():Any[*]");
+        PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> execute("testFail():Any[*]"));
+        assertPureException(PureExecutionException.class, "Constraint :[notAny] violated in the Class ClassWrapper", "/test/repro.pure", 16, 5, 16, 5, 16, 45, e);
+    }
+
+    @Test
+    public void testConstraintInFunctionWithTypeParameters()
+    {
+        compileTestSource("/test/repro.pure",
+                "function myFunction<T>(col:T[*], toRemove:Any[*]):T[*]\n" +
+                        "[\n" +
+                        "   notEmptyBefore: $col->size() > 0,\n" +
+                        "   notEmptyAfter: $return->size() > 0\n" +
+                        "]\n" +
+                        "{\n" +
+                        "   $col->filter(x | !$toRemove->exists(y | $x == $y));\n" +
+                        "}\n" +
+                        "\n" +
+                        "function testSucceed():Any[*]\n" +
+                        "{\n" +
+                        "   myFunction([1, 2, 3], [4, 5, 6]);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function testFailPre():Any[*]\n" +
+                        "{\n" +
+                        "   myFunction([], [4, 5, 6]);\n" +
+                        "}\n" +
+                        "function testFailPost():Any[*]\n" +
+                        "{\n" +
+                        "   myFunction([1, 2, 3], [1, 2, 3]);\n" +
+                        "}\n"
+        );
+        execute("testSucceed():Any[*]");
+        PureExecutionException ePre = Assert.assertThrows(PureExecutionException.class, () -> execute("testFailPre():Any[*]"));
+        assertPureException(PureExecutionException.class, "Constraint (PRE):[notEmptyBefore] violated. (Function:myFunction_T_MANY__Any_MANY__T_MANY_)", "/test/repro.pure", 17, 4, 17, 4, 17, 13, ePre);
+        PureExecutionException ePost = Assert.assertThrows(PureExecutionException.class, () -> execute("testFailPost():Any[*]"));
+        assertPureException(PureExecutionException.class, "Constraint (POST):[notEmptyAfter] violated. (Function:myFunction_T_MANY__Any_MANY__T_MANY_)", "/test/repro.pure", 21, 4, 21, 4, 21, 13, ePost);
+    }
+
     protected static MutableCodeStorage getCodeStorage()
     {
         CodeRepository platform = CodeRepository.newPlatformCodeRepository();

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/constraints/AbstractTestConstraints.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/constraints/AbstractTestConstraints.java
@@ -1559,6 +1559,33 @@ public abstract class AbstractTestConstraints extends AbstractPureTestWithCoreCo
     }
 
     @Test
+    public void testConstraintInClassWithTypeParameters2()
+    {
+        compileTestSource("/test/repro.pure",
+                "Class Wrapper<T>\n" +
+                        "[\n" +
+                        "   notEmpty: $this.values->size() > 0\n" +
+                        "]\n" +
+                        "{\n" +
+                        "   values: T[*];\n" +
+                        "}\n" +
+                        "\n" +
+                        "function testSucceed():Any[*]\n" +
+                        "{\n" +
+                        "    ^Wrapper<Integer>(values=1);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function testFail():Any[*]\n" +
+                        "{\n" +
+                        "    ^Wrapper<Any>(values=[]);\n" +
+                        "}\n"
+        );
+        execute("testSucceed():Any[*]");
+        PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> execute("testFail():Any[*]"));
+        assertPureException(PureExecutionException.class, "Constraint :[notEmpty] violated in the Class Wrapper", "/test/repro.pure", 16, 5, 16, 5, 16, 28, e);
+    }
+
+    @Test
     public void testConstraintInFunctionWithTypeParameters()
     {
         compileTestSource("/test/repro.pure",

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/literal/TestInstanceCollectionType.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/literal/TestInstanceCollectionType.java
@@ -15,12 +15,11 @@
 package org.finos.legend.pure.m3.tests.literal;
 
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
-import org.finos.legend.pure.m3.navigation.M3Paths;
-import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -40,15 +39,7 @@ public class TestInstanceCollectionType extends AbstractPureTestWithCoreCompiled
     public void cleanRuntime()
     {
         runtime.delete("fromString.pure");
-
-        try
-        {
-            runtime.compile();
-        }
-        catch (PureCompilationException e)
-        {
-            setUp();
-        }
+        runtime.compile();
     }
 
     @Test
@@ -204,16 +195,11 @@ public class TestInstanceCollectionType extends AbstractPureTestWithCoreCompiled
 
     private void assertValueSpecificationGenericType(String expectedGenericTypeString, String valueSpecificationString)
     {
-        assertValueSpecificationGenericType(null, expectedGenericTypeString, valueSpecificationString);
-    }
-
-    private void assertValueSpecificationGenericType(String message, String expectedGenericTypeString, String valueSpecificationString)
-    {
         String functionDescriptor = "test::" + UUID.randomUUID().toString().replace('-', '_') + "():Any[*]";
         compileTestSource("sourceId.pure", "import test::*;\nfunction " + functionDescriptor + "\n{\n" + valueSpecificationString + "\n}\n");
         FunctionDefinition<?> function = (FunctionDefinition<?>) runtime.getFunction(functionDescriptor);
-        ValueSpecification valueSpecification = function._expressionSequence().getFirst();
-        assertGenericTypesEqual((message == null) ? valueSpecificationString : message, expectedGenericTypeString, valueSpecification._genericType());
+        ValueSpecification valueSpecification = function._expressionSequence().getAny();
+        assertGenericTypesEqual(valueSpecificationString, expectedGenericTypeString, valueSpecification._genericType());
         runtime.delete("sourceId.pure");
     }
 

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/literal/TestLiteral.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/literal/TestLiteral.java
@@ -16,8 +16,6 @@ package org.finos.legend.pure.m3.tests.literal;
 
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -25,18 +23,20 @@ import org.junit.Test;
 public class TestLiteral extends AbstractPureTestWithCoreCompiledPlatform
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getExtra());
     }
 
     @Test
     public void testLiteralList()
     {
-        compileTestSource("fromString.pure", "function testMany():String[*]\n" +
-                                                   "{\n" +
-                                                   "    let a = ['z','k']\n" +
-                                                   "}\n");
-        CoreInstance func = this.runtime.getFunction("testMany():String[*]");
+        compileTestSource("fromString.pure",
+                "function testMany():String[*]\n" +
+                        "{\n" +
+                        "    let a = ['z','k']\n" +
+                        "}\n");
+        CoreInstance func = runtime.getFunction("testMany():String[*]");
         Assert.assertEquals("testMany__String_MANY_ instance ConcreteFunctionDefinition\n" +
                             "    classifierGenericType(Property):\n" +
                             "        Anonymous_StripedId instance GenericType\n" +

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/literal/TestMultiplicity.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/literal/TestMultiplicity.java
@@ -14,14 +14,12 @@
 
 package org.finos.legend.pure.m3.tests.literal;
 
-import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.impl.test.Verify;
+import org.eclipse.collections.api.RichIterable;
 import org.finos.legend.pure.m3.AbstractPureTestWithCoreCompiledPlatform;
-import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -30,28 +28,31 @@ import org.junit.Test;
 public class TestMultiplicity extends AbstractPureTestWithCoreCompiledPlatform
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getExtra());
     }
 
     @After
-    public void cleanRuntime() {
+    public void cleanRuntime()
+    {
         runtime.delete("fromString.pure");
     }
 
     @Test
     public void testSingleLiteralMultiplicity()
     {
-        compileTestSource("fromString.pure","function test::testFn():Any[*]\n" +
-                "{\n" +
-                "  1\n" +
-                "}");
-        ConcreteFunctionDefinition testFn = (ConcreteFunctionDefinition)this.runtime.getFunction("test::testFn():Any[*]");
+        compileTestSource("fromString.pure",
+                "function test::testFn():Any[*]\n" +
+                        "{\n" +
+                        "  1\n" +
+                        "}");
+        ConcreteFunctionDefinition<?> testFn = (ConcreteFunctionDefinition<?>) runtime.getFunction("test::testFn():Any[*]");
         Assert.assertNotNull(testFn);
 
-        ListIterable<ValueSpecification> expressions = (ListIterable<ValueSpecification>)testFn._expressionSequence();
-        Verify.assertSize(1, expressions);
-        ValueSpecification expression = expressions.get(0);
+        RichIterable<? extends ValueSpecification> expressions = testFn._expressionSequence();
+        Assert.assertEquals(1, expressions.size());
+        ValueSpecification expression = expressions.getAny();
         CoreInstance multiplicity = expression._multiplicity();
         Assert.assertEquals(1, Multiplicity.multiplicityLowerBoundToInt(multiplicity));
         Assert.assertEquals(1, Multiplicity.multiplicityUpperBoundToInt(multiplicity));
@@ -60,16 +61,17 @@ public class TestMultiplicity extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testLiteralCollectionMultiplicity()
     {
-        compileTestSource("fromString.pure","function test::testFn():Any[*]\n" +
-                "{\n" +
-                "  [1, 2, 3]\n" +
-                "}");
-        ConcreteFunctionDefinition testFn = (ConcreteFunctionDefinition)this.runtime.getFunction("test::testFn():Any[*]");
+        compileTestSource("fromString.pure",
+                "function test::testFn():Any[*]\n" +
+                        "{\n" +
+                        "  [1, 2, 3]\n" +
+                        "}");
+        ConcreteFunctionDefinition<?> testFn = (ConcreteFunctionDefinition<?>) runtime.getFunction("test::testFn():Any[*]");
         Assert.assertNotNull(testFn);
 
-        ListIterable<ValueSpecification> expressions = (ListIterable<ValueSpecification>)testFn._expressionSequence();
-        Verify.assertSize(1, expressions);
-        ValueSpecification expression = expressions.get(0);
+        RichIterable<? extends ValueSpecification> expressions = testFn._expressionSequence();
+        Assert.assertEquals(1, expressions.size());
+        ValueSpecification expression = expressions.getAny();
         CoreInstance multiplicity = expression._multiplicity();
         Assert.assertEquals(3, Multiplicity.multiplicityLowerBoundToInt(multiplicity));
         Assert.assertEquals(3, Multiplicity.multiplicityUpperBoundToInt(multiplicity));
@@ -78,16 +80,16 @@ public class TestMultiplicity extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testSingleFunctionExpressionMultiplicity()
     {
-        compileTestSource("fromString.pure","function test::testFn():Any[*]\n" +
+        compileTestSource("fromString.pure", "function test::testFn():Any[*]\n" +
                 "{\n" +
                 "  [1, 2, 3]->first();\n" +
                 "}");
-        ConcreteFunctionDefinition testFn = (ConcreteFunctionDefinition)this.runtime.getFunction("test::testFn():Any[*]");
+        ConcreteFunctionDefinition<?> testFn = (ConcreteFunctionDefinition<?>) runtime.getFunction("test::testFn():Any[*]");
         Assert.assertNotNull(testFn);
 
-        ListIterable<ValueSpecification> expressions = (ListIterable<ValueSpecification>)testFn._expressionSequence();
-        Verify.assertSize(1, expressions);
-        ValueSpecification expression = expressions.get(0);
+        RichIterable<? extends ValueSpecification> expressions = testFn._expressionSequence();
+        Assert.assertEquals(1, expressions.size());
+        ValueSpecification expression = expressions.getAny();
         CoreInstance multiplicity = expression._multiplicity();
         Assert.assertEquals(0, Multiplicity.multiplicityLowerBoundToInt(multiplicity));
         Assert.assertEquals(1, Multiplicity.multiplicityUpperBoundToInt(multiplicity));
@@ -96,16 +98,16 @@ public class TestMultiplicity extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testSingleFunctionExpressionCollectionMultiplicity()
     {
-        compileTestSource("fromString.pure","function test::testFn():Any[*]\n" +
+        compileTestSource("fromString.pure", "function test::testFn():Any[*]\n" +
                 "{\n" +
                 "  [[1, 2, 3]->first()];\n" +
                 "}");
-        ConcreteFunctionDefinition testFn = (ConcreteFunctionDefinition)this.runtime.getFunction("test::testFn():Any[*]");
+        ConcreteFunctionDefinition<?> testFn = (ConcreteFunctionDefinition<?>) runtime.getFunction("test::testFn():Any[*]");
         Assert.assertNotNull(testFn);
 
-        ListIterable<ValueSpecification> expressions = (ListIterable<ValueSpecification>)testFn._expressionSequence();
-        Verify.assertSize(1, expressions);
-        ValueSpecification expression = expressions.get(0);
+        RichIterable<? extends ValueSpecification> expressions = testFn._expressionSequence();
+        Assert.assertEquals(1, expressions.size());
+        ValueSpecification expression = expressions.getAny();
         CoreInstance multiplicity = expression._multiplicity();
         Assert.assertEquals(0, Multiplicity.multiplicityLowerBoundToInt(multiplicity));
         Assert.assertEquals(1, Multiplicity.multiplicityUpperBoundToInt(multiplicity));

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/literal/TestNestedCollection.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/literal/TestNestedCollection.java
@@ -180,4 +180,66 @@ public class TestNestedCollection extends AbstractPureTestWithCoreCompiledPlatfo
                         "}"));
         assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 4, 12, e);
     }
+
+    @Test
+    public void testCollectionInClassConstraint()
+    {
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "Class TestClass\n" +
+                        "[\n" +
+                        "  nonEmpty: length($this.name + $this.optionalName) > 0\n" +
+                        "]\n" +
+                        "{\n" +
+                        "    name : String[1];\n" +
+                        "    optionalName : String[0..1];\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 3, 39, e);
+    }
+
+    @Test
+    public void testCollectionInFunctionPreConstraint()
+    {
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "function testFn(name:String[1], optionalName:String[0..1]):String[1]\n" +
+                        "[\n" +
+                        "  nonEmpty: length($name + $optionalName) > 0\n" +
+                        "]\n" +
+                        "{\n" +
+                        "    $name + if($optionalName->isEmpty(), |'', |' ' + $optionalName->toOne());\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 3, 29, e);
+    }
+
+    @Test
+    public void testCollectionInFunctionPostConstraint()
+    {
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "function testFn(name:String[1], optionalName:String[0..1]):String[1]\n" +
+                        "[\n" +
+                        "  nonEmpty: size([$return, $optionalName]) > 0\n" +
+                        "]\n" +
+                        "{\n" +
+                        "    $name + if($optionalName->isEmpty(), |'', |' ' + $optionalName->toOne());\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 3, 29, e);
+    }
+
+    @Test
+    public void testCollectionInConstraintMessageFn()
+    {
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "Class TestClass\n" +
+                        "[\n" +
+                        "  nonEmpty\n" +
+                        "  (\n" +
+                        "      ~function : ($this.name->length() > 0) || (!$this.optionalName->isEmpty() && ($this.optionalName->toOne()->length() > 0))\n" +
+                        "      ~message  : 'name (' + $this.name + ') or optionalName (' + $this.optionalName + ') must be non-empty'\n" +
+                        "  )\n" +
+                        "]\n" +
+                        "{\n" +
+                        "    name : String[1];\n" +
+                        "    optionalName : String[0..1];\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 6, 73, e);
+    }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/literal/TestNestedCollection.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/literal/TestNestedCollection.java
@@ -24,204 +24,160 @@ import org.junit.Test;
 public class TestNestedCollection extends AbstractPureTestWithCoreCompiledPlatform
 {
     @BeforeClass
-    public static void setUp() {
+    public static void setUp()
+    {
         setUpRuntime(getExtra());
     }
 
     @After
-    public void cleanRuntime() {
+    public void cleanRuntime()
+    {
         runtime.delete("fromString.pure");
+        runtime.compile();
     }
 
     @Test
     public void testCollectionWithNoNesting()
     {
-        compileTestSource("fromString.pure", "function test():String[*]\n" +
-                                                   "{\n" +
-                                                   "    let a = ['a', 'b', 'c', 'd'];\n" +
-                                                   "}\n");
+        compileTestSource("fromString.pure",
+                "function test():String[*]\n" +
+                        "{\n" +
+                        "    let a = ['a', 'b', 'c', 'd'];\n" +
+                        "}\n");
         // Expect no compilation exception
     }
 
     @Test
     public void testCollectionWithDirectNesting()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function test():String[*]\n" +
-                    "{\n" +
-                    "    let a = ['e', 'f', ['g', 'h']];\n" +
-                    "}\n");
-            Assert.fail("Expected a compilation exception, got none");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 2", "fromString.pure", 3, 24, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "function test():String[*]\n" +
+                        "{\n" +
+                        "    let a = ['e', 'f', ['g', 'h']];\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 2", "fromString.pure", 3, 24, e);
     }
 
     @Test
     public void testCollectionWithIllusoryNesting()
     {
-        compileTestSource("fromString.pure", "function test():String[*]\n" +
-                                                   "{\n" +
-                                                   "    let a = ['i', ['j']];\n" +
-                                                   "}\n");
+        compileTestSource("fromString.pure",
+                "function test():String[*]\n" +
+                        "{\n" +
+                        "    let a = ['i', ['j']];\n" +
+                        "}\n");
         // Expect no compilation exception
     }
 
     @Test
     public void testCollectionWithNonCollectionVariableExpression()
     {
-        compileTestSource("fromString.pure", "function test():String[*]\n" +
-                                                   "{\n" +
-                                                   "    let x = 'k';" +
-                                                   "    let a = [$x, 'l'];\n" +
-                                                   "}\n");
+        compileTestSource("fromString.pure",
+                "function test():String[*]\n" +
+                        "{\n" +
+                        "    let x = 'k';" +
+                        "    let a = [$x, 'l'];\n" +
+                        "}\n");
         // Expect no compilation exception
     }
 
     @Test
     public void testCollectionWithCollectionVariableExpression()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function test():String[*]\n" +
-                    "{\n" +
-                    "    let x = ['m', 'n'];\n" +
-                    "    let a = [$x, 'o', 'p'];\n" +
-                    "}\n");
-            Assert.fail("Expected a compilation exception, got none");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 2", "fromString.pure", 4, 15, 4, 15, 4, 15, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "function test():String[*]\n" +
+                        "{\n" +
+                        "    let x = ['m', 'n'];\n" +
+                        "    let a = [$x, 'o', 'p'];\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 2", "fromString.pure", 4, 15, 4, 15, 4, 15, e);
     }
 
     @Test
     public void testCollectionWithCollectionVariableExpressionFromFunction()
     {
-        try
-        {
-            runtime.createInMemorySource("fromString.pure", "function test():String[*]\n" +
-                    "{\n" +
-                    "    let x = 'm, n'->split(', ');\n" +
-                    "    let a = [$x, 'o', 'p'];\n" +
-                    "}\n");
-            runtime.compile();
-            Assert.fail("Expected a compilation exception, got none");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: *", "fromString.pure", 4, 15, 4, 15, 4, 15, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "function test():String[*]\n" +
+                        "{\n" +
+                        "    let x = 'm, n'->split(', ');\n" +
+                        "    let a = [$x, 'o', 'p'];\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: *", "fromString.pure", 4, 15, 4, 15, 4, 15, e);
     }
 
     @Test
     public void testCollectionWithNonCollectionFunctionExpression()
     {
-        runtime.createInMemorySource("fromString.pure", "function test():String[*]\n" +
-                                                   "{\n" +
-                                                   "    let a = [trim('q'), 'r'];\n" +
-                                                   "}\n");
-        runtime.compile();
+        compileTestSource("fromString.pure",
+                "function test():String[*]\n" +
+                        "{\n" +
+                        "    let a = [trim('q'), 'r'];\n" +
+                        "}\n");
         // Expect no compilation exception
     }
 
     @Test
     public void testCollectionWithCollectionFunctionExpression()
     {
-        try
-        {
-            runtime.createInMemorySource("fromString.pure", "function test():String[*]\n" +
-                    "{\n" +
-                    "    let a = [split('s', ', '), 't', 'u'];\n" +
-                    "}\n");
-            runtime.compile();
-            Assert.fail("Expected a compilation exception, got none");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: *", "fromString.pure", 3, 14, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "function test():String[*]\n" +
+                        "{\n" +
+                        "    let a = [split('s', ', '), 't', 'u'];\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: *", "fromString.pure", 3, 14, e);
     }
 
     @Test
     public void testCollectionWithZeroOneExpression()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function test(x:String[0..1]):String[*]\n" +
-                    "{\n" +
-                    "    ['a', $x, 'c'];\n" +
-                    "}");
-            Assert.fail("Expected a compilation exception, got none");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 3, 12, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "function test(x:String[0..1]):String[*]\n" +
+                        "{\n" +
+                        "    ['a', $x, 'c'];\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 3, 12, e);
     }
 
     @Test
     public void testCollectionWithZeroOneWrappedInCollection()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function test():String[*]\n" +
-                    "{\n" +
-                    "    let a = [[['a', 'b']->first()], 't', 'u'];\n" +
-                    "}\n");
-            Assert.fail("Expected a compilation exception, got none");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 3, 14, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "function test():String[*]\n" +
+                        "{\n" +
+                        "    let a = [[['a', 'b']->first()], 't', 'u'];\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 3, 14, e);
     }
 
 
     @Test
     public void testCollectionWithZeroOneExpressionReturnedFromFunction()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function test(x:String[0..1]):String[*]\n" +
-                    "{\n" +
-                    "    ['a', doSomething(), 'c'];\n" +
-                    "}" +
-                    "function doSomething():String[0..1]\n" +
-                                        "{\n" +
-                                        "    [];\n" +
-                                        "}");
-            Assert.fail("Expected a compilation exception, got none");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 3, 11, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "function test(x:String[0..1]):String[*]\n" +
+                        "{\n" +
+                        "    ['a', doSomething(), 'c'];\n" +
+                        "}" +
+                        "function doSomething():String[0..1]\n" +
+                        "{\n" +
+                        "    [];\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 3, 11, e);
     }
 
     @Test
     public void testCollectionWithZeroOneExpressionReturnedFromFunctionWithLet()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function test(x:String[0..1]):String[*]\n" +
-                    "{\n" +
-                    "    let a = [doSomething()];\n" +
-                    "    ['a', $a];\n" +
-                    "}" +
-                    "function doSomething():String[0..1]\n" +
-                                        "{\n" +
-                                        "    [];\n" +
-                                        "}");
-            Assert.fail("Expected a compilation exception, got none");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 4, 12, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource("fromString.pure",
+                "function test(x:String[0..1]):String[*]\n" +
+                        "{\n" +
+                        "    let a = [doSomething()];\n" +
+                        "    ['a', $a];\n" +
+                        "}" +
+                        "function doSomething():String[0..1]\n" +
+                        "{\n" +
+                        "    [];\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Required multiplicity: 1, found: 0..1", "fromString.pure", 4, 12, e);
     }
 }


### PR DESCRIPTION
Validate function definitions and message functions in constraints. These were previously not being validated.

Validating these has revealed issues with parsing and post-processing of constraints. In particular, type and multiplicity parameters from the owning class (if present) were not being included in the type of the parameter "this". These issues are also fixed.