### PR TITLE
Fix handling of type parameters when computing best generic type

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/generictype/Support.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/generictype/Support.java
@@ -249,10 +249,13 @@ public class Support
             }
         }
 
-        if (nonTopConcreteGenericTypeList.isEmpty())
+        int typeParameterCount = nonConcreteGenericTypes.size();
+        int nonTopConcreteGenericTypeCount = nonTopConcreteGenericTypeList.size();
+
+        if (nonTopConcreteGenericTypeCount == 0)
         {
             // All types are Any or non-concrete
-            switch (nonConcreteGenericTypes.size())
+            switch (typeParameterCount)
             {
                 case 0:
                 {
@@ -272,7 +275,13 @@ public class Support
             }
         }
 
-        if (nonTopConcreteGenericTypeList.size() == 1)
+        if (typeParameterCount > 0)
+        {
+            // We have a mix of non-concrete and (non-Any) concrete: return Nil
+            return Type.wrapGenericType(bottomType, replaceSourceInfo ? newSourceInfo : null, processorSupport);
+        }
+
+        if (nonTopConcreteGenericTypeCount == 1)
         {
             // Only one concrete non-top type, so we return a copy of it
             return GenericType.copyGenericType(nonTopConcreteGenericTypeList.get(0), replaceSourceInfo, newSourceInfo, processorSupport);
@@ -332,10 +341,14 @@ public class Support
                 nonBottomConcreteGenericTypeList.add(genericType);
             }
         }
-        if (nonBottomConcreteGenericTypeList.isEmpty())
+
+        int typeParameterCount = nonConcreteGenericTypes.size();
+        int nonBottomConcreteGenericTypesCount = nonBottomConcreteGenericTypeList.size();
+
+        if (nonBottomConcreteGenericTypesCount == 0)
         {
             // All types are Nil or non-concrete
-            switch (nonConcreteGenericTypes.size())
+            switch (typeParameterCount)
             {
                 case 0:
                 {
@@ -354,18 +367,17 @@ public class Support
                 }
             }
         }
