### PR TITLE
Fix URLPatternLibrary regex exception handling

### DIFF
--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/pattern/TestURLPatternLibraryOrder.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/pattern/TestURLPatternLibraryOrder.java
@@ -30,7 +30,7 @@ public class TestURLPatternLibraryOrder
                 new PurePattern(null, "/gggg/ppppppppp/current/account/{accountId}/{user}", null, null, Lists.fixedSize.empty()),
                 new PurePattern(null, "/gggg/ppppppppp/current/{user}", null, null, Lists.fixedSize.empty()));
 
-        MutableList<PurePattern> res = patterns.sortThis(URLPatternLibrary.URLPatternComparator);
+        MutableList<PurePattern> res = patterns.sortThis(URLPatternLibrary::comparePatterns);
 
         Assert.assertEquals(Lists.mutable.with("/pure/diagram/colors",
                 "/gggg/ppppppppp/current/account/{accountId}/{user}",

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/validation/TestServiceURL.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/validation/TestServiceURL.java
@@ -75,391 +75,348 @@ public class TestServiceURL extends AbstractPureTestWithCoreCompiledPlatform
     @Test
     public void testSimpleHappyPath()
     {
-        compileTestSource("fromString.pure", "function {service.url='/testURL/{param}'} myFunc(param:String[1]):String[1]\n" +
-                "{\n" +
-                "   'ee';\n" +
-                "}\n");
+        compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{param}'} myFunc(param:String[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n");
     }
 
     @Test
     public void testRegExpHappyPath()
     {
-        compileTestSource("fromString.pure", "function {service.url='/testURL/{param:a(b)*c}'} myFunc(param:String[1]):String[1]\n" +
-                "{\n" +
-                "   'ee';\n" +
-                "}\n");
+        compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{param:a(b)*c}'} myFunc(param:String[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n");
     }
 
     @Test
     public void testVariableNameNonOrdered()
     {
-        compileTestSource("fromString.pure", "function {service.url='/testURL/{param}/{param2}'} myFunc(param2:String[1], param:String[1]):String[1]\n" +
-                "{\n" +
-                "   'ee';\n" +
-                "}\n");
+        compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{param}/{param2}'} myFunc(param2:String[1], param:String[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n");
     }
 
     @Test
     public void testAllMandatoryArgumentsInURI()
     {
-
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='/testURL/{param}'} myFunc(param:String[1], otherOne:String[1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "Parameter multiplicity issue. All parameters with multiplicity [1] must be a part of the service url", e);
-        }
-
-
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{param}'} myFunc(param:String[1], otherOne:String[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Parameter multiplicity issue. All parameters with multiplicity [1] must be a part of the service url", e);
     }
 
     @Test
     public void testOptionalArguments()
     {
-        compileTestSource("fromString.pure", "function {service.url='/testURL/{param}'} myFunc(param:String[1], otherOne:String[0..1]):String[1]\n" +
-                "{\n" +
-                "   'ee';\n" +
-                "}\n");
+        compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{param}'} myFunc(param:String[1], otherOne:String[0..1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n");
     }
 
     @Test
     public void testOptionalArgumentsInUri()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='/testURL/{param}'} myFunc(param:String[0..1], otherOne:String[0..1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "Parameter multiplicity issue. A service function parameter specified in the URI has to be String[1]", 1, 56, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{param}'} myFunc(param:String[0..1], otherOne:String[0..1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Parameter multiplicity issue. A service function parameter specified in the URI has to be String[1]", 1, 56, e);
     }
 
     @Test
     public void testZeroToManyQueryParameters()
     {
-        compileTestSource("fromString.pure", "function {service.url='/testURL/{param}'} myFunc(param:String[1], otherOne:String[*]):String[1]\n" +
-                "{\n" +
-                "   'ee';\n" +
-                "}\n");
+        compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{param}'} myFunc(param:String[1], otherOne:String[*]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n");
     }
 
     @Test
     public void testOneToManyQueryParameter()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='/testURL}'} myFunc(param:String[1..*], otherOne:String[0..1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "Parameter multiplicity issue. Parameters not part of the service url must have multiplicity [0..1] or [*]", 1, 49, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL}'} myFunc(param:String[1..*], otherOne:String[0..1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Parameter multiplicity issue. Parameters not part of the service url must have multiplicity [0..1] or [*]", 1, 49, e);
     }
 
     @Test
     public void testZeroToManyServiceUrlParameter()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='/testURL/{param}'} myFunc(param:String[*], otherOne:String[0..1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "Parameter multiplicity issue. A service function parameter specified in the URI has to be String[1]", 1, 56, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{param}'} myFunc(param:String[*], otherOne:String[0..1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Parameter multiplicity issue. A service function parameter specified in the URI has to be String[1]", 1, 56, e);
     }
 
     @Test
     public void testOneToManyServiceUrlParameter()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='/testURL/{param}}'} myFunc(param:String[1..*], otherOne:String[0..1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "Parameter multiplicity issue. A service function parameter specified in the URI has to be String[1]", 1, 57, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{param}}'} myFunc(param:String[1..*], otherOne:String[0..1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Parameter multiplicity issue. A service function parameter specified in the URI has to be String[1]", 1, 57, e);
     }
 
     @Test
     public void testNoURIArguments()
     {
-        compileTestSource("fromString.pure", "function {service.url='/testURL'} myFunc(param:String[0..1], otherOne:String[0..1]):String[1]\n" +
-                "{\n" +
-                "   'ee';\n" +
-                "}\n");
+        compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL'} myFunc(param:String[0..1], otherOne:String[0..1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n");
     }
 
     @Test
     public void testPrimitiveArgsInURI()
     {
-        compileTestSource("fromString.pure", "function {service.url='/testURL/{s}/{d}/{dt}/{sd}/{b}/{i}/{f}'} myFunc(s:String[1], d:Date[1], dt:DateTime[1], sd:StrictDate[1], b:Boolean[1], i:Integer[1], f:Float[1]):String[1]\n" +
-                "{\n" +
-                "   'ee';\n" +
-                "}\n");
+        compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{s}/{d}/{dt}/{sd}/{b}/{i}/{f}'} myFunc(s:String[1], d:Date[1], dt:DateTime[1], sd:StrictDate[1], b:Boolean[1], i:Integer[1], f:Float[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n");
     }
 
     @Test
     public void testEnumArgInURI()
     {
-        compileTestSource("fromString.pure", "Enum MyEnum {VALUE1}" +
-                "" +
-                "function {service.url='/testURL/{enum}'} myFunc(enum:MyEnum[1]):String[1]\n" +
-                "{\n" +
-                "   'ee';\n" +
-                "}\n");
+        compileTestSource(
+                "fromString.pure",
+                "Enum MyEnum {VALUE1}\n" +
+                        "function {service.url='/testURL/{enum}'} myFunc(enum:MyEnum[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n");
     }
 
     @Test
     public void testPrimitiveArgsInQueryParameters()
     {
-        compileTestSource("fromString.pure", "function {service.url='/testURL'} myFunc(s:String[0..1], d:Date[0..1], dt:DateTime[0..1], sd:StrictDate[0..1], b:Boolean[0..1], i:Integer[0..1], f:Float[0..1]):String[1]\n" +
-                "{\n" +
-                "   'ee';\n" +
-                "}\n");
+        compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL'} myFunc(s:String[0..1], d:Date[0..1], dt:DateTime[0..1], sd:StrictDate[0..1], b:Boolean[0..1], i:Integer[0..1], f:Float[0..1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n");
     }
 
     @Test
     public void testEnumInQueryParameters()
     {
-        compileTestSource("fromString.pure", "Enum MyEnum {VALUE1}" +
-                "" +
-                "function {service.url='/testURL}'} myFunc(enum:MyEnum[0..1]):String[1]\n" +
-                "{\n" +
-                "   'ee';\n" +
-                "}\n");
+        compileTestSource(
+                "fromString.pure",
+                "Enum MyEnum {VALUE1}\n" +
+                        "function {service.url='/testURL}'} myFunc(enum:MyEnum[0..1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n");
     }
 
     @Test
     public void testInvalidTypeInQueryParameters()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "" +
