### PR TITLE
Fix a bug in SourceInformation.isValid

### DIFF
--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/SourceInformation.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/SourceInformation.java
@@ -273,6 +273,8 @@ public class SourceInformation implements Comparable<SourceInformation>
         return (this.sourceId != null) &&
                 (this.startLine >= 1) &&
                 (this.startColumn >= 1) &&
+                (this.column >= 1) &&
+                (this.endColumn >= 1) &&
                 isNotBefore(this.line, this.column, this.startLine, this.startColumn) &&
                 isNotBefore(this.endLine, this.endColumn, this.line, this.column);
     }

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/TestSourceInformation.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/TestSourceInformation.java
@@ -321,6 +321,10 @@ public class TestSourceInformation
         Assert.assertFalse(new SourceInformation(sourceId, 5, 1, 5, 3, 5, 2).isValid());
         Assert.assertFalse(new SourceInformation(sourceId, 5, 3, 5, 2, 5, 8).isValid());
         Assert.assertFalse(new SourceInformation(sourceId, 5, 3, 5, 5, 4, 8).isValid());
+
+        Assert.assertTrue(new SourceInformation(sourceId, 5, 3, 6, 1, 7, 8).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 5, 3, 6, 0, 7, 8).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 5, 3, 6, 1, 7, 0).isValid());
     }
 
     private void assertSubsumes(SourceInformation sourceInfo1, SourceInformation sourceInfo2)


### PR DESCRIPTION
Fix a bug in SourceInformation.isValid that failed to catch some cases where the main or end column was invalid. Add corresponding tests.