### PR TITLE
Modify Mutable VCS interface to support string revision references

### DIFF
--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/vcs/MutableVersionControlledCodeStorage.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/vcs/MutableVersionControlledCodeStorage.java
@@ -23,8 +23,20 @@ import java.io.InputStream;
 
 public interface MutableVersionControlledCodeStorage extends VersionControlledCodeStorage, MutableRepositoryCodeStorage
 {
+    default void update(UpdateReport report, String version)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default void update(UpdateReport report, String path, String version)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
     void update(UpdateReport report, long version);
 
+    @Deprecated
     void update(UpdateReport report, String path, long version);
 
     RichIterable<String> revert(String path);


### PR DESCRIPTION
Add update functions to MutableVCS interface to use string functions.

Default functions added and existing functions marked as deprecated to make interface change backwards compatible.