### PR TITLE
Support building and running with Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Maven dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v3
         env:
           cache-name: cache-mvn-deps
         with:
@@ -43,9 +43,11 @@ jobs:
             ${{ runner.os }}-
 
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.13.0
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
+          java-package: jdk
           server-id: ossrh
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD

--- a/.github/workflows/clean-after-failed-release.yml
+++ b/.github/workflows/clean-after-failed-release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.FINOS_GITHUB_TOKEN }}

--- a/.github/workflows/legend-stack-release.yml
+++ b/.github/workflows/legend-stack-release.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.FINOS_GITHUB_TOKEN }}
 
@@ -38,11 +38,12 @@ jobs:
           git config --global user.email "37706051+finos-admin@users.noreply.github.com"
           git config --global user.name "FINOS Administrator"
 
-      - name: Set up Maven Central
-        uses: actions/setup-java@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v3.13.0
         with:
-          distribution: "zulu"
-          java-version: "11"
+          distribution: 'temurin'
+          java-version: 17
+          java-package: jdk
           server-id: ossrh
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD

--- a/.github/workflows/ossrh-close-staging-repo.yml
+++ b/.github/workflows/ossrh-close-staging-repo.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.FINOS_GITHUB_TOKEN }}
 
@@ -47,11 +47,12 @@ jobs:
           git config --global user.email "37706051+finos-admin@users.noreply.github.com"
           git config --global user.name "FINOS Administrator"
 
-      - name: Set up Maven Central
-        uses: actions/setup-java@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v3.13.0
         with:
-          distribution: "zulu"
-          java-version: "11"
+          distribution: 'temurin'
+          java-version: 17
+          java-package: jdk
           server-id: ossrh
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.FINOS_GITHUB_TOKEN }}
 
@@ -41,11 +41,12 @@ jobs:
           git config --global user.email "37706051+finos-admin@users.noreply.github.com"
           git config --global user.name "FINOS Administrator"
 
-      - name: Set up Maven Central
-        uses: actions/setup-java@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v3.13.0
         with:
-          distribution: "zulu"
-          java-version: "11"
+          distribution: 'temurin'
+          java-version: 17
+          java-package: jdk
           server-id: ossrh
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD

--- a/legend-pure-m3-core/pom.xml
+++ b/legend-pure-m3-core/pom.xml
@@ -252,15 +252,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
             <version>0.8.1</version>
@@ -277,6 +268,16 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-testutils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/ParserLibrary.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/ParserLibrary.java
@@ -15,64 +15,25 @@
 package org.finos.legend.pure.m3.serialization.grammar;
 
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.api.set.SetIterable;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Maps;
-import org.eclipse.collections.impl.factory.Sets;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.RelationType;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.serialization.runtime.navigation.NavigationHandler;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 
-import java.util.Comparator;
 import java.util.Objects;
