### PR TITLE
Improve compiled state integrity tests

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/TestM3CoreCompiledStateIntegrity.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/TestM3CoreCompiledStateIntegrity.java
@@ -14,10 +14,6 @@
 
 package org.finos.legend.pure.m3.tests;
 
-import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableRepositoryCodeStorage;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
 import org.junit.BeforeClass;
 
 
@@ -26,7 +22,6 @@ public class TestM3CoreCompiledStateIntegrity extends AbstractCompiledStateInteg
     @BeforeClass
     public static void initialize()
     {
-        MutableRepositoryCodeStorage codeStorage = new CompositeCodeStorage(new ClassLoaderCodeStorage(CodeRepositoryProviderHelper.findPlatformCodeRepository()));
-        initialize(codeStorage);
+        initialize("platform");
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-pure/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-pure/pom.xml
@@ -117,5 +117,16 @@
             <artifactId>eclipse-collections</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-pure/src/test/java/org/finos/legend/pure/m2/dsl/diagram/TestM2DiagramCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-pure/src/test/java/org/finos/legend/pure/m2/dsl/diagram/TestM2DiagramCompiledStateIntegrity.java
@@ -1,0 +1,27 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m2.dsl.diagram;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+
+public class TestM2DiagramCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("platform_dsl_diagram");
+    }
+}

--- a/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-m2-dsl-graph-pure/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-m2-dsl-graph-pure/pom.xml
@@ -129,5 +129,17 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-m2-dsl-graph-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/graph/TestM2GraphCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-m2-dsl-graph-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/graph/TestM2GraphCompiledStateIntegrity.java
@@ -1,0 +1,27 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m2.inlinedsl.graph;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+
+public class TestM2GraphCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("platform_dsl_graph");
+    }
+}

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-pure/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-pure/pom.xml
@@ -140,5 +140,17 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-pure/src/test/java/org/finos/legend/pure/m2/dsl/mapping/TestM2MappingCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-pure/src/test/java/org/finos/legend/pure/m2/dsl/mapping/TestM2MappingCompiledStateIntegrity.java
@@ -1,0 +1,27 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m2.dsl.mapping;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+
+public class TestM2MappingCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("platform_dsl_mapping");
+    }
+}

--- a/legend-pure-dsl/legend-pure-dsl-path/legend-pure-m2-dsl-path-pure/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-path/legend-pure-m2-dsl-path-pure/pom.xml
@@ -115,6 +115,17 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
         </dependency>
-    </dependencies>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/legend-pure-dsl/legend-pure-dsl-path/legend-pure-m2-dsl-path-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/path/TestM2PathCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-path/legend-pure-m2-dsl-path-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/path/TestM2PathCompiledStateIntegrity.java
@@ -1,0 +1,27 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m2.inlinedsl.path;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+
+public class TestM2PathCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("platform_dsl_path");
+    }
+}

--- a/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-pure/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-pure/pom.xml
@@ -131,5 +131,17 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-pure/src/test/java/org/finos/legend/pure/m2/dsl/store/TestM2StoreCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-pure/src/test/java/org/finos/legend/pure/m2/dsl/store/TestM2StoreCompiledStateIntegrity.java
@@ -1,0 +1,27 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m2.dsl.store;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+
+public class TestM2StoreCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("platform_dsl_store");
+    }
+}

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-pure/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-pure/pom.xml
@@ -115,6 +115,17 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
         </dependency>
-    </dependencies>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/tds/TestM2TDSCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/tds/TestM2TDSCompiledStateIntegrity.java
@@ -1,0 +1,27 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m2.inlinedsl.tds;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+
+public class TestM2TDSCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("platform_dsl_tds");
+    }
+}

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-m2-functions-base-pure/pom.xml
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-m2-functions-base-pure/pom.xml
@@ -115,6 +115,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-pure-functions/legend-pure-functions-base/legend-pure-m2-functions-base-pure/src/test/java/org/finos/legend/pure/m2/functions/TestM2FunctionsBaseCompiledStateIntegrity.java
+++ b/legend-pure-functions/legend-pure-functions-base/legend-pure-m2-functions-base-pure/src/test/java/org/finos/legend/pure/m2/functions/TestM2FunctionsBaseCompiledStateIntegrity.java
@@ -1,0 +1,27 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m2.functions;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+
+public class TestM2FunctionsBaseCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("platform_functions");
+    }
+}

--- a/legend-pure-functions/legend-pure-functions-json/legend-pure-m2-functions-json-pure/pom.xml
+++ b/legend-pure-functions/legend-pure-functions-json/legend-pure-m2-functions-json-pure/pom.xml
@@ -78,5 +78,17 @@
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-pure-functions/legend-pure-functions-json/legend-pure-m2-functions-json-pure/src/test/java/org/finos/legend/pure/m2/functions/json/TestM2FunctionsJsonCompiledStateIntegrity.java
+++ b/legend-pure-functions/legend-pure-functions-json/legend-pure-m2-functions-json-pure/src/test/java/org/finos/legend/pure/m2/functions/json/TestM2FunctionsJsonCompiledStateIntegrity.java
@@ -1,0 +1,27 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m2.functions.json;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+
+public class TestM2FunctionsJsonCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("platform_functions_json");
+    }
+}


### PR DESCRIPTION
Add an easier initialize method to AbstractCompiledStateIntegrityTest. Add compiled state integrity tests for all DSLs and base and json functions.