### PR TITLE
Fix a bug with the implementation of map in compiled mode

### DIFF
--- a/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/collection/map.pure
+++ b/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/collection/map.pure
@@ -69,7 +69,17 @@ function <<test.Test>> {test.excludePlatform = 'Java compiled'} meta::pure::func
     assertEquals(['a','b','c'], $f->map($property));
 }
 
+Class meta::pure::functions::collection::tests::map::OptionalString
+{
+    value : String[0..1];
+}
 
+function <<test.Test>> meta::pure::functions::collection::tests::map::testMapWithDynamicFunctionFromZeroOneToZeroOne():Boolean[1]
+{
+    let x = {|^meta::pure::functions::collection::tests::map::OptionalString(value='1')->map(x|$x.value);};
+    let n = ^LambdaFunction<{->String[0..1]}>(expressionSequence = $x.expressionSequence);
+    assertEquals('1', $n->evaluate([]));
+}
 
 Class meta::pure::functions::collection::tests::map::model::M_Person
 {

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/grammar/collection/Map.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/grammar/collection/Map.java
@@ -81,22 +81,18 @@ public class Map extends AbstractNative implements Native
             CoreInstance sourceType = GenericType.reprocessTypeParametersUsingGenericTypeOwnerContext(source.getValueForMetaPropertyToOne(M3Properties.genericType), Instance.getValueForMetaPropertyToManyResolved(classifierGenericType, "typeArguments", processorSupport).get(0), processorSupport);
             String type = TypeProcessor.typeToJavaObjectSingle(sourceType, true, processorSupport);
 
-            result.append(Multiplicity.isToOne(returnMultiplicity, false) ? "One" : "Many");
-            result.append("Over");
-            result.append(isSourceToOne ? "One" : "Many");
-            result.append('(');
-            result.append(isFunctionReturnToOne ? list : "CompiledSupport.toPureCollection(" + list + ")");
-            result.append(", new org.eclipse.collections.api.block.function.Function2<");
-            result.append(type);
-            result.append(", ExecutionSupport, ");
-            result.append(returnType);
-            result.append(">(){public ");
-            result.append(returnType);
-            result.append(" value(final ");
-            result.append(type);
-            result.append(" _lambdaParameter, final ExecutionSupport executionSupport){return _lambdaParameter._");
-            result.append(PackageableElement.getSystemPathForPackageableElement(property, "_"));
-            result.append("();}}, es)\n");
+            result.append(Multiplicity.isToOne(returnMultiplicity, false) ? "One" : "Many").append("Over").append(isSourceToOne ? "One" : "Many").append('(');
+            if (isFunctionReturnToOne)
+            {
+                result.append(list);
+            }
+            else
+            {
+                result.append("CompiledSupport.toPureCollection(").append(list).append(")");
+            }
+            result.append(", new org.eclipse.collections.api.block.function.Function2<").append(type).append(", ExecutionSupport, ").append(returnType).append(">(){public ").append(returnType);
+            result.append(" value(final ").append(type).append(" _lambdaParameter, final ExecutionSupport executionSupport){return _lambdaParameter._");
+            PackageableElement.writeSystemPathForPackageableElement(result, property, "_").append("();}}, es)\n");
         }
         else
         {
@@ -112,27 +108,25 @@ public class Map extends AbstractNative implements Native
                 list = TypeProcessor.typeToJavaObjectSingle(Instance.getValueForMetaPropertyToOneResolved(param, M3Properties.genericType, processorSupport), false, processorSupport) + processorContext.getClassImplSuffix() + "." + list;
             }
 
