### PR TITLE
Make TestFunctionReturnMultiplicity less brittle

### DIFF
--- a/legend-pure-m2-functions-pure/src/main/resources/platform_functions/meta/sourceInformation.pure
+++ b/legend-pure-m2-functions-pure/src/main/resources/platform_functions/meta/sourceInformation.pure
@@ -28,7 +28,7 @@ Class meta::pure::functions::meta::SourceInformation
 native function meta::pure::functions::meta::sourceInformation(node:Any[1]):SourceInformation[0..1];
 
 
-function <<test.Test>>   meta::pure::functions::meta::tests::sourceInformation::testClassSourceInformation():Boolean[1]
+function <<test.Test>> meta::pure::functions::meta::tests::sourceInformation::testClassSourceInformation():Boolean[1]
 {
     let sourceInfo = TestClass->sourceInformation()->toOne();
     assertEq('/platform_functions/meta/sourceInformation.pure', $sourceInfo.source);

--- a/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/Loader.java
+++ b/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/Loader.java
@@ -38,8 +38,6 @@ import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.m4.exception.PureException;
 
-import java.nio.file.Path;
-
 public class Loader
 {
     private static void updateStateFullContextCache(ListIterable<CoreInstance> parsedResults, Context context) throws PureCompilationException

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/tools/ConcurrentHashSet.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/tools/ConcurrentHashSet.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.m4.tools;
 
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.map.ConcurrentMutableMap;
-import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.ParallelUnsortedSetIterable;
 import org.eclipse.collections.api.set.UnsortedSetIterable;
 import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
@@ -24,6 +23,7 @@ import org.eclipse.collections.impl.set.mutable.AbstractMutableSet;
 import org.eclipse.collections.impl.set.mutable.SetAdapter;
 
 import java.util.Iterator;
+import java.util.Spliterator;
 import java.util.concurrent.ExecutorService;
 
 public class ConcurrentHashSet<T> extends AbstractMutableSet<T>
@@ -41,12 +41,12 @@ public class ConcurrentHashSet<T> extends AbstractMutableSet<T>
 
     public ConcurrentHashSet()
     {
-        this(ConcurrentHashMap.<T, Object>newMap());
+        this(ConcurrentHashMap.newMap());
     }
 
     public ConcurrentHashSet(int initialSize)
     {
-        this(ConcurrentHashMap.<T, Object>newMap(initialSize));
+        this(ConcurrentHashMap.newMap(initialSize));
     }
 
     @Override
@@ -86,28 +86,28 @@ public class ConcurrentHashSet<T> extends AbstractMutableSet<T>
     }
 
     @Override
-    public MutableSet<T> with(T element)
+    public ConcurrentHashSet<T> with(T element)
     {
         add(element);
         return this;
     }
 
     @Override
-    public MutableSet<T> without(T element)
+    public ConcurrentHashSet<T> without(T element)
     {
         remove(element);
         return this;
     }
 
     @Override
-    public MutableSet<T> withAll(Iterable<? extends T> elements)
+    public ConcurrentHashSet<T> withAll(Iterable<? extends T> elements)
     {
         addAllIterable(elements);
         return this;
     }
 
     @Override
-    public MutableSet<T> withoutAll(Iterable<? extends T> elements)
+    public ConcurrentHashSet<T> withoutAll(Iterable<? extends T> elements)
     {
         removeAllIterable(elements);
         return this;
@@ -146,7 +146,7 @@ public class ConcurrentHashSet<T> extends AbstractMutableSet<T>
     @Override
     public void each(Procedure<? super T> procedure)
     {
-        this.keySet.each(procedure);
+        this.map.forEachKey(procedure);
     }
 
     @Override
@@ -156,9 +156,17 @@ public class ConcurrentHashSet<T> extends AbstractMutableSet<T>
     }
 
     @Override
+    public Spliterator<T> spliterator()
+    {
+        return this.keySet.spliterator();
+    }
+
+    @Override
     public ConcurrentHashSet<T> clone()
     {
-        return new ConcurrentHashSet<>(ConcurrentHashMap.newMap(this.map));
+        ConcurrentHashSet<T> clone = (ConcurrentHashSet<T>) super.clone();
+        clone.map.putAll(this.map);
+        return clone;
     }
 
     public static <NT> ConcurrentHashSet<NT> newSet()

--- a/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/tools/SafeAppendable.java
+++ b/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/tools/SafeAppendable.java
@@ -73,6 +73,10 @@ public interface SafeAppendable extends Appendable
         {
             return wrap((StringBuilder) appendable);
         }
+        if (appendable instanceof StringBuffer)
+        {
+            return wrap((StringBuffer) appendable);
+        }
         return new SafeAppendable()
         {
             @Override
@@ -190,6 +194,82 @@ public interface SafeAppendable extends Appendable
             public SafeAppendable append(Object o)
             {
                 builder.append(o);
+                return this;
+            }
+        };
+    }
+
+    static SafeAppendable wrap(StringBuffer buffer)
+    {
+        return new SafeAppendable()
+        {
+            @Override
+            public SafeAppendable append(CharSequence csq)
+            {
+                buffer.append(csq);
+                return this;
+            }
+
+            @Override
+            public SafeAppendable append(CharSequence csq, int start, int end)
+            {
+                buffer.append(csq);
+                return this;
+            }
+
+            @Override
+            public SafeAppendable append(char c)
+            {
+                buffer.append(c);
+                return this;
+            }
+
+            @Override
+            public SafeAppendable append(String s)
+            {
+                buffer.append(s);
+                return this;
+            }
+
+            @Override
+            public SafeAppendable append(boolean b)
+            {
+                buffer.append(b);
+                return this;
+            }
+
+            @Override
+            public SafeAppendable append(int i)
+            {
+                buffer.append(i);
+                return this;
+            }
+
+            @Override
+            public SafeAppendable append(long l)
+            {
+                buffer.append(l);
+                return this;
+            }
+
+            @Override
+            public SafeAppendable append(float f)
+            {
+                buffer.append(f);
+                return this;
+            }
+
+            @Override
+            public SafeAppendable append(double d)
+            {
+                buffer.append(d);
+                return this;
+            }
+
+            @Override
+            public SafeAppendable append(Object o)
+            {
+                buffer.append(o);
                 return this;
             }
         };

--- a/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/serialization/binary/TestDistributedMetadataSpecification.java
+++ b/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/serialization/binary/TestDistributedMetadataSpecification.java
@@ -121,8 +121,8 @@ public class TestDistributedMetadataSpecification
 
         RuntimeException e = Assert.assertThrows(RuntimeException.class, () -> DistributedMetadataSpecification.loadSpecifications(Thread.currentThread().getContextClassLoader(), "non_existent"));
         Assert.assertEquals("Cannot find metadata \"non_existent\" (resource name \"metadata/specs/non_existent.json\")\n" +
-                "Directly asked for:[non_existent]\n" +
-                "Loaded up to now (with dependencies):{}\n" +
+                "Directly asked for: [non_existent]\n" +
+                "Loaded up to now (with dependencies): {}\n" +
                 "The requested repos are coming from PAR projects scanning. You may not have included the project containing the distributed metadata for Java generation.", e.getMessage());
     }
 
