### PR TITLE
Add optional lineSeparator parameter to readFile native function

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/_class/AbstractTestConstraints.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/_class/AbstractTestConstraints.java
@@ -14,24 +14,22 @@
 
 package org.finos.legend.pure.m3.tests.elements._class;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableRepositoryCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.finos.legend.pure.m4.serialization.grammar.antlr.PureParserException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.nio.file.Path;
 
 public abstract class AbstractTestConstraints extends AbstractPureTestWithCoreCompiled
 {

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/io/AbstractTestHttp.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/io/AbstractTestHttp.java
@@ -14,9 +14,13 @@
 
 package org.finos.legend.pure.m3.tests.function.base.io;
 
-import com.sun.net.httpserver.*;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -34,7 +38,7 @@ public abstract class AbstractTestHttp extends AbstractPureTestWithCoreCompiled
     }
 
     @AfterClass
-    public static void stopHttp() throws Exception
+    public static void stopHttp()
     {
         httpServer.stop(0);
     }
@@ -49,6 +53,7 @@ public abstract class AbstractTestHttp extends AbstractPureTestWithCoreCompiled
     public void cleanRuntime()
     {
         runtime.delete("testHttp.pure");
+        runtime.compile();
     }
 
     @Test

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/io/AbstractTestPrint.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/io/AbstractTestPrint.java
@@ -15,11 +15,19 @@
 package org.finos.legend.pure.m3.tests.function.base.io;
 
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
 public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
 {
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete("fromString.pure");
+        runtime.compile();
+    }
+
     @Test
     public void testPrint()
     {
@@ -28,7 +36,7 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
                 "    print('Hello World', 1);\n" +
                 "}\n");
         this.execute("testPrint():Nil[0]");
-        Assert.assertEquals("'Hello World'", this.functionExecution.getConsole().getLine(0));
+        Assert.assertEquals("'Hello World'", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -39,7 +47,7 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
                 "    'a'->print(1);\n" +
                 "}\n");
         this.execute("testArrowWithFunctionNoParameters():Nil[0]");
-        Assert.assertEquals("'a'", this.functionExecution.getConsole().getLine(0));
+        Assert.assertEquals("'a'", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -50,7 +58,7 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
                 "    print(123, 1);\n" +
                 "}\n");
         this.execute("testPrintInteger():Nil[0]");
-        Assert.assertEquals("123", this.functionExecution.getConsole().getLine(0));
+        Assert.assertEquals("123", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -61,7 +69,7 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
                 "    print(123.456, 1);\n" +
                 "}\n");
         this.execute("testPrintFloat():Nil[0]");
-        Assert.assertEquals("123.456", this.functionExecution.getConsole().getLine(0));
+        Assert.assertEquals("123.456", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -72,7 +80,7 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
                 "    print(%2016-07-08, 1);\n" +
                 "}\n");
         this.execute("testPrintDate():Nil[0]");
-        Assert.assertEquals("2016-07-08", this.functionExecution.getConsole().getLine(0));
+        Assert.assertEquals("2016-07-08", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -83,7 +91,7 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
                 "    print(true, 1);\n" +
                 "}\n");
         this.execute("testPrintBoolean():Nil[0]");
-        Assert.assertEquals("true", this.functionExecution.getConsole().getLine(0));
+        Assert.assertEquals("true", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -98,7 +106,7 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
                 "   1\n" +
                 "   2\n" +
                 "   3\n" +
-                "]", this.functionExecution.getConsole().getLine(0));
+                "]", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -113,7 +121,7 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
                 "   1.0\n" +
                 "   2.5\n" +
                 "   3.0\n" +
