### PR TITLE
Pure IDE: more improvements

### DIFF
--- a/legend-pure-ide-light/pom.xml
+++ b/legend-pure-ide-light/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <skip.yarn>false</skip.yarn>
-        <pure-ide.web-application.version>8.28.0</pure-ide.web-application.version>
+        <pure-ide.web-application.version>8.38.0</pure-ide.web-application.version>
         <pure-ide.web-application.url>https://registry.npmjs.org/@finos/legend-application-pure-ide-deployment/-/legend-application-pure-ide-deployment-${pure-ide.web-application.version}.tgz</pure-ide.web-application.url>
     </properties>
 

--- a/legend-pure-ide-light/pom.xml
+++ b/legend-pure-ide-light/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <skip.yarn>false</skip.yarn>
-        <pure-ide.web-application.version>8.38.0</pure-ide.web-application.version>
+        <pure-ide.web-application.version>8.39.0</pure-ide.web-application.version>
         <pure-ide.web-application.url>https://registry.npmjs.org/@finos/legend-application-pure-ide-deployment/-/legend-application-pure-ide-deployment-${pure-ide.web-application.version}.tgz</pure-ide.web-application.url>
     </properties>
 

--- a/legend-pure-ide-light/pom.xml
+++ b/legend-pure-ide-light/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <skip.yarn>false</skip.yarn>
         <pure-ide.web-application.version>8.28.0</pure-ide.web-application.version>
+        <pure-ide.web-application.url>https://registry.npmjs.org/@finos/legend-application-pure-ide-deployment/-/legend-application-pure-ide-deployment-${pure-ide.web-application.version}.tgz</pure-ide.web-application.url>
     </properties>
 
     <build>
@@ -56,7 +57,7 @@
                 </executions>
                 <configuration>
                     <skip>${skip.yarn}</skip>
-                    <url>https://registry.npmjs.org/@finos/legend-application-pure-ide-deployment/-/legend-application-pure-ide-deployment-${pure-ide.web-application.version}.tgz</url>
+                    <url>${pure-ide.web-application.url}</url>
                     <unpack>true</unpack>
                     <outputDirectory>${project.build.directory}/web-content</outputDirectory>
                 </configuration>

--- a/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/FileManagement.java
+++ b/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/FileManagement.java
@@ -26,6 +26,7 @@ import org.finos.legend.pure.m3.serialization.filesystem.repository.ScratchCodeR
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.CodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.CodeStorageNode;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.CodeStorageNodeStatus;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.CodeStorageTools;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.Version;
 import org.json.simple.JSONObject;
