### PR TITLE
Define packages individually in m3.pure

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/m3.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/m3.pure
@@ -15,162 +15,161 @@
 ^Package Root
 {
     Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'Root',
-    Package.properties[children] : [
-            ^Package meta
-            {
-                Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'meta',
-                Package.properties[children] : [
-                                        ^Package pure
-                                        {
-                                            Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'pure',
-                                            Package.properties[children] : [^Package metamodel
-                                                                            {
-                                                                                Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'metamodel',
-                                                                                Package.properties[children] :  [
-                                                                                                                    ^Package type
-                                                                                                                    {
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'type',
-                                                                                                                        Package.properties[children] :
-                                                                                                                        [
-                                                                                                                            ^Package generics
-                                                                                                                            {
-                                                                                                                                Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'generics',
-                                                                                                                                Package.properties[children] : [],
-                                                                                                                                Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel].children[type]
-                                                                                                                            }
-                                                                                                                        ],
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
-                                                                                                                    }
-                                                                                                                    ,
-                                                                                                                    ^Package treepath
-                                                                                                                    {
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'treepath',
-                                                                                                                        Package.properties[children] :
-                                                                                                                        [],
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
-                                                                                                                    }
-                                                                                                                    ,
-                                                                                                                    ^Package constraint
-                                                                                                                     {
-                                                                                                                         Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'constraint',
-                                                                                                                         Package.properties[children] :
-                                                                                                                         [],
-                                                                                                                         Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
-                                                                                                                     }
-                                                                                                                     ,
-                                                                                                                    ^Package function
-                                                                                                                    {
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'function',
-                                                                                                                        Package.properties[children] :
-                                                                                                                        [
-                                                                                                                            ^Package property
-                                                                                                                            {
-                                                                                                                                Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'property',
-                                                                                                                                Package.properties[children] : [],
-                                                                                                                                Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel].children[function]
-                                                                                                                            }
-                                                                                                                        ],
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
-                                                                                                                    }
-                                                                                                                    ,
-                                                                                                                    ^Package relation
-                                                                                                                    {
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'relation',
-                                                                                                                        Package.properties[children] : [],
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
-                                                                                                                    }
-                                                                                                                    ,
-                                                                                                                    ^Package relationship
-                                                                                                                    {
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'relationship',
-                                                                                                                        Package.properties[children] : [],
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
-                                                                                                                    }
-                                                                                                                    ,
-                                                                                                                    ^Package valuespecification
-                                                                                                                    {
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'valuespecification',
-                                                                                                                        Package.properties[children] : [],
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
-                                                                                                                    }
-                                                                                                                    ,
-                                                                                                                    ^Package multiplicity
-                                                                                                                    {
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'multiplicity',
-                                                                                                                        Package.properties[children] : [],
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
-                                                                                                                    }
-                                                                                                                    ,
-                                                                                                                    ^Package extension
-                                                                                                                    {
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'extension',
-                                                                                                                        Package.properties[children] : [],
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
-                                                                                                                    }
-                                                                                                                    ,
-                                                                                                                    ^Package import
-                                                                                                                    {
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'import',
-                                                                                                                        Package.properties[children] : [],
-                                                                                                                        Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
-                                                                                                                    }
-                                                                                                                ],
-                                                                                Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure]
-                                                                            },
-                                                                            ^Package functions
-                                                                            {
-                                                                                Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'functions',
-                                                                                Package.properties[children] :
-                                                                                                        [
-                                                                                                            ^Package lang
-                                                                                                            {
-                                                                                                                Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'lang',
-                                                                                                                Package.properties[children] : [],
-                                                                                                                Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[functions]
-                                                                                                            }
-                                                                                                        ],
-                                                                                Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure]
-                                                                            },
-                                                                            ^Package tools
-                                                                            {
-                                                                                Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'tools',
-                                                                                Package.properties[children] : [],
-                                                                                Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure]
-                                                                            },
-                                                                            ^Package router
-                                                                            {
-                                                                                Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'router',
-                                                                                Package.properties[children] : [],
-                                                                                Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure]
-                                                                            },
-                                                                            ^Package test
-                                                                            {
-                                                                                Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'test',
-                                                                                Package.properties[children] : [],
-                                                                                Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure]
-                                                                            }],
-                                            Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta]
-                                        }
-                                    ]
-                                    ,
-                                    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root
-            }
-            ,
-            ^Package system
-            {
-                Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'system',
-                Package.properties[children] :
-                [
-                    ^Package imports
-                    {
-                        Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'imports',
-                        Package.properties[children] : [],
-                        Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[system]
-                    }
-                ],
-                Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root
-            }
-    ]
+    Package.properties[children] : []
+}
+
+^Package meta @Root.children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'meta',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root
+}
+
+^Package system @Root.children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'system',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root
+}
+
+^Package pure @Root.children[meta].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'pure',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta]
+}
+
+^Package metamodel @Root.children[meta].children[pure].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'metamodel',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure]
+}
+
+^Package functions @Root.children[meta].children[pure].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'functions',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure]
+}
+
+^Package tools @Root.children[meta].children[pure].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'tools',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure]
+}
+
+^Package router @Root.children[meta].children[pure].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'router',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure]
+}
+
+^Package test @Root.children[meta].children[pure].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'test',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure]
+}
+
+^Package type @Root.children[meta].children[pure].children[metamodel].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'type',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
+}
+
+^Package treepath @Root.children[meta].children[pure].children[metamodel].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'treepath',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
+}
+
+^Package constraint @Root.children[meta].children[pure].children[metamodel].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'constraint',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
+}
+
+^Package function @Root.children[meta].children[pure].children[metamodel].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'function',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
+}
+
+^Package relation @Root.children[meta].children[pure].children[metamodel].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'relation',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
+}
+
+^Package relationship @Root.children[meta].children[pure].children[metamodel].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'relationship',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
+}
+
+^Package valuespecification @Root.children[meta].children[pure].children[metamodel].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'valuespecification',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
+}
+
+^Package multiplicity @Root.children[meta].children[pure].children[metamodel].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'multiplicity',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
+}
+
+^Package extension @Root.children[meta].children[pure].children[metamodel].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'extension',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
+}
+
+^Package import @Root.children[meta].children[pure].children[metamodel].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'import',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel]
+}
+
+^Package lang @Root.children[meta].children[pure].children[functions].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'lang',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[functions]
+}
+
+^Package generics @Root.children[meta].children[pure].children[metamodel].children[type].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'generics',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel].children[type]
+}
+
+^Package property @Root.children[meta].children[pure].children[metamodel].children[function].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'property',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[meta].children[pure].children[metamodel].children[function]
+}
+
+^Package imports @Root.children[system].children
+{
+    Root.children[meta].children[pure].children[metamodel].children[ModelElement].properties[name] : 'imports',
+    Package.properties[children] : [],
+    Root.children[meta].children[pure].children[metamodel].children[PackageableElement].properties[package] : Root.children[system]
 }
 
 ^Root.children[meta].children[pure].children[metamodel].children[import].children[ImportGroup] coreImport @Root.children[system].children[imports].children

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractCompiledStateIntegrityTest.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractCompiledStateIntegrityTest.java
@@ -150,6 +150,60 @@ public abstract class AbstractCompiledStateIntegrityTest
     }
 
     @Test
