### PR TITLE
Add tests for ephemeral PackageableElements

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/basics/meta/elementToPath.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/basics/meta/elementToPath.pure
@@ -109,21 +109,18 @@ function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testEn
     assertEquals('Root&meta&pure&functions&meta&tests&model', elementToPath(CC_GeographicEntityType->cast(@PackageableElement).package->at(0), '&', true));
 }
 
-function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testNamedEphemeralPackageableElement():Boolean[1]
+function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testEphemeralPackageableElements():Boolean[1]
 {
     assertEquals('pkg::MyElement', ^PackageableElement(name='MyElement', package=^Package(name='pkg', package=^Package(name='Root')))->elementToPath());
     assertEquals('Root::pkg::MyElement', ^PackageableElement(name='MyElement', package=^Package(name='pkg', package=^Package(name='Root')))->elementToPath(true));
     assertEquals('pkg::MyElement', ^PackageableElement(name='MyElement', package=^Package(name='pkg', package=^Package(name='Other')))->elementToPath());
     assertEquals('Other::pkg::MyElement', ^PackageableElement(name='MyElement', package=^Package(name='pkg', package=^Package(name='Other')))->elementToPath(true));
-}
 
-function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testUnnamedEphemeralPackageableElement():Any[*]
-{
     assertEquals('', ^PackageableElement()->elementToPath());
     assertEquals('', ^PackageableElement()->elementToPath(true));
 }
 
-function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testTopLevelElementPath():Boolean[1]
+function <<test.Test>> meta::pure::functions::meta::tests::elementPath::testTopLevelElementPath():Boolean[1]
 {
     assertEquals([Package], elementPath(Package));
     assertEquals([Number], elementPath(Number));
@@ -134,12 +131,12 @@ function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testTo
     assertEquals([String], elementPath(String));
 }
 
-function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testRootElementPath():Boolean[1]
+function <<test.Test>> meta::pure::functions::meta::tests::elementPath::testRootElementPath():Boolean[1]
 {
     assertEquals([::], elementPath(::));
 }
 
