### PR TITLE
Add returnType in propertyGraphFetchTree

### DIFF
--- a/legend-pure-m2-dsl-graph-pure/src/main/resources/platform_dsl_graph/graph.pure
+++ b/legend-pure-m2-dsl-graph-pure/src/main/resources/platform_dsl_graph/graph.pure
@@ -47,10 +47,16 @@ Class meta::pure::graphFetch::PropertyGraphFetchTree extends GraphFetchTree
    subType : Class<Any>[0..1];
    
    isPrimitive(){
-      $this.property.genericType.rawType->toOne()->instanceOf(PrimitiveType) || $this.property.genericType.rawType->toOne()->instanceOf(Enumeration)
+      $this.returnType()->instanceOf(PrimitiveType) || $this.returnType->instanceOf(Enumeration)
    }:Boolean[1];
 
    isQualifiedProperty(){
       $this.property->instanceOf(QualifiedProperty)
    }:Boolean[1];
+   
+   returnType(){
+      if($this.subType->isEmpty(),
+        | $this.property->genericType.rawType->toOne(),
+        | $this.subType->toOne());
+   }:Type[1];
 }

--- a/legend-pure-m2-dsl-graph-pure/src/main/resources/platform_dsl_graph/graph.pure
+++ b/legend-pure-m2-dsl-graph-pure/src/main/resources/platform_dsl_graph/graph.pure
@@ -47,7 +47,7 @@ Class meta::pure::graphFetch::PropertyGraphFetchTree extends GraphFetchTree
    subType : Class<Any>[0..1];
    
    isPrimitive(){
-      $this.returnType()->instanceOf(PrimitiveType) || $this.returnType->instanceOf(Enumeration)
+      $this.returnType()->instanceOf(PrimitiveType) || $this.returnType()->instanceOf(Enumeration)
    }:Boolean[1];
 
    isQualifiedProperty(){
@@ -56,7 +56,7 @@ Class meta::pure::graphFetch::PropertyGraphFetchTree extends GraphFetchTree
    
    returnType(){
       if($this.subType->isEmpty(),
-        | $this.property->genericType.rawType->toOne(),
+        | $this.property.genericType.rawType->toOne(),
         | $this.subType->toOne());
    }:Type[1];
 }


### PR DESCRIPTION
There are so many places in the codebase where we are calculating returnType of propertyGraphFetchTree, Hence its good to add it as a qualified property in class itself.