### PR TITLE
Remove static JSON method in PureModelVersion

### DIFF
--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/classpath/PureModelVersion.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/classpath/PureModelVersion.java
@@ -22,7 +22,6 @@ import java.util.Properties;
 public class PureModelVersion
 {
     public static final Optional<String> PURE_MODEL_VERSION = version("pure_model_version");
-    public static final String PURE_MODEL_VERSION_SPEC = String.format("{\"pure-model\" : %s}", PURE_MODEL_VERSION);
 
     // Note: the version contains three states:
     // 1. A value which is the VCS version of the model


### PR DESCRIPTION
Deleting legacy code - we should use the non-JSON method and let client handle formatting if need. Current usages take the JSON and parse to get the model version number - so we may as well just use the non-JSON method and get version number directly