-
-import static org.junit.Assert.assertEquals;
 
 public class ParserLibrary
 {
-    private static final Comparator<Parser> PARSER_COMPARATOR = new Comparator<Parser>()
-    {
-        @Override
-        public int compare(Parser parser1, Parser parser2)
-        {
-            if (parser1 == parser2)
-            {
-                return 0;
-            }
-
-            String name1 = parser1.getName();
-            String name2 = parser2.getName();
-            if (name1.equals(name2))
-            {
-                return 0;
-            }
-
-            // TODO maybe check transitively
-            SetIterable<String> requiredParsers1 = parser1.getRequiredParsers();
-            SetIterable<String> requiredParsers2 = parser2.getRequiredParsers();
-            if (requiredParsers2.contains(name1))
-            {
-                return -1;
-            }
-            else if (requiredParsers1.contains(name2))
-            {
-                return 1;
-            }
-            else
-            {
-                return name1.compareTo(name2);
-            }
-        }
-    };
-
     private final ImmutableMap<String, Parser> parsers;
     private final ImmutableMap<String, NavigationHandler> navigationHandlers;
 
@@ -130,24 +91,23 @@ public class ParserLibrary
 
     public ListIterable<String> getRequiredFiles()
     {
+        MutableSet<String> fileSet = Sets.mutable.empty();
         MutableList<String> files = Lists.mutable.with();
-        for (Parser parser : this.parsers.valuesView().toSortedList(PARSER_COMPARATOR))
-        {
-            for (String file : parser.getRequiredFiles())
-            {
-                if (!files.contains(file))
-                {
-                    files.add(file);
-                }
-            }
-        }
+        this.parsers.valuesView()
+                .toSortedList(ParserLibrary::compareParsers)
+                .forEach(p -> p.getRequiredFiles().select(fileSet::add, files));
         return files;
     }
 
     public Pair<Object, RelationType> resolveRelationElementAccessor(PackageableElement element, MutableList<? extends String> path, SourceInformation sourceInformation, ProcessorSupport processorSupport)
     {
-        MutableList<Pair<Object, RelationType>> res = this.parsers.valuesView().collect(c -> c.resolveRelationElementAccessor(element, path, sourceInformation, processorSupport)).select(Objects::nonNull).toList();
-        assertEquals("Found 0 ore more than one (" + res.size() + ") handlers for resolving the element Accessor " + element.getName() + " " + path.makeString("."), 1, res.size());
+        MutableList<Pair<Object, RelationType>> res = this.parsers.valuesView()
+                .collect(c -> c.resolveRelationElementAccessor(element, path, sourceInformation, processorSupport))
+                .select(Objects::nonNull, Lists.mutable.empty());
+        if (res.size() != 1)
+        {
+            throw new RuntimeException("Found 0 or more than one (" + res.size() + ") handlers for resolving the element Accessor " + element.getName() + " " + path.makeString("."));
+        }
         return res.get(0);
     }
 
@@ -206,5 +166,31 @@ public class ParserLibrary
             }
         }
         return index.toImmutable();
+    }
+
+    private static int compareParsers(Parser parser1, Parser parser2)
+    {
+        if (parser1 == parser2)
+        {
+            return 0;
+        }
+
+        String name1 = parser1.getName();
+        String name2 = parser2.getName();
+        if (name1.equals(name2))
+        {
+            return 0;
+        }
+
+        // TODO maybe check transitively
+        if (parser2.getRequiredParsers().contains(name1))
+        {
+            return -1;
+        }
+        if (parser1.getRequiredParsers().contains(name2))
+        {
+            return 1;
+        }
+        return name1.compareTo(name2);
     }
 }

--- a/legend-pure-runtime-java-engine-compiled/pom.xml
+++ b/legend-pure-runtime-java-engine-compiled/pom.xml
@@ -170,6 +170,10 @@
 
         <dependency>
             <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
             <artifactId>opentracing-util</artifactId>
         </dependency>
         <dependency>

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
@@ -100,12 +100,10 @@ public final class JavaSourceCodeGenerator
                     "import org.finos.legend.pure.m3.navigation.ProcessorSupport;\n" +
                     "import org.finos.legend.pure.m3.execution.ExecutionSupport;\n" +
 
-                    "import org.junit.Test;\n" +
                     "import org.finos.legend.pure.m3.exception.PureExecutionException;\n" +
                     "import org.finos.legend.pure.m4.coreinstance.CoreInstance;\n" +
                     "import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;\n" +
                     "import org.finos.legend.pure.m4.coreinstance.primitive.date.DateFunctions;\n" +
-                    "import org.finos.legend.pure.runtime.java.compiled.*;\n" +
                     "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.coreinstance.*;\n" +
                     "import org.finos.legend.pure.runtime.java.compiled.metadata.*;\n" +
                     "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.map.*;\n" +
@@ -117,7 +115,6 @@ public final class JavaSourceCodeGenerator
                     "import org.finos.legend.pure.m3.tools.ListHelper;\n" +
 
                     "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n" +
-                    "import org.finos.legend.pure.runtime.java.compiled.*;\n" +
                     "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;\n" +
                     "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.*;\n" +
                     "import org.finos.legend.pure.runtime.java.compiled.execution.*;\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/ClassJsonFactoryProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/ClassJsonFactoryProcessor.java
