### PR TITLE
Fix contravariant type inference with type parameters

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/M3PropertyPaths.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/M3PropertyPaths.java
@@ -14,11 +14,10 @@
 
 package org.finos.legend.pure.m3.navigation;
 
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.ImmutableSet;
-import org.eclipse.collections.impl.factory.Sets;
 import org.finos.legend.pure.m3.navigation._package._Package;
 
 /**
@@ -32,6 +31,7 @@ public class M3PropertyPaths
 
     public static final ImmutableList<String> applications = makePropertyPath(M3Paths.Function, M3Properties.applications);
     public static final ImmutableList<String> children = makePropertyPath(M3Paths.Package, M3Properties.children);
+    public static final ImmutableList<String> classifierGenericType = makePropertyPath(M3Paths.Any, M3Properties.classifierGenericType);
     public static final ImmutableList<String> func = makePropertyPath(M3Paths.FunctionExpression, M3Properties.func);
     public static final ImmutableList<String> function = makePropertyPath(M3Paths.FunctionType, M3Properties.function);
     public static final ImmutableList<String> functionName_Function = makePropertyPath(M3Paths.Function, M3Properties.functionName);
@@ -62,6 +62,7 @@ public class M3PropertyPaths
     public static final ImmutableList<String> stereotypes = makePropertyPath(M3Paths.Class, M3Properties.stereotypes);
     public static final ImmutableList<String> taggedValues = makePropertyPath(M3Paths.Class, M3Properties.taggedValues);
 
+    @SuppressWarnings("unchecked")
     public static final ImmutableSet<ImmutableList<String>> BACK_REFERENCE_PROPERTY_PATHS = Sets.immutable.with(
             applications,
             modelElements,
@@ -80,9 +81,6 @@ public class M3PropertyPaths
 
     private static ListIterable<String> getM4PropertyPath(String typePath, String propertyName)
     {
-        MutableList<String> path = _Package.convertM3PathToM4(typePath);
-        path.add(M3Properties.properties);
-        path.add(propertyName);
-        return path;
+        return _Package.convertM3PathToM4(typePath).with(M3Properties.properties).with(propertyName);
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/relation/_Column.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/relation/_Column.java
@@ -14,18 +14,18 @@
 
 package org.finos.legend.pure.m3.navigation.relation;
 
-import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.Column;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
 import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.M3PropertyPaths;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation._package._Package;
+import org.finos.legend.pure.m3.tools.ListHelper;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
-
-import java.util.List;
+import org.finos.legend.pure.m4.tools.SafeAppendable;
 
 public class _Column
 {
@@ -45,7 +45,7 @@ public class _Column
         columnGenericType._rawType((Type) _Package.getByUserPath(M3Paths.Column, processorSupport));
         columnGenericType._typeArguments(Lists.mutable.with(sourceType, targetType));
         columnGenericType._multiplicityArgumentsAdd((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity) org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity.newMultiplicity(0, 1, processorSupport));
-        columnInstance.setKeyValues(Lists.mutable.with("classifierGenericType"), Lists.mutable.with(columnGenericType));
+        columnInstance.setKeyValues(M3PropertyPaths.classifierGenericType, Lists.mutable.with(columnGenericType));
         return columnInstance;
     }
 
@@ -57,25 +57,29 @@ public class _Column
 
     public static Column<?, ?> updateSource(Column<?, ?> col, GenericType sourceType)
     {
-        List<? extends GenericType> _typeArguments = col._classifierGenericType()._typeArguments().toList();
-        col._classifierGenericType()._typeArguments(Lists.mutable.with(sourceType, _typeArguments.get(1)));
+        col._classifierGenericType()._typeArguments(Lists.mutable.with(sourceType, getColumnType(col)));
         return col;
     }
 
     public static GenericType getColumnType(Column<?, ?> column)
     {
-        return column._classifierGenericType()._typeArguments().toList().get(1);
+        return ListHelper.wrapListIterable(column._classifierGenericType()._typeArguments()).get(1);
     }
 
     public static GenericType getColumnSourceType(Column<?, ?> column)
     {
-        return column._classifierGenericType()._typeArguments().toList().get(0);
+        return ListHelper.wrapListIterable(column._classifierGenericType()._typeArguments()).get(0);
     }
 
-
-    public static String print(CoreInstance c, ProcessorSupport processorSupport)
+    public static String print(CoreInstance column, ProcessorSupport processorSupport)
     {
-        Column<?, ?> col = (Column<?, ?>) c;
-        return (col._nameWildCard() ? "?" : col._name()) + ":" + org.finos.legend.pure.m3.navigation.generictype.GenericType.print(getColumnType(col), processorSupport);
+        return print(new StringBuilder(), column, processorSupport).toString();
+    }
+
+    public static <T extends Appendable> T print(T appendable, CoreInstance col, ProcessorSupport processorSupport)
+    {
+        Column<?, ?> column = (Column<?, ?>) col;
+        org.finos.legend.pure.m3.navigation.generictype.GenericType.print(SafeAppendable.wrap(appendable).append(column._nameWildCard() ? "?" : column._name()).append(':'), getColumnType(column), processorSupport);
+        return appendable;
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/type/Type.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/type/Type.java
@@ -19,6 +19,8 @@ import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.SetIterable;
 import org.eclipse.collections.impl.factory.Sets;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Any;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.PrimitiveType;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
@@ -54,17 +56,21 @@ public class Type
      * type is an instance of the class PrimitiveType.
      *
      * @param type Pure type
+     * @param processorSupport processor support
      * @return whether type is an instance of PrimitiveType
      */
     public static boolean isPrimitiveType(CoreInstance type, ProcessorSupport processorSupport)
     {
-        return (type != null) && processorSupport.type_subTypeOf(type.getClassifier(), processorSupport.package_getByUserPath(M3Paths.PrimitiveType));
+        return (type != null) &&
+                ((type instanceof PrimitiveType) ||
+                        (!(type instanceof Any) && processorSupport.type_subTypeOf(type.getClassifier(), processorSupport.package_getByUserPath(M3Paths.PrimitiveType))));
     }
 
     /**
      * Return whether type is the bottom type (i.e., Nil).
      *
      * @param type Pure type
+     * @param processorSupport processor support
      * @return whether type is the bottom type
      */
     public static boolean isBottomType(CoreInstance type, ProcessorSupport processorSupport)