@@ -148,14 +148,14 @@ public class TestDistributedMetadataSpecification
 
             RuntimeException e1 = Assert.assertThrows(RuntimeException.class, () -> DistributedMetadataSpecification.loadSpecifications(classLoader, "ghi", "jkl"));
             Assert.assertEquals("Cannot find metadata \"xyz\" (resource name \"metadata/specs/xyz.json\")\n" +
-                    "Directly asked for:[ghi, jkl]\n" +
-                    "Loaded up to now (with dependencies):{jkl=[xyz]}\n" +
+                    "Directly asked for: [ghi, jkl]\n" +
+                    "Loaded up to now (with dependencies): {jkl=[xyz]}\n" +
                     "The requested repos are coming from PAR projects scanning. You may not have included the project containing the distributed metadata for Java generation.", e1.getMessage());
 
             RuntimeException e2 = Assert.assertThrows(RuntimeException.class, () -> DistributedMetadataSpecification.loadSpecifications(classLoader, "ghi", "mno"));
             Assert.assertEquals("Cannot find metadata \"mno\" (resource name \"metadata/specs/mno.json\")\n" +
-                    "Directly asked for:[ghi, mno]\n" +
-                    "Loaded up to now (with dependencies):{}\n" +
+                    "Directly asked for: [ghi, mno]\n" +
+                    "Loaded up to now (with dependencies): {}\n" +
                     "The requested repos are coming from PAR projects scanning. You may not have included the project containing the distributed metadata for Java generation.", e2.getMessage());
         }
     }
@@ -198,14 +198,14 @@ public class TestDistributedMetadataSpecification
 
             RuntimeException e1 = Assert.assertThrows(RuntimeException.class, () -> DistributedMetadataSpecification.loadSpecifications(classLoader, "ghi", "jkl"));
             Assert.assertEquals("Cannot find metadata \"xyz\" (resource name \"metadata/specs/xyz.json\")\n" +
-                    "Directly asked for:[ghi, jkl]\n" +
-                    "Loaded up to now (with dependencies):{jkl=[xyz]}\n" +
+                    "Directly asked for: [ghi, jkl]\n" +
+                    "Loaded up to now (with dependencies): {jkl=[xyz]}\n" +
                     "The requested repos are coming from PAR projects scanning. You may not have included the project containing the distributed metadata for Java generation.", e1.getMessage());
 
             RuntimeException e2 = Assert.assertThrows(RuntimeException.class, () -> DistributedMetadataSpecification.loadSpecifications(classLoader, "ghi", "mno"));
             Assert.assertEquals("Cannot find metadata \"mno\" (resource name \"metadata/specs/mno.json\")\n" +
-                    "Directly asked for:[ghi, mno]\n" +
-                    "Loaded up to now (with dependencies):{}\n" +
+                    "Directly asked for: [ghi, mno]\n" +
+                    "Loaded up to now (with dependencies): {}\n" +
                     "The requested repos are coming from PAR projects scanning. You may not have included the project containing the distributed metadata for Java generation.", e2.getMessage());
         }
     }


### PR DESCRIPTION
Make TestFunctionReturnMultiplicity less brittle, so that it doesn't fail every time the synthetic id of Class changes. In passing, clean up code in several files, including Context and GraphLoader.