@@ -42,7 +42,6 @@ public class ClassJsonFactoryProcessor
             "import org.finos.legend.pure.runtime.java.extension.external.json.compiled.natives.JsonParserHelper;\n" +
             "import org.finos.legend.pure.m4.exception.PureException;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.execution.*;\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/NativeFunctionProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/NativeFunctionProcessor.java
@@ -14,11 +14,11 @@
 
 package org.finos.legend.pure.runtime.java.compiled.generation.processors;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Properties;
@@ -28,12 +28,37 @@ import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 import org.finos.legend.pure.runtime.java.compiled.extension.CompiledExtension;
 import org.finos.legend.pure.runtime.java.compiled.generation.ProcessorContext;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.Native;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.collection.Add;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.collection.At;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.collection.Concatenate;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.collection.Fold;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.collection.Init;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.collection.RemoveDuplicates;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.collection.Sort;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.collection.Tail;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.io.Print;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.collection.*;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.lang.*;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.lang.Cast;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.lang.DynamicNew;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.lang.Eval;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.lang.Evaluate;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.lang.If;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.lang.Match;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.math.Abs;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.meta.*;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.string.*;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.meta.EvaluateAndDeactivate;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.meta.GenericType;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.meta.GenericTypeClass;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.meta.GetUnitValue;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.meta.Id;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.meta.InstanceOf;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.meta.NewUnit;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.string.Format;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.string.Length;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.string.Replace;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.string.Split;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.string.StartsWith;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.string.Substring2;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.string.Substring3;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.string.ToString;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.basics.tests.Assert;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar._boolean.conjunctions.And;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar._boolean.conjunctions.Not;
@@ -43,9 +68,24 @@ import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar._boolean.equality.Is;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar._boolean.inequalities.LessThan;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar._boolean.inequalities.LessThanEqual;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.collection.*;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.lang.*;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.math.*;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.collection.Filter;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.collection.First;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.collection.IsEmpty;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.collection.Map;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.collection.Range;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.collection.Size;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.lang.Compare;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.lang.Copy;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.lang.ExtractEnumValue;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.lang.GetAll;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.lang.Let;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.lang.New;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.lang.NewWithKeyExpr;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.math.Divide;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.math.DivideDecimal;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.math.Minus;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.math.Plus;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.math.Times;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.mulitplicity.ToOne;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.mulitplicity.ToOneMany;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.grammar.mulitplicity.ToOneManyWithMessage;
@@ -61,7 +101,6 @@ public class NativeFunctionProcessor
             "import org.eclipse.collections.api.map.MutableMap;\n",
             "import org.eclipse.collections.impl.factory.Lists;\n",
             "import org.eclipse.collections.impl.map.mutable.UnifiedMap;\n",
-            "import org.finos.legend.pure.runtime.java.compiled.*;\n",
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.coreinstance.*;\n",
             "import org.eclipse.collections.api.block.function.Function2;\n",
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.map.PureMap;\n",
@@ -70,13 +109,10 @@ public class NativeFunctionProcessor
             "import org.finos.legend.pure.m3.execution.ExecutionSupport;\n",
             "import org.eclipse.collections.impl.factory.Maps;\n",
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n",
-            "import org.finos.legend.pure.runtime.java.compiled.*;\n",
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;\n",
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.*;\n",
             "import org.finos.legend.pure.runtime.java.compiled.execution.*;\n",
-            "import org.finos.legend.pure.runtime.java.compiled.execution.sourceInformation.*;\n",
-            //tests only
-            "import org.junit.Test;\n");
+            "import org.finos.legend.pure.runtime.java.compiled.execution.sourceInformation.*;\n");
 
     private final MutableMap<String, Native> natives;
 

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassImplProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassImplProcessor.java
@@ -56,7 +56,6 @@ public class ClassImplProcessor
             "import org.finos.legend.pure.m4.ModelRepository;\n" +
             "import org.finos.legend.pure.m4.coreinstance.SourceInformation;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.execution.*;\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassLazyImplProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassLazyImplProcessor.java
@@ -46,7 +46,6 @@ public class ClassLazyImplProcessor
             "import org.finos.legend.pure.m4.ModelRepository;\n" +
             "import org.finos.legend.pure.m4.coreinstance.SourceInformation;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataLazy;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.*;\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/MeasureImplProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/MeasureImplProcessor.java
