### PR TITLE
Add SourceInformation.subsumes

### DIFF
--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
@@ -518,7 +518,7 @@ public class AntlrContextToM3CoreInstance
                 {
                     searchPropertyValues = !(next instanceof Package);
                 }
-                else if (oldSourceInfo.getSourceId().equals(sourceInfo.getSourceId()) && oldSourceInfo.contains(sourceInfo))
+                else if (oldSourceInfo.subsumes(sourceInfo))
                 {
                     this.newSourceInfoMap.add(Tuples.pair(next, new SourceInformation(sourceInfo.getSourceId(), sourceInfo.getStartLine() + offset, sourceInfo.getStartColumn(), sourceInfo.getLine() + offset, sourceInfo.getColumn(), sourceInfo.getEndLine() + offset, sourceInfo.getEndColumn())));
                     searchPropertyValues = true;

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/SourceInformation.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/SourceInformation.java
@@ -84,18 +84,30 @@ public class SourceInformation implements Comparable<SourceInformation>
         return appendMessage(new StringBuilder(this.sourceId.length() + 16)).toString();
     }
 
+    /**
+     * This method is deprecated and kept only for backward compatibility. Use {@link #appendMessage} instead.
+     */
     @Deprecated
     public void writeMessage(StringBuilder builder)
     {
         appendMessage(builder);
     }
 
+    /**
+     * This method is deprecated and kept only for backward compatibility. Use {@link #appendMessage} instead.
+     */
     @Deprecated
     public void writeMessage(Appendable appendable) throws IOException
     {
         appendMessage(appendable);
     }
 
+    /**
+     * Append the source information message to the given Appendable, and return the Appendable.
+     *
+     * @param appendable target appendable
+     * @return given appendable
+     */
     public <T extends Appendable> T appendMessage(T appendable)
     {
         SafeAppendable safeAppendable = SafeAppendable.wrap(appendable);
@@ -125,6 +137,9 @@ public class SourceInformation implements Comparable<SourceInformation>
         return getM4SourceString(this.sourceId, this.startLine, this.startColumn, this.line, this.column, this.endLine, this.endColumn);
     }
 
+    /**
+     * This method is deprecated and kept only for backward compatibility. Use {@link #appendM4String} instead.
+     */
     @Deprecated
     public void writeM4String(Appendable appendable)
     {
@@ -214,12 +229,31 @@ public class SourceInformation implements Comparable<SourceInformation>
         return Integer.compare(this.endColumn, other.endColumn);
     }
 
+    /**
+     * This method is deprecated and kept only for backward compatibility. Use {@link #subsumes} instead.
+     */
+    @Deprecated
     public boolean contains(SourceInformation contained)
     {
         return (contained.getStartLine() > this.getStartLine() && contained.getEndLine() < this.getEndLine()) ||
                 (contained.getStartLine() == this.getStartLine() && contained.getEndLine() < this.getEndLine() && contained.getStartColumn() >= this.getStartColumn()) ||
                 (contained.getStartLine() > this.getStartLine() && contained.getEndLine() == this.getEndLine() && this.getEndColumn() >= contained.getEndColumn()) ||
                 (contained.getStartLine() == this.getStartLine() && contained.getEndLine() == this.getEndLine() && contained.getStartColumn() >= this.getStartColumn() && this.getEndColumn() >= contained.getEndColumn());
+    }
+
+    /**
+     * Check whether this source information subsumes other. This is true if the source ids are equal, and the start and
+     * end boundaries of other are contained within or equal to the start and end boundaries of this.
+     *
+     * @param other other source information
+     * @return whether this subsumes other
+     */
+    public boolean subsumes(SourceInformation other)
+    {
+        return (other != null) &&
+                this.sourceId.equals(other.sourceId) &&
+                ((this.startLine < other.startLine) || ((this.startLine == other.startLine) && (this.startColumn <= other.startColumn))) &&
+                ((this.endLine > other.endLine) || ((this.endLine == other.endLine) && (this.endColumn >= other.endColumn)));
     }
 
     @Override
@@ -233,12 +267,18 @@ public class SourceInformation implements Comparable<SourceInformation>
         return appendM4SourceInformation(new StringBuilder(sourceId.length() + 32), sourceId, startLine, startColumn, line, column, endLine, endColumn).toString();
     }
 
+    /**
+     * This method is deprecated and kept for backward compatibility. Use {@link #appendM4SourceInformation} instead.
+     */
     @Deprecated
     public static void writeM4SourceInformation(StringBuilder builder, String sourceId, int startLine, int startColumn, int line, int column, int endLine, int endColumn)
     {
         appendM4SourceInformation(builder, sourceId, startLine, startColumn, line, column, endLine, endColumn);
     }
 
