### PR TITLE
Introduce functionType profile

### DIFF
--- a/legend-pure-m2-functions-pure/src/main/resources/platform_functions/date/today.pure
+++ b/legend-pure-m2-functions-pure/src/main/resources/platform_functions/date/today.pure
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 // Returns the current day.
-native function meta::pure::functions::date::today():StrictDate[1];
+native function <<functionType.SideEffectFunction>> meta::pure::functions::date::today():StrictDate[1];

--- a/legend-pure-m2-functions-pure/src/main/resources/platform_functions/runtime/currentUserId.pure
+++ b/legend-pure-m2-functions-pure/src/main/resources/platform_functions/runtime/currentUserId.pure
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-native function meta::pure::runtime::currentUserId():String[1];
+native function <<functionType.SideEffectFunction>> meta::pure::runtime::currentUserId():String[1];

--- a/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreParser.g4
+++ b/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreParser.g4
@@ -129,7 +129,7 @@ enumDefinition: ENUM stereotypes? taggedValues? qualifiedName
 enumValue: stereotypes? taggedValues? identifier
 ;
 
-nativeFunction: NATIVE FUNCTION qualifiedName typeAndMultiplicityParameters? functionTypeSignature END_LINE
+nativeFunction: NATIVE FUNCTION stereotypes? qualifiedName typeAndMultiplicityParameters? functionTypeSignature END_LINE
 ;
 
 functionTypeSignature:  GROUP_OPEN (functionVariableExpression (COMMA functionVariableExpression)*)? GROUP_CLOSE COLON type multiplicity

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
@@ -2997,12 +2997,14 @@ public class AntlrContextToM3CoreInstance
         {
             this.typeParametersAndMultiplicityParameters(ctx.typeAndMultiplicityParameters(), typeParametersNames, multiplicityParametersNames);
         }
+        ListIterable<CoreInstance> stereotypes = (ctx.stereotypes() == null) ? null : stereotypes(ctx.stereotypes(), importId);
         FunctionType signature = functionTypeSignature(ctx.functionTypeSignature(), function, typeParametersNames, multiplicityParametersNames, importId, spacePlusTabs(space, 1));
 
         function._functionName(ctx.qualifiedName().identifier().getText());
         PackageInstance packageInstance = this.buildPackage(ctx.qualifiedName().packagePath());
 
         function._package(packageInstance);
+        function._stereotypesCoreInstance(stereotypes);
         packageInstance._childrenAdd(function);
         GenericTypeInstance genericTypeInstance = GenericTypeInstance.createPersistent(this.repository);
         Type type = (Type) this.processorSupport.package_getByUserPath(M3Paths.NativeFunction);

--- a/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/all.pure
+++ b/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/all.pure
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-native function meta::pure::functions::collection::getAll<T>(type:Class<T>[1]):T[*];
-native function meta::pure::functions::collection::getAllVersions<T>(type:Class<T>[1]):T[*];
+native function <<functionType.SideEffectFunction>> meta::pure::functions::collection::getAll<T>(type:Class<T>[1]):T[*];
+native function <<functionType.SideEffectFunction>> meta::pure::functions::collection::getAllVersions<T>(type:Class<T>[1]):T[*];
 

--- a/legend-pure-m3-core/src/main/resources/platform/pure/grammar/milestoning.pure
+++ b/legend-pure-m3-core/src/main/resources/platform/pure/grammar/milestoning.pure
@@ -53,9 +53,9 @@ Profile meta::pure::profiles::milestoning
     stereotypes: [generatedmilestoningproperty, generatedmilestoningdateproperty];
 }
 
-native function meta::pure::functions::collection::getAllVersionsInRange<T>(type:Class<T>[1], start:Date[1], end:Date[1]):T[*];
-native function meta::pure::functions::collection::getAll<T>(type:Class<T>[1], milestoningDate:Date[1]):T[*];
-native function meta::pure::functions::collection::getAll<T>(type:Class<T>[1], processingDate:Date[1], businessDate:Date[1]):T[*];
+native function <<functionType.SideEffectFunction>> meta::pure::functions::collection::getAllVersionsInRange<T>(type:Class<T>[1], start:Date[1], end:Date[1]):T[*];
+native function <<functionType.SideEffectFunction>> meta::pure::functions::collection::getAll<T>(type:Class<T>[1], milestoningDate:Date[1]):T[*];
+native function <<functionType.SideEffectFunction>> meta::pure::functions::collection::getAll<T>(type:Class<T>[1], processingDate:Date[1], businessDate:Date[1]):T[*];
 
 
 