@@ -47,7 +47,6 @@ public class MeasureImplProcessor
             "import org.finos.legend.pure.m4.ModelRepository;\n" +
             "import org.finos.legend.pure.m4.coreinstance.SourceInformation;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.execution.*;\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/MeasureInterfaceProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/MeasureInterfaceProcessor.java
@@ -32,7 +32,6 @@ public class MeasureInterfaceProcessor
             "import org.finos.legend.pure.runtime.java.compiled.execution.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.execution.sourceInformation.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;\n" +
             "import org.finos.legend.pure.m3.execution.ExecutionSupport;\n";
 

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/UnitImplProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/UnitImplProcessor.java
@@ -46,7 +46,6 @@ public class UnitImplProcessor
             "import org.finos.legend.pure.m4.ModelRepository;\n" +
             "import org.finos.legend.pure.m4.coreinstance.SourceInformation;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.execution.*;\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/UnitInstanceImplProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/UnitInstanceImplProcessor.java
@@ -46,7 +46,6 @@ public class UnitInstanceImplProcessor
             "import org.finos.legend.pure.m4.ModelRepository;\n" +
             "import org.finos.legend.pure.m4.coreinstance.SourceInformation;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.execution.*;\n" +

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/UnitInstanceInterfaceProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/UnitInstanceInterfaceProcessor.java
@@ -34,7 +34,6 @@ public class UnitInstanceInterfaceProcessor
             "import org.finos.legend.pure.runtime.java.compiled.execution.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.execution.sourceInformation.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;\n" +
             "import org.finos.legend.pure.m3.execution.ExecutionSupport;\n";
 

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/UnitInterfaceProcessor.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/UnitInterfaceProcessor.java
@@ -32,7 +32,6 @@ public class UnitInterfaceProcessor
             "import org.finos.legend.pure.runtime.java.compiled.execution.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.execution.sourceInformation.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;" +
             "import org.finos.legend.pure.m3.execution.ExecutionSupport;\n";
 

--- a/legend-pure-runtime-java-extension-dsl-graph/pom.xml
+++ b/legend-pure-runtime-java-extension-dsl-graph/pom.xml
@@ -129,6 +129,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.pure</groupId>

--- a/legend-pure-runtime-java-extension-dsl-path/pom.xml
+++ b/legend-pure-runtime-java-extension-dsl-path/pom.xml
@@ -139,6 +139,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 </project>

--- a/legend-pure-runtime-java-extension-functions-json/pom.xml
+++ b/legend-pure-runtime-java-extension-functions-json/pom.xml
@@ -198,6 +198,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/legend-pure-runtime-java-extension-functions-relation/pom.xml
+++ b/legend-pure-runtime-java-extension-functions-relation/pom.xml
@@ -172,6 +172,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
 <!--        <dependency>-->

--- a/legend-pure-runtime-java-extension-functions/pom.xml
+++ b/legend-pure-runtime-java-extension-functions/pom.xml
@@ -144,6 +144,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/legend-pure-runtime-java-extension-store-relational/pom.xml
+++ b/legend-pure-runtime-java-extension-store-relational/pom.xml
@@ -173,6 +173,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -94,11 +94,12 @@
         <!-- Overridden by sub-modules without Java code -->
         <javadoc.skip>false</javadoc.skip>
 
+        <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <maven.compiler.release>8</maven.compiler.release>
+        <java.version.range>[11,12),[17,18)</java.version.range>
 
         <!-- Dependency version -->
         <antlr.version>4.8-1</antlr.version>
@@ -198,7 +199,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -342,7 +343,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[11.0.13,12)</version>
+                                    <version>${java.version.range}</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
                                 <bannedDependencies>


### PR DESCRIPTION
Support building and running with Java 17. The system remains compatible with both Java 8 and 11.

Upgrade the project workflows to use Java 17 instead of 11.

Note that because dynamic compilation of generated Java code is done with source and target Java 7, the system remains incompatible with Java 20 and later (as support for source/target/release 7 was dropped in Java 20).