### PR TITLE
Revert "Add Comments to SQLQuery metamodel (#656)"

### DIFF
--- a/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/functions.pure
+++ b/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/functions.pure
@@ -123,7 +123,6 @@ function meta::relational::metamodel::datatype::pureTypeForDbColumn(column : met
 Class meta::relational::mapping::RelationalActivity extends meta::pure::mapping::Activity
 {
    sql : String[1];
-   comment : String[0..1];
    executionTimeInNanoSecond : Integer[0..1];
    sqlGenerationTimeInNanoSecond : Integer[0..1];
    connectionAcquisitionTimeInNanoSecond : Integer[0..1];

--- a/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/grammar/relational.pure
+++ b/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/grammar/relational.pure
@@ -168,7 +168,6 @@ Class meta::relational::metamodel::Alias extends meta::relational::metamodel::Re
 
 Class meta::relational::metamodel::SQLQuery extends meta::relational::metamodel::RelationalOperationElement
 {
-   comment : String[0..1];
 }
 
 Class meta::relational::metamodel::TableAlias extends Alias


### PR DESCRIPTION
Reverting for now as it is blocking visibility on TeamCity, will merge with other backwards incompatible changes when starting with release.