### PR TITLE
Fix bug with dynamic evaluation of and/or

### DIFF
--- a/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/conjunctions/and.pure
+++ b/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/conjunctions/and.pure
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 native function meta::pure::functions::boolean::and(first:Boolean[1], second:Boolean[1]):Boolean[1];
 
 function <<test.Test>> meta::pure::functions::boolean::tests::and::testBinaryTruthTable():Boolean[1]
@@ -46,4 +45,25 @@ function <<test.Test>> meta::pure::functions::boolean::tests::and::testTernaryEx
 {
     assert((1 == 1) && (2 != 3) && true);
     assertFalse((1 == 2) && (2 != 3) && false);
+}
+
+function <<test.Test>> meta::pure::functions::boolean::tests::and::testShortCircuit():Boolean[1]
+{
+    let val1 = ^List<String>(values=['Claudius', 'Ptolemy']);
+    let val2 = 'Claudius Ptolemy';
+    assert($val1->instanceOf(List) && ($val1->cast(@List<String>).values == ['Claudius', 'Ptolemy']));
+    assertFalse($val2->instanceOf(List) && ($val2->cast(@List<String>).values == ['Claudius', 'Ptolemy']));
+}
+
+function <<test.Test>> meta::pure::functions::boolean::tests::and::testShortCircuitInDynamicEvaluation():Boolean[1]
+{
+    let fn1 = {|let val1 = ^List<String>(values=['Claudius', 'Ptolemy']);
+                $val1->instanceOf(List) && ($val1->cast(@List<String>).values == ['Claudius', 'Ptolemy']);};
+    let lambda1 = ^LambdaFunction<{->Boolean[1]}>(expressionSequence = $fn1.expressionSequence);
+    assertEquals(true, $lambda1->evaluate([]));
+
+    let fn2 = {|let val2 = 'Claudius Ptolemy';
+                $val2->instanceOf(List) && ($val2->cast(@List<String>).values == ['Claudius', 'Ptolemy']);};
+    let lambda2 = ^LambdaFunction<{->Boolean[1]}>(expressionSequence = $fn2.expressionSequence);
+    assertEquals(false, $lambda2->evaluate([]));
 }

--- a/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/conjunctions/or.pure
+++ b/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/conjunctions/or.pure
@@ -45,3 +45,24 @@ function <<test.Test>> meta::pure::functions::boolean::tests::or::testTernaryExp
     assert((1 != 1) || (2 == 3) || true);
     assertFalse((1 == 2) || (2 == 3) || false);
 }