+    /**
+     * This method is deprecated and kept for backward compatibility. Use {@link #appendM4SourceInformation} instead.
+     */
     @Deprecated
     public static void writeM4SourceInformation(Appendable appendable, String sourceId, int startLine, int startColumn, int line, int column, int endLine, int endColumn)
     {

--- a/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/TestSourceInformation.java
+++ b/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/TestSourceInformation.java
@@ -1,0 +1,118 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m4.coreinstance;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSourceInformation
+{
+    @Test
+    public void testSubsumes()
+    {
+        String source1 = "/platform/test/source1.pure";
+        String source2 = "/platform/test/source2.pure";
+
+        SourceInformation source1_1_1_10_1 = new SourceInformation(source1, 1, 1, 10, 1);
+        SourceInformation source1_1_5_1_7 = new SourceInformation(source1, 1, 5, 1, 7);
+        SourceInformation source1_1_5_6_1 = new SourceInformation(source1, 1, 5, 6, 1);
+        SourceInformation source1_2_1_6_1 = new SourceInformation(source1, 2, 1, 6, 1);
+        SourceInformation source1_5_1_10_1 = new SourceInformation(source1, 5, 1, 10, 1);
+        SourceInformation source1_5_3_8_8 = new SourceInformation(source1, 5, 3, 8, 8);
+        SourceInformation source2_1_1_10_1 = new SourceInformation(source2, 1, 1, 10, 1);
+
+        assertSubsumes(source1_1_1_10_1, source1_1_1_10_1);
+        assertSubsumes(source1_1_1_10_1, source1_1_5_1_7);
+        assertSubsumes(source1_1_1_10_1, source1_1_5_6_1);
+        assertSubsumes(source1_1_1_10_1, source1_2_1_6_1);
+        assertSubsumes(source1_1_1_10_1, source1_5_1_10_1);
+        assertSubsumes(source1_1_1_10_1, source1_5_3_8_8);
+        assertNotSubsumes(source1_1_1_10_1, source2_1_1_10_1);
+
+        assertNotSubsumes(source1_1_5_1_7, source1_1_1_10_1);
+        assertSubsumes(source1_1_5_1_7, source1_1_5_1_7);
+        assertNotSubsumes(source1_1_5_1_7, source1_1_5_6_1);
+        assertNotSubsumes(source1_1_5_1_7, source1_2_1_6_1);
+        assertNotSubsumes(source1_1_5_1_7, source1_5_1_10_1);
+        assertNotSubsumes(source1_1_5_1_7, source1_5_3_8_8);
+        assertNotSubsumes(source1_1_5_1_7, source2_1_1_10_1);
+
+        assertNotSubsumes(source1_1_5_6_1, source1_1_1_10_1);
+        assertSubsumes(source1_1_5_6_1, source1_1_5_1_7);
+        assertSubsumes(source1_1_5_6_1, source1_1_5_6_1);
+        assertSubsumes(source1_1_5_6_1, source1_2_1_6_1);
+        assertNotSubsumes(source1_1_5_6_1, source1_5_1_10_1);
+        assertNotSubsumes(source1_1_5_6_1, source1_5_3_8_8);
+        assertNotSubsumes(source1_1_5_6_1, source2_1_1_10_1);
+
+        assertNotSubsumes(source1_2_1_6_1, source1_1_1_10_1);
+        assertNotSubsumes(source1_2_1_6_1, source1_1_5_1_7);
+        assertNotSubsumes(source1_2_1_6_1, source1_1_5_6_1);
+        assertSubsumes(source1_2_1_6_1, source1_2_1_6_1);
+        assertNotSubsumes(source1_2_1_6_1, source1_5_1_10_1);
+        assertNotSubsumes(source1_2_1_6_1, source1_5_3_8_8);
+        assertNotSubsumes(source1_2_1_6_1, source2_1_1_10_1);
+
+        assertNotSubsumes(source1_5_1_10_1, source1_1_1_10_1);
+        assertNotSubsumes(source1_5_1_10_1, source1_1_5_1_7);
+        assertNotSubsumes(source1_5_1_10_1, source1_1_5_6_1);
+        assertNotSubsumes(source1_5_1_10_1, source1_2_1_6_1);
+        assertSubsumes(source1_5_1_10_1, source1_5_1_10_1);
+        assertSubsumes(source1_5_1_10_1, source1_5_3_8_8);
+        assertNotSubsumes(source1_5_1_10_1, source2_1_1_10_1);
+
+        assertNotSubsumes(source1_5_3_8_8, source1_1_1_10_1);
+        assertNotSubsumes(source1_5_3_8_8, source1_1_5_1_7);
+        assertNotSubsumes(source1_5_3_8_8, source1_1_5_6_1);
+        assertNotSubsumes(source1_5_3_8_8, source1_2_1_6_1);
+        assertNotSubsumes(source1_5_3_8_8, source1_5_1_10_1);
+        assertSubsumes(source1_5_3_8_8, source1_5_3_8_8);
+        assertNotSubsumes(source1_5_3_8_8, source2_1_1_10_1);
+
+        assertNotSubsumes(source2_1_1_10_1, source1_1_1_10_1);
+        assertNotSubsumes(source2_1_1_10_1, source1_1_5_1_7);
+        assertNotSubsumes(source2_1_1_10_1, source1_1_5_6_1);
+        assertNotSubsumes(source2_1_1_10_1, source1_2_1_6_1);
+        assertNotSubsumes(source2_1_1_10_1, source1_5_1_10_1);
+        assertNotSubsumes(source2_1_1_10_1, source1_5_3_8_8);
+        assertSubsumes(source2_1_1_10_1, source2_1_1_10_1);
+    }
+
+    private void assertSubsumes(SourceInformation sourceInfo1, SourceInformation sourceInfo2)
+    {
+        assertSubsumes(true, sourceInfo1, sourceInfo2);
+    }
+
+    private void assertNotSubsumes(SourceInformation sourceInfo1, SourceInformation sourceInfo2)
+    {
+        assertSubsumes(false, sourceInfo1, sourceInfo2);
+    }
+
+    private void assertSubsumes(boolean expected, SourceInformation sourceInfo1, SourceInformation sourceInfo2)
+    {
+        if (sourceInfo1.subsumes(sourceInfo2) != expected)
+        {
+            StringBuilder builder = new StringBuilder("Expected ");
+            sourceInfo1.appendMessage(builder).append(" to ");
+            if (!expected)
+            {
+                builder.append("not ");
+            }
+            builder.append("contain ");
+            sourceInfo2.appendMessage(builder);
+            Assert.fail(builder.toString());
+        }
+    }
+}


### PR DESCRIPTION
Add SourceInformation.subsumes. This is similar to the existing contains method, but it takes the source id into account. The contains method is deprecated and kept only for backward compatibility.