-function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testElementPath():Boolean[1]
+function <<test.Test>> meta::pure::functions::meta::tests::elementPath::testElementPath():Boolean[1]
 {
     assertEquals(
         [
@@ -179,4 +176,21 @@ function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testEl
          meta
         ],
         elementPath(meta));
+}
+
+function <<test.Test>> meta::pure::functions::meta::tests::elementPath::testEphemeralPackageableElement():Boolean[1]
+{
+    let rootPkg = ^Package(name='Root');
+    let pkgPkg = ^Package(name='pkg', package=$rootPkg);
+    let element = ^PackageableElement(name='MyElement', package=$pkgPkg);
+    assertEquals([$rootPkg], $rootPkg->elementPath());
+    assertEquals([$rootPkg, $pkgPkg], $pkgPkg->elementPath());
+    assertEquals([$rootPkg, $pkgPkg, $element], $element->elementPath());
+
+    let otherRootPkg = ^Package(name='Other');
+    let otherPkgPkg = ^Package(name='pkg', package=$otherRootPkg);
+    let otherElement = ^PackageableElement(name='MyElement', package=$otherPkgPkg);
+    assertEquals([$otherRootPkg], $otherRootPkg->elementPath());
+    assertEquals([$otherRootPkg, $otherPkgPkg], $otherPkgPkg->elementPath());
+    assertEquals([$otherRootPkg, $otherPkgPkg, $otherElement], $otherElement->elementPath());
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/_enum/TestEnumerationValues.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/_enum/TestEnumerationValues.java
@@ -31,23 +31,17 @@ public class TestEnumerationValues extends AbstractPureTestWithCoreCompiledPlatf
     @Test
     public void testEnumerationWithDuplicateValues()
     {
-        try
-        {
-            compileTestSource("testSource.pure",
-                    "Enum test::TestEnum\n" +
-                            "{\n" +
-                            "    VAL1,\n" +
-                            "    VAL2,\n" +
-                            "    VAL1,\n" +
-                            "    VAL3,\n" +
-                            "    VAL2,\n" +
-                            "    VAL1\n" +
-                            "}");
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "Enumeration test::TestEnum has duplicate values: VAL1, VAL2", "testSource.pure", 1, 1, 1, 12, 9, 1, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "testSource.pure",
+                "Enum test::TestEnum\n" +
+                        "{\n" +
+                        "    VAL1,\n" +
+                        "    VAL2,\n" +
+                        "    VAL1,\n" +
+                        "    VAL3,\n" +
+                        "    VAL2,\n" +
+                        "    VAL1\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, "Enumeration test::TestEnum has duplicate values: VAL1, VAL2", "testSource.pure", 1, 1, 1, 12, 9, 1, e);
     }
 }

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-m2-functions-base-pure/src/main/resources/platform_functions/meta/newAssociation.pure
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-m2-functions-base-pure/src/main/resources/platform_functions/meta/newAssociation.pure
@@ -13,3 +13,81 @@
 // limitations under the License.
 
 native function meta::pure::functions::meta::newAssociation(name:String[1], p1:Property<Nil,Any|*>[1], p2:Property<Nil,Any|*>[1]):Association[1];
+
+
+
+
+function <<test.Test>> meta::pure::functions::meta::tests::newAssociation::testNewAssociation():Boolean[1]
+{
+    let classA = newClass('test::pkg::ClassA');
+    let classB = newClass('test::pkg::ClassB');
+    let aToB = newProperty('aToB', ^GenericType(rawType=$classA), ^GenericType(rawType=$classB), ZeroMany);
+    let bToA = newProperty('bToA', ^GenericType(rawType=$classB), ^GenericType(rawType=$classA), ZeroMany);
+
+    let myAssociation = newAssociation('pkg1::pkg2::pkg3::MyAssociation', $aToB, $bToA);
+    assertInstanceOf($myAssociation, Association);
+    assertEquals('MyAssociation', $myAssociation.name);
+    assertIs($aToB, $myAssociation.properties->at(0));
+    assertIs($bToA, $myAssociation.properties->at(1));
+
+    let pkg3 = $myAssociation.package->toOne();
+    assertInstanceOf($pkg3, Package);
+    assertEquals('pkg3', $pkg3.name);
+    assertFalse($pkg3.children->contains($myAssociation));
+
+    let pkg2 = $pkg3.package->toOne();
+    assertInstanceOf($pkg2, Package);
+    assertEquals('pkg2', $pkg2.name);
+
+    let pkg1 = $pkg2.package->toOne();
+    assertInstanceOf($pkg1, Package);
+    assertEquals('pkg1', $pkg1.name);
+
+    let rootPkg = $pkg1.package->toOne();
+    assertInstanceOf($rootPkg, Package);
+    assertEquals('Root', $rootPkg.name);
+
+    let noPackage = newAssociation('AssociationWithNoPackage', $aToB, $bToA);
+    assertInstanceOf($noPackage, Association);
+    assertEquals('AssociationWithNoPackage', $noPackage.name);
+    assertEquals('Root', $noPackage.package->toOne().name);
+    assertFalse($noPackage.package->toOne().children->contains($noPackage));
+}
+
+function <<test.Test>> meta::pure::functions::meta::tests::newAssociation::testNewAssociationElementToPath():Boolean[1]
+{
+    let classA = newClass('test::pkg::ClassA');
+    let classB = newClass('test::pkg::ClassB');
+    let aToB = newProperty('aToB', ^GenericType(rawType=$classA), ^GenericType(rawType=$classB), ZeroMany);
+    let bToA = newProperty('bToA', ^GenericType(rawType=$classB), ^GenericType(rawType=$classA), ZeroMany);
+
+    let myAssociation = newAssociation('test::pkg::MyAssociation', $aToB, $bToA);
+    assertEquals('test::pkg::MyAssociation', $myAssociation->elementToPath());
+    assertEquals('Root::test::pkg::MyAssociation', $myAssociation->elementToPath(true));
+
+    let otherAssociation = newAssociation('pkg1::pkg2::pkg3::OtherAssociation', $aToB, $bToA);
+    assertEquals('pkg1::pkg2::pkg3::OtherAssociation', $otherAssociation->elementToPath());
+    assertEquals('Root::pkg1::pkg2::pkg3::OtherAssociation', $otherAssociation->elementToPath(true));
+
+    let noPackage = newAssociation('AssociationWithNoPackage', $aToB, $bToA);
+    assertEquals('AssociationWithNoPackage', $noPackage->elementToPath());
+    assertEquals('Root::AssociationWithNoPackage', $noPackage->elementToPath(true));
+}
+
+function <<test.Test>> meta::pure::functions::meta::tests::newAssociation::testNewAssociationElementPath():Boolean[1]
+{
+    let classA = newClass('test::pkg::ClassA');
+    let classB = newClass('test::pkg::ClassB');
+    let aToB = newProperty('aToB', ^GenericType(rawType=$classA), ^GenericType(rawType=$classB), ZeroMany);
+    let bToA = newProperty('bToA', ^GenericType(rawType=$classB), ^GenericType(rawType=$classA), ZeroMany);
+
+    let myAssociation = newAssociation('pkg1::pkg2::pkg3::MyAssociation', $aToB, $bToA);
+    let pkg3 = $myAssociation.package->toOne();
+    let pkg2 = $pkg3.package->toOne();
+    let pkg1 = $pkg2.package->toOne();
+    let rootPkg = $pkg1.package->toOne();
+    assertEquals([$rootPkg, $pkg1, $pkg2, $pkg3, $myAssociation], $myAssociation->elementPath());
+
+    let noPackage = newAssociation('AssociationWithNoPackage', $aToB, $bToA);
+    assertEquals([$noPackage.package->toOne(), $noPackage], $noPackage->elementPath());
+}

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-m2-functions-base-pure/src/main/resources/platform_functions/meta/newClass.pure
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-m2-functions-base-pure/src/main/resources/platform_functions/meta/newClass.pure
@@ -13,3 +13,64 @@
 // limitations under the License.
 
 native function meta::pure::functions::meta::newClass(name:String[1]):Class<Any>[1];
+
+
+
+
+function <<test.Test>> meta::pure::functions::meta::tests::newClass::testNewClass():Boolean[1]
+{
+    let myClass = newClass('pkg1::pkg2::pkg3::MyClass');
+    assertInstanceOf($myClass, Class);
+    assertEquals('MyClass', $myClass.name);
+
+    let pkg3 = $myClass.package->toOne();
+    assertInstanceOf($pkg3, Package);
+    assertEquals('pkg3', $pkg3.name);
+    assertFalse($pkg3.children->contains($myClass));
+
+    let pkg2 = $pkg3.package->toOne();
+    assertInstanceOf($pkg2, Package);
+    assertEquals('pkg2', $pkg2.name);
+
+    let pkg1 = $pkg2.package->toOne();
+    assertInstanceOf($pkg1, Package);
+    assertEquals('pkg1', $pkg1.name);
+
+    let rootPkg = $pkg1.package->toOne();
+    assertInstanceOf($rootPkg, Package);
+    assertEquals('Root', $rootPkg.name);
+
+    let noPackage = newClass('ClassWithNoPackage');
+    assertInstanceOf($noPackage, Class);
+    assertEquals('ClassWithNoPackage', $noPackage.name);
+    assertEquals('Root', $noPackage.package->toOne().name);
+    assertFalse($noPackage.package->toOne().children->contains($noPackage));
+}
+
+function <<test.Test>> meta::pure::functions::meta::tests::newClass::testNewClassElementToPath():Boolean[1]
+{
+    let myClass = newClass('test::pkg::MyClass');
+    assertEquals('test::pkg::MyClass', $myClass->elementToPath());
+    assertEquals('Root::test::pkg::MyClass', $myClass->elementToPath(true));
+
+    let otherClass = newClass('pkg1::pkg2::pkg3::OtherClass');
+    assertEquals('pkg1::pkg2::pkg3::OtherClass', $otherClass->elementToPath());
+    assertEquals('Root::pkg1::pkg2::pkg3::OtherClass', $otherClass->elementToPath(true));
+
+    let noPackage = newClass('ClassWithNoPackage');
+    assertEquals('ClassWithNoPackage', $noPackage->elementToPath());
+    assertEquals('Root::ClassWithNoPackage', $noPackage->elementToPath(true));
+}
+
+function <<test.Test>> meta::pure::functions::meta::tests::newClass::testNewClassElementPath():Boolean[1]
+{
+    let myClass = newClass('pkg1::pkg2::pkg3::MyClass');
+    let pkg3 = $myClass.package->toOne();
+    let pkg2 = $pkg3.package->toOne();
+    let pkg1 = $pkg2.package->toOne();
+    let rootPkg = $pkg1.package->toOne();
+    assertEquals([$rootPkg, $pkg1, $pkg2, $pkg3, $myClass], $myClass->elementPath());
+
+    let noPackage = newClass('ClassWithNoPackage');
+    assertEquals([$noPackage.package->toOne(), $noPackage], $noPackage->elementPath());
+}

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-m2-functions-base-pure/src/main/resources/platform_functions/meta/newEnumeration.pure
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-m2-functions-base-pure/src/main/resources/platform_functions/meta/newEnumeration.pure
@@ -13,3 +13,66 @@
 // limitations under the License.
 
 native function meta::pure::functions::meta::newEnumeration(name:String[1], values:String[*]):Enumeration<Any>[1];
+
+
+
+
+function <<test.Test>> meta::pure::functions::meta::tests::newEnumeration::testNewEnumeration():Boolean[1]
+{
+    let myEnumeration = newEnumeration('pkg1::pkg2::pkg3::MyEnumeration', ['val1', 'val2']);
+    assertInstanceOf($myEnumeration, Enumeration);
+    assertEquals('MyEnumeration', $myEnumeration->cast(@ModelElement).name);
+
+    let pkg3 = $myEnumeration->cast(@PackageableElement).package->toOne();
+    assertInstanceOf($pkg3, Package);
+    assertEquals('pkg3', $pkg3.name);
+    assertFalse($pkg3.children->contains($myEnumeration));
+
+    let pkg2 = $pkg3.package->toOne();
+    assertInstanceOf($pkg2, Package);
+    assertEquals('pkg2', $pkg2.name);
+
+    let pkg1 = $pkg2.package->toOne();
+    assertInstanceOf($pkg1, Package);
+    assertEquals('pkg1', $pkg1.name);
+
+    let rootPkg = $pkg1.package->toOne();
+    assertInstanceOf($rootPkg, Package);
+    assertEquals('Root', $rootPkg.name);
+
+    let noPackage = newEnumeration('EnumerationWithNoPackage', ['val3']);
+    let noPackagePkg = $noPackage->cast(@PackageableElement).package->toOne();
+    assertInstanceOf($noPackage, Enumeration);
+    assertEquals('EnumerationWithNoPackage', $noPackage->cast(@ModelElement).name);
+    assertEquals('Root', $noPackagePkg.name);
+    assertFalse($noPackagePkg.children->contains($noPackage));
+}
+
+function <<test.Test>> meta::pure::functions::meta::tests::newEnumeration::testNewEnumerationElementToPath():Boolean[1]
+{
+    let myEnumeration = newEnumeration('test::pkg::MyEnumeration', ['val1', 'val2']);
+    assertEquals('test::pkg::MyEnumeration', $myEnumeration->elementToPath());
+    assertEquals('Root::test::pkg::MyEnumeration', $myEnumeration->elementToPath(true));
+
+    let otherEnumeration = newEnumeration('pkg1::pkg2::pkg3::OtherEnumeration', ['val3', 'val4']);
+    assertEquals('pkg1::pkg2::pkg3::OtherEnumeration', $otherEnumeration->elementToPath());
+    assertEquals('Root::pkg1::pkg2::pkg3::OtherEnumeration', $otherEnumeration->elementToPath(true));
+
+    let noPackage = newEnumeration('EnumerationWithNoPackage', ['val5']);
+    assertEquals('EnumerationWithNoPackage', $noPackage->elementToPath());
+    assertEquals('Root::EnumerationWithNoPackage', $noPackage->elementToPath(true));
+}
+
+function <<test.Test>> meta::pure::functions::meta::tests::newEnumeration::testNewEnumerationElementPath():Boolean[1]
+{
+    let myEnumeration = newEnumeration('pkg1::pkg2::pkg3::MyEnumeration', ['val1', 'val2']);
+    let pkg3 = $myEnumeration->cast(@PackageableElement).package->toOne();
+    let pkg2 = $pkg3.package->toOne();
+    let pkg1 = $pkg2.package->toOne();
+    let rootPkg = $pkg1.package->toOne();
+    assertEquals([$rootPkg, $pkg1, $pkg2, $pkg3, $myEnumeration], $myEnumeration->elementPath());
+
+    let noPackage = newEnumeration('EnumerationWithNoPackage', ['val3']);
+    let noPackagePkg = $noPackage->cast(@PackageableElement).package->toOne();
+    assertEquals([$noPackagePkg, $noPackage], $noPackage->elementPath());
+}

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-compiled-functions-base/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/natives/meta/NewEnumeration.java
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-compiled-functions-base/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/natives/meta/NewEnumeration.java
@@ -30,7 +30,7 @@ public class NewEnumeration extends AbstractNative
     @Override
     public String build(CoreInstance topLevelElement, CoreInstance functionExpression, ListIterable<String> transformedParams, ProcessorContext processorContext)
     {
-        return "FunctionsGen.newEnumeration(" + transformedParams.get(0) + "," + transformedParams.get(1) + ",((CompiledExecutionSupport)es).getMetadataAccessor(), " + NativeFunctionProcessor.buildM4SourceInformation(functionExpression.getSourceInformation()) + ")";
+        return "FunctionsGen.newEnumeration(" + transformedParams.get(0) + ",CompiledSupport.toPureCollection(" + transformedParams.get(1) + "),((CompiledExecutionSupport)es).getMetadataAccessor(), " + NativeFunctionProcessor.buildM4SourceInformation(functionExpression.getSourceInformation()) + ")";
     }
 
     @Override
@@ -42,7 +42,7 @@ public class NewEnumeration extends AbstractNative
                 "            @Override\n" +
                 "            public Object execute(ListIterable<?> vars, final ExecutionSupport es)\n" +
                 "            {\n" +
-                "                return FunctionsGen.newEnumeration((String) vars.get(0), (RichIterable) vars.get(1), ((CompiledExecutionSupport) es).getMetadataAccessor(), null);\n" +
+                "                return FunctionsGen.newEnumeration((String) vars.get(0), CompiledSupport.toPureCollection(vars.get(1)), ((CompiledExecutionSupport) es).getMetadataAccessor(), null);\n" +
                 "            }\n" +
                 "        }";
     }

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-interpreted-functions-base/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/natives/meta/NewAssociation.java
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-interpreted-functions-base/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/natives/meta/NewAssociation.java
@@ -14,33 +14,33 @@
 
 package org.finos.legend.pure.runtime.java.extension.functions.interpreted.natives.meta;
 