+
+function <<test.Test>> meta::pure::functions::boolean::tests::or::testShortCircuit():Boolean[1]
+{
+    let val1 = ^List<String>(values=['Claudius', 'Ptolemy']);
+    let val2 = 'Claudius Ptolemy';
+    assertFalse(!$val1->instanceOf(List) || ($val1->cast(@List<String>).values != ['Claudius', 'Ptolemy']));
+    assert(!$val2->instanceOf(List) || ($val2->cast(@List<String>).values != ['Claudius', 'Ptolemy']));
+}
+
+function <<test.Test>> meta::pure::functions::boolean::tests::or::testShortCircuitInDynamicEvaluation():Boolean[1]
+{
+    let fn1 = {|let val1 = ^List<String>(values=['Claudius', 'Ptolemy']);
+                !$val1->instanceOf(List) || ($val1->cast(@List<String>).values != ['Claudius', 'Ptolemy']);};
+    let lambda1 = ^LambdaFunction<{->Boolean[1]}>(expressionSequence = $fn1.expressionSequence);
+    assertEquals(false, $lambda1->evaluate([]));
+
+    let fn2 = {|let val2 = 'Claudius Ptolemy';
+                !$val2->instanceOf(List) || ($val2->cast(@List<String>).values != ['Claudius', 'Ptolemy']);};
+    let lambda2 = ^LambdaFunction<{->Boolean[1]}>(expressionSequence = $fn2.expressionSequence);
+    assertEquals(true, $lambda2->evaluate([]));
+}

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/_boolean/AbstractTestAnd.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/_boolean/AbstractTestAnd.java
@@ -15,22 +15,30 @@
 package org.finos.legend.pure.m3.tests.function.base._boolean;
 
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
+import org.junit.After;
 import org.junit.Test;
 
 public abstract class AbstractTestAnd extends AbstractPureTestWithCoreCompiled
 {
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete("fromString.pure");
+        runtime.compile();
+    }
+
     @Test
     public void testBasicParse()
     {
-            compileTestSource("fromString.pure",
-                    "function test():Boolean[1]\n" +
-                            "{\n" +
-                            "   assert(true == and(true, true), |'');\n" +
-                            "   assert(false == and(false, true), |'');\n" +
-                            "   assert(false == and(true, false), |'');\n" +
-                            "   assert(false == and(false, false), |'');\n" +
-                            "}\n");
-            this.execute("test():Boolean[1]");
+        compileTestSource("fromString.pure",
+                "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   assert(true == and(true, true), |'');\n" +
+                        "   assert(false == and(false, true), |'');\n" +
+                        "   assert(false == and(true, false), |'');\n" +
+                        "   assert(false == and(false, false), |'');\n" +
+                        "}\n");
+        execute("test():Boolean[1]");
     }
 
     @Test
@@ -44,6 +52,58 @@ public abstract class AbstractTestAnd extends AbstractPureTestWithCoreCompiled
                         "   assert(false == and_Boolean_1__Boolean_1__Boolean_1_->eval(true, false), |'');\n" +
                         "   assert(false == and_Boolean_1__Boolean_1__Boolean_1_->eval(false, false), |'');\n" +
                         "}\n");
-        this.execute("test():Boolean[1]");
+        execute("test():Boolean[1]");
+    }
+
+    @Test
+    public void testShortCircuit()
+    {
+        compileTestSource("fromString.pure",
+                "Class A\n" +
+                        "{\n" +
+                        "    value:Any[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class B\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   let a1 = ^A(value=^B(name='Claudius Ptolemy'));\n" +
+                        "   let a2 = ^A(value=1);\n" +
+                        "   assert($a1.value->instanceOf(B) && ($a1.value->cast(@B).name == 'Claudius Ptolemy'));\n" +
+                        "   assertFalse($a2.value->instanceOf(B) && ($a2.value->cast(@B).name == 'Claudius Ptolemy'));\n" +
+                        "}\n");
+        execute("test():Boolean[1]");
+    }
+
+    @Test
+    public void testShortCircuitInDynamicEvaluation()
+    {
+        compileTestSource("fromString.pure",
+                "Class A\n" +
+                        "{\n" +
+                        "    value:Any[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class B\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   let fn1 = {|let a = ^A(value=^B(name='Claudius Ptolemy'));\n" +
+                        "               $a.value->instanceOf(B) && ($a.value->cast(@B).name == 'Claudius Ptolemy');};\n" +
+                        "   let lambda1 = ^LambdaFunction<{->Boolean[1]}>(expressionSequence = $fn1.expressionSequence);\n" +
+                        "   assertEquals(true, $lambda1->evaluate([]));\n" +
+                        "   let fn2 = {|let a = ^A(value=1);\n" +
+                        "               $a.value->instanceOf(B) && ($a.value->cast(@B).name == 'Claudius Ptolemy');};\n" +
+                        "   let lambda2 = ^LambdaFunction<{->Boolean[1]}>(expressionSequence = $fn2.expressionSequence);\n" +
+                        "   assertEquals(false, $lambda2->evaluate([]));\n" +
+                        "}\n");
+        execute("test():Boolean[1]");
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/_boolean/AbstractTestNot.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/_boolean/AbstractTestNot.java
@@ -15,20 +15,28 @@
 package org.finos.legend.pure.m3.tests.function.base._boolean;
 
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
+import org.junit.After;
 import org.junit.Test;
 
 public abstract class AbstractTestNot extends AbstractPureTestWithCoreCompiled
 {
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete("fromString.pure");
+        runtime.compile();
+    }
+
     @Test
     public void testBasicParse()
     {
-            compileTestSource("fromString.pure",
-                    "function test():Boolean[1]\n" +
-                            "{\n" +
-                            "   assert(true == not(false), |'');\n" +
-                            "   assert(false == not(true), |'');\n" +
-                            "}\n");
-            this.execute("test():Boolean[1]");
+        compileTestSource("fromString.pure",
+                "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   assert(true == not(false), |'');\n" +
+                        "   assert(false == not(true), |'');\n" +
+                        "}\n");
+        execute("test():Boolean[1]");
     }
 
     @Test
@@ -40,6 +48,6 @@ public abstract class AbstractTestNot extends AbstractPureTestWithCoreCompiled
                         "   assert(true == not_Boolean_1__Boolean_1_->eval(false), |'');\n" +
                         "   assert(false == not_Boolean_1__Boolean_1_->eval(true), |'');\n" +
                         "}\n");