-                    "Class MyClass {}" +
-                    "function {service.url='/testURL'} myFunc(param:MyClass[0..1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "Parameter type issue. All parameters must be a primitive type or enum", 1, 64, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "Class MyClass {}\n" +
+                        "function {service.url='/testURL'} myFunc(param:MyClass[0..1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Parameter type issue. All parameters must be a primitive type or enum", 2, 48, e);
     }
 
     @Test
     public void testInvalidTypeInURIParameters()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "" +
-                    "Class MyClass {}" +
-                    "function {service.url='/testURL/{param}'} myFunc(param:MyClass[1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "Parameter type issue. All parameters must be a primitive type or enum", 1, 72, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "Class MyClass {}\n" +
+                        "function {service.url='/testURL/{param}'} myFunc(param:MyClass[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Parameter type issue. All parameters must be a primitive type or enum", 2, 56, e);
     }
 
     @Test
     public void testRegExpError()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='/testURL/{param:testReg{b}'} myFunc(param:String[1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "Error in the user provided regexp: testReg{b", 1, 46, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{param:testReg{b}'} myFunc(param:String[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Error in the user provided regexp: testReg{b", "fromString.pure", 1, 40, 1, 40, 1, 48, e);
+    }
+
+    @Test
+    public void testRegExpErrorMultiline()
+    {
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url=\n" +
+                        "         '/testURL/{param1:testReg[abc]}/{param2:testReg{b}'\n" +
+                        "        }\n" +
+                        " myFunc(param:String[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Error in the user provided regexp: testReg{b", "fromString.pure", 2, 50, 2, 50, 2, 58, e);
     }
 
     @Test
     public void testReturnTypeError()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='/testURL/{param}'} myFunc(param:String[1]):Integer[1]\n" +
