### PR TITLE
Switch VCS revisions to String from Long

### DIFF
--- a/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/FileManagement.java
+++ b/legend-pure-ide-light/src/main/java/org/finos/legend/pure/ide/light/api/FileManagement.java
@@ -38,6 +38,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 @Api(tags = "File Management")
@@ -308,7 +309,9 @@ public class FileManagement
     private void writeRepoNode(StringBuilder builder, MutableRepositoryCodeStorage cs, String path, CodeStorageNode repo)
     {
         VersionControlledCodeStorage codeStorage = (VersionControlledCodeStorage) cs;
-        long currentRevision = codeStorage.getCurrentRevision(path);
+        // Assume SVN until Git code storage is added
+        Optional<String> currentRev = codeStorage.getCurrentRevision(path);
+        long currentRevision = currentRev.isPresent() ? Long.parseLong(currentRev.get()) : 0L;
         String repoName = codeStorage.getRepositoryForPath(path).getName();
         builder.append("{\"li_attr\":{\"id\":\"file_");
         builder.append(path);

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/RepositoryRevisionCache.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/RepositoryRevisionCache.java
@@ -18,9 +18,11 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.list.primitive.LongList;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.vcs.Revision;
 
+import java.util.List;
+
 public interface RepositoryRevisionCache
 {
-    LongList getAllRevisions(String path);
+    List<String> getAllRevisions(String path);
 
     RichIterable<Revision> getRevisionsByPath(RichIterable<String> paths);
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/classpath/PureModelVersion.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/classpath/PureModelVersion.java
@@ -16,14 +16,15 @@ package org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classp
 
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Optional;
 import java.util.Properties;
 
 public class PureModelVersion
 {
-    public static final long PURE_MODEL_VERSION = version("pure_model_version");
+    public static final Optional<String> PURE_MODEL_VERSION = version("pure_model_version");
     public static final String PURE_MODEL_VERSION_SPEC = String.format("{\"pure-model\" : %d}", PURE_MODEL_VERSION);
 
-    private static long version(String name)
+    private static Optional<String> version(String name)
     {
         try
         {
@@ -33,12 +34,12 @@ public class PureModelVersion
             {
                 properties.load(stream);
                 String versionAsString = properties.getProperty("version");
-                return (versionAsString == null) ? 0L : Long.parseLong(versionAsString);
+                return Optional.ofNullable(versionAsString);
             }
         }
         catch (Exception ignore)
         {
-            return 0L;
+            return Optional.empty();
         }
     }
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/classpath/VersionControlledClassLoaderCodeStorage.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/classpath/VersionControlledClassLoaderCodeStorage.java
@@ -15,17 +15,18 @@
 package org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath;
 
 import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.api.list.primitive.LongList;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.factory.primitive.LongLists;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.CodeStorageNode;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.RepositoryCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.RepositoryRevisionCache;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.vcs.Revision;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.vcs.VersionControlledCodeStorage;
+
+import java.util.List;
+import java.util.Optional;
 
 
 public class VersionControlledClassLoaderCodeStorage extends ClassLoaderCodeStorage implements VersionControlledCodeStorage
@@ -61,17 +62,17 @@ public class VersionControlledClassLoaderCodeStorage extends ClassLoaderCodeStor
     }
 
     @Override
-    public long getCurrentRevision(String path)
+    public Optional<String> getCurrentRevision(String path)
     {
-        return isVersioned(path) ? PureModelVersion.PURE_MODEL_VERSION : -1L;
+        return isVersioned(path) ? PureModelVersion.PURE_MODEL_VERSION : Optional.empty();
     }
 
     @Override
-    public LongList getAllRevisions(String path)
+    public List<String> getAllRevisions(String path)
     {
         if (!isVersioned(path))
         {
-            return LongLists.immutable.empty();
+            return Lists.mutable.empty();
         }
         if (this.repositoryRevisionCache == null)
         {

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/composite/CompositeCodeStorage.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/composite/CompositeCodeStorage.java
@@ -19,7 +19,6 @@ import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.procedure.Procedure2;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.list.primitive.LongList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
@@ -48,6 +47,8 @@ import org.finos.legend.pure.m3.serialization.runtime.Source;
 import java.io.*;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
 
 public class CompositeCodeStorage implements MutableVersionControlledCodeStorage
 {
@@ -286,17 +287,17 @@ public class CompositeCodeStorage implements MutableVersionControlledCodeStorage
     }
 
     @Override
-    public long getCurrentRevision(String path)
+    public Optional<String> getCurrentRevision(String path)
     {
         RepositoryCodeStorage codeStorage = getCodeStorage(path);
-        return (codeStorage instanceof VersionControlledCodeStorage) ? ((VersionControlledCodeStorage) codeStorage).getCurrentRevision(path) : -1;
+        return (codeStorage instanceof VersionControlledCodeStorage) ? ((VersionControlledCodeStorage) codeStorage).getCurrentRevision(path) : Optional.empty();
     }
 
     @Override
-    public LongList getAllRevisions(String path)
+    public List<String> getAllRevisions(String path)
     {
         RepositoryCodeStorage codeStorage = getCodeStorage(path);
-        return (codeStorage instanceof VersionControlledCodeStorage) ? ((VersionControlledCodeStorage) codeStorage).getAllRevisions(path) : LongLists.immutable.empty();
+        return (codeStorage instanceof VersionControlledCodeStorage) ? ((VersionControlledCodeStorage) codeStorage).getAllRevisions(path) : Lists.mutable.empty();
     }
 
     @Override

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/vcs/Revision.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/vcs/Revision.java
@@ -24,32 +24,22 @@ import java.util.Date;
 
 public class Revision
 {
-    public static final Function<Revision, Long> GET_REVISION = new Function<Revision, Long>()
+    public static final Function<Revision, String> GET_REVISION = new Function<Revision, String>()
     {
         @Override
-        public Long valueOf(Revision revision)
+        public String valueOf(Revision revision)
         {
             return revision.getRevision();
         }
     };
 
-    public static final LongFunction<Revision> GET_REVISION_LONG = new LongFunction<Revision>()
-    {
-        @Override
-        public long longValueOf(Revision revision)
-        {
-            return revision.getRevision();
-        }
-    };
-
-
-    private final long revision;
+    private final String revision;
     private ImmutableList<ChangedPath> changedPaths;
     private final String author;
     private final String message;
     private final Date date;
 
-    public Revision(long revision, String author, Date date, String message)
+    public Revision(String revision, String author, Date date, String message)
     {
         this.revision = revision;
         this.author = author.trim();
@@ -77,7 +67,7 @@ public class Revision
         return this.message;
     }
 
-    public long getRevision()
+    public String getRevision()
     {
         return this.revision;
     }
@@ -111,7 +101,7 @@ public class Revision
     @Override
     public int hashCode()
     {
-        return (int)(this.revision ^ (this.revision >>> 32));
+        return this.revision.hashCode();
     }
 
 }

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/vcs/VersionControlledCodeStorage.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/vcs/VersionControlledCodeStorage.java
@@ -19,6 +19,9 @@ import org.eclipse.collections.api.list.primitive.LongList;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.CodeStorageNode;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.RepositoryCodeStorage;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface VersionControlledCodeStorage extends RepositoryCodeStorage
 {
     /**
@@ -37,7 +40,7 @@ public interface VersionControlledCodeStorage extends RepositoryCodeStorage
      * @param path Pure path
      * @return current revision number or -1
      */
-    long getCurrentRevision(String path);
+    Optional<String> getCurrentRevision(String path);
 
     /**
      * Get all revision numbers at which changes were made to the
@@ -47,7 +50,7 @@ public interface VersionControlledCodeStorage extends RepositoryCodeStorage
      * @param path Pure path
      * @return all revision numbers for path
      */
-    LongList getAllRevisions(String path);
+    List<String> getAllRevisions(String path);
 
     RichIterable<Revision> getAllRevisionLogs(RichIterable<String> path);
 

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/binary/BinaryModelRepositorySerializer.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/binary/BinaryModelRepositorySerializer.java
@@ -32,6 +32,7 @@ import org.finos.legend.pure.m4.serialization.binary.BinaryWriters;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Optional;
 
 public class BinaryModelRepositorySerializer
 {
@@ -105,8 +106,8 @@ public class BinaryModelRepositorySerializer
             return null;
         }
         RepositoryCodeStorage codeStorage = this.runtime.getCodeStorage();
-        long repoRevision = codeStorage instanceof VersionControlledCodeStorage ? ((VersionControlledCodeStorage) codeStorage).getCurrentRevision(this.repositoryName) : -1L;
-        return (repoRevision == -1L) ? null : ("SNAPSHOT-FROM-SVN-" + repoRevision);
+        Optional<String> repoRevision = codeStorage instanceof VersionControlledCodeStorage ? ((VersionControlledCodeStorage) codeStorage).getCurrentRevision(this.repositoryName) : Optional.empty();
+        return repoRevision.isPresent() ? ("SNAPSHOT-FROM-SVN-" + repoRevision.get()) : null;
     }
 
     private static Pair<String, String> getFilePathSortKey(String path)


### PR DESCRIPTION
Switch VCS revisions to String from Long to enable work on Git Code Storage