### PR TITLE
Add more non_keywords for compatibility

### DIFF
--- a/legend-pure-runtime-java-extension-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
+++ b/legend-pure-runtime-java-extension-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
@@ -37,7 +37,7 @@ public class TestDatabaseConnect extends PerThreadPoolableConnectionProvider
     private static final String TEST_DB_NAME = "pure-h2-test-Db";
     private static final DataSource TEST_DATA_SOURCE = new DataSource(TEST_DB_HOST_NAME, -1, TEST_DB_NAME, null);
     private static final String DEFAULT_H2_PROPERTIES = System.getProperty("legend.test.h2.properties",
-            ";NON_KEYWORDS=ANY,ASYMMETRIC,AUTHORIZATION,CURRENT_PATH,CURRENT_ROLE,DAY,DEFAULT,HOUR,MINUTE,MONTH,SECOND,SESSION_USER,SET,SOME,SYMMETRIC,SYSTEM_USER,TO,UESCAPE,USER,TO,YEAR");
+            ";NON_KEYWORDS=ANY,ASYMMETRIC,AUTHORIZATION,CAST,CURRENT_PATH,CURRENT_ROLE,DAY,DEFAULT,ELSE,END,HOUR,KEY,MINUTE,MONTH,SECOND,SESSION_USER,SET,SOME,SYMMETRIC,SYSTEM_USER,TO,UESCAPE,USER,VALUE,WHEN,YEAR");
     private static final Function0<String> CONNECTION_URL = new Function0<String>()
     {
         @Override


### PR DESCRIPTION
Adds missing new keywords (when compared to v1.4.200) to preserve compatibility through upgrade.

Deletes duplicate 'TO'.