-                    "{\n" +
-                    "   1;\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "Return type issue. A service function has to return a 'String' or a subtype of 'ServiceResult'.", 1, 67, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{param}'} myFunc(param:String[1]):Integer[1]\n" +
+                        "{\n" +
+                        "   1;\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Return type issue. A service function has to return a 'String' or a subtype of 'ServiceResult'.", 1, 67, e);
     }
 
     @Test
     public void testServiceReturnReturnType()
     {
         // verify that this compiles
-        compileTestSource("fromString.pure", "Class EmptyResult<T> extends ServiceResult<T|0>" +
-                "{" +
-                "}" +
-                "" +
-                "function {service.url='/testURL/{param}'} myFunc(param:String[1]):EmptyResult<Any>[1]\n" +
-                "{\n" +
-                "   ^EmptyResult<Any>();\n" +
-                "}\n");
+        compileTestSource(
+                "fromString.pure",
+                "Class EmptyResult<T> extends ServiceResult<T|0>\n" +
+                        "{\n" +
+                        "}\n" +
+                        "\n" +
+                        "function {service.url='/testURL/{param}'} myFunc(param:String[1]):EmptyResult<Any>[1]\n" +
+                        "{\n" +
+                        "   ^EmptyResult<Any>();\n" +
+                        "}\n");
     }
 
     @Test
     public void testReturnMultiplicityError()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='/testURL/{param}'} myFunc(param:String[1]):String[*]\n" +
-                    "{\n" +
-                    "   1;\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "Return multiplicity issue. A service function has to return one ([1]) element.", 1, 67, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='/testURL/{param}'} myFunc(param:String[1]):String[*]\n" +
+                        "{\n" +
+                        "   1;\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "Return multiplicity issue. A service function has to return one ([1]) element.", 1, 67, e);
     }
 
     @Test
     public void testOverlap()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='/hello/{param:testReg}'} myFunc(param:String[1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n" +
-                    "function {service.url='/hello/{param:testReg}'} myFunc3(param:String[1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "A function has already been registered with the key '/hello/' (myFunc3_String_1__String_1_)", 5, 23, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='/hello/{param:testReg}'} myFunc(param:String[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n" +
+                        "function {service.url='/hello/{param:testReg}'} myFunc3(param:String[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "A function has already been registered with the key '/hello/' (myFunc3_String_1__String_1_)", 5, 23, e);
     }
 
     @Test
     public void testOverlapOptionalParameters()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='/hello/{param}'} myFunc(param:String[1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n" +
-                    "function {service.url='/hello/{param}'} myFunc3(param:String[1], param2:String[0..1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "A function has already been registered with the key '/hello/' (myFunc3_String_1__String_$0_1$__String_1_)", 5, 23, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='/hello/{param}'} myFunc(param:String[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n" +
+                        "function {service.url='/hello/{param}'} myFunc3(param:String[1], param2:String[0..1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "A function has already been registered with the key '/hello/' (myFunc3_String_1__String_$0_1$__String_1_)", 5, 23, e);
     }
 
     @Test
     public void testOverlappingURIsQueryParamOnly()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='/hello'} myFunc(param:String[0..1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n" +
-                    "function {service.url='/hello'} myFunc3(param:String[0..1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "A function has already been registered with the key '/hello' (myFunc3_String_$0_1$__String_1_)", 5, 23, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='/hello'} myFunc(param:String[0..1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n" +
+                        "function {service.url='/hello'} myFunc3(param:String[0..1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "A function has already been registered with the key '/hello' (myFunc3_String_$0_1$__String_1_)", 5, 23, e);
     }
 
     @Test
     public void keyStructureStart()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='hello/{param:testReg}'} myFunc(param:String[1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "The URL needs to start with '/' (hello/)", 1, 23, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='hello/{param:testReg}'} myFunc(param:String[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "The URL needs to start with '/' (hello/)", 1, 23, e);
     }
 
     @Test
     public void keyStructure()
     {
-        try
-        {
-            compileTestSource("fromString.pure", "function {service.url='/hello{param:testReg}'} myFunc(param:String[1]):String[1]\n" +
-                    "{\n" +
-                    "   'ee';\n" +
-                    "}\n");
-            Assert.fail();
-        }
-        catch (RuntimeException e)
-        {
-            assertPureException(PureCompilationException.class, "The first part of the URL (/hello) needs to end with '/'", 1, 23, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function {service.url='/hello{param:testReg}'} myFunc(param:String[1]):String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n"));
+        assertPureException(PureCompilationException.class, "The first part of the URL (/hello) needs to end with '/'", 1, 23, e);
     }
 
     @Test
     public void keyStructureNoParams()
     {
-        compileTestSource("fromString.pure", "function {service.url='/hello'} myFunc():String[1]\n" +
-                "{\n" +
-                "   'ee';\n" +
-                "}\n");
+        compileTestSource(
+                "fromString.pure",
+                "function {service.url='/hello'} myFunc():String[1]\n" +
+                        "{\n" +
+                        "   'ee';\n" +
+                        "}\n");
     }
 }


### PR DESCRIPTION
Fix URLPatternLibrary regex exception handling, specifically the generation of the source information. Previously the end coordinates were not supplied. Also, the previous behavior yielded different results depending on the Java version in use. This, in particular, meant that the success of some tests depended on the Java version.

In passing, use named groups in the main regex to make the code clearer.