### PR TITLE
Avoid warning when executing maven with multithreading option

### DIFF
--- a/legend-pure-maven-generation-java/src/main/java/org/finos/legend/pure/maven/javaCompiled/PureCompiledJarMojo.java
+++ b/legend-pure-maven-generation-java/src/main/java/org/finos/legend/pure/maven/javaCompiled/PureCompiledJarMojo.java
@@ -34,7 +34,7 @@ import java.util.Set;
 
 import static org.finos.legend.pure.runtime.java.compiled.generation.orchestrator.JavaCodeGeneration.durationSinceInSeconds;
 
-@Mojo(name = "build-pure-compiled-jar")
+@Mojo(name = "build-pure-compiled-jar", threadSafe = true)
 public class PureCompiledJarMojo extends AbstractMojo
 {
     @Parameter(defaultValue = "${project}", readonly = true, required = true)

--- a/legend-pure-maven-generation-par/src/main/java/org/finos/legend/pure/maven/par/PureJarMojo.java
+++ b/legend-pure-maven-generation-par/src/main/java/org/finos/legend/pure/maven/par/PureJarMojo.java
@@ -24,7 +24,7 @@ import org.finos.legend.pure.m3.generator.par.PureJarGenerator;
 import java.io.File;
 import java.util.Set;
 
-@Mojo(name = "build-pure-jar")
+@Mojo(name = "build-pure-jar", threadSafe = true)
 public class PureJarMojo extends AbstractMojo
 {
     @Parameter


### PR DESCRIPTION
Avoid warning when executing maven with multithreading option