### PR TITLE
Function stereotype to signify normalize/preeval required

### DIFF
--- a/legend-pure-m3-core/src/main/resources/platform/pure/profile.pure
+++ b/legend-pure-m3-core/src/main/resources/platform/pure/profile.pure
@@ -14,5 +14,5 @@
 
 Profile meta::pure::profiles::functionType
 {
-    stereotypes : [SideEffectFunction, NotImplementedFunction];
+    stereotypes : [SideEffectFunction, NotImplementedFunction, NormalizeRequiredFunction];
 }

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/function/TestFunctionReturnMultiplicity.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/function/TestFunctionReturnMultiplicity.java
@@ -81,7 +81,7 @@ public class TestFunctionReturnMultiplicity extends AbstractPureTestWithCoreComp
         CoreInstance result = this.compileAndExecute("test():Any[*]");
         ListIterable<? extends CoreInstance> values = result.getValueForMetaPropertyToMany("values");
         Assert.assertEquals(7, values.size());
-        Assert.assertEquals("a instanceOf String,1 instanceOf Integer,2.0 instanceOf Float,2015-03-12 instanceOf StrictDate,2015-03-12T23:59:00+0000 instanceOf DateTime,true instanceOf Boolean,Class(48517) instanceOf Class", values.makeString(","));
+        Assert.assertEquals("a instanceOf String,1 instanceOf Integer,2.0 instanceOf Float,2015-03-12 instanceOf StrictDate,2015-03-12T23:59:00+0000 instanceOf DateTime,true instanceOf Boolean,Class(48518) instanceOf Class", values.makeString(","));
     }
 
 
@@ -116,7 +116,7 @@ public class TestFunctionReturnMultiplicity extends AbstractPureTestWithCoreComp
                 "}\n");
         CoreInstance result = this.compileAndExecute("test():Any[*]");
         CoreInstance value = result.getValueForMetaPropertyToOne("values");
-        Assert.assertEquals("Class(48517) instanceOf Class", value.toString());
+        Assert.assertEquals("Class(48518) instanceOf Class", value.toString());
     }
 
     @Test


### PR DESCRIPTION
Add a new stereotype to mark functions as requiring a preeval/normalize call before being routed.