@@ -76,6 +82,7 @@ public class Type
      * Return whether type is the top type (i.e., Any).
      *
      * @param type Pure type
+     * @param processorSupport processor support
      * @return whether type is the top type
      */
     public static boolean isTopType(CoreInstance type, ProcessorSupport processorSupport)


### PR DESCRIPTION
Fix a bug with contravariant type inference with non-concrete generic types. This can occur with function expressions that return function types where one of the parameter types might be non-concrete. For example, consider this function:
```
function collectionToStrings<T|m>(col:T[m], func:Function<{T[1]->String[1]}>[0..1]):String[m]
{
    let toStringFunc = if($func->isEmpty(), |{x:T[1] | $x->toString()}, |$func->toOne());
    $col->map(x | $toStringFunc->eval($x));
}
```
The issue would occur in computing the type for the if expression. Before the fix, the type would be computed as `Function<Nil[1]->String[1]>`, whereas it should be `Function<T[1]->String[1]>`.

This also improves how generic types are hashed when finding the best common generic type. The previous hashing strategy was not fully correct for the case where the raw type was a function type. That is, it might return different hash codes for function types that were equal. The historical reason for this was that the cost of figuring out whether something was a function type outweighed the benefits of having a fully correct hashing strategy. However, now the cost of figuring out whether something is a function type is significantly less, so the benefits now outweigh the costs. The hashing strategy is now fully correct.

In passing, do some clean ups, bug fixes, and other improvements that came up while investigating the issue in question.