### PR TITLE
Add more H2 backward compatibility settings

### DIFF
--- a/legend-pure-runtime-java-extension-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/interpreted/natives/ExecuteInDb.java
+++ b/legend-pure-runtime-java-extension-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/interpreted/natives/ExecuteInDb.java
@@ -85,6 +85,7 @@ public class ExecuteInDb extends NativeFunction
             .withKeyValue(Types.DATE, M3Paths.StrictDate)
             .withKeyValue(Types.TIME, M3Paths.DateTime)
             .withKeyValue(Types.TIMESTAMP, M3Paths.DateTime)
+            .withKeyValue(Types.TIMESTAMP_WITH_TIMEZONE, M3Paths.DateTime)
 
             .withKeyValue(Types.BOOLEAN, M3Paths.Boolean)
             .withKeyValue(Types.BIT, M3Paths.Boolean)
@@ -280,6 +281,7 @@ public class ExecuteInDb extends NativeFunction
                             break;
                         }
                         case Types.TIMESTAMP:
+                        case Types.TIMESTAMP_WITH_TIMEZONE:
                         {
                             java.sql.Timestamp timestamp = rs.getTimestamp(i, calendar);
                             if (timestamp != null)

--- a/legend-pure-runtime-java-extension-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
+++ b/legend-pure-runtime-java-extension-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
@@ -34,7 +34,7 @@ public class TestDatabaseConnect extends PerThreadPoolableConnectionProvider
     private static final String TEST_DB_NAME = "pure-h2-test-Db";
     private static final DataSource TEST_DATA_SOURCE = new DataSource(TEST_DB_HOST_NAME, -1, TEST_DB_NAME, null);
     private static final String DEFAULT_H2_PROPERTIES = System.getProperty("legend.test.h2.properties",
-            ";NON_KEYWORDS=ANY,ASYMMETRIC,AUTHORIZATION,CAST,CURRENT_PATH,CURRENT_ROLE,DAY,DEFAULT,ELSE,END,HOUR,KEY,MINUTE,MONTH,SECOND,SESSION_USER,SET,SOME,SYMMETRIC,SYSTEM_USER,TO,UESCAPE,USER,VALUE,WHEN,YEAR");
+            ";NON_KEYWORDS=ANY,ASYMMETRIC,AUTHORIZATION,CAST,CURRENT_PATH,CURRENT_ROLE,DAY,DEFAULT,ELSE,END,HOUR,KEY,MINUTE,MONTH,SECOND,SESSION_USER,SET,SOME,SYMMETRIC,SYSTEM_USER,TO,UESCAPE,USER,VALUE,WHEN,YEAR;MODE=LEGACY");
 
     private final KeyLockManager<String> userLocks = KeyLockManager.newManager();
 

--- a/legend-pure-runtime-java-extension-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
+++ b/legend-pure-runtime-java-extension-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
@@ -96,9 +96,10 @@ public class TestDatabaseConnect extends PerThreadPoolableConnectionProvider
     private static String getConnectionURL()
     {
         String port = System.getProperty("legend.test.h2.port");
-        return (port != null) ?
+        return ((port != null) ?
                 ("jdbc:h2:tcp://127.0.0.1:" + port + "/mem:testDB") :
-                ("jdbc:h2:mem:" + DEFAULT_H2_PROPERTIES);
+                "jdbc:h2:mem:")
+                + DEFAULT_H2_PROPERTIES;
     }
 
     private static Pair<ThreadLocal<PerThreadPoolableConnectionWrapper>, BasicDataSource> newTestDataSourcePair()


### PR DESCRIPTION
Required to handle new parsedatetime() return values in interpreted mode and to better match previous H2's SQL semantics.

More detail on compatibility can be found: https://www.h2database.com/html/features.html#compatibility