--- a/legend-pure-m3-core/src/main/resources/platform/pure/profile.pure
+++ b/legend-pure-m3-core/src/main/resources/platform/pure/profile.pure
@@ -1,4 +1,4 @@
-// Copyright 2022 Goldman Sachs
+// Copyright 2023 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,5 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Returns the current time to a system dependent precision.
-native function <<functionType.SideEffectFunction>> meta::pure::functions::date::now():DateTime[1];
+Profile meta::pure::profiles::functionType
+{
+    stereotypes : [SideEffectFunction];
+}

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/classpath/TestClassLoaderCodeStorage.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/classpath/TestClassLoaderCodeStorage.java
@@ -94,7 +94,7 @@ public class TestClassLoaderCodeStorage
         Verify.assertSetsEqual(
                 Sets.mutable.with("/test/codestorage/fake.pure", "/test/org/finos/legend/pure/m3/serialization/filesystem/test/level1/level1.pure", "/test/org/finos/legend/pure/m3/serialization/filesystem/test/level1/level2/level2.pure"),
                 this.testCodeStorage.getUserFiles().toSet());
-        Verify.assertEquals(104, this.combinedCodeStorage.getUserFiles().toSet().size());
+        Verify.assertEquals(105, this.combinedCodeStorage.getUserFiles().toSet().size());
     }
 
     @Test

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/grammar/v1/TestM3AntlrParser.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/grammar/v1/TestM3AntlrParser.java
@@ -17,10 +17,12 @@ package org.finos.legend.pure.m3.serialization.grammar.v1;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.mutable.FastList;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.NativeFunctionInstance;
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3AntlrParser;
 import org.finos.legend.pure.m3.statelistener.StatsStateListener;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -628,6 +630,20 @@ public class TestM3AntlrParser extends AbstractPureTestWithCoreCompiledPlatform
                 "native function meta::pure::functions::date::date(year:Integer[1], month:Integer[1], day:Integer[1], hour:Integer[1], minute:Integer[1]):Date[1];\n" +
                 "native function meta::pure::functions::date::date(year:Integer[1], month:Integer[1], day:Integer[1], hour:Integer[1], minute:Integer[1], second:Number[1]):Date[1];\n";
         new M3AntlrParser(null).parse(code, "test", true, 0, this.repository, this.newInstances, this.stateListener, this.context, 0, null);
+    }
+
+    @Test
+    public void testStereotypeOnNativeFunction()
+    {
+        String code =
+                "\n" +
+                "Profile meta::pure::function::dummyProfile\n" +
+                "{\n" +
+                "   stereotypes : [Dummy];" +
+                "}\n" +
+                "native function <<dummyProfile.Dummy>> meta::pure::functions::date::date(year:Integer[1]):Date[1];\n";
+        new M3AntlrParser(null).parse(code, "test", true, 0, this.repository, this.newInstances, this.stateListener, this.context, 0, null);
+        Assert.assertEquals(1, this.newInstances.selectInstancesOf(NativeFunctionInstance.class).getOnly()._stereotypesCoreInstance().size());
     }
 
     @Test

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/function/TestFunctionReturnMultiplicity.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/function/TestFunctionReturnMultiplicity.java
@@ -81,7 +81,7 @@ public class TestFunctionReturnMultiplicity extends AbstractPureTestWithCoreComp
         CoreInstance result = this.compileAndExecute("test():Any[*]");
         ListIterable<? extends CoreInstance> values = result.getValueForMetaPropertyToMany("values");
         Assert.assertEquals(7, values.size());
-        Assert.assertEquals("a instanceOf String,1 instanceOf Integer,2.0 instanceOf Float,2015-03-12 instanceOf StrictDate,2015-03-12T23:59:00+0000 instanceOf DateTime,true instanceOf Boolean,Class(48505) instanceOf Class", values.makeString(","));
+        Assert.assertEquals("a instanceOf String,1 instanceOf Integer,2.0 instanceOf Float,2015-03-12 instanceOf StrictDate,2015-03-12T23:59:00+0000 instanceOf DateTime,true instanceOf Boolean,Class(48515) instanceOf Class", values.makeString(","));
     }
 
 
@@ -116,7 +116,7 @@ public class TestFunctionReturnMultiplicity extends AbstractPureTestWithCoreComp
                 "}\n");
         CoreInstance result = this.compileAndExecute("test():Any[*]");
         CoreInstance value = result.getValueForMetaPropertyToOne("values");
-        Assert.assertEquals("Class(48505) instanceOf Class", value.toString());
+        Assert.assertEquals("Class(48515) instanceOf Class", value.toString());
     }
 
     @Test


### PR DESCRIPTION
This PR introduces `functionType` profile with `SideEffect` stereotype which would be used to mark `SideEffect` functions whose executions are impacted by external factors.
Ex - I/O functions (like getAll), today