-                "]", this.functionExecution.getConsole().getLine(0));
+                "]", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -127,7 +135,7 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
         Assert.assertEquals("[\n" +
                 "   1973-11-13T23:09:11+0000\n" +
                 "   2016-07-08\n" +
-                "]", this.functionExecution.getConsole().getLine(0));
+                "]", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -135,14 +143,14 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
     {
         compileTestSource("fromString.pure","function testPrintStringCollection():Nil[0]\n" +
                 "{\n" +
-                "    print([\'testString\', \'2.5\', \'%2016-07-08\'], 1);\n" +
+                "    print(['testString', '2.5', '%2016-07-08'], 1);\n" +
                 "}\n");
         this.execute("testPrintStringCollection():Nil[0]");
         Assert.assertEquals("[\n" +
-                "   \'testString\'\n" +
-                "   \'2.5\'\n" +
-                "   \'%2016-07-08\'\n" +
-                "]", this.functionExecution.getConsole().getLine(0));
+                "   'testString'\n" +
+                "   '2.5'\n" +
+                "   '%2016-07-08'\n" +
+                "]", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -150,7 +158,7 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
     {
         compileTestSource("fromString.pure","function testPrintMixedCollection():Nil[0]\n" +
                 "{\n" +
-                "    print([1, 2.5, \'testString\', %2016-07-08], 1);\n" +
+                "    print([1, 2.5, 'testString', %2016-07-08], 1);\n" +
                 "}\n");
         this.execute("testPrintMixedCollection():Nil[0]");
         Assert.assertEquals("[\n" +
@@ -158,7 +166,7 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
                             "   2.5\n" +
                             "   'testString'\n" +
                             "   2016-07-08\n" +
-                            "]", this.functionExecution.getConsole().getLine(0));
+                            "]", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -277,7 +285,7 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
                 "                    values(Property):\n" +
                 "                        [~>] tst__String_1_ instance ConcreteFunctionDefinition\n" +
                 "            propertyName(Property):\n" +
-                "                values instance String", this.functionExecution.getConsole().getLine(0));
+                "                values instance String", functionExecution.getConsole().getLine(0));
     }
 
     @Test
@@ -309,6 +317,6 @@ public abstract class AbstractTestPrint extends AbstractPureTestWithCoreCompiled
                 "    referenceUsages(Property):\n" +
                 "        [>0] Anonymous_StripedId instance ReferenceUsage\n" +
                 "        [>0] Anonymous_StripedId instance ReferenceUsage\n" +
