### PR TITLE
Compiled mode: set default values for new instances in reactivator flow

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/meta/AbstractTestReactivate.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/meta/AbstractTestReactivate.java
@@ -186,4 +186,22 @@ public abstract class AbstractTestReactivate extends AbstractPureTestWithCoreCom
                         "}\n");
         Assert.assertEquals(runtime.getCoreInstance("test::pkg1"), ((InstanceValue) execute("test::pkg1::test():Any[1]"))._values().getOnly());
     }
+
+    @Test
+    public void testReactivateNewDefaultValues()
+    {
+        compileTestSource("testSource.pure",
+                "Class test::A\n" +
+                        "{\n" +
+                        "  a:Boolean[1] = true;\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test::f():Boolean[1]\n" +
+                        "{\n" +
+                        "  let l = {| ^test::A()};\n" +
+                        "  let a = $l.expressionSequence->evaluateAndDeactivate()->toOne()->reactivate()->cast(@test::A)->toOne();\n" +
+                        "  assert($a.a, | '');\n" +
+                        "}\n");
+        execute("test::f():Boolean[1]");
+    }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/Pure.java
@@ -33,6 +33,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Concre
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.NativeFunction;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.DefaultValue;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
@@ -731,8 +732,33 @@ public class Pure
                     {
                         m.invoke(result, Lists.fixedSize.of(res));
                     }
+
                 }
             });
+
+            // Set default values
+            aClass._properties().forEach(new CheckedProcedure<Property<?, ?>>()
+            {
+                @Override
+                public void safeValue(Property<?, ?> p) throws Exception
+                {
+                    DefaultValue defaultValue = p._defaultValue();
+                    if (defaultValue != null)
+                    {
+                        Object result = reactivate(defaultValue._functionDefinition()._expressionSequence().getFirst(), new PureMap(Maps.fixedSize.empty()), bridge, es);
+                        Method method = c.getMethod("_" + p._name(), RichIterable.class);
+                        if (result instanceof RichIterable)
+                        {
+                            method.invoke(result, result);
+                        }
+                        else
+                        {
+                            method.invoke(result, Lists.fixedSize.of(result));
+                        }
+                    }
+                }
+            });
+
 
             return result;
         }


### PR DESCRIPTION
This fixes a bug in the compiled mode version of reactivator where evaluation of calls to new does not set default values defined on the class being instantiated