### PR TITLE
Return empty map when fetching metadata for non-existing classifier

### DIFF
--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
@@ -107,7 +107,7 @@ public class MetadataLazy implements Metadata
     @Override
     public MapIterable<String, CoreInstance> getMetadata(String classifier)
     {
-        return hasClassifier(classifier) ? loadAllClassifierInstances(classifier).asUnmodifiable() : null;
+        return hasClassifier(classifier) ? loadAllClassifierInstances(classifier).asUnmodifiable() : Maps.fixedSize.empty();
     }
 
     @Override


### PR DESCRIPTION
This PR changes the behavior of `MetadataLazy` to align with the behavior of `MetadataEager`. 
While fetching metadata of non-existing classifiers an empty map should be returned instead of null to avoid NPE down the stack.