### PR TITLE
Avoid direct casting primitive core instances 

### DIFF
--- a/legend-pure-m3-bootstrap-generator/src/main/java/org/finos/legend/pure/m3/bootstrap/generator/M3ToJavaGenerator.java
+++ b/legend-pure-m3-bootstrap-generator/src/main/java/org/finos/legend/pure/m3/bootstrap/generator/M3ToJavaGenerator.java
@@ -1262,11 +1262,8 @@ public class M3ToJavaGenerator
         if (isPrimitiveTypeProperty(propertyReturnGenericType))
         {
             String cast = getPrimitiveClass(propertyReturnGenericType);
-            if (!isToOne)
-            {
-                cast = "RichIterable<? extends " + cast + ">";
-            }
-            return "(" + cast + ")" + expression;
+            String fn = cast + ".CAST_CORE_INSTANCE_FN";
+            return applyFunction2WithCardinality(property, fn, expression, false, isToOne);
         }
         else
         {

--- a/legend-pure-m3-bootstrap-generator/src/main/java/org/finos/legend/pure/m3/bootstrap/generator/M3ToJavaGenerator.java
+++ b/legend-pure-m3-bootstrap-generator/src/main/java/org/finos/legend/pure/m3/bootstrap/generator/M3ToJavaGenerator.java
@@ -1262,7 +1262,7 @@ public class M3ToJavaGenerator
         if (isPrimitiveTypeProperty(propertyReturnGenericType))
         {
             String cast = getPrimitiveClass(propertyReturnGenericType);
-            String fn = cast + ".CAST_CORE_INSTANCE_FN";
+            String fn = cast + ".CONVERT_CORE_INSTANCE_FN";
             return applyFunction2WithCardinality(property, fn, expression, false, isToOne);
         }
         else

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/PrimitiveUtilities.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/PrimitiveUtilities.java
@@ -24,7 +24,6 @@ import org.finos.legend.pure.m4.coreinstance.primitive.DateCoreInstance;
 import org.finos.legend.pure.m4.coreinstance.primitive.DecimalCoreInstance;
 import org.finos.legend.pure.m4.coreinstance.primitive.FloatCoreInstance;
 import org.finos.legend.pure.m4.coreinstance.primitive.IntegerCoreInstance;
-import org.finos.legend.pure.m4.coreinstance.primitive.date.DateFunctions;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
 
 import java.math.BigDecimal;
@@ -42,7 +41,7 @@ public class PrimitiveUtilities
 
     public static boolean getBooleanValue(CoreInstance instance)
     {
-        return (instance instanceof BooleanCoreInstance) ? ((BooleanCoreInstance)instance).getValue() : ModelRepository.BOOLEAN_TRUE.equals(instance.getName());
+        return BooleanCoreInstance.FROM_CORE_INSTANCE_FN.valueOf(instance);
     }
 
     public static boolean getBooleanValue(CoreInstance instance, boolean defaultIfNull)
@@ -52,7 +51,7 @@ public class PrimitiveUtilities
 
     public static PureDate getDateValue(CoreInstance instance)
     {
-        return (instance instanceof DateCoreInstance) ? ((DateCoreInstance)instance).getValue() : DateFunctions.parsePureDate(instance.getName());
+        return DateCoreInstance.FROM_CORE_INSTANCE_FN.valueOf(instance);
     }
 
     public static PureDate getDateValue(CoreInstance instance, PureDate defaultIfNull)
@@ -62,7 +61,7 @@ public class PrimitiveUtilities
 
     public static BigDecimal getFloatValue(CoreInstance instance)
     {
-        return (instance instanceof FloatCoreInstance) ? ((FloatCoreInstance)instance).getValue() : new BigDecimal(instance.getName());
+        return FloatCoreInstance.FROM_CORE_INSTANCE_FN.valueOf(instance);
     }
 
     public static BigDecimal getFloatValue(CoreInstance instance, BigDecimal defaultIfNull)
@@ -82,27 +81,7 @@ public class PrimitiveUtilities
 
     public static Number getIntegerValue(CoreInstance instance)
     {
-        if (instance instanceof IntegerCoreInstance)
-        {
-            return ((IntegerCoreInstance)instance).getValue();
-        }
-
-        String name = instance.getName();
-        try
-        {
-            return Integer.valueOf(name);
-        }
-        catch (NumberFormatException e)
-        {
-            try
-            {
-                return Long.valueOf(name);
-            }
-            catch (NumberFormatException e1)
-            {
-                return new BigInteger(name);
-            }
-        }
+        return IntegerCoreInstance.FROM_CORE_INSTANCE_FN.valueOf(instance);
     }
 
     public static Number getIntegerValue(CoreInstance instance, Integer defaultIfNull)

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/PrimitiveUtilities.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/PrimitiveUtilities.java
@@ -41,7 +41,7 @@ public class PrimitiveUtilities
 
     public static boolean getBooleanValue(CoreInstance instance)
     {
-        return BooleanCoreInstance.FROM_CORE_INSTANCE_FN.valueOf(instance);
+        return BooleanCoreInstance.valueOfCoreInstance(instance);
     }
 
     public static boolean getBooleanValue(CoreInstance instance, boolean defaultIfNull)
@@ -51,7 +51,7 @@ public class PrimitiveUtilities
 
     public static PureDate getDateValue(CoreInstance instance)
     {
-        return DateCoreInstance.FROM_CORE_INSTANCE_FN.valueOf(instance);
+        return DateCoreInstance.valueOfCoreInstance(instance);
     }
 
     public static PureDate getDateValue(CoreInstance instance, PureDate defaultIfNull)
@@ -61,7 +61,7 @@ public class PrimitiveUtilities
 
     public static BigDecimal getFloatValue(CoreInstance instance)
     {
-        return FloatCoreInstance.FROM_CORE_INSTANCE_FN.valueOf(instance);
+        return FloatCoreInstance.valueOfCoreInstance(instance);
     }
 
     public static BigDecimal getFloatValue(CoreInstance instance, BigDecimal defaultIfNull)
@@ -81,7 +81,7 @@ public class PrimitiveUtilities
 
     public static Number getIntegerValue(CoreInstance instance)
     {
-        return IntegerCoreInstance.FROM_CORE_INSTANCE_FN.valueOf(instance);
+        return IntegerCoreInstance.valueOfCoreInstance(instance);
     }
 
     public static Number getIntegerValue(CoreInstance instance, Integer defaultIfNull)

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/ModelRepository.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/ModelRepository.java
@@ -446,7 +446,7 @@ public class ModelRepository
         return newDateTimeCoreInstance(getPureDate(name));
     }
 