-                "        [>0] Anonymous_StripedId instance ReferenceUsage", this.functionExecution.getConsole().getLine(0));
+                "        [>0] Anonymous_StripedId instance ReferenceUsage", functionExecution.getConsole().getLine(0));
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/io/AbstractTestReadFile.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/io/AbstractTestReadFile.java
@@ -1,0 +1,151 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.tests.function.base.io;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableRepositoryCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.serialization.grammar.StringEscape;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public abstract class AbstractTestReadFile extends AbstractPureTestWithCoreCompiled
+{
+    private static final String TEST_FILE_NAME = "/read_file_test/test.pure";
+    private static final String TEST_TEXT_FILE_NAME = "/read_file_test/io/readFileTestText.txt";
+
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete(TEST_FILE_NAME);
+        runtime.compile();
+    }
+
+    @Test
+    public void testReadFileNoLineSeparator()
+    {
+        compileTestSource(
+                TEST_FILE_NAME,
+                "function readTestFile():String[0..1]\n" +
+                        "{\n" +
+                        "  readFile('" + StringEscape.escape(TEST_TEXT_FILE_NAME) + "')\n" +
+                        "}\n"
+        );
+        String expected = getTestText();
+        String actual = executeAndGetStringResult("readTestFile():String[0..1]");
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testReadFileNewLine()
+    {
+        testReadFileWithLineSeparator("\n");
+    }
+
+    @Test
+    public void testReadFileCarriageReturn()
+    {
+        testReadFileWithLineSeparator("\r");
+    }
+
+    @Test
+    public void testReadFileNewLineCarriageReturn()
+    {
+        testReadFileWithLineSeparator("\n\r");
+    }
+
+    @Test
+    public void testReadFileCarriageReturnNewLine()
+    {
+        testReadFileWithLineSeparator("\r\n");
+    }
+
+    @Test
+    public void testReadFileEmptyString()
+    {
+        testReadFileWithLineSeparator("");
+    }
+
+    private void testReadFileWithLineSeparator(String lineSeparator)
+    {
+        compileTestSource(
+                TEST_FILE_NAME,
+                "function readTestFile():String[0..1]\n" +
+                        "{\n" +
+                        "  readFile('" + StringEscape.escape(TEST_TEXT_FILE_NAME) + "', '" + StringEscape.escape(lineSeparator) + "')\n" +
+                        "}\n"
+        );
+        String expected = getTestText().replaceAll("\\R", lineSeparator);
+        String actual = executeAndGetStringResult("readTestFile():String[0..1]");
+        Assert.assertEquals(expected, actual);
+    }
+
+    private String executeAndGetStringResult(String functionDesc)
+    {
+        CoreInstance func = runtime.getFunction(functionDesc);
+        Assert.assertNotNull(functionDesc, func);
+        CoreInstance result = functionExecution.start(func, Lists.immutable.empty());
+        return PrimitiveUtilities.getStringValue(result.getValueForMetaPropertyToOne(M3Properties.values));
+    }
+
+    private String getTestText()
+    {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        String resourceName = TEST_TEXT_FILE_NAME.substring(1);
+        URL url = classLoader.getResource(resourceName);
+        if (url == null)
+        {
+            throw new RuntimeException("Could not find resource: " + resourceName);
+        }
+        try (Reader reader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))
+        {
+            StringBuilder builder = new StringBuilder();
+            char[] buffer = new char[1024];
+            int read;
+            while ((read = reader.read(buffer)) != -1)
+            {
+                builder.append(buffer, 0, read);
+            }
+            return builder.toString();
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    protected static MutableRepositoryCodeStorage getCodeStorage()
+    {
+        MutableList<CodeRepository> repositories = Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
+        repositories.add(new GenericCodeRepository("read_file_test", null, "platform", "platform_functions"));
+        return new CompositeCodeStorage(new ClassLoaderCodeStorage(repositories));
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/test/resources/read_file_test/io/readFileTestText.txt
+++ b/legend-pure-core/legend-pure-m3-core/src/test/resources/read_file_test/io/readFileTestText.txt
@@ -1,4 +1,4 @@
-// Copyright 2022 Goldman Sachs
+// Copyright 2024 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-function meta::pure::functions::io::readFile(filePath:String[1]):String[0..1]
-{
-    readFile($filePath, [])
-}
-
-// Read the text of a file. If lineSeparator is supplied, then it will replace any line separators found in the file.
-// This can be used, for example, to ensure consistency of line separator independently of the underlying file system.
-native function meta::pure::functions::io::readFile(filePath:String[1], lineSeparator:String[0..1]):String[0..1];
+This is a test
+This is only a test
+Do not panic

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-compiled-functions-base/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/FunctionsHelper.java
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-compiled-functions-base/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/FunctionsHelper.java
@@ -49,6 +49,7 @@ import org.finos.legend.pure.m3.execution.ExecutionSupport;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.function.FunctionDescriptor;
 import org.finos.legend.pure.m3.navigation.function.InvalidFunctionDescriptorException;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.RepositoryCodeStorage;
 import org.finos.legend.pure.m3.serialization.runtime.SourceRegistry;
 import org.finos.legend.pure.m3.tools.StatisticsUtil;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
@@ -1500,9 +1501,15 @@ public class FunctionsHelper
 
 
     // IO -----------------------------------------------------------------------
-    public static String readFile(String path, ExecutionSupport es)
+    public static String readFile(String path, String lineSeparator, ExecutionSupport es)
     {
-        return ((CompiledExecutionSupport) es).getCodeStorage().exists(path) ? ((CompiledExecutionSupport) es).getCodeStorage().getContentAsText(path) : null;
+        RepositoryCodeStorage codeStorage = ((CompiledExecutionSupport) es).getCodeStorage();
+        if (!codeStorage.exists(path))
+        {
+            return null;
+        }
+        String content = codeStorage.getContentAsText(path);
+        return (lineSeparator == null) ? content : content.replaceAll("\\R", lineSeparator);
     }
     // IO -----------------------------------------------------------------------
 

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-compiled-functions-base/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/natives/io/ReadFile.java
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-compiled-functions-base/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/natives/io/ReadFile.java
@@ -21,6 +21,6 @@ public class ReadFile extends AbstractNativeFunctionGeneric
 {
     public ReadFile()
     {
-        super("FunctionsGen.readFile", new Class[]{String.class, ExecutionSupport.class}, false, true, false, "readFile_String_1__String_$0_1$_");
+        super("FunctionsGen.readFile", new Class[]{String.class, String.class, ExecutionSupport.class}, false, true, false, "readFile_String_1__String_$0_1$__String_$0_1$_");
     }
 }

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-compiled-functions-base/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/io/TestHttpCompiled.java
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-compiled-functions-base/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/io/TestHttpCompiled.java
@@ -15,7 +15,6 @@
 package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.base.io;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.function.base.io.AbstractTestHttp;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
@@ -26,7 +25,7 @@ public class TestHttpCompiled extends AbstractTestHttp
     @BeforeClass
     public static void setUp()
     {
-        AbstractPureTestWithCoreCompiled.setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
+        setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
     }
 
     public static FunctionExecution getFunctionExecution()

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-compiled-functions-base/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/io/TestPrintCompiled.java
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-compiled-functions-base/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/io/TestPrintCompiled.java
@@ -15,11 +15,9 @@
 package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.base.io;
 
 import org.finos.legend.pure.m3.execution.FunctionExecution;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.function.base.io.AbstractTestPrint;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestPrintCompiled extends AbstractTestPrint
@@ -27,13 +25,7 @@ public class TestPrintCompiled extends AbstractTestPrint
     @BeforeClass
     public static void setUp()
     {
-        AbstractPureTestWithCoreCompiled.setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
-    }
-
-    @After
-    public void cleanRuntime()
-    {
-        AbstractPureTestWithCoreCompiled.runtime.delete("fromString.pure");
+        setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
     }
 
     public static FunctionExecution getFunctionExecution()

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-compiled-functions-base/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/io/TestReadFile.java
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-compiled-functions-base/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/io/TestReadFile.java
@@ -1,0 +1,35 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.base.io;
+
+import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.tests.function.base.io.AbstractTestReadFile;
+import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
+import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
+import org.junit.BeforeClass;
+
+public class TestReadFile extends AbstractTestReadFile
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage(), JavaModelFactoryRegistryLoader.loader());
+    }
+
+    protected static FunctionExecution getFunctionExecution()
+    {
+        return new FunctionExecutionCompiledBuilder().build();
+    }
+}

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-interpreted-functions-base/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/FunctionExtensionInterpreted.java
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-interpreted-functions-base/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/FunctionExtensionInterpreted.java
@@ -210,7 +210,7 @@ public class FunctionExtensionInterpreted extends BaseInterpretedExtension
 
                 //IO
                 Tuples.pair("executeHTTPRaw_URL_1__HTTPMethod_1__String_$0_1$__String_$0_1$__HTTPResponse_1_", Http::new),