-        this.execute("test():Boolean[1]");
+        execute("test():Boolean[1]");
     }
 }

--- a/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/_boolean/AbstractTestOr.java
+++ b/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/_boolean/AbstractTestOr.java
@@ -15,22 +15,30 @@
 package org.finos.legend.pure.m3.tests.function.base._boolean;
 
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
+import org.junit.After;
 import org.junit.Test;
 
 public abstract class AbstractTestOr extends AbstractPureTestWithCoreCompiled
 {
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete("fromString.pure");
+        runtime.compile();
+    }
+
     @Test
     public void testBasicParse()
     {
-            compileTestSource("fromString.pure",
-                    "function test():Boolean[1]\n" +
-                            "{\n" +
-                            "   assert(true == or(true, true), |'');\n" +
-                            "   assert(true == or(false, true), |'');\n" +
-                            "   assert(true == or(true, false), |'');\n" +
-                            "   assert(false == or(false, false), |'');\n" +
-                            "}\n");
-            this.execute("test():Boolean[1]");
+        compileTestSource("fromString.pure",
+                "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   assert(true == or(true, true), |'');\n" +
+                        "   assert(true == or(false, true), |'');\n" +
+                        "   assert(true == or(true, false), |'');\n" +
+                        "   assert(false == or(false, false), |'');\n" +
+                        "}\n");
+        execute("test():Boolean[1]");
     }
 
     @Test
@@ -44,6 +52,58 @@ public abstract class AbstractTestOr extends AbstractPureTestWithCoreCompiled
                         "   assert(true == or_Boolean_1__Boolean_1__Boolean_1_->eval(true, false), |'');\n" +
                         "   assert(false == or_Boolean_1__Boolean_1__Boolean_1_->eval(false, false), |'');\n" +
                         "}\n");
