### PR TITLE
Add Comments to SQLQuery metamodel

### DIFF
--- a/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/functions.pure
+++ b/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/functions.pure
@@ -123,6 +123,7 @@ function meta::relational::metamodel::datatype::pureTypeForDbColumn(column : met
 Class meta::relational::mapping::RelationalActivity extends meta::pure::mapping::Activity
 {
    sql : String[1];
+   comment : String[0..1];
    executionTimeInNanoSecond : Integer[0..1];
    sqlGenerationTimeInNanoSecond : Integer[0..1];
    connectionAcquisitionTimeInNanoSecond : Integer[0..1];

--- a/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/grammar/relational.pure
+++ b/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/grammar/relational.pure
@@ -168,6 +168,7 @@ Class meta::relational::metamodel::Alias extends meta::relational::metamodel::Re
 
 Class meta::relational::metamodel::SQLQuery extends meta::relational::metamodel::RelationalOperationElement
 {
+   comment : String[0..1];
 }
 
 Class meta::relational::metamodel::TableAlias extends Alias


### PR DESCRIPTION
To have query metadata for every execution we are prepending SQL Queries with SQL Comments to hold the execution trace ID (introduced as part of an associated change in Engine for this) which can be used to pull the respective zipkin trace.