-                Tuples.pair("readFile_String_1__String_$0_1$_", ReadFile::new),
+                Tuples.pair("readFile_String_1__String_$0_1$__String_$0_1$_", ReadFile::new),
 
                 //Lang
                 Tuples.pair("match_Any_MANY__Function_$1_MANY$__P_o__T_m_", Match::new),

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-interpreted-functions-base/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/io/TestPrint.java
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-interpreted-functions-base/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/io/TestPrint.java
@@ -17,7 +17,6 @@ package org.finos.legend.pure.runtime.java.interpreted.function.base.io;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.function.base.io.AbstractTestPrint;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestPrint extends AbstractTestPrint
@@ -26,12 +25,6 @@ public class TestPrint extends AbstractTestPrint
     public static void setUp()
     {
         setUpRuntime(getFunctionExecution());
-    }
-
-    @After
-    public void cleanRuntime()
-    {
-        runtime.delete("fromString.pure");
     }
 
     protected static FunctionExecution getFunctionExecution()

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-interpreted-functions-base/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/io/TestReadFile.java
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-runtime-java-extension-interpreted-functions-base/src/test/java/org/finos/legend/pure/runtime/java/interpreted/function/base/io/TestReadFile.java
@@ -1,0 +1,34 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.interpreted.function.base.io;
+
+import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.tests.function.base.io.AbstractTestReadFile;
+import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
+import org.junit.BeforeClass;
+
+public class TestReadFile extends AbstractTestReadFile
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution(), getCodeStorage());
+    }
+
+    protected static FunctionExecution getFunctionExecution()
+    {
+        return new FunctionExecutionInterpreted();
+    }
+}


### PR DESCRIPTION
Add an optional lineSeparator parameter to readFile native function. When supplied, line separators in the underlying text will be replaced with the give line separtor. This can be used, for example, to ensure line separator consistency independently of the underlying file system.