-        this.execute("test():Boolean[1]");
+        execute("test():Boolean[1]");
+    }
+
+    @Test
+    public void testShortCircuit()
+    {
+        compileTestSource("fromString.pure",
+                "Class A\n" +
+                        "{\n" +
+                        "    value:Any[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class B\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   let a1 = ^A(value=^B(name='Claudius Ptolemy'));\n" +
+                        "   let a2 = ^A(value=1);\n" +
+                        "   assertFalse(!$a1.value->instanceOf(B) || ($a1.value->cast(@B).name != 'Claudius Ptolemy'));\n" +
+                        "   assert(!$a2.value->instanceOf(B) || ($a2.value->cast(@B).name != 'Claudius Ptolemy'));\n" +
+                        "}\n");
+        execute("test():Boolean[1]");
+    }
+
+    @Test
+    public void testShortCircuitInDynamicEvaluation()
+    {
+        compileTestSource("fromString.pure",
+                "Class A\n" +
+                        "{\n" +
+                        "    value:Any[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class B\n" +
+                        "{\n" +
+                        "    name:String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   let fn1 = {|let a = ^A(value=^B(name='Claudius Ptolemy'));\n" +
+                        "               !$a.value->instanceOf(B) || ($a.value->cast(@B).name != 'Claudius Ptolemy');};\n" +
+                        "   let lambda1 = ^LambdaFunction<{->Boolean[1]}>(expressionSequence = $fn1.expressionSequence);\n" +
+                        "   assertEquals(false, $lambda1->evaluate([]));\n" +
+                        "   let fn2 = {|let a = ^A(value=1);\n" +
+                        "               !$a.value->instanceOf(B) || ($a.value->cast(@B).name != 'Claudius Ptolemy');};\n" +
+                        "   let lambda2 = ^LambdaFunction<{->Boolean[1]}>(expressionSequence = $fn2.expressionSequence);\n" +
+                        "   assertEquals(true, $lambda2->evaluate([]));\n" +
+                        "}\n");
+        execute("test():Boolean[1]");
     }
 }

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/basics/lang/If.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/basics/lang/If.java
@@ -126,9 +126,9 @@ public class If extends AbstractNative
         return "new DefendedPureFunction3<Boolean, " + FullJavaPaths.Function + ", " + FullJavaPaths.Function + ", Object>()\n" +
                 "        {\n" +
                 "            @Override\n" +
-                "            public Object value(Boolean condition, " + FullJavaPaths.Function + " truth, " + FullJavaPaths.Function + " falsy, ExecutionSupport es)\n" +
+                "            public Object value(Boolean condition, " + FullJavaPaths.Function + " t, " + FullJavaPaths.Function + " f, ExecutionSupport es)\n" +
                 "            {\n" +
-                "                return condition ? CoreGen.evaluate(es, truth, Lists.mutable.empty()) : CoreGen.evaluate(es, falsy, Lists.mutable.empty());\n" +
+                "                return condition ? CoreGen.evaluate(es, t, Lists.fixedSize.empty()) : CoreGen.evaluate(es, f, Lists.fixedSize.empty());\n" +
                 "            }\n" +
                 "        }";
     }

--- a/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Reactivator.java
+++ b/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Reactivator.java
@@ -262,6 +262,17 @@ public class Reactivator
             throw new PureDynamicReactivateException(sfe.getSourceInformation(), "Can not reactivate function, unexpected:" + func._name());
         }
 
+        String funcName = func._name();
+        // The functions "and" and "or" require special handling to avoid premature evaluation of parameters
+        if ("and_Boolean_1__Boolean_1__Boolean_1_".equals(funcName))
+        {
+            return sfe._parametersValues().allSatisfy(value -> (Boolean) reactivateWithoutJavaCompilationImpl(value, lambdaOpenVariablesMap, es, false, bridge));
+        }
+        if ("or_Boolean_1__Boolean_1__Boolean_1_".equals(funcName))
+        {
+            return sfe._parametersValues().anySatisfy(value -> (Boolean) reactivateWithoutJavaCompilationImpl(value, lambdaOpenVariablesMap, es, false, bridge));
+        }
+
         MutableList<RichIterable<?>> paramValues = sfe._parametersValues().collect(value ->
         {
             Object newValue = reactivateWithoutJavaCompilationImpl(value, lambdaOpenVariablesMap, es, false, bridge);
@@ -279,7 +290,7 @@ public class Reactivator
             }
             return Lists.fixedSize.of(newValue);
         }, Lists.mutable.empty());
