### PR TITLE
PCT - Update the documentationByName to Multimap

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/aggregate/model/Documentation.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/aggregate/model/Documentation.java
@@ -14,11 +14,10 @@
 
 package org.finos.legend.pure.m3.pct.aggregate.model;
 
-import org.eclipse.collections.api.factory.Maps;
-
-import java.util.Map;
+import org.eclipse.collections.api.multimap.MutableMultimap;
+import org.eclipse.collections.impl.factory.Multimaps;
 
 public class Documentation
 {
-    public Map<String, FunctionDocumentation> documentationByName = Maps.mutable.empty();
+    public MutableMultimap<String, FunctionDocumentation> documentationByName = Multimaps.mutable.list.empty();
 }


### PR DESCRIPTION
Use Multimap to hold multiple sourceIDs for the same function name.
This will allow all the occurrences of functions on the report