### PR TITLE
IDE Light: Read runtime options from system properties

### DIFF
--- a/legend-pure-ide-light/pom.xml
+++ b/legend-pure-ide-light/pom.xml
@@ -156,6 +156,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
         </dependency>

--- a/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/PureIDEServer.java
+++ b/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/PureIDEServer.java
@@ -23,11 +23,7 @@ import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 import io.federecio.dropwizard.swagger.SwaggerResource;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
-import org.finos.legend.pure.ide.light.api.Activities;
-import org.finos.legend.pure.ide.light.api.Suggestion;
-import org.finos.legend.pure.ide.light.api.FileManagement;
-import org.finos.legend.pure.ide.light.api.LifeCycle;
-import org.finos.legend.pure.ide.light.api.Service;
+import org.finos.legend.pure.ide.light.api.*;
 import org.finos.legend.pure.ide.light.api.concept.Concept;
 import org.finos.legend.pure.ide.light.api.concept.MovePackageableElements;
 import org.finos.legend.pure.ide.light.api.concept.RenameConcept;
@@ -100,6 +96,9 @@ public abstract class PureIDEServer extends Application<ServerConfiguration>
         environment.jersey().register(new Activities(pureSession));
         environment.jersey().register(new FileManagement(pureSession));
         environment.jersey().register(new LifeCycle(pureSession));
+        environment.jersey().register(new RuntimeOptions(pureSession));
+        environment.jersey().register(new EngineMode(pureSession));
+        environment.jersey().register(new EmbeddedH2(pureSession));
 
         environment.jersey().register(new Suggestion(pureSession));
 

--- a/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/EmbeddedH2.java
+++ b/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/EmbeddedH2.java
@@ -1,0 +1,49 @@
+package org.finos.legend.pure.ide.light.api;
+
+import io.swagger.annotations.Api;
+import org.finos.legend.pure.ide.light.session.PureSession;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import java.util.Optional;
+
+
+@Api(tags = "Enable/disable external H2 for running tests")
+@Path("/h2")
+public class EmbeddedH2
+{
+    private final PureSession pureSession;
+
+    public EmbeddedH2(PureSession pureSession)
+    {
+        this.pureSession = pureSession;
+    }
+
+    @GET
+    @Path("isExternalH2Enabled")
+    public boolean isExternalH2Enabled()
+    {
+        return !this.pureSession.isEmbeddedH2Enabled();
+    }
+
+    @GET
+    @Path("enableExtenalH2")
+    public void enableExternalH2()
+    {
+        this.pureSession.disableEmbeddedH2(Optional.empty());
+    }
+    @GET
+    @Path("enableExternalH2/{port}")
+    public void enableEmbeddedH2WithPort(@PathParam("port") String port)
+    {
+        this.pureSession.disableEmbeddedH2(Optional.of(port));
+    }
+
+    @GET
+    @Path("disableExternalH2")
+    public void disableExternalH2()
+    {
+        this.pureSession.enableEmbeddedH2();
+    }
+}