-        String funcName = func._name();
+
         if (funcName != null)
         {
             switch (funcName)

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/function/TestFunctionReturnMultiplicity.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/modeling/function/TestFunctionReturnMultiplicity.java
@@ -81,7 +81,7 @@ public class TestFunctionReturnMultiplicity extends AbstractPureTestWithCoreComp
         CoreInstance result = this.compileAndExecute("test():Any[*]");
         ListIterable<? extends CoreInstance> values = result.getValueForMetaPropertyToMany("values");
         Assert.assertEquals(7, values.size());
-        Assert.assertEquals("a instanceOf String,1 instanceOf Integer,2.0 instanceOf Float,2015-03-12 instanceOf StrictDate,2015-03-12T23:59:00+0000 instanceOf DateTime,true instanceOf Boolean,Class(49582) instanceOf Class", values.makeString(","));
+        Assert.assertEquals("a instanceOf String,1 instanceOf Integer,2.0 instanceOf Float,2015-03-12 instanceOf StrictDate,2015-03-12T23:59:00+0000 instanceOf DateTime,true instanceOf Boolean,Class(50512) instanceOf Class", values.makeString(","));
     }
 
 
@@ -116,7 +116,7 @@ public class TestFunctionReturnMultiplicity extends AbstractPureTestWithCoreComp
                 "}\n");
         CoreInstance result = this.compileAndExecute("test():Any[*]");
         CoreInstance value = result.getValueForMetaPropertyToOne("values");
-        Assert.assertEquals("Class(49582) instanceOf Class", value.toString());
+        Assert.assertEquals("Class(50512) instanceOf Class", value.toString());
     }
 
     @Test

--- a/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/_boolean/TestCompileAnd.java
+++ b/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/_boolean/TestCompileAnd.java
@@ -15,11 +15,9 @@
 package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.base._boolean;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.function.base._boolean.AbstractTestAnd;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestCompileAnd extends AbstractTestAnd
@@ -27,18 +25,11 @@ public class TestCompileAnd extends AbstractTestAnd
     @BeforeClass
     public static void setUp()
     {
-        AbstractPureTestWithCoreCompiled.setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
-    }
-
-    @After
-    public void cleanRuntime()
-    {
-        AbstractPureTestWithCoreCompiled.runtime.delete("fromString.pure");
+        setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
     }
 
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();
     }
-
 }

--- a/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/_boolean/TestCompileNot.java
+++ b/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/_boolean/TestCompileNot.java
@@ -15,11 +15,9 @@
 package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.base._boolean;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.function.base._boolean.AbstractTestNot;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestCompileNot extends AbstractTestNot
@@ -27,18 +25,11 @@ public class TestCompileNot extends AbstractTestNot
     @BeforeClass
     public static void setUp()
     {
-        AbstractPureTestWithCoreCompiled.setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
-    }
-
-    @After
-    public void cleanRuntime()
-    {
-        AbstractPureTestWithCoreCompiled.runtime.delete("fromString.pure");
+        setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
     }
 
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();
     }
-
 }

--- a/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/_boolean/TestCompileOr.java
+++ b/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/_boolean/TestCompileOr.java
@@ -15,11 +15,9 @@
 package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.base._boolean;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.function.base._boolean.AbstractTestOr;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestCompileOr extends AbstractTestOr
@@ -27,18 +25,11 @@ public class TestCompileOr extends AbstractTestOr
     @BeforeClass
     public static void setUp()
     {
-        AbstractPureTestWithCoreCompiled.setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
-    }
-
-    @After
-    public void cleanRuntime()
-    {
-        AbstractPureTestWithCoreCompiled.runtime.delete("fromString.pure");
+        setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
     }
 
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();
     }
-
 }

--- a/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/_boolean/TestCompilePrecedence.java
+++ b/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/_boolean/TestCompilePrecedence.java
@@ -15,11 +15,9 @@
 package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.base._boolean;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.function.base._boolean.AbstractTestPrecedence;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestCompilePrecedence extends AbstractTestPrecedence
@@ -27,12 +25,11 @@ public class TestCompilePrecedence extends AbstractTestPrecedence
     @BeforeClass
     public static void setUp()
     {
-        AbstractPureTestWithCoreCompiled.setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
+        setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
     }
 
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();
     }