-import java.util.Stack;
-
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.pure.m3.compiler.Context;
+import org.finos.legend.pure.m3.compiler.postprocessing.PostProcessor;
+import org.finos.legend.pure.m3.exception.PureExecutionException;
+import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
-import org.finos.legend.pure.m3.exception.PureExecutionException;
-import org.finos.legend.pure.m3.compiler.Context;
-import org.finos.legend.pure.m3.navigation.Instance;
-import org.finos.legend.pure.m3.navigation.ValueSpecificationBootstrap;
-import org.finos.legend.pure.m3.compiler.postprocessing.PostProcessor;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
-import org.finos.legend.pure.m3.navigation._package._Package;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.ValueSpecificationBootstrap;
+import org.finos.legend.pure.m3.navigation._package._Package;
 import org.finos.legend.pure.m3.serialization.grammar.ParserLibrary;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.inlinedsl.InlineDSLLibrary;
 import org.finos.legend.pure.m3.tools.ListHelper;
-import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
-import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.interpreted.ExecutionSupport;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 import org.finos.legend.pure.runtime.java.interpreted.VariableContext;
 import org.finos.legend.pure.runtime.java.interpreted.natives.InstantiationContext;
 import org.finos.legend.pure.runtime.java.interpreted.natives.NativeFunction;
 import org.finos.legend.pure.runtime.java.interpreted.profiler.Profiler;
