### PR TITLE
Trino connector | Adding Trino as new DatabaseType

### DIFF
--- a/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/relationalRuntime.pure
+++ b/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/relationalRuntime.pure
@@ -19,7 +19,7 @@ import meta::relational::metamodel::relation::*;
 
 Enum meta::relational::runtime::DatabaseType
 {
-   DB2, H2, MemSQL, Sybase, SybaseIQ, Composite, Postgres, SqlServer, Hive, Snowflake, Presto, Trino, BigQuery, Redshift, Databricks, Spanner, Athena
+   DB2, H2, MemSQL, Sybase, SybaseIQ, Composite, Postgres, SqlServer, Hive, Snowflake, Presto, Trino, BigQuery, Redshift, Databricks, Spanner, Athena, Trino
 }
 
 Class meta::relational::runtime::DatabaseConnection extends Connection


### PR DESCRIPTION
As part of the effort to add a new Trino connector, we are adding Trino as the new Database Type.