### PR TITLE
Upgrade h2 to v2.1.214

### DIFF
--- a/legend-pure-m2-store-relational-grammar/src/test/java/org/finos/legend/pure/m2/relational/AbstractTestPureDBFunction.java
+++ b/legend-pure-m2-store-relational-grammar/src/test/java/org/finos/legend/pure/m2/relational/AbstractTestPureDBFunction.java
@@ -42,7 +42,7 @@ public abstract class AbstractTestPureDBFunction extends AbstractPureTestWithCor
                         "Database mydb()\n"
         );
         PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> compileAndExecute("test():Any[0..1]"));
-        assertPureException(PureExecutionException.class, Pattern.compile("Error executing sql query; SQL reason: Syntax error in SQL statement \"CREATE LOCAL TEMPORARY TABLE \\(\\[\\*]COL INT\\) ?\"; expected \"identifier\"; SQL statement:\n" +
+        assertPureException(PureExecutionException.class, Pattern.compile("Error executing sql query; SQL reason: Syntax error in SQL statement \"Create LOCAL TEMPORARY TABLE \\[\\*]\\(col INT\\) ?\"; expected \"identifier\"; SQL statement:\n" +
                 "Create LOCAL TEMPORARY TABLE \\(col INT\\) \\[42001-\\d++]; SQL error code: 42001; SQL state: 42001"), 8, 4, e);
     }
 
@@ -84,7 +84,7 @@ public abstract class AbstractTestPureDBFunction extends AbstractPureTestWithCor
                         "Database mydb()\n"
         );
         PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> compileAndExecute("test():Any[0..1]"));
-        assertPureException(PureExecutionException.class, Pattern.compile("Error executing sql query; SQL reason: Table \"TT\" not found; SQL statement:\n" +
-                "select \\* from tt \\[42102-\\d++]; SQL error code: 42102; SQL state: 42S02"), 8, 4, e);
+        assertPureException(PureExecutionException.class, Pattern.compile("Error executing sql query; SQL reason: Table \"TT\" not found \\(this database is empty\\); SQL statement:\n" +
+                "select \\* from tt \\[42104-\\d++]; SQL error code: 42104; SQL state: 42S04"), 8, 4, e);
     }
 }

--- a/legend-pure-runtime-java-extension-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
+++ b/legend-pure-runtime-java-extension-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
@@ -28,8 +28,6 @@ import org.finos.legend.pure.runtime.java.extension.store.relational.shared.Conn
 import org.finos.legend.pure.runtime.java.extension.store.relational.shared.DataSource;
 import org.finos.legend.pure.runtime.java.extension.store.relational.shared.DataSourceConnectionDisplayInfo;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
 

--- a/legend-pure-runtime-java-extension-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
+++ b/legend-pure-runtime-java-extension-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
@@ -28,6 +28,8 @@ import org.finos.legend.pure.runtime.java.extension.store.relational.shared.Conn
 import org.finos.legend.pure.runtime.java.extension.store.relational.shared.DataSource;
 import org.finos.legend.pure.runtime.java.extension.store.relational.shared.DataSourceConnectionDisplayInfo;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -36,13 +38,16 @@ public class TestDatabaseConnect extends PerThreadPoolableConnectionProvider
     public static final String TEST_DB_HOST_NAME = "local";
     private static final String TEST_DB_NAME = "pure-h2-test-Db";
     private static final DataSource TEST_DATA_SOURCE = new DataSource(TEST_DB_HOST_NAME, -1, TEST_DB_NAME, null);
-
+    private static final String DEFAULT_H2_PROPERTIES = System.getProperty("legend.test.h2.properties",
+            ";NON_KEYWORDS=ANY,ASYMMETRIC,AUTHORIZATION,CURRENT_PATH,CURRENT_ROLE,DAY,DEFAULT,HOUR,MINUTE,MONTH,SECOND,SESSION_USER,SET,SOME,SYMMETRIC,SYSTEM_USER,TO,UESCAPE,USER,TO,YEAR");
     private static final Function0<String> CONNECTION_URL = new Function0<String>()
     {
         @Override
         public String value()
         {
-            return System.getProperty("legend.test.h2.port") != null ? "jdbc:h2:tcp://127.0.0.1:" + System.getProperty("legend.test.h2.port") + "/mem:testDB" : "jdbc:h2:mem:;ALIAS_COLUMN_NAME=TRUE";
+            return System.getProperty("legend.test.h2.port") != null ?
+                    "jdbc:h2:tcp://127.0.0.1:" + System.getProperty("legend.test.h2.port") + "/mem:testDB" : "jdbc:h2:mem:"
+                    + DEFAULT_H2_PROPERTIES;
         }
     };
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <guava.version>30.0-jre</guava.version>
-        <h2.version>1.4.200</h2.version>
+        <h2.version>2.1.214</h2.version>
 
         <!-- Plugin -->
         <jacoco.maven.plugin.version>0.8.5</jacoco.maven.plugin.version>


### PR DESCRIPTION
Upgrades h2 version and fixes broken tests.

legend.test.h2.properties system property is added to preserve compatibility and to be configurable.
NON_KEYWORDS is used on keywords that were added between 1.4.200 and 2.1.214 to maintain behavior of current SQL.

Before merging, legend-engine will require setting the legend.test.h2.properties to preserve compatibility.