### PR TITLE
Fix & test for instanceOf being used in a re-activate/compile value specification flow

### DIFF
--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/meta/AbstractTestInstanceOf.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/meta/AbstractTestInstanceOf.java
@@ -80,4 +80,28 @@ public abstract class AbstractTestInstanceOf extends PureExpressionTest
         assertExpressionFalse("^test::MyClass()->test::indirectInstanceOf(test::Enum1)");
         assertExpressionFalse("^test::MyClass()->test::indirectInstanceOf(test::Enum2)");
     }
+
+    @Test
+    public void testWithCompileValueSpecification()
+    {
+        compileTestSource("fromString.pure","Enum test::Enum1 { VALUE1, VALUE2 }\n" +
+                "Enum test::Enum2 { VALUE3, VALUE4 }\n" +
+                "Class test::MyClass {}\n" +
+                "function test::compileAndEval(val : String[1]):Boolean[1]\n" +
+                "{\n" +
+                "    $val->compileValueSpecification().result->toOne()->reactivate()->cast(@Function<{->Boolean[1]}>)->toOne()->eval();\n" +
+                "}\n");
+
+        assertExpressionTrue("'{| \\'myStr\\'->instanceOf(String)}'->test::compileAndEval()");
+        assertExpressionTrue("'{| instanceOf((\\'myStr\\' + \\'other\\'), String)}'->test::compileAndEval()");
+        assertExpressionFalse("'{| \\'myStr\\'->instanceOf(test::Enum2)}'->test::compileAndEval()");
+        assertExpressionFalse("'{| \\'myStr\\'->instanceOf(Integer)}'->test::compileAndEval()");
+
+        assertExpressionTrue("'{| test::Enum2.VALUE3->instanceOf(test::Enum2)}'->test::compileAndEval()");
+        assertExpressionFalse("'{| test::Enum2.VALUE3->instanceOf(String)}'->test::compileAndEval()");
+        assertExpressionFalse("'{| test::Enum2.VALUE3->instanceOf(test::Enum1)}'->test::compileAndEval()");
+
+        assertExpressionTrue("'{| ^test::MyClass()->instanceOf(test::MyClass)}'->test::compileAndEval()");
+        assertExpressionFalse("'{| ^test::MyClass()->instanceOf(String)}'->test::compileAndEval()");
+    }
 }

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/basics/meta/InstanceOf.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/basics/meta/InstanceOf.java
@@ -54,6 +54,18 @@ public class InstanceOf extends AbstractNative
         {
             return "Pure.instanceOf(" + transformedParams.get(0) + "," + transformedParams.get(1) + ", es)";
         }
+    }
 
+    @Override
+    public String buildBody()
+    {
+        return "new SharedPureFunction<Object>()\n" +
+                "        {\n" +
+                "            @Override\n" +
+                "            public Object execute(ListIterable<?> vars, final ExecutionSupport es)\n" +
+                "            {\n" +
+                "                return Pure.instanceOf(vars.get(0), (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type) vars.get(1), es);\n" +
+                "            }\n" +
+                "        }";
     }
 }


### PR DESCRIPTION
Resolves issues with pre-eval 

```
Caused by: java.lang.UnsupportedOperationException: Not Implemented for function: instanceOf_Any_1__Type_1__Boolean_1_
at org.finos.legend.pure.generated.platform_pure_basics_meta_instanceOf$1.execute(platform_pure_basics_meta_instanceOf.java:33)
at org.finos.legend.pure.runtime.java.compiled.generation.processors.support.Pure._evaluateToMany(Pure.java:429)
at org.finos.legend.pure.runtime.java.compiled.generation.processors.support.Reactivator.reactivateWithoutJavaCompilationImpl(Reactivator.java:282)
at org.finos.legend.pure.runtime.java.compiled.generation.processors.support.Reactivator.reactivateWithoutJavaCompilationImpl(Reactivator.java:169)
at org.finos.legend.pure.runtime.java.compiled.generation.processors.support.Reactivator.reactivateWithoutJavaCompilation(Reactivator.java:153)
```