-        int nonBottomConcreteGenericTypesCount = nonBottomConcreteGenericTypeList.size();
+
+        if (typeParameterCount > 0)
+        {
+            // We have a mix of non-concrete and (non-Nil) concrete: return Any
+            return Type.wrapGenericType(topType, replaceSourceInfo ? newSourceInfo : null, processorSupport);
+        }
+
         if (nonBottomConcreteGenericTypesCount == 1)
         {
-            if (!nonConcreteGenericTypes.isEmpty())
-            {
-                return Type.wrapGenericType(topType, replaceSourceInfo ? newSourceInfo : null, processorSupport);
-            }
-            else
-            {
-                // Only one concrete type, so we return a copy of it
-                return GenericType.copyGenericType(nonBottomConcreteGenericTypeList.get(0), replaceSourceInfo, newSourceInfo, processorSupport);
-            }
+            // Only one concrete type, so we return a copy of it
+            return GenericType.copyGenericType(nonBottomConcreteGenericTypeList.get(0), replaceSourceInfo, newSourceInfo, processorSupport);
         }
 
         // General case

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/function/inference/TestFunctionTypeInference.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/function/inference/TestFunctionTypeInference.java
@@ -21,13 +21,13 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionTy
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.SimpleFunctionExpression;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.exception.PureUnmatchedFunctionException;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.navigation.generictype.GenericType;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
@@ -614,9 +614,9 @@ public class TestFunctionTypeInference extends AbstractPureTestWithCoreCompiledP
     {
         compileInferenceTest(
                 "Class meta::core::runtime::Runtime\n" +
-                        "{}" +
+                        "{}\n" +
                         "Class meta::pure::mapping::Mapping\n" +
-                        "{}" +
+                        "{}\n" +
                         "function <<functionType.NotImplementedFunction>> meta::pure::mapping::from<T|m>(t:T[m], runtime:meta::core::runtime::Runtime[1]):T[m]\n" +
                         "{\n" +
                         "    $t\n" +
@@ -625,26 +625,24 @@ public class TestFunctionTypeInference extends AbstractPureTestWithCoreCompiledP
                         "function <<functionType.NotImplementedFunction>> meta::pure::mapping::from<T|m>(t:T[m], m:meta::pure::mapping::Mapping[1], runtime:meta::core::runtime::Runtime[1]):T[m]\n" +
                         "{\n" +
                         "    $t\n" +
-                        "}" +
+                        "}\n" +
                         "function <<functionType.NotImplementedFunction>> meta::pure::mapping::from<T|m>(t:T[m], m:meta::pure::mapping::Mapping[1]):T[m]\n" +
                         "{\n" +
                         "    $t\n" +
-                        "}" +
-                        "function x():Function<Any>[1]" +
-                        "{" +
-                        "  if(true,|meta::pure::mapping::from_T_m__Runtime_1__T_m_,|meta::pure::mapping::from_T_m__Mapping_1__Runtime_1__T_m_)" +
-                        "}" +
-                        "function z():Function<{Nil[*], Nil[1]->Any[*]}>[1]" +
-                        "{" +
-                        "  if(true,|meta::pure::mapping::from_T_m__Runtime_1__T_m_,|meta::pure::mapping::from_T_m__Mapping_1__T_m_)" +
-                        "}" +
-                        "function z2():Function<Any>[1]" +
-                        "{" +
-                        "  if(true,|getAllVersionsInRange_Class_1__Date_1__Date_1__T_MANY_,|getAll_Class_1__T_MANY_)" +
-                        "}"
+                        "}\n" +
+                        "function x():Function<Any>[1]\n" +
+                        "{\n" +
+                        "  if(true,|meta::pure::mapping::from_T_m__Runtime_1__T_m_,|meta::pure::mapping::from_T_m__Mapping_1__Runtime_1__T_m_)\n" +
+                        "}\n" +
+                        "function z():Function<{Nil[*], Nil[1]->Any[*]}>[1]\n" +
+                        "{\n" +
+                        "  if(true,|meta::pure::mapping::from_T_m__Runtime_1__T_m_,|meta::pure::mapping::from_T_m__Mapping_1__T_m_)\n" +
+                        "}\n" +
+                        "function z2():Function<Any>[1]\n" +
+                        "{\n" +
+                        "  if(true,|getAllVersionsInRange_Class_1__Date_1__Date_1__T_MANY_,|getAll_Class_1__T_MANY_)\n" +
+                        "}\n"
         );
-
-
     }
 
     @Test

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/function/inference/TestReturnInference.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/function/inference/TestReturnInference.java
@@ -37,44 +37,39 @@ public class TestReturnInference extends AbstractPureTestWithCoreCompiledPlatfor
     public void clearRuntime()
     {
         runtime.delete("fromString.pure");
+        runtime.compile();
     }
 
     @Test
     public void testReturnInferenceFail()
     {
-        try
-        {
-            runtime.createInMemorySource("fromString.pure", "function test(s:String[1]):Any[*]\n" +
-                    "{\n" +
-                    "   let r = '10';\n" +
-                    "   ex(w:String[1]|$w+$s+$r);\n" +
-                    "}\n" +
-                    "\n" +
-                    "function ex(f:Function<Any>[1]):Any[*]\n" +
-                    "{\n" +
-                    "   print($f->eval('ee'));\n" +
-                    "}\n" +
-                    "\n" +
-                    "function go():Any[*]\n" +
-                    "{\n" +
-                    "   print(test('www'),5);\n" +
-                    "}");
-            this.runtime.compile();
-            Assert.fail("Expected compilation exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, PureUnmatchedFunctionException.FUNCTION_UNMATCHED_MESSAGE + "eval(_:Function<Any>[1],_:String[1])\n" +
-                    PureUnmatchedFunctionException.EMPTY_CANDIDATES_WITH_PACKAGE_IMPORTED_MESSAGE +
-                    PureUnmatchedFunctionException.NONEMPTY_CANDIDATES_WITH_PACKAGE_NOT_IMPORTED_MESSAGE +
-                    "\tmeta::pure::functions::lang::eval(Function<{->V[m]}>[1]):V[m]\n" +
-                    "\tmeta::pure::functions::lang::eval(Function<{S[n], T[o], U[p], W[q], X[r], Y[s], Z[t]->V[m]}>[1], S[n], T[o], U[p], W[q], X[r], Y[s], Z[t]):V[m]\n" +
-                    "\tmeta::pure::functions::lang::eval(Function<{T[n], U[p], W[q], X[r], Y[s], Z[t]->V[m]}>[1], T[n], U[p], W[q], X[r], Y[s], Z[t]):V[m]\n" +
-                    "\tmeta::pure::functions::lang::eval(Function<{T[n], U[p], W[q], X[r], Y[s]->V[m]}>[1], T[n], U[p], W[q], X[r], Y[s]):V[m]\n" +
-                    "\tmeta::pure::functions::lang::eval(Function<{T[n], U[p], W[q], X[r]->V[m]}>[1], T[n], U[p], W[q], X[r]):V[m]\n" +
-                    "\tmeta::pure::functions::lang::eval(Function<{T[n], U[p], W[q]->V[m]}>[1], T[n], U[p], W[q]):V[m]\n" +
-                    "\tmeta::pure::functions::lang::eval(Function<{T[n], U[p]->V[m]}>[1], T[n], U[p]):V[m]\n" +
-                    "\tmeta::pure::functions::lang::eval(Function<{T[n]->V[m]}>[1], T[n]):V[m]\n", "fromString.pure", 9, 14, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function test(s:String[1]):Any[*]\n" +
+                        "{\n" +
+                        "   let r = '10';\n" +
+                        "   ex(w:String[1]|$w+$s+$r);\n" +
+                        "}\n" +
+                        "\n" +
+                        "function ex(f:Function<Any>[1]):Any[*]\n" +
+                        "{\n" +
+                        "   print($f->eval('ee'));\n" +
+                        "}\n" +
+                        "\n" +
+                        "function go():Any[*]\n" +
+                        "{\n" +
+                        "   print(test('www'),5);\n" +
+                        "}"));
+        assertPureException(PureCompilationException.class, PureUnmatchedFunctionException.FUNCTION_UNMATCHED_MESSAGE + "eval(_:Function<Any>[1],_:String[1])\n" +
+                PureUnmatchedFunctionException.EMPTY_CANDIDATES_WITH_PACKAGE_IMPORTED_MESSAGE +
+                PureUnmatchedFunctionException.NONEMPTY_CANDIDATES_WITH_PACKAGE_NOT_IMPORTED_MESSAGE +
+                "\tmeta::pure::functions::lang::eval(Function<{->V[m]}>[1]):V[m]\n" +
+                "\tmeta::pure::functions::lang::eval(Function<{S[n], T[o], U[p], W[q], X[r], Y[s], Z[t]->V[m]}>[1], S[n], T[o], U[p], W[q], X[r], Y[s], Z[t]):V[m]\n" +
+                "\tmeta::pure::functions::lang::eval(Function<{T[n], U[p], W[q], X[r], Y[s], Z[t]->V[m]}>[1], T[n], U[p], W[q], X[r], Y[s], Z[t]):V[m]\n" +
+                "\tmeta::pure::functions::lang::eval(Function<{T[n], U[p], W[q], X[r], Y[s]->V[m]}>[1], T[n], U[p], W[q], X[r], Y[s]):V[m]\n" +
+                "\tmeta::pure::functions::lang::eval(Function<{T[n], U[p], W[q], X[r]->V[m]}>[1], T[n], U[p], W[q], X[r]):V[m]\n" +
+                "\tmeta::pure::functions::lang::eval(Function<{T[n], U[p], W[q]->V[m]}>[1], T[n], U[p], W[q]):V[m]\n" +
+                "\tmeta::pure::functions::lang::eval(Function<{T[n], U[p]->V[m]}>[1], T[n], U[p]):V[m]\n" +
+                "\tmeta::pure::functions::lang::eval(Function<{T[n]->V[m]}>[1], T[n]):V[m]\n", "fromString.pure", 9, 14, e);
     }
 }


### PR DESCRIPTION
Fix handling of type parameters when computing best generic type. In particular, this extends a fix from one special case (covariant with 1 concrete generic type) to all cases (covariant and contravariant with any number of concrete generic types).