--- a/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/EngineMode.java
+++ b/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/EngineMode.java
@@ -1,0 +1,130 @@
+package org.finos.legend.pure.ide.light.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.annotations.Api;
+import org.finos.legend.pure.ide.light.session.PureSession;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.util.Optional;
+
+@Api(tags = "Engine Execution Mode Options")
+@Path("/engineMode")
+public class EngineMode
+{
+    private final PureSession pureSession;
+
+    public EngineMode(PureSession session)
+    {
+        this.pureSession = session;
+    }
+
+    @GET
+    @Path("getAllProperties")
+    public Response getAllEngineProperties(@Context HttpServletRequest request, @Context HttpServletResponse response)
+    {
+        return Response.ok((StreamingOutput) outputStream ->
+        {
+            ObjectMapper om = new ObjectMapper();
+            outputStream.write(om.writeValueAsBytes(this.pureSession.getEngineProperties()));
+            outputStream.close();
+        }).build();
+    }
+
+    @GET
+    @Path("enable")
+    public void enableEngineMode()
+    {
+        this.pureSession.enableEngineMode();
+    }
+
+    @GET
+    @Path("disable")
+    public void disableEngineMode()
+    {
+        this.pureSession.disableEngineMode();
+    }
+
+    @GET
+    @Path("isEnabled")
+    public boolean isEngineModeEnabled()
+    {
+        return this.pureSession.isEngineModeEnabled();
+    }
+
+    @GET
+    @Path("setTestServerHost/{host}")
+    public void setEngineTestServerHost(@PathParam("host") String host)
+    {
+        this.pureSession.setLegendTestServerHost(host);
+    }
+
+    @GET
+    @Path("setTestServerPort/{port}")
+    public void setEngineTestServerPort(@PathParam("port") String port)
+    {
+        this.pureSession.setLegendTestServerPort(port);
+    }
+
+    @GET
+    @Path("setTestClientVersion/{clientVersion}")
+    public void setEngineTestClientVersion(@PathParam("clientVersion") String clientVersion)
+    {
+        this.pureSession.setLegendTestClientVersion(clientVersion);
+    }
+
+    @GET
+    @Path("setTestServerVersion/{serverVersion}")
+    public void setEngineTestServerVersion(@PathParam("serverVersion") String serverVersion)
+    {
+        this.pureSession.setLegendTestServerVersion(serverVersion);
+    }
+
+    @GET
+    @Path("setTestSerializationKind/{kind}")
+    public void setEngineTestSerializationKind(@PathParam("kind") String kind)
+    {
+        this.pureSession.setLegendTestSerializationKind(kind);
+    }
+
+    @GET
+    @Path("getTestServerHost")
+    public String getEngineTestServerHost()
+    {
+        return this.pureSession.getLegendTestServerHost();
+    }
+
+    @GET
+    @Path("getTestServerPort")
+    public String getEngineTestServerPort()
+    {
+        return this.pureSession.getLegendTestServerPort();
+    }
+
+    @GET
+    @Path("getTestClientVersion")
+    public String getEngineTestClientVersion()
+    {
+        return this.pureSession.getLegendTestClientVersion();
+    }
+
+    @GET
+    @Path("getTestServerVersion")
+    public String getEngineTestServerVersion()
+    {
+        return this.pureSession.getLegendTestServerVersion();
+    }
+
+    @GET
+    @Path("getTestSerializationKind")
+    public String getEngineTestSerializationKind()
+    {
+        return this.pureSession.getLegendTestSerializationKind();
+    }
+}

--- a/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/RuntimeOptions.java
+++ b/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/RuntimeOptions.java
@@ -1,0 +1,63 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.ide.light.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.annotations.Api;
+import org.finos.legend.pure.ide.light.session.PureSession;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+
+@Api(tags = "Runtime Options")
+@Path("/runtimeOptions")
+public class RuntimeOptions {
+    private PureSession pureSession;
+
+    public RuntimeOptions(PureSession pureSession) {
+        this.pureSession = pureSession;
+    }
+
+    @GET
+    @Path("set/{name}/{value}")
+    public void setRuntimeOption(@PathParam("name") String name, @PathParam("value") Boolean value) {
+        this.pureSession.setRuntimeOption(name, value);
+    }
+
+    @GET
+    @Path("get/{name}")
+    public boolean getRuntimeOption(@PathParam("name") String name) {
+        return this.pureSession.getRuntimeOption(name).orElse(false);
+    }
+
+    @GET
+    @Path("getAll")
+    public Response getAllPureOptions(@Context HttpServletRequest request, @Context HttpServletResponse response) {
+        return Response.ok((StreamingOutput) outputStream ->
+        {
+            ObjectMapper om = new ObjectMapper();
+            outputStream.write(om.writeValueAsBytes(this.pureSession.getAllRuntimeOptions()));
+            outputStream.close();
+        }).build();
+    }
+
+
+}

--- a/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/execution/function/Execute.java
+++ b/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/execution/function/Execute.java
@@ -24,6 +24,7 @@ import org.finos.legend.pure.ide.light.helpers.JSONResponseTools;
 import org.finos.legend.pure.ide.light.session.PureSession;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -93,5 +94,16 @@ public class Execute
                 JSONResponseTools.sendJSONErrorResponse(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e, false);
             }
         }).build();
+    }
+
+    @GET
+    @Path("cancelExecution")
+    public void cancelExecution()
+    {
+        FunctionExecution functionExecution = pureSession.getFunctionExecution();
+        if (functionExecution instanceof FunctionExecutionInterpreted)
+        {
+            ((FunctionExecutionInterpreted) functionExecution).cancelExecution();
+        }
     }
 }


### PR DESCRIPTION
Allow setting of runtime options from system properties in Pure IDE Light. Allows developers to set options in execution plan generation to aid debugging/development in Pure IDE Light (for example options look [here](https://github.com/finos/legend-engine/blob/aaa58d3c160c35ce2938e65fe847c3fedbef1173/legend-engine-pure-code-compiled-core/src/main/resources/core/pure/protocol/vX_X_X/invocations/execution.pure#L187))