-
 }

--- a/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/lang/TestIfCompiled.java
+++ b/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/lang/TestIfCompiled.java
@@ -14,7 +14,7 @@
 
 package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.base.lang;
 
-import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.test.Verify;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
@@ -32,44 +32,39 @@ public class TestIfCompiled extends AbstractPureTestWithCoreCompiled
     @BeforeClass
     public static void setUp()
     {
-        AbstractPureTestWithCoreCompiled.setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
+        setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
     }
 
     @After
     public void cleanRuntime()
     {
-        AbstractPureTestWithCoreCompiled.runtime.delete("fromString.pure");
+        runtime.delete("fromString.pure");
+        runtime.compile();
     }
 
     @Test
     public void testUnAssignedIfInFuncExpression()
     {
-        try
-        {
-            String func = "function meta::pure::functions::lang::tests::if::testUnAssignedIfInFuncExpression():String[1]\n" +
-                    "{\n" +
-                    "   let ifVar =  if(true, | let b = 'true', | if(true, | let b = 'true', | 'false'););\n" +
-                    "   if(true, | let b = 'true', | if(true, | let b = 'true', | 'false'););\n" +
-                    "   if(true, | let b = 'true', | if(true, | let b = 'true', | 'false'););\n" +
-                    "   let iff = if(true, | let b = 'true', | if(true, | let b = 'true', | 'false'););\n" +
-                    "   if(true, | let b = 'true'; if(true, | let b = 'true', | 'false'); let bb = 'bb';, | let c = 'see');\n" +
-                    "   let a = 'be';\n" +
-                    "   if(true, | let b = 'true', | 'false');\n" +
-                    "}";
-            this.compileTestSource("fromString.pure", func);
-        }
-        catch (Exception e)
-        {
-            Assert.fail(e.getMessage());
-        }
+        compileTestSource(
+                "fromString.pure",
+                "function meta::pure::functions::lang::tests::if::testUnAssignedIfInFuncExpression():String[1]\n" +
+                "{\n" +
+                "   let ifVar =  if(true, | let b = 'true', | if(true, | let b = 'true', | 'false'););\n" +
+                "   if(true, | let b = 'true', | if(true, | let b = 'true', | 'false'););\n" +
+                "   if(true, | let b = 'true', | if(true, | let b = 'true', | 'false'););\n" +
+                "   let iff = if(true, | let b = 'true', | if(true, | let b = 'true', | 'false'););\n" +
+                "   if(true, | let b = 'true'; if(true, | let b = 'true', | 'false'); let bb = 'bb';, | let c = 'see');\n" +
+                "   let a = 'be';\n" +
+                "   if(true, | let b = 'true', | 'false');\n" +
+                "}");
     }
 
     @Test
     public void testIfWithDifferentMultiplicities()
     {
-        try
-        {
-            AbstractPureTestWithCoreCompiled.compileTestSource("fromString.pure", "Class A\n" +
+        compileTestSource(
+                "fromString.pure",
+                "Class A\n" +
                     "{\n" +
                     "  id : Integer[1];\n" +
                     "}\n" +
@@ -82,11 +77,6 @@ public class TestIfCompiled extends AbstractPureTestWithCoreCompiled
                     "      | let newIds = $ids->tail();\n" +
                     "        $ids->map(id | $newIds->testFn());)\n" +
                     "}");
-        }
-        catch (Exception e)
-        {
-            Assert.fail(e.getMessage());
-        }
     }
 
     @Test
@@ -113,9 +103,9 @@ public class TestIfCompiled extends AbstractPureTestWithCoreCompiled
                 "  $result;\n" +
                 "}\n");
 
-        CoreInstance testTrue = this.runtime.getFunction("test::testTrue():Any[*]");
+        CoreInstance testTrue = runtime.getFunction("test::testTrue():Any[*]");
         Assert.assertNotNull(testTrue);