+    public void testCorePackages()
+    {
+        // Root
+        CoreInstance root = repository.getTopLevel(M3Paths.Root);
+        Assert.assertNotNull(root);
+        Assert.assertTrue(processorSupport.instance_instanceOf(root, M3Paths.Package));
+        Assert.assertEquals(M3Paths.Root, root.getName());
+        Assert.assertEquals(M3Paths.Root, PrimitiveUtilities.getStringValue(root.getValueForMetaPropertyToOne(M3Properties.name)));
+        Assert.assertEquals(M3Paths.Root, PackageableElement.getUserPathForPackageableElement(root));
+        Assert.assertNull(root.getValueForMetaPropertyToOne(M3Properties._package));
+
+        CoreInstance meta = assertCorePackage("meta", root);
+        CoreInstance metaPure = assertCorePackage("meta::pure", meta);
+        CoreInstance metaPureMetamodel = assertCorePackage("meta::pure::metamodel", metaPure);
+        CoreInstance metaPureFunctions = assertCorePackage("meta::pure::functions", metaPure);
+        assertCorePackage("meta::pure::tools", metaPure);
+        assertCorePackage("meta::pure::router", metaPure);
+        assertCorePackage("meta::pure::test", metaPure);
+
+        CoreInstance metaPureMetamodelType = assertCorePackage("meta::pure::metamodel::type", metaPureMetamodel);
+        assertCorePackage("meta::pure::metamodel::treepath", metaPureMetamodel);
+        assertCorePackage("meta::pure::metamodel::constraint", metaPureMetamodel);
+        CoreInstance metaPureMetamodelFunction = assertCorePackage("meta::pure::metamodel::function", metaPureMetamodel);
+        assertCorePackage("meta::pure::metamodel::relation", metaPureMetamodel);
+        assertCorePackage("meta::pure::metamodel::relationship", metaPureMetamodel);
+        assertCorePackage("meta::pure::metamodel::valuespecification", metaPureMetamodel);
+        assertCorePackage("meta::pure::metamodel::multiplicity", metaPureMetamodel);
+        assertCorePackage("meta::pure::metamodel::extension", metaPureMetamodel);
+        assertCorePackage("meta::pure::metamodel::import", metaPureMetamodel);
+
+        assertCorePackage("meta::pure::functions::lang", metaPureFunctions);
+        assertCorePackage("meta::pure::metamodel::type::generics", metaPureMetamodelType);
+        assertCorePackage("meta::pure::metamodel::function::property", metaPureMetamodelFunction);
+
+        CoreInstance system = assertCorePackage("system", root);
+        assertCorePackage("system::imports", system);
+    }
+
+    private CoreInstance assertCorePackage(String path, CoreInstance parent)
+    {
+        int lastColon = path.lastIndexOf(':');
+        String name = (lastColon == -1) ? path : path.substring(lastColon + 1);
+        CoreInstance pkg = parent.getValueInValueForMetaPropertyToManyWithKey(M3Properties.children, M3Properties.name, name);
+        Assert.assertNotNull(path, pkg);
+        Assert.assertTrue(path, processorSupport.instance_instanceOf(pkg, M3Paths.Package));
+        Assert.assertSame(path, parent, pkg.getValueForMetaPropertyToOne(M3Properties._package));
+        Assert.assertEquals(path, name, pkg.getName());
+        Assert.assertEquals(path, name, PrimitiveUtilities.getStringValue(pkg.getValueForMetaPropertyToOne(M3Properties.name)));
+        Assert.assertEquals(path, PackageableElement.getUserPathForPackageableElement(pkg));
+        Assert.assertNotEquals(path, Lists.fixedSize.empty(), pkg.getValueForMetaPropertyToMany(M3Properties.children));
+        return pkg;
+    }
+
+    @Test
     public void testNullClassifiers()
     {
         MutableList<CoreInstance> nullClassifiers = selectNodes(n -> n.getClassifier() == null);

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/lineinfo/TestLineInfo.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/lineinfo/TestLineInfo.java
@@ -116,7 +116,7 @@ public class TestLineInfo extends AbstractPureTestWithCoreCompiledPlatform
         CoreInstance classifierGenericType = propertiesByName.get("classifierGenericType");
         Assert.assertNotNull(classifierGenericType);
         // Note: these source coordinates may change if m3.pure changes
-        assertSourceInformation("/platform/pure/grammar/m3.pure", 1015, 13, 1015, 126, 1022, 17, classifierGenericType.getSourceInformation());
+        assertSourceInformation("/platform/pure/grammar/m3.pure", 1014, 13, 1014, 126, 1021, 17, classifierGenericType.getSourceInformation());
 
         // Test function
         CoreInstance func = runtime.getCoreInstance("pkg1::pkg2::printSomething__Any_1_");
@@ -136,7 +136,7 @@ public class TestLineInfo extends AbstractPureTestWithCoreCompiledPlatform
         Assert.assertNotNull(funcType);
         Assert.assertEquals(M3Paths.ConcreteFunctionDefinition, PackageableElement.getUserPathForPackageableElement(funcType, "::"));
         // Note: these source coordinates may change if m3.pure changes
-        assertSourceInformation("/platform/pure/grammar/m3.pure", 2269, 1, 2269, 88, 2293, 1, funcType.getSourceInformation());
+        assertSourceInformation("/platform/pure/grammar/m3.pure", 2268, 1, 2268, 88, 2292, 1, funcType.getSourceInformation());
     }
 
     @Test


### PR DESCRIPTION
Define packages individually in m3.pure. Add a test to ensure we have the correct core packages in the correct hierarchy.

In passing, remove some unnecessary exception wrapping in JavaCodeGeneration.