-    public CoreInstance newStrictTimeCoreInstance(String name)
+    public StrictTimeCoreInstance newStrictTimeCoreInstance(String name)
     {
         return newStrictTimeCoreInstance(getPureStrictTime(name));
     }

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/BooleanCoreInstance.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/BooleanCoreInstance.java
@@ -15,6 +15,7 @@
 package org.finos.legend.pure.m4.coreinstance.primitive;
 
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function2;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.ModelRepository;
 
@@ -24,7 +25,37 @@ public final class BooleanCoreInstance extends PrimitiveCoreInstance<Boolean>
     {
         public Boolean valueOf(CoreInstance coreInstance)
         {
-            return coreInstance == null ? null : ((BooleanCoreInstance)coreInstance).getValue();
+            if (coreInstance == null)
+            {
+                return null;
+            }
+            else if (coreInstance instanceof BooleanCoreInstance)
+            {
+                return ((BooleanCoreInstance)coreInstance).getValue();
+            }
+            else
+            {
+                return ModelRepository.BOOLEAN_TRUE.equals(coreInstance.getName());
+            }
+        }
+    };
+
+    public static final Function2<CoreInstance, ModelRepository, BooleanCoreInstance> CAST_CORE_INSTANCE_FN = new Function2<CoreInstance, ModelRepository, BooleanCoreInstance>()
+    {
+        public BooleanCoreInstance value(CoreInstance coreInstance, ModelRepository repository)
+        {
+            if (coreInstance == null)
+            {
+                return null;
+            }
+            else if (coreInstance instanceof BooleanCoreInstance)
+            {
+                return (BooleanCoreInstance) coreInstance;
+            }
+            else
+            {
+                return repository.newBooleanCoreInstance(coreInstance.getName());
+            }
         }
     };
 

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/BooleanCoreInstance.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/BooleanCoreInstance.java
@@ -21,43 +21,8 @@ import org.finos.legend.pure.m4.ModelRepository;
 
 public final class BooleanCoreInstance extends PrimitiveCoreInstance<Boolean>
 {
-    public static final Function<CoreInstance, Boolean> FROM_CORE_INSTANCE_FN = new Function<CoreInstance, Boolean>()
-    {
-        public Boolean valueOf(CoreInstance coreInstance)
-        {
-            if (coreInstance == null)
-            {
-                return null;
-            }
-            else if (coreInstance instanceof BooleanCoreInstance)
-            {
-                return ((BooleanCoreInstance)coreInstance).getValue();
-            }
-            else
-            {
-                return ModelRepository.BOOLEAN_TRUE.equals(coreInstance.getName());
-            }
-        }
-    };
-
-    public static final Function2<CoreInstance, ModelRepository, BooleanCoreInstance> CAST_CORE_INSTANCE_FN = new Function2<CoreInstance, ModelRepository, BooleanCoreInstance>()
-    {
-        public BooleanCoreInstance value(CoreInstance coreInstance, ModelRepository repository)
-        {
-            if (coreInstance == null)
-            {
-                return null;
-            }
-            else if (coreInstance instanceof BooleanCoreInstance)
-            {
-                return (BooleanCoreInstance) coreInstance;
-            }
-            else
-            {
-                return repository.newBooleanCoreInstance(coreInstance.getName());
-            }
-        }
-    };
+    public static final Function<CoreInstance, Boolean> FROM_CORE_INSTANCE_FN = BooleanCoreInstance::valueOfCoreInstance;
+    public static final Function2<CoreInstance, ModelRepository, BooleanCoreInstance> CONVERT_CORE_INSTANCE_FN = BooleanCoreInstance::convertCoreInstance;
 
     BooleanCoreInstance(Boolean value, CoreInstance classifier, int internalSyntheticId)
     {
@@ -74,5 +39,37 @@ public final class BooleanCoreInstance extends PrimitiveCoreInstance<Boolean>
     public CoreInstance copy()
     {
         return new BooleanCoreInstance(this.getValue(), this.getClassifier(), this.getSyntheticId());
+    }
+
+    public static BooleanCoreInstance convertCoreInstance(CoreInstance coreInstance, ModelRepository repository)
+    {
+        if (coreInstance == null)
+        {
+            return null;
+        }
+        else if (coreInstance instanceof BooleanCoreInstance)
+        {
+            return (BooleanCoreInstance) coreInstance;
+        }
+        else
+        {
+            return repository.newBooleanCoreInstance(coreInstance.getName());
+        }
+    }
+
+    public static Boolean valueOfCoreInstance(CoreInstance coreInstance)
+    {
+        if (coreInstance == null)
+        {
+            return null;
+        }
+        else if (coreInstance instanceof BooleanCoreInstance)
+        {
+            return ((BooleanCoreInstance)coreInstance).getValue();
+        }
+        else
+        {
+            return ModelRepository.BOOLEAN_TRUE.equals(coreInstance.getName());
+        }
     }
 }

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/DateCoreInstance.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/DateCoreInstance.java
@@ -23,43 +23,8 @@ import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
 
 public final class DateCoreInstance extends PrimitiveCoreInstance<PureDate>
 {
-    public static final Function<CoreInstance, PureDate> FROM_CORE_INSTANCE_FN = new Function<CoreInstance, PureDate>()
-    {
-        public PureDate valueOf(CoreInstance coreInstance)
-        {
-            if (coreInstance == null)
-            {
-                return null;
-            }
-            else if (coreInstance instanceof DateCoreInstance)
-            {
-                return coreInstance == null ? null : ((DateCoreInstance)coreInstance).getValue();
-            }
-            else
-            {
-                return DateFunctions.parsePureDate(coreInstance.getName());
-            }
-        }
-    };
-
-    public static final Function2<CoreInstance, ModelRepository, DateCoreInstance> CAST_CORE_INSTANCE_FN = new Function2<CoreInstance, ModelRepository, DateCoreInstance>()
-    {
-        public DateCoreInstance value(CoreInstance coreInstance, ModelRepository repository)
-        {
-            if (coreInstance == null)
-            {
-                return null;
-            }
-            else if (coreInstance instanceof DateCoreInstance)
-            {
-                return (DateCoreInstance) coreInstance;
-            }
-            else
-            {
-                return repository.newDateCoreInstance(coreInstance.getName());
-            }
-        }
-    };
+    public static final Function<CoreInstance, PureDate> FROM_CORE_INSTANCE_FN = DateCoreInstance::valueOfCoreInstance;
+    public static final Function2<CoreInstance, ModelRepository, DateCoreInstance> CONVERT_CORE_INSTANCE_FN = DateCoreInstance::convertCoreInstance;
 
     private String name = null;
 
@@ -82,5 +47,37 @@ public final class DateCoreInstance extends PrimitiveCoreInstance<PureDate>
     public CoreInstance copy()
     {
         return new DateCoreInstance(this.getValue(), this.getClassifier(), this.getSyntheticId());
+    }
+
+    public static DateCoreInstance convertCoreInstance(CoreInstance coreInstance, ModelRepository repository)
+    {
+        if (coreInstance == null)
+        {
+            return null;
+        }
+        else if (coreInstance instanceof DateCoreInstance)
+        {
+            return (DateCoreInstance) coreInstance;
+        }
+        else
+        {
+            return repository.newDateCoreInstance(coreInstance.getName());
+        }
+    }
+
+    public static PureDate valueOfCoreInstance(CoreInstance coreInstance)
+    {
+        if (coreInstance == null)
+        {
+            return null;
+        }
+        else if (coreInstance instanceof DateCoreInstance)
+        {
+            return ((DateCoreInstance)coreInstance).getValue();
+        }
+        else
+        {
+            return DateFunctions.parsePureDate(coreInstance.getName());
+        }
     }
 }

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/DateCoreInstance.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/DateCoreInstance.java
@@ -15,7 +15,10 @@
 package org.finos.legend.pure.m4.coreinstance.primitive;
 
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function2;
+import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.primitive.date.DateFunctions;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
 
 public final class DateCoreInstance extends PrimitiveCoreInstance<PureDate>
@@ -24,7 +27,37 @@ public final class DateCoreInstance extends PrimitiveCoreInstance<PureDate>
     {
         public PureDate valueOf(CoreInstance coreInstance)
         {
-            return coreInstance == null ? null : ((DateCoreInstance)coreInstance).getValue();
+            if (coreInstance == null)
+            {
+                return null;
+            }
+            else if (coreInstance instanceof DateCoreInstance)
+            {
+                return coreInstance == null ? null : ((DateCoreInstance)coreInstance).getValue();
+            }
+            else
+            {
+                return DateFunctions.parsePureDate(coreInstance.getName());
+            }
+        }
+    };
+
+    public static final Function2<CoreInstance, ModelRepository, DateCoreInstance> CAST_CORE_INSTANCE_FN = new Function2<CoreInstance, ModelRepository, DateCoreInstance>()
+    {
+        public DateCoreInstance value(CoreInstance coreInstance, ModelRepository repository)
+        {
+            if (coreInstance == null)
+            {
+                return null;
+            }
+            else if (coreInstance instanceof DateCoreInstance)
+            {
+                return (DateCoreInstance) coreInstance;
+            }
+            else
+            {
+                return repository.newDateCoreInstance(coreInstance.getName());
+            }
         }
     };
 

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/FloatCoreInstance.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/FloatCoreInstance.java
@@ -23,43 +23,8 @@ import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
 public final class FloatCoreInstance extends PrimitiveCoreInstance<BigDecimal>
 {
-    public static final Function<CoreInstance, BigDecimal> FROM_CORE_INSTANCE_FN = new Function<CoreInstance, BigDecimal>()
-    {
-        public BigDecimal valueOf(CoreInstance coreInstance)
-        {
-            if (coreInstance == null)
-            {
-                return null;
-            }
-            else if (coreInstance instanceof FloatCoreInstance)
-            {
-                return ((FloatCoreInstance)coreInstance).getValue();
-            }
-            else
-            {
-                return new BigDecimal(coreInstance.getName());
-            }
-        }
-    };
-
-    public static final Function2<CoreInstance, ModelRepository, FloatCoreInstance> CAST_CORE_INSTANCE_FN = new Function2<CoreInstance, ModelRepository, FloatCoreInstance>()
-    {
-        public FloatCoreInstance value(CoreInstance coreInstance, ModelRepository repository)
-        {
-            if (coreInstance == null)
-            {
-                return null;
-            }
-            else if (coreInstance instanceof FloatCoreInstance)
-            {
-                return (FloatCoreInstance) coreInstance;
-            }
-            else
-            {
-                return repository.newFloatCoreInstance(coreInstance.getName());
-            }
-        }
-    };
+    public static final Function<CoreInstance, BigDecimal> FROM_CORE_INSTANCE_FN = FloatCoreInstance::valueOfCoreInstance;
+    public static final Function2<CoreInstance, ModelRepository, FloatCoreInstance> CONVERT_CORE_INSTANCE_FN = FloatCoreInstance::convertCoreInstance;
 
     private String name = null;
 
@@ -82,5 +47,37 @@ public final class FloatCoreInstance extends PrimitiveCoreInstance<BigDecimal>
     public CoreInstance copy()
     {
         return new FloatCoreInstance(this.getValue(), this.getClassifier(), this.getSyntheticId());
+    }
+
+    public static FloatCoreInstance convertCoreInstance(CoreInstance coreInstance, ModelRepository repository)
+    {
+        if (coreInstance == null)
+        {
+            return null;
+        }
+        else if (coreInstance instanceof FloatCoreInstance)
+        {
+            return (FloatCoreInstance) coreInstance;
+        }
+        else
+        {
+            return repository.newFloatCoreInstance(coreInstance.getName());
+        }
+    }
+
+    public static BigDecimal valueOfCoreInstance(CoreInstance coreInstance)
+    {
+        if (coreInstance == null)
+        {
+            return null;
+        }
+        else if (coreInstance instanceof FloatCoreInstance)
+        {
+            return ((FloatCoreInstance)coreInstance).getValue();
+        }
+        else
+        {
+            return new BigDecimal(coreInstance.getName());
+        }
     }
 }

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/FloatCoreInstance.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/FloatCoreInstance.java
@@ -17,6 +17,8 @@ package org.finos.legend.pure.m4.coreinstance.primitive;
 import java.math.BigDecimal;
 
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function2;
+import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
 public final class FloatCoreInstance extends PrimitiveCoreInstance<BigDecimal>
@@ -25,7 +27,37 @@ public final class FloatCoreInstance extends PrimitiveCoreInstance<BigDecimal>
     {
         public BigDecimal valueOf(CoreInstance coreInstance)
         {
-            return coreInstance == null ? null : ((FloatCoreInstance)coreInstance).getValue();
+            if (coreInstance == null)
+            {
+                return null;
+            }
+            else if (coreInstance instanceof FloatCoreInstance)
+            {
+                return ((FloatCoreInstance)coreInstance).getValue();
+            }
+            else
+            {
+                return new BigDecimal(coreInstance.getName());
+            }
+        }
+    };
+
+    public static final Function2<CoreInstance, ModelRepository, FloatCoreInstance> CAST_CORE_INSTANCE_FN = new Function2<CoreInstance, ModelRepository, FloatCoreInstance>()
+    {
+        public FloatCoreInstance value(CoreInstance coreInstance, ModelRepository repository)
+        {
+            if (coreInstance == null)
+            {
+                return null;
+            }
+            else if (coreInstance instanceof FloatCoreInstance)
+            {
+                return (FloatCoreInstance) coreInstance;
+            }
+            else
+            {
+                return repository.newFloatCoreInstance(coreInstance.getName());
+            }
         }
     };
 

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/IntegerCoreInstance.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/IntegerCoreInstance.java
@@ -17,6 +17,8 @@ package org.finos.legend.pure.m4.coreinstance.primitive;
 import java.math.BigInteger;
 
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function2;
+import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
 public final class IntegerCoreInstance extends PrimitiveCoreInstance<Number>
@@ -25,7 +27,52 @@ public final class IntegerCoreInstance extends PrimitiveCoreInstance<Number>
     {
         public Number valueOf(CoreInstance coreInstance)
         {
-            return coreInstance == null ? null : ((IntegerCoreInstance)coreInstance).getValue();
+            if (coreInstance == null)
+            {
+                return null;
+            }
+            else if (coreInstance instanceof IntegerCoreInstance)
+            {
+                return ((IntegerCoreInstance) coreInstance).getValue();
+            }
+            else
+            {
+                String name = coreInstance.getName();
+                try
+                {
+                    return Integer.valueOf(name);
+                }
+                catch (NumberFormatException e)
+                {
+                    try
+                    {
+                        return Long.valueOf(name);
+                    }
+                    catch (NumberFormatException e1)
+                    {
+                        return new BigInteger(name);
+                    }
+                }
+            }
+        }
+    };
+
+    public static final Function2<CoreInstance, ModelRepository, IntegerCoreInstance> CAST_CORE_INSTANCE_FN = new Function2<CoreInstance, ModelRepository, IntegerCoreInstance>()
+    {
+        public IntegerCoreInstance value(CoreInstance coreInstance, ModelRepository repository)
+        {
+            if (coreInstance == null)
+            {
+                return null;
+            }
+            else if (coreInstance instanceof IntegerCoreInstance)
+            {
+                return (IntegerCoreInstance) coreInstance;
+            }
+            else
+            {
+                return repository.newIntegerCoreInstance(coreInstance.getName());
+            }
         }
     };
 

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/IntegerCoreInstance.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/IntegerCoreInstance.java
@@ -23,58 +23,8 @@ import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
 public final class IntegerCoreInstance extends PrimitiveCoreInstance<Number>
 {
-    public static final Function<CoreInstance, Number> FROM_CORE_INSTANCE_FN = new Function<CoreInstance, Number>()
-    {
-        public Number valueOf(CoreInstance coreInstance)
-        {
-            if (coreInstance == null)
-            {
-                return null;
-            }
-            else if (coreInstance instanceof IntegerCoreInstance)
-            {
-                return ((IntegerCoreInstance) coreInstance).getValue();
-            }
-            else
-            {
-                String name = coreInstance.getName();
-                try
-                {
-                    return Integer.valueOf(name);
-                }
-                catch (NumberFormatException e)
-                {
-                    try
-                    {
-                        return Long.valueOf(name);
-                    }
-                    catch (NumberFormatException e1)
-                    {
-                        return new BigInteger(name);
-                    }
-                }
-            }
-        }
-    };
-
-    public static final Function2<CoreInstance, ModelRepository, IntegerCoreInstance> CAST_CORE_INSTANCE_FN = new Function2<CoreInstance, ModelRepository, IntegerCoreInstance>()
-    {
-        public IntegerCoreInstance value(CoreInstance coreInstance, ModelRepository repository)
-        {
-            if (coreInstance == null)
-            {
-                return null;
-            }
-            else if (coreInstance instanceof IntegerCoreInstance)
-            {
-                return (IntegerCoreInstance) coreInstance;
-            }
-            else
-            {
-                return repository.newIntegerCoreInstance(coreInstance.getName());
-            }
-        }
-    };
+    public static final Function<CoreInstance, Number> FROM_CORE_INSTANCE_FN = IntegerCoreInstance::valueOfCoreInstance;
+    public static final Function2<CoreInstance, ModelRepository, IntegerCoreInstance> CONVERT_CORE_INSTANCE_FN = IntegerCoreInstance::convertCoreInstance;
 
     private String name = null;
 
@@ -112,5 +62,52 @@ public final class IntegerCoreInstance extends PrimitiveCoreInstance<Number>
     public CoreInstance copy()
     {
         return new IntegerCoreInstance(this.getValue(), this.getClassifier(), this.getSyntheticId());
+    }
+
+    public static IntegerCoreInstance convertCoreInstance(CoreInstance coreInstance, ModelRepository repository)
+    {
+        if (coreInstance == null)
+        {
+            return null;
+        }
+        else if (coreInstance instanceof IntegerCoreInstance)
+        {
+            return (IntegerCoreInstance) coreInstance;
+        }
+        else
+        {
+            return repository.newIntegerCoreInstance(coreInstance.getName());
+        }
+    }
+
+    public static Number valueOfCoreInstance(CoreInstance coreInstance)
+    {
+        if (coreInstance == null)
+        {
+            return null;
+        }
+        else if (coreInstance instanceof IntegerCoreInstance)
+        {
+            return ((IntegerCoreInstance) coreInstance).getValue();
+        }
+        else
+        {
+            String name = coreInstance.getName();
+            try
+            {
+                return Integer.valueOf(name);
+            }
+            catch (NumberFormatException e)
+            {
+                try
+                {
+                    return Long.valueOf(name);
+                }
+                catch (NumberFormatException e1)
+                {
+                    return new BigInteger(name);
+                }
+            }
+        }
     }
 }

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/StrictTimeCoreInstance.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/StrictTimeCoreInstance.java
@@ -15,8 +15,11 @@
 package org.finos.legend.pure.m4.coreinstance.primitive;
 
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function2;
+import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.primitive.strictTime.PureStrictTime;
+import org.finos.legend.pure.m4.coreinstance.primitive.strictTime.StrictTimeFunctions;
 
 public final class StrictTimeCoreInstance extends PrimitiveCoreInstance<PureStrictTime>
 {
@@ -24,7 +27,37 @@ public final class StrictTimeCoreInstance extends PrimitiveCoreInstance<PureStri
     {
         public PureStrictTime valueOf(CoreInstance coreInstance)
         {
-            return coreInstance == null ? null : ((StrictTimeCoreInstance)coreInstance).getValue();
+            if (coreInstance == null)
+            {
+                return null;
+            }
+            else if (coreInstance instanceof StrictTimeCoreInstance)
+            {
+                return ((StrictTimeCoreInstance) coreInstance).getValue();
+            }
+            else
+            {
+                return StrictTimeFunctions.parsePureStrictTime(coreInstance.getName());
+            }
+        }
+    };
+
+    public static final Function2<CoreInstance, ModelRepository, StrictTimeCoreInstance> CAST_CORE_INSTANCE_FN = new Function2<CoreInstance, ModelRepository, StrictTimeCoreInstance>()
+    {
+        public StrictTimeCoreInstance value(CoreInstance coreInstance, ModelRepository repository)
+        {
+            if (coreInstance == null)
+            {
+                return null;
+            }
+            else if (coreInstance instanceof StrictTimeCoreInstance)
+            {
+                return (StrictTimeCoreInstance) coreInstance;
+            }
+            else
+            {
+                return repository.newStrictTimeCoreInstance(coreInstance.getName());
+            }
         }
     };
 

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/StrictTimeCoreInstance.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/StrictTimeCoreInstance.java
@@ -23,43 +23,8 @@ import org.finos.legend.pure.m4.coreinstance.primitive.strictTime.StrictTimeFunc
 
 public final class StrictTimeCoreInstance extends PrimitiveCoreInstance<PureStrictTime>
 {
-    public static final Function<CoreInstance, PureStrictTime> FROM_CORE_INSTANCE_FN = new Function<CoreInstance, PureStrictTime>()
-    {
-        public PureStrictTime valueOf(CoreInstance coreInstance)
-        {
-            if (coreInstance == null)
-            {
-                return null;
-            }
-            else if (coreInstance instanceof StrictTimeCoreInstance)
-            {
-                return ((StrictTimeCoreInstance) coreInstance).getValue();
-            }
-            else
-            {
-                return StrictTimeFunctions.parsePureStrictTime(coreInstance.getName());
-            }
-        }
-    };
-
-    public static final Function2<CoreInstance, ModelRepository, StrictTimeCoreInstance> CAST_CORE_INSTANCE_FN = new Function2<CoreInstance, ModelRepository, StrictTimeCoreInstance>()
-    {
-        public StrictTimeCoreInstance value(CoreInstance coreInstance, ModelRepository repository)
-        {
-            if (coreInstance == null)
-            {
-                return null;
-            }
-            else if (coreInstance instanceof StrictTimeCoreInstance)
-            {
-                return (StrictTimeCoreInstance) coreInstance;
-            }
-            else
-            {
-                return repository.newStrictTimeCoreInstance(coreInstance.getName());
-            }
-        }
-    };
+    public static final Function<CoreInstance, PureStrictTime> FROM_CORE_INSTANCE_FN = StrictTimeCoreInstance::valueOfCoreInstance;
+    public static final Function2<CoreInstance, ModelRepository, StrictTimeCoreInstance> CONVERT_CORE_INSTANCE_FN = StrictTimeCoreInstance::convertCoreInstance;
 
     private String name = null;
 
@@ -82,5 +47,37 @@ public final class StrictTimeCoreInstance extends PrimitiveCoreInstance<PureStri
     public CoreInstance copy()
     {
         return new StrictTimeCoreInstance(this.getValue(), this.getClassifier(), this.getSyntheticId());
+    }
+
+    public static StrictTimeCoreInstance convertCoreInstance(CoreInstance coreInstance, ModelRepository repository)
+    {
+        if (coreInstance == null)
+        {
+            return null;
+        }
+        else if (coreInstance instanceof StrictTimeCoreInstance)
+        {
+            return (StrictTimeCoreInstance) coreInstance;
+        }
+        else
+        {
+            return repository.newStrictTimeCoreInstance(coreInstance.getName());
+        }
+    }
+
+    public static PureStrictTime valueOfCoreInstance(CoreInstance coreInstance)
+    {
+        if (coreInstance == null)
+        {
+            return null;
+        }
+        else if (coreInstance instanceof StrictTimeCoreInstance)
+        {
+            return ((StrictTimeCoreInstance) coreInstance).getValue();
+        }
+        else
+        {
+            return StrictTimeFunctions.parsePureStrictTime(coreInstance.getName());
+        }
     }
 }

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/StringCoreInstance.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/StringCoreInstance.java
@@ -15,6 +15,8 @@
 package org.finos.legend.pure.m4.coreinstance.primitive;
 
 import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function2;
+import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
 public final class StringCoreInstance extends PrimitiveCoreInstance<String>
@@ -23,7 +25,37 @@ public final class StringCoreInstance extends PrimitiveCoreInstance<String>
     {
         public String valueOf(CoreInstance coreInstance)
         {
-            return coreInstance == null ? null : ((StringCoreInstance)coreInstance).getValue();
+            if (coreInstance == null)
+            {
+                return null;
+            }
+            else if (coreInstance instanceof StringCoreInstance)
+            {
+                return ((StringCoreInstance) coreInstance).getValue();
+            }
+            else
+            {
+                return coreInstance.getName();
+            }
+        }
+    };
+
+    public static final Function2<CoreInstance, ModelRepository, StringCoreInstance> CAST_CORE_INSTANCE_FN = new Function2<CoreInstance, ModelRepository, StringCoreInstance>()
+    {
+        public StringCoreInstance value(CoreInstance coreInstance, ModelRepository repository)
+        {
+            if (coreInstance == null)
+            {
+                return null;
+            }
+            else if (coreInstance instanceof StringCoreInstance)
+            {
+                return (StringCoreInstance) coreInstance;
+            }
+            else
+            {
+                return repository.newStringCoreInstance(coreInstance.getName());
+            }
         }
     };
 

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/StringCoreInstance.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/StringCoreInstance.java
@@ -21,43 +21,8 @@ import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
 public final class StringCoreInstance extends PrimitiveCoreInstance<String>
 {
-    public static final Function<CoreInstance, String> FROM_CORE_INSTANCE_FN = new Function<CoreInstance, String>()
-    {
-        public String valueOf(CoreInstance coreInstance)
-        {
-            if (coreInstance == null)
-            {
-                return null;
-            }
-            else if (coreInstance instanceof StringCoreInstance)
-            {
-                return ((StringCoreInstance) coreInstance).getValue();
-            }
-            else
-            {
-                return coreInstance.getName();
-            }
-        }
-    };
-
-    public static final Function2<CoreInstance, ModelRepository, StringCoreInstance> CAST_CORE_INSTANCE_FN = new Function2<CoreInstance, ModelRepository, StringCoreInstance>()
-    {
-        public StringCoreInstance value(CoreInstance coreInstance, ModelRepository repository)
-        {
-            if (coreInstance == null)
-            {
-                return null;
-            }
-            else if (coreInstance instanceof StringCoreInstance)
-            {
-                return (StringCoreInstance) coreInstance;
-            }
-            else
-            {
-                return repository.newStringCoreInstance(coreInstance.getName());
-            }
-        }
-    };
+    public static final Function<CoreInstance, String> FROM_CORE_INSTANCE_FN = StringCoreInstance::valueOfCoreInstance;
+    public static final Function2<CoreInstance, ModelRepository, StringCoreInstance> CONVERT_CORE_INSTANCE_FN = StringCoreInstance::convertCoreInstance;
 
     StringCoreInstance(String value, CoreInstance classifier, int internalSyntheticId)
     {
@@ -74,5 +39,37 @@ public final class StringCoreInstance extends PrimitiveCoreInstance<String>
     public CoreInstance copy()
     {
         return new StringCoreInstance(this.getValue(), this.getClassifier(), this.getSyntheticId());
+    }
+
+    public static StringCoreInstance convertCoreInstance(CoreInstance coreInstance, ModelRepository repository)
+    {
+        if (coreInstance == null)
+        {
+            return null;
+        }
+        else if (coreInstance instanceof StringCoreInstance)
+        {
+            return (StringCoreInstance) coreInstance;
+        }
+        else
+        {
+            return repository.newStringCoreInstance(coreInstance.getName());
+        }
+    }
+
+    public static  String valueOfCoreInstance(CoreInstance coreInstance)
+    {
+        if (coreInstance == null)
+        {
+            return null;
+        }
+        else if (coreInstance instanceof StringCoreInstance)
+        {
+            return ((StringCoreInstance) coreInstance).getValue();
+        }
+        else
+        {
+            return coreInstance.getName();
+        }
     }
 }


### PR DESCRIPTION
This PR proposes a change to avoid direct casting primitive core instances during interpreted flow to better interoperate with compile primitives ValCoreInstance.  By delegating to the primitive class, we can either direct cast or create a new instance to meet the expected type.  

This is important for the legend-engine compile function, as interpreted flow interoperate with compiled instances.  Without this change, the code ends on class cast exception like this:

```
Caused by: java.lang.ClassCastException: class org.finos.legend.pure.runtime.java.compiled.generation.processors.support.coreinstance.ValCoreInstance cannot be cast to class org.finos.legend.pure.m4.coreinstance.primitive.StringCoreInstance (org.finos.legend.pure.runtime.java.compiled.generation.processors.support.coreinstance.ValCoreInstance and org.finos.legend.pure.m4.coreinstance.primitive.StringCoreInstance are in unnamed module of loader 'app')
	at org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinitionInstance.addKeyValue(ConcreteFunctionDefinitionInstance.java:1012)
	at org.finos.legend.pure.m3.navigation.Instance.addValueToProperty(Instance.java:90)
	at org.finos.legend.pure.runtime.java.interpreted.natives.grammar.lang.Copy.copy(Copy.java:204)
	at org.finos.legend.pure.runtime.java.interpreted.natives.grammar.lang.Copy.execute(Copy.java:165)
	at org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted.executeFunction(FunctionExecutionInterpreted.java:486)
	... 34 more
```