@@ -242,7 +243,7 @@ public class FileManagement
     {
         try
         {
-            CodeStorage codeStorage = session.getCodeStorage();
+            MutableCodeStorage codeStorage = session.getCodeStorage();
             if (codeStorage == null)
             {
                 throw new RuntimeException("Cannot find code storage");
@@ -271,7 +272,7 @@ public class FileManagement
 
             return Response.ok((StreamingOutput) outputStream ->
             {
-                outputStream.write(this.transformContent(content, codeStorage.isImmutable(filePath)));
+                outputStream.write(this.transformContent(content, codeStorage.isRepositoryImmutable(codeStorage.getRepositoryForPath(filePath))));
                 outputStream.close();
             }).build();
         }
@@ -292,7 +293,6 @@ public class FileManagement
         object.put("RO", isImmutable);
         return object.toJSONString().getBytes();
     }
-
 
     private void writeNode(StringBuilder builder, MutableCodeStorage codeStorage, String path, CodeStorageNode node)
     {
@@ -321,7 +321,7 @@ public class FileManagement
         builder.append("{\"li_attr\":{\"id\":\"file_");
         builder.append(path);
         builder.append("\",\"path\":\"").append(path).append("\",\"file\":false,\"repo\":\"true\"");
-        builder.append(",\"RO\":").append(codeStorage.isImmutable(path));
+        builder.append(",\"RO\":").append(codeStorage.isRepositoryImmutable(codeStorage.getRepositoryForPath(path)));
         builder.append("},\"text\":\"");
         builder.append(repo.getName());
         if (currentRevision >= 0)
@@ -346,7 +346,7 @@ public class FileManagement
         builder.append("{\"li_attr\":{\"id\":\"file_");
         builder.append(path);
         builder.append("\",\"path\":\"").append(path).append("\",\"file\":false");
-        builder.append(",\"RO\":").append(codeStorage.isImmutable(path));
+        builder.append(",\"RO\":").append(codeStorage.isRepositoryImmutable(codeStorage.getRepositoryForPath(path)));
         builder.append("},\"text\":\"");
         builder.append(directory.getName());
         builder.append("\",\"state\":\"closed\",\"children\":").append(!codeStorage.isEmptyFolder(path)).append("}");
@@ -357,7 +357,7 @@ public class FileManagement
         builder.append("{\"li_attr\":{\"id\":\"file_");
         builder.append(path);
         builder.append("\",\"path\":\"").append(path).append("\",\"file\":true");
-        builder.append(",\"RO\":").append(codeStorage.isImmutable(path));
+        builder.append(",\"RO\":").append(codeStorage.isRepositoryImmutable(codeStorage.getRepositoryForPath(path)));
 
         if (file.getStatus() != CodeStorageNodeStatus.NORMAL)
         {

--- a/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/FileManagement.java
+++ b/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/FileManagement.java
@@ -320,7 +320,7 @@ public class FileManagement
         String repoName = codeStorage.getRepoName(path);
         builder.append("{\"li_attr\":{\"id\":\"file_");
         builder.append(path);
-        builder.append("\",\"path\":\"").append(path).append("\",\"file\":false,\"repo\":\"true\"");
+        builder.append("\",\"path\":\"").append(path).append("\",\"file\":false,\"repo\":true");
         builder.append(",\"RO\":").append(codeStorage.isRepositoryImmutable(codeStorage.getRepositoryForPath(path)));
         builder.append("},\"text\":\"");
         builder.append(repo.getName());

--- a/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/FileManagement.java
+++ b/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/FileManagement.java
@@ -320,7 +320,7 @@ public class FileManagement
         String repoName = codeStorage.getRepoName(path);
         builder.append("{\"li_attr\":{\"id\":\"file_");
         builder.append(path);
-        builder.append("\",\"path\":\"").append(path).append("\",\"file\":\"false\",\"repo\":\"true\"");
+        builder.append("\",\"path\":\"").append(path).append("\",\"file\":false,\"repo\":\"true\"");
         builder.append(",\"RO\":").append(codeStorage.isImmutable(path));
         builder.append("},\"text\":\"");
         builder.append(repo.getName());
@@ -345,7 +345,7 @@ public class FileManagement
     {
         builder.append("{\"li_attr\":{\"id\":\"file_");
         builder.append(path);
-        builder.append("\",\"path\":\"").append(path).append("\",\"file\":\"false\"");
+        builder.append("\",\"path\":\"").append(path).append("\",\"file\":false");
         builder.append(",\"RO\":").append(codeStorage.isImmutable(path));
         builder.append("},\"text\":\"");
         builder.append(directory.getName());
@@ -356,7 +356,7 @@ public class FileManagement
     {
         builder.append("{\"li_attr\":{\"id\":\"file_");
         builder.append(path);
-        builder.append("\",\"path\":\"").append(path).append("\",\"file\":\"true\"");
+        builder.append("\",\"path\":\"").append(path).append("\",\"file\":true");
         builder.append(",\"RO\":").append(codeStorage.isImmutable(path));
 
         if (file.getStatus() != CodeStorageNodeStatus.NORMAL)

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/PureCodeStorage.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/PureCodeStorage.java
@@ -444,10 +444,21 @@ public class PureCodeStorage implements MutableCodeStorage
     }
 
     @Override
-    public boolean isImmutable(String path)
+    public CodeRepository getRepositoryForPath(String path)
     {
-        RepositoryCodeStorage codeStorage = getCodeStorage(path);
-        return codeStorage instanceof ImmutableRepositoryCodeStorage;
+        if (!path.isEmpty() && (path.charAt(0) == '/'))
+        {
+            int index = path.indexOf('/', 1);
+            String rootPath = index != -1 ? path.substring(1, index) : path.substring(1);
+            return this.repositoriesByName.get(rootPath);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isRepositoryImmutable(CodeRepository repository)
+    {
+        return repository != null && this.codeStorageByName.get(repository.getName()) instanceof ImmutableRepositoryCodeStorage;
     }
 
     @Override
@@ -1022,7 +1033,6 @@ public class PureCodeStorage implements MutableCodeStorage
             return CodeStorageNodeStatus.UNKNOWN;
         }
     }
-
 
     public static String getSourceRepoName(String sourceId)
     {

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/PureCodeStorage.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/PureCodeStorage.java
@@ -41,6 +41,7 @@ import org.finos.legend.pure.m3.serialization.filesystem.repository.ScratchCodeR
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.CodeStorageNode;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.CodeStorageNodeStatus;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.CodeStorageTools;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.ImmutableRepositoryCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableRepositoryCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.RepositoryCodeStorage;
@@ -440,6 +441,13 @@ public class PureCodeStorage implements MutableCodeStorage
     {
         RepositoryCodeStorage codeStorage = getCodeStorage(path);
         return (codeStorage instanceof VersionControlledCodeStorage) && ((VersionControlledCodeStorage) codeStorage).isVersioned(path);
+    }
+
+    @Override
+    public boolean isImmutable(String path)
+    {
+        RepositoryCodeStorage codeStorage = getCodeStorage(path);
+        return codeStorage instanceof ImmutableRepositoryCodeStorage;
     }
 
     @Override

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/CodeStorage.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/CodeStorage.java
@@ -76,6 +76,15 @@ public interface CodeStorage
     boolean isVersioned(String path);
 
     /**
+     * Return whether the given file or directory is
+     * immutable.
+     *
+     * @param path file or directory path
+     * @return whether path is immutable
+     */
+    boolean isImmutable(String path);
+
+    /**
      * Get the current revision number of the given file
      * or directory.  Returns -1 if the file or directory
      * is not under version control.

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/CodeStorage.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/CodeStorage.java
@@ -44,6 +44,11 @@ public interface CodeStorage
 
     CodeRepository getRepository(String name);
 
+    default CodeRepository getRepositoryForPath(String path)
+    {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
     CodeStorageNode getNode(String path);
 
     RichIterable<CodeStorageNode> getFiles(String path);
@@ -74,15 +79,6 @@ public interface CodeStorage
      * @return whether path is under version control
      */
     boolean isVersioned(String path);
-
-    /**
-     * Return whether the given file or directory is
-     * immutable.
-     *
-     * @param path file or directory path
-     * @return whether path is immutable
-     */
-    boolean isImmutable(String path);
 
     /**
      * Get the current revision number of the given file

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/MutableCodeStorage.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/MutableCodeStorage.java
@@ -16,6 +16,7 @@ package org.finos.legend.pure.m3.serialization.filesystem.usercodestorage;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.list.ListIterable;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.vcs.UpdateReport;
 import org.finos.legend.pure.m3.serialization.runtime.Message;
 
@@ -26,6 +27,8 @@ import java.io.OutputStream;
 public interface MutableCodeStorage extends CodeStorage
 {
     void initialize(Message message);
+
+    boolean isRepositoryImmutable(CodeRepository repository);
 
     RichIterable<CodeStorageNode> getModifiedUserFiles();
 

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/Source.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/Source.java
@@ -446,6 +446,10 @@ public class Source
                     {
                         if (result instanceof FunctionExpression)
                         {
+                            return 5;
+                        }
+                        if (result instanceof InstanceValue)
+                        {
                             return 4;
                         }
                         if (result instanceof ValueSpecification)

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestSourceNavigation.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestSourceNavigation.java
@@ -255,4 +255,30 @@ public class TestSourceNavigation extends AbstractPureTestWithCoreCompiledPlatfo
         Assert.assertEquals(1, found.getSourceInformation().getLine());
         Assert.assertEquals(22, found.getSourceInformation().getColumn());
     }
+
+    @Test
+    public void testNavigateFunctionDescriptor()
+    {
+        Source source = runtime.createInMemorySource(
+                "test.pure",
+                "function doSomething(param: String[1]): Any[*]\n" +
+                        "{\n" +
+                        "  [\n" +
+                        "    print_Any_MANY__Integer_1__Nil_0_\n" +
+                        "  ];\n" +
+                        "  print_Any_MANY__Integer_1__Nil_0_;\n" +
+                        "}"
+        );
+
+        runtime.compile();
+        CoreInstance found = source.navigate(4, 7, processorSupport);
+        Assert.assertEquals("/system/extra.pure", found.getSourceInformation().getSourceId());
+        Assert.assertEquals(23, found.getSourceInformation().getLine());
+        Assert.assertEquals(44, found.getSourceInformation().getColumn());
+
+        found = source.navigate(6, 7, processorSupport);
+        Assert.assertEquals("/system/extra.pure", found.getSourceInformation().getSourceId());
+        Assert.assertEquals(23, found.getSourceInformation().getLine());
+        Assert.assertEquals(44, found.getSourceInformation().getColumn());
+    }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestSourceNavigation.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestSourceNavigation.java
@@ -272,13 +272,13 @@ public class TestSourceNavigation extends AbstractPureTestWithCoreCompiledPlatfo
 
         runtime.compile();
         CoreInstance found = source.navigate(4, 7, processorSupport);
-        Assert.assertEquals("/system/extra.pure", found.getSourceInformation().getSourceId());
-        Assert.assertEquals(23, found.getSourceInformation().getLine());
+        Assert.assertEquals("/platform/pure/basics/io/print.pure", found.getSourceInformation().getSourceId());
+        Assert.assertEquals(15, found.getSourceInformation().getLine());
         Assert.assertEquals(44, found.getSourceInformation().getColumn());
 
         found = source.navigate(6, 7, processorSupport);
-        Assert.assertEquals("/system/extra.pure", found.getSourceInformation().getSourceId());
-        Assert.assertEquals(23, found.getSourceInformation().getLine());
+        Assert.assertEquals("/platform/pure/basics/io/print.pure", found.getSourceInformation().getSourceId());
+        Assert.assertEquals(15, found.getSourceInformation().getLine());
         Assert.assertEquals(44, found.getSourceInformation().getColumn());
     }
 }


### PR DESCRIPTION
Refer to https://github.com/finos/legend-studio/pull/1822 and https://github.com/finos/legend-studio/pull/1877 for the full changelog

- [x] Make web application URL configurable
- [x] `REQUIRES BACKEND` Better indicator/visual cue for readonly files; disabling edition of readonly sources
- [x] Hotkeys: `Alt + Z` for toggling text-wrap in file editor
- [x] Hotkeys: Support multiple hotkeys for find files/text commands to make it more similar to `vscode`
- [x] Upgrade `monaco-editor` to DEV version to fix problem with bracket matching: this is temporary solution, we will need to ugrade to stable version when available
- [x] `REQUIRES BACKEND` Fix `Ctrl+B` on function descriptor doesn't work, e.g. `contains_Any_MANY__Any_1__Boolean_1_`
- [x] Allow fixing compilation on very first start (in case initialization failed)
- [x] Clear compilation errors in all file before `executeGo`: right now, if you make mistake in one place and go to another file to fix it, for example, delete a duplicated function defined in another file, the compilation does not go away in the other file
- [x] Improve syntax highlighting:
  - [x] Improve on syntax highlighting of function descriptor `execution_StoreQuery_1__RoutedValueSpecification_$0_1$__Mapping_1__Runtime_1__ExecutionContext_1__Extension_MANY__DebugContext_1__Result_1_`: should we consider adding `$` to the definition of word
  - [x] Support syntax highlight for string escaping: e.g. `'Finding all instances of class \''`
  - [x] Fix syntax-highlighting for long generic types: `paths: Pair<String, PathInformation>[*], connection : DatabaseConnection[1]` will look weird: we probably should do it in a way that `<` push and `>` pops the context (watch out for arrows), a few cases to test `Person->patchByIds(^Map<String, Any>()->cast(@Map<String, Any>[*])->put('children', []), ['1']);`, `Function<{T[1]->Boolean[1]}>`
- [x] Allow cleaning test result
- [x] Embedded a terminal inside of console using `xterm`
  - [x] Adopt VSCode theme
  - [x] Clear console
  - [x] Toggle preserve log
  - [x] Search bar
  - [x] Navigatable error source information in console: e.g. `resource:/welcome.pure line:22 column:3`
  - [x] Implement `help` command and integrate extension mechanism for that, and `ansi` command
  - [x] Basic commands: `clear`, `help`, `ansi`, `go`, etc.
  - [x] Implement word navigation using keyboard and backspace/delete
  - [x] Support history of commands
  - [x] Implement `echo`
  - [x] Implement `cd`, `ls` (40mins each) - no slash -> not a path, must be a concept
  - [x] Implement `code`/`open`/`edit`/`vi` - no slash -> not a path, must be a concept
  - [x] Implement `welcome` command to open `welcome.pure` file
  - [x] Fixed a minor issue with cursor movement at extremes (one problem remains - https://github.com/xtermjs/xterm.js/issues/4405)
- [x] Bug fixes:
  - [x] Fix suggestion for copyright not working, when typing `/copyright`: in general, we now support suggestions for special commands, starting with `/`
  - [x] Fix toggling expansion caret not working in test runner panel
- [x] Componentize the test result console into single component to be used in test result panel so as to allow clicking on links
- [x] Reworked search panel
  - [x] split search panel into `search`, `reference` and `suggestion`:
  - [x] only show suggestion when suggestion state is available
  - [x] setup `References` panel to have refresh, clear, placeholder message, collapse
  - [x] redefine hotkey behavior, move search popup to inside panel, follow VSCode behavior (handle Enter key and debounced search)