-        CoreInstance resultTrue = this.functionExecution.start(testTrue, Lists.immutable.<CoreInstance>empty());
+        CoreInstance resultTrue = functionExecution.start(testTrue, Lists.immutable.empty());
         Verify.assertInstanceOf(InstanceValue.class, resultTrue);
         InstanceValue trueInstanceValue = (InstanceValue) resultTrue;
         Verify.assertSize(1, trueInstanceValue._values());
@@ -123,9 +113,9 @@ public class TestIfCompiled extends AbstractPureTestWithCoreCompiled
         Verify.assertInstanceOf(Double.class, trueValue);
         Assert.assertEquals(1.0d, trueValue);
 
-        CoreInstance testFalse = this.runtime.getFunction("test::testFalse():Any[*]");
+        CoreInstance testFalse = runtime.getFunction("test::testFalse():Any[*]");
         Assert.assertNotNull(testFalse);
-        CoreInstance resultFalse = this.functionExecution.start(testFalse, Lists.immutable.<CoreInstance>empty());
+        CoreInstance resultFalse = functionExecution.start(testFalse, Lists.immutable.empty());
         Verify.assertInstanceOf(InstanceValue.class, resultFalse);
         InstanceValue falseInstanceValue = (InstanceValue) resultFalse;
         Verify.assertSize(1, falseInstanceValue._values());

--- a/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/_boolean/TestInterpretedAnd.java
+++ b/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/_boolean/TestInterpretedAnd.java
@@ -17,7 +17,6 @@ package org.finos.legend.pure.runtime.java.interpreted.function.base._boolean;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base._boolean.AbstractTestAnd;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestInterpretedAnd extends AbstractTestAnd
@@ -26,13 +25,6 @@ public class TestInterpretedAnd extends AbstractTestAnd
     public static void setUp()
     {
         setUpRuntime(getFunctionExecution());
-    }
-
-    @After
-    public void cleanRuntime()
-    {
-        runtime.delete("fromString.pure");
-        runtime.compile();
     }
 
     protected static FunctionExecution getFunctionExecution()

--- a/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/_boolean/TestInterpretedNot.java
+++ b/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/_boolean/TestInterpretedNot.java
@@ -17,7 +17,6 @@ package org.finos.legend.pure.runtime.java.interpreted.function.base._boolean;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base._boolean.AbstractTestNot;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestInterpretedNot extends AbstractTestNot
@@ -26,13 +25,6 @@ public class TestInterpretedNot extends AbstractTestNot
     public static void setUp()
     {
         setUpRuntime(getFunctionExecution());
-    }
-
-    @After
-    public void cleanRuntime()
-    {
-        runtime.delete("fromString.pure");
-        runtime.compile();
     }
 
     protected static FunctionExecution getFunctionExecution()

--- a/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/_boolean/TestInterpretedOr.java
+++ b/legend-pure-runtime-java-extension-functions/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/_boolean/TestInterpretedOr.java
@@ -17,7 +17,6 @@ package org.finos.legend.pure.runtime.java.interpreted.function.base._boolean;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base._boolean.AbstractTestOr;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestInterpretedOr extends AbstractTestOr
@@ -26,13 +25,6 @@ public class TestInterpretedOr extends AbstractTestOr
     public static void setUp()
     {
         setUpRuntime(getFunctionExecution());
-    }
-
-    @After
-    public void cleanRuntime()
-    {
-        runtime.delete("fromString.pure");
-        runtime.compile();
     }
 
     protected static FunctionExecution getFunctionExecution()


### PR DESCRIPTION
Fix bug with dynamic evaluation of and/or to ensure that both are short-circuit operations. That is, conjuncts/disjuncts are evaluated in order and evaluation is terminated once one evaluates to false/true. This is particularly important for cases where later conjuncts/disjuncts depend on previous ones, such as instanceOf checks followed by casts.