+
+import java.util.Stack;
 
 public class NewAssociation extends NativeFunction
 {
@@ -70,7 +70,6 @@ public class NewAssociation extends NativeFunction
         PostProcessor.process(Lists.immutable.with(newAssociation), this.repository, new ParserLibrary(), new InlineDSLLibrary(), null, context, processorSupport, null, null);
 
         Instance.addValueToProperty(newAssociation, M3Properties._package, pack, processorSupport);
-        Instance.addValueToProperty(pack, M3Properties.children, newAssociation, processorSupport);
 
         return ValueSpecificationBootstrap.wrapValueSpecification(newAssociation, true, processorSupport);
     }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/modeling/_enum/TestEnumeration.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/modeling/_enum/TestEnumeration.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2024 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,24 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.pure.runtime.java.compiled.modeling._enum;
+package org.finos.legend.pure.runtime.java.interpreted.modeling._enum;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.elements._enum.AbstractTestEnumeration;
-import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
+import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 import org.junit.BeforeClass;
 
-public class TestEnumerationCompiled extends AbstractTestEnumeration
+public class TestEnumeration extends AbstractTestEnumeration
 {
     @BeforeClass
     public static void setUp()
     {
-        setUpRuntime(getFunctionExecution(), getCodeStorage(), JavaModelFactoryRegistryLoader.loader());
+        setUpRuntime(getFunctionExecution(), getCodeStorage(), getFactoryRegistryOverride(), getOptions(), getExtra());
     }
 
-    public static FunctionExecution getFunctionExecution()
+    protected static FunctionExecution getFunctionExecution()
     {
-        return new FunctionExecutionCompiledBuilder().build();
+        return new FunctionExecutionInterpreted();
     }
 }


### PR DESCRIPTION
Add tests for ephemeral PackageableElements, primarily for elementPath and elementToPath. Add tests specifically for ephemeral elements created by newClass, newEnumeration, and newAssociation.

Also, fix an issue with the compiled mode implementation of newEnumeration, and improve the compiled mode implementation for creating ephemeral packages when they do not exist.