-            result.append(isFunctionReturnToOne ? "One" : "Many");
-            result.append("Over");
-            result.append(isSourceToOne ? "One" : "Many");
-            result.append('(');
-            result.append(isSourceToOne ? list : "CompiledSupport.toPureCollection(" + list + ")");
-            result.append(", (org.eclipse.collections.api.block.function.Function2<");
-            result.append(type);
-            result.append(", ExecutionSupport, ");
-            result.append(returnType);
-
-            if (processorSupport.valueSpecification_instanceOf(lambdaOrProperty, M3Paths.LambdaFunction) && processorSupport.instance_instanceOf(lambdaOrProperty, M3Paths.InstanceValue) && !processorContext.isInLineAllLambda())
+            result.append(isFunctionReturnToOne ? "One" : "Many").append("Over").append(isSourceToOne ? "One" : "Many").append('(');
+            if (isSourceToOne)
             {
-                result.append(">)(");
-                result.append(ValueSpecificationProcessor.createFunctionForLambda(topLevelElement, lambdaOrProperty.getValueForMetaPropertyToOne(M3Properties.values), false, processorSupport, processorContext));
-                result.append("), es)\n");
+                result.append(list);
             }
             else
             {
-                result.append(">)(PureCompiledLambda.getPureFunction(");
-                result.append(transformedParams.get(1));
-                result.append(", es)), es)\n");
+                result.append("CompiledSupport.toPureCollection(").append(list).append(")");
+            }
+            result.append(", (org.eclipse.collections.api.block.function.Function2<").append(type).append(", ExecutionSupport, ").append(returnType);
+
+            if (processorSupport.valueSpecification_instanceOf(lambdaOrProperty, M3Paths.LambdaFunction) && processorSupport.instance_instanceOf(lambdaOrProperty, M3Paths.InstanceValue) && !processorContext.isInLineAllLambda())
+            {
+                result.append(">)(")
+                        .append(ValueSpecificationProcessor.createFunctionForLambda(topLevelElement, lambdaOrProperty.getValueForMetaPropertyToOne(M3Properties.values), false, processorSupport, processorContext)).append("), es)\n");
+            }
+            else
+            {
+                result.append(">)(PureCompiledLambda.getPureFunction(").append(transformedParams.get(1)).append(", es)), es)\n");
             }
         }
         if (isSourceToOne && isFunctionReturnToOne && !isFunctionExpressionToOne)
@@ -163,15 +157,15 @@ public class Map extends AbstractNative implements Native
                "                }\n" +
                "                else\n" +
                "                {\n" +
-               "                    throw new RuntimeException(func+\" is not supported yet!\");\n" +
+               "                    throw new RuntimeException(func + \" is not supported yet!\");\n" +
                "                }\n" +
                "                if (Pure.hasToOneUpperBound(multiplicity))\n" +
                "                {\n" +
-               "                    return CompiledSupport.mapToOneOverMany((RichIterable)o, (Function2)CoreGen.getSharedPureFunction(func,es), es);\n" +
+               "                    return (o instanceof RichIterable) ? CompiledSupport.mapToOneOverMany((RichIterable)o, (Function2)CoreGen.getSharedPureFunction(func,es), es) : CompiledSupport.mapToOneOverOne(o, (Function2)CoreGen.getSharedPureFunction(func,es), es);\n" +
                "                }\n" +
                "                else\n" +
                "                {\n" +
-               "                    return CompiledSupport.mapToManyOverMany((RichIterable)o, (Function2)CoreGen.getSharedPureFunction(func,es), es);\n" +
+               "                    return (o instanceof RichIterable) ? CompiledSupport.mapToManyOverMany((RichIterable)o, (Function2)CoreGen.getSharedPureFunction(func,es), es) : CompiledSupport.mapToManyOverOne(o, (Function2)CoreGen.getSharedPureFunction(func,es), es);\n" +
                "                }\n" +
                "            }\n" +
                "        }";

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/function/TestFunctionReturnMultiplicity.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/function/TestFunctionReturnMultiplicity.java
@@ -81,7 +81,7 @@ public class TestFunctionReturnMultiplicity extends AbstractPureTestWithCoreComp
         CoreInstance result = this.compileAndExecute("test():Any[*]");
         ListIterable<? extends CoreInstance> values = result.getValueForMetaPropertyToMany("values");
         Assert.assertEquals(7, values.size());
-        Assert.assertEquals("a instanceOf String,1 instanceOf Integer,2.0 instanceOf Float,2015-03-12 instanceOf StrictDate,2015-03-12T23:59:00+0000 instanceOf DateTime,true instanceOf Boolean,Class(49272) instanceOf Class", values.makeString(","));
+        Assert.assertEquals("a instanceOf String,1 instanceOf Integer,2.0 instanceOf Float,2015-03-12 instanceOf StrictDate,2015-03-12T23:59:00+0000 instanceOf DateTime,true instanceOf Boolean,Class(49427) instanceOf Class", values.makeString(","));
     }
 
 
@@ -116,7 +116,7 @@ public class TestFunctionReturnMultiplicity extends AbstractPureTestWithCoreComp
                 "}\n");
         CoreInstance result = this.compileAndExecute("test():Any[*]");
         CoreInstance value = result.getValueForMetaPropertyToOne("values");
-        Assert.assertEquals("Class(49272) instanceOf Class", value.toString());
+        Assert.assertEquals("Class(49427) instanceOf Class", value.toString());
     }
 
     @Test


### PR DESCRIPTION
Fix a bug with the implementation of map in compiled mode.  Specifically, the implementation used when calling map via eval/evaluate didn't properly handle the case where the collection to map over had cardinality 1 or 0..1.

In passing, add better error handling in Reactivator.