### PR TITLE
Fix duplicate import groups

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/_package/_Package.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/_package/_Package.java
@@ -27,7 +27,6 @@ import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
-import org.finos.legend.pure.m4.coreinstance.indexing.IndexSpecifications;
 
 public class _Package
 {
@@ -84,10 +83,7 @@ public class _Package
 
     public static CoreInstance findInPackage(CoreInstance pkg, String name)
     {
-        // TODO eliminate duplicate import group names, then use an id index lookup
-//        return pkg.getValueInValueForMetaPropertyToMany(M3Properties.children, name);
-        ListIterable<? extends CoreInstance> childrenWithName = pkg.getValueInValueForMetaPropertyToManyByIndex(M3Properties.children, IndexSpecifications.getCoreInstanceNameIndexSpec(), name);
-        return childrenWithName.getFirst();
+        return pkg.getValueInValueForMetaPropertyToMany(M3Properties.children, name);
     }
 
     public static MutableList<String> convertM3PathToM4(String m3UserPath)

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractImportGroupsTest.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractImportGroupsTest.java
@@ -1,0 +1,211 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.tests;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
+import org.finos.legend.pure.m3.coreinstance.Package;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportAccessor;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportGroup;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositorySet;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableRepositoryCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
+import org.finos.legend.pure.m3.serialization.runtime.PureRuntime;
+import org.finos.legend.pure.m3.serialization.runtime.PureRuntimeBuilder;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+
+public abstract class AbstractImportGroupsTest
+{
+    private static PureRuntime runtime;
+    private static Package systemImports;
+
+    private final MutableList<String> testSourceIds = Lists.mutable.empty();
+
+    protected static void initialize(String... repositories)
+    {
+        CodeRepositorySet repos = CodeRepositorySet.newBuilder()
+                .withCodeRepositories(CodeRepositoryProviderHelper.findCodeRepositories())
+                .build()
+                .subset(repositories);
+        initialize(new CompositeCodeStorage(new ClassLoaderCodeStorage(repos.getRepositories())));
+    }
+
+    protected static void initialize(MutableRepositoryCodeStorage codeStorage)
+    {
+//        System.out.println(codeStorage.getAllRepositories().collect(r -> r.getName(), Lists.mutable.empty()).sortThis().makeString("Repositories: ", ", ", ""));
+
+        runtime = new PureRuntimeBuilder(codeStorage).buildAndInitialize();
+        systemImports = (Package) runtime.getProcessorSupport().package_getByUserPath("system::imports");
+        Assert.assertNotNull(systemImports);
+    }
+
+    @AfterClass
+    public static void cleanUp()
+    {
+        if (runtime != null)
+        {
+            runtime.reset();
+        }
+        runtime = null;
+        systemImports = null;
+    }
+
+    @Before
+    public void clearTestSources()
+    {
+        this.testSourceIds.clear();
+    }
+
+    @After
+    public void deleteTestSources()
+    {
+        if (this.testSourceIds.notEmpty())
+        {
+            this.testSourceIds.forEach(runtime::delete);
+            runtime.compile();
+        }
+    }
+
+    @Test
+    public void testEmptySource()
+    {
+        String sourceId = "/platform/empty/emptySource.pure";
+        testImportGroups(
+                sourceId,
+                "",
+                importGroup("import__platform_empty_emptySource_pure_1", sourceId, 0, 0, 0, 0));
+    }
+
+    protected void testImportGroups(String sourceId, String code, ImportGroupForAssert... expected)
+    {
+        MutableList<ImportGroup> importGroups = compileTestSource(sourceId, code);
+        Assert.assertEquals(ArrayAdapter.adapt(expected), importGroups.collect(AbstractImportGroupsTest::importGroup));
+    }
+
+    protected MutableList<ImportGroup> compileTestSource(String sourceId, String code)
+    {
+        this.testSourceIds.add(sourceId);
+        runtime.createInMemoryAndCompile(Maps.fixedSize.with(sourceId, code));
+        MutableList<ImportGroup> importGroups = systemImports._children().collectIf(
+                ig -> (ig.getSourceInformation() != null) && sourceId.equals(ig.getSourceInformation().getSourceId()),
+                ig -> (ImportGroup) ig,
+                Lists.mutable.empty());
+        assertNoDuplicateImportGroups(importGroups);
+        return importGroups;
+    }
+
+    private void assertNoDuplicateImportGroups(Iterable<? extends ImportGroup> importGroups)
+    {
+        MutableMap<String, MutableList<CoreInstance>> importGroupsByName = Maps.mutable.empty();
+        importGroups.forEach(ig -> importGroupsByName.getIfAbsentPut(ig._name(), Lists.mutable::empty).add(ig));
+        importGroupsByName.removeIf((name, list) -> list.size() == 1);
+        if (importGroupsByName.notEmpty())
+        {
+            StringBuilder builder = new StringBuilder("The following ImportGroups have name conflicts:");
+            importGroupsByName.keysView().toSortedList().forEach(name ->
+            {
+                MutableList<CoreInstance> list = importGroupsByName.get(name);
+                builder.append(System.lineSeparator()).append(name).append(" (").append(list.size()).append("):");
+                list.forEach(ig -> ig.getSourceInformation().appendMessage(builder.append(System.lineSeparator()).append("\t")));
+            });
+            Assert.fail(builder.toString());
+        }
+    }
+
+    protected static ImportGroupForAssert importGroup(String name, String sourceId, int startLine, int startCol, int endLine, int endCol, String... importPaths)
+    {
+        SourceInformation sourceInfo = new SourceInformation(sourceId, startLine, startCol, endLine, endCol);
+        ListIterable<String> importPathList = (importPaths == null) ? Lists.immutable.empty() : ArrayAdapter.adapt(importPaths);
+        return new ImportGroupForAssert(name, importPathList, sourceInfo);
+    }
+
+    protected static ImportGroupForAssert importGroup(ImportGroup importGroup)
+    {
+        return new ImportGroupForAssert(importGroup._name(), importGroup._imports().collect(ImportAccessor::_path, Lists.mutable.empty()), importGroup.getSourceInformation());
+    }
+
+    protected static class ImportGroupForAssert
+    {
+        private final String name;
+        private final ListIterable<String> importPaths;
+        private final SourceInformation sourceInfo;
+
+        private ImportGroupForAssert(String name, ListIterable<String> importPaths, SourceInformation sourceInfo)
+        {
+            this.name = Objects.requireNonNull(name);
+            this.importPaths = (importPaths == null) ? Lists.immutable.empty() : importPaths;
+            this.sourceInfo = sourceInfo;
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (this == other)
+            {
+                return true;
+            }
+
+            if (!(other instanceof ImportGroupForAssert))
+            {
+                return false;
+            }
+
+            ImportGroupForAssert that = (ImportGroupForAssert) other;
+            return this.name.equals(that.name) &&
+                    this.importPaths.equals(that.importPaths) &&
+                    Objects.equals(this.sourceInfo, that.sourceInfo);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(this.name, this.importPaths, this.sourceInfo);
+        }
+
+        @Override
+        public String toString()
+        {
+            StringBuilder builder = new StringBuilder("ImportGroup{name='").append(this.name).append("' paths=[");
+            if (this.importPaths.notEmpty())
+            {
+                this.importPaths.appendString(builder, "'", "', '", "'");
+            }
+            builder.append("] sourceInfo=");
+            if (this.sourceInfo == null)
+            {
+                builder.append("null");
+            }
+            else
+            {
+                this.sourceInfo.appendMessage(builder);
+            }
+            return builder.append("}").toString();
+        }
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/TestImportGroups_Pure.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/TestImportGroups_Pure.java
@@ -1,0 +1,115 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.tests;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestImportGroups_Pure extends AbstractImportGroupsTest
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        initialize("platform");
+    }
+
+    @Test
+    public void testImplicitSectionNoImports()
+    {
+        String sourceId = "/platform/pure/pureTestNoImports.pure";
+        testImportGroups(
+                sourceId,
+                        "Class meta::test::TestClass\n" +
+                        "{\n" +
+                        "}\n",
+                importGroup("import__platform_pure_pureTestNoImports_pure_1", sourceId, 0, 0, 0, 0)
+        );
+    }
+
+    @Test
+    public void testImplicitSectionWithImports()
+    {
+        String sourceId = "/platform/pure/pureTestWithImports.pure";
+        testImportGroups(
+                sourceId,
+                        "import meta::pure::metamodel::constraints::*;\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Class meta::test::TestClass\n" +
+                        "{\n" +
+                        "}\n",
+                importGroup("import__platform_pure_pureTestWithImports_pure_1", sourceId, 1, 1, 2, 38, "meta::pure::metamodel::constraints", "meta::pure::metamodel::types")
+        );
+    }
+
+    @Test
+    public void testOneSectionNoImports()
+    {
+        String sourceId = "/platform/pure/pureTestNoImports.pure";
+        testImportGroups(
+                sourceId,
+                "###Pure\n" +
+                        "Class meta::test::TestClass\n" +
+                        "{\n" +
+                        "}\n",
+                importGroup("import__platform_pure_pureTestNoImports_pure_1", sourceId, 0, 0, 0, 0),
+                importGroup("import__platform_pure_pureTestNoImports_pure_2", sourceId, 1, 0, 1, 0)
+        );
+    }
+
+    @Test
+    public void testOneSectionWithImports()
+    {
+        String sourceId = "/platform/pure/pureTestWithImports.pure";
+        testImportGroups(
+                sourceId,
+                "###Pure\n" +
+                        "import meta::pure::metamodel::constraints::*;\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Class meta::test::TestClass\n" +
+                        "{\n" +
+                        "}\n",
+                importGroup("import__platform_pure_pureTestWithImports_pure_1", sourceId, 0, 0, 0, 0),
+                importGroup("import__platform_pure_pureTestWithImports_pure_2", sourceId, 2, 1, 3, 38, "meta::pure::metamodel::constraints", "meta::pure::metamodel::types")
+        );
+    }
+
+    @Test
+    public void testManySections()
+    {
+        String sourceId = "/platform/pure/pureTestWithImports.pure";
+        testImportGroups(
+                sourceId,
+                "###Pure\n" +
+                        "import meta::pure::metamodel::constraints::*;\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Class meta::test::TestClass1\n" +
+                        "{\n" +
+                        "}\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Class meta::test::TestClass2\n" +
+                        "{\n" +
+                        "}\n",
+                importGroup("import__platform_pure_pureTestWithImports_pure_1", sourceId, 0, 0, 0, 0),
+                importGroup("import__platform_pure_pureTestWithImports_pure_2", sourceId, 2, 1, 3, 38, "meta::pure::metamodel::constraints", "meta::pure::metamodel::types"),
+                importGroup("import__platform_pure_pureTestWithImports_pure_3", sourceId, 10, 1, 10, 38, "meta::pure::metamodel::types")
+        );
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/profile/TestPureRuntimeStereotype.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/profile/TestPureRuntimeStereotype.java
@@ -30,17 +30,17 @@ public class TestPureRuntimeStereotype extends AbstractPureTestWithCoreCompiledP
         setUpRuntime(getExtra());
     }
 
-
     @After
     public void cleanRuntime()
     {
         runtime.delete("userId.pure");
         runtime.delete("sourceId.pure");
         runtime.delete("classId.pure");
+        runtime.compile();
     }
 
     @Test
-    public void testPureRuntimeProfileStereotypeClass() throws Exception
+    public void testPureRuntimeProfileStereotypeClass()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Profile testProfile{stereotypes:[s1,s2];}")
                         .createInMemorySource("userId.pure", "Class <<testProfile.s1>> A{}")
@@ -55,7 +55,7 @@ public class TestPureRuntimeStereotype extends AbstractPureTestWithCoreCompiledP
     }
 
     @Test
-    public void testPureRuntimeProfileStereotypeClassError() throws Exception
+    public void testPureRuntimeProfileStereotypeClassError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Profile testProfile{stereotypes:[s1,s2];}")
                         .createInMemorySource("userId.pure", "Class <<testProfile.s1>> A{}")
@@ -71,7 +71,7 @@ public class TestPureRuntimeStereotype extends AbstractPureTestWithCoreCompiledP
     }
 
     @Test
-    public void testPureRuntimeProfileStereotypeClassValueError() throws Exception
+    public void testPureRuntimeProfileStereotypeClassValueError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Profile testProfile{stereotypes:[s1,s2];}")
                         .createInMemorySource("userId.pure", "Class <<testProfile.s1>> A{}")
@@ -84,11 +84,10 @@ public class TestPureRuntimeStereotype extends AbstractPureTestWithCoreCompiledP
                         .updateSource("sourceId.pure", "Profile testProfile{stereotypes:[s1,s2];}")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
-
     }
 
     @Test
-    public void testPureRuntimeProfileStereotypeClassInverse() throws Exception
+    public void testPureRuntimeProfileStereotypeClassInverse()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class <<testProfile.s1>> A{}")
                         .createInMemorySource("userId.pure", "Profile testProfile{stereotypes:[s1,s2];}")
@@ -99,11 +98,10 @@ public class TestPureRuntimeStereotype extends AbstractPureTestWithCoreCompiledP
                         .createInMemorySource("sourceId.pure", "Class <<testProfile.s1>> A{}")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
-
     }
 
     @Test
-    public void testPureRuntimeProfileUsedInFunction() throws Exception
+    public void testPureRuntimeProfileUsedInFunction()
     {
 
         runtime.createInMemorySource("userId.pure", "Profile my::profile::testProfile{stereotypes:[s1,s2];tags: [name];}");
@@ -126,9 +124,8 @@ public class TestPureRuntimeStereotype extends AbstractPureTestWithCoreCompiledP
     }
 
     @Test
-    public void testPureRuntimeProfileUsedInNew() throws Exception
+    public void testPureRuntimeProfileUsedInNew()
     {
-
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("userId.pure", "Profile my::pack::testProfile{stereotypes:[s1,s2];tags: [name];}")
                         .createInMemorySource("sourceId.pure", "import meta::pure::functions::meta::*;\n" +
                                 "import my::pack::*;\n" +
@@ -143,7 +140,7 @@ public class TestPureRuntimeStereotype extends AbstractPureTestWithCoreCompiledP
     }
 
     @Test
-    public void testPureRuntimeProfileWithEnumWithReferenceToEnum() throws Exception
+    public void testPureRuntimeProfileWithEnumWithReferenceToEnum()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("userId.pure", "Profile my::pack::testProfile{stereotypes:[s1,s2];tags: [name];}")
                         .createInMemorySource("sourceId.pure", "import my::pack::*;\n" + "Enum my::pack::myEnum{ <<testProfile.s1>> VAL1, VAL2}")
@@ -154,6 +151,5 @@ public class TestPureRuntimeStereotype extends AbstractPureTestWithCoreCompiledP
                                 "Profile my::pack::testProfile{stereotypes:[s1,s2];tags: [name];}")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
-
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-grammar/src/test/java/org/finos/legend/pure/m2/dsl/diagram/TestImportGroups_Diagram.java
+++ b/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-grammar/src/test/java/org/finos/legend/pure/m2/dsl/diagram/TestImportGroups_Diagram.java
@@ -1,0 +1,121 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m2.dsl.diagram;
+
+import org.finos.legend.pure.m3.tests.AbstractImportGroupsTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestImportGroups_Diagram extends AbstractImportGroupsTest
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        initialize("platform_dsl_diagram");
+    }
+
+    @Test
+    public void testOneSectionNoImports()
+    {
+        String sourceId = "/platform/diagram/diagramTestNoImports.pure";
+        testImportGroups(
+                sourceId,
+                "###Diagram\n" +
+                        "Diagram meta::test::TestDiagram1(width=10.0, height=10.0)\n" +
+                        "{\n" +
+                        "}\n",
+                importGroup("import__platform_diagram_diagramTestNoImports_pure_1", sourceId, 0, 0, 0, 0),
+                importGroup("import__platform_diagram_diagramTestNoImports_pure_2", sourceId, 1, 0, 1, 0)
+        );
+    }
+
+    @Test
+    public void testOneSectionWithImports()
+    {
+        String sourceId = "/platform/diagram/diagramTestWithImports.pure";
+        testImportGroups(
+                sourceId,
+                "###Diagram\n" +
+                        "import meta::pure::metamodel::constraints::*;\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Diagram meta::test::TestDiagram1(width=10.0, height=10.0)\n" +
+                        "{\n" +
+                        "}\n",
+                importGroup("import__platform_diagram_diagramTestWithImports_pure_1", sourceId, 0, 0, 0, 0),
+                importGroup("import__platform_diagram_diagramTestWithImports_pure_2", sourceId, 2, 1, 3, 38, "meta::pure::metamodel::constraints", "meta::pure::metamodel::types")
+        );
+    }
+
+    @Test
+    public void testManySections()
+    {
+        String sourceId = "/platform/diagram/diagramTestWithManySections.pure";
+        testImportGroups(
+                sourceId,
+                "###Diagram\n" +
+                        "import meta::pure::metamodel::constraints::*;\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Diagram meta::test::TestDiagram1(width=10.0, height=10.0)\n" +
+                        "{\n" +
+                        "}\n" +
+                        "\n" +
+                        "###Diagram\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Diagram meta::test::TestDiagram2(width=10.0, height=10.0)\n" +
+                        "{\n" +
+                        "}\n",
+                importGroup("import__platform_diagram_diagramTestWithManySections_pure_1", sourceId, 0, 0, 0, 0),
+                importGroup("import__platform_diagram_diagramTestWithManySections_pure_2", sourceId, 2, 1, 3, 38, "meta::pure::metamodel::constraints", "meta::pure::metamodel::types"),
+                importGroup("import__platform_diagram_diagramTestWithManySections_pure_3", sourceId, 10, 1, 10, 38, "meta::pure::metamodel::types")
+        );
+    }
+
+    @Test
+    public void testMixedSections()
+    {
+        String sourceId = "/platform/diagram/diagramTestWithMixedSections.pure";
+        testImportGroups(
+                sourceId,
+                "###Diagram\n" +
+                        "import meta::pure::metamodel::constraints::*;\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Diagram meta::test::TestDiagram1(width=10.0, height=10.0)\n" +
+                        "{\n" +
+                        "}\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "import meta::pure::metamodel::constraints::*;\n" +
+                        "\n" +
+                        "Class meta::test::TestClass\n" +
+                        "{\n" +
+                        "}\n" +
+                        "\n" +
+                        "###Diagram\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Diagram meta::test::TestDiagram2(width=10.0, height=10.0)\n" +
+                        "{\n" +
+                        "}\n",
+                importGroup("import__platform_diagram_diagramTestWithMixedSections_pure_1", sourceId, 0, 0, 0, 0),
+                importGroup("import__platform_diagram_diagramTestWithMixedSections_pure_2", sourceId, 2, 1, 3, 38, "meta::pure::metamodel::constraints", "meta::pure::metamodel::types"),
+                importGroup("import__platform_diagram_diagramTestWithMixedSections_pure_3", sourceId, 10, 1, 10, 44, "meta::pure::metamodel::constraints"),
+                importGroup("import__platform_diagram_diagramTestWithMixedSections_pure_4", sourceId, 17, 1, 17, 38, "meta::pure::metamodel::types")
+        );
+    }
+}

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/MappingParser.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/MappingParser.java
@@ -92,7 +92,6 @@ public class MappingParser implements IMappingParser
     {
         String result = parseDefinition(true, string, sourceName, addLines, offset, repository, listener, context, count);
         new M3AntlrParser(false).parse(result, sourceName, false, offset, repository, coreInstancesResult, listener, context, count, null);
-
     }
 
     private String parseDefinition(boolean useFastParser, String code, String sourceName, boolean addLines, int offset, ModelRepository repository, M3M4StateListener listener, Context context, int count)

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/test/java/org/finos/legend/pure/m2/dsl/mapping/TestImportGroups_Mapping.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/test/java/org/finos/legend/pure/m2/dsl/mapping/TestImportGroups_Mapping.java
@@ -1,0 +1,121 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m2.dsl.mapping;
+
+import org.finos.legend.pure.m3.tests.AbstractImportGroupsTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestImportGroups_Mapping extends AbstractImportGroupsTest
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        initialize("platform_dsl_mapping");
+    }
+
+    @Test
+    public void testOneSectionNoImports()
+    {
+        String sourceId = "/platform/mapping/mappingTestNoImports.pure";
+        testImportGroups(
+                sourceId,
+                "###Mapping\n" +
+                        "Mapping meta::test::TestMapping1\n" +
+                        "(\n" +
+                        ")\n",
+                importGroup("import__platform_mapping_mappingTestNoImports_pure_1", sourceId, 0, 0, 0, 0),
+                importGroup("import__platform_mapping_mappingTestNoImports_pure_2", sourceId, 1, 0, 1, 0)
+        );
+    }
+
+    @Test
+    public void testOneSectionWithImports()
+    {
+        String sourceId = "/platform/mapping/mappingTestWithImports.pure";
+        testImportGroups(
+                sourceId,
+                "###Mapping\n" +
+                        "import meta::pure::metamodel::constraints::*;\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Mapping meta::test::TestMapping1\n" +
+                        "(\n" +
+                        ")\n",
+                importGroup("import__platform_mapping_mappingTestWithImports_pure_1", sourceId, 0, 0, 0, 0),
+                importGroup("import__platform_mapping_mappingTestWithImports_pure_2", sourceId, 2, 1, 3, 38, "meta::pure::metamodel::constraints", "meta::pure::metamodel::types")
+        );
+    }
+
+    @Test
+    public void testManySections()
+    {
+        String sourceId = "/platform/mapping/mappingTestWithManySections.pure";
+        testImportGroups(
+                sourceId,
+                "###Mapping\n" +
+                        "import meta::pure::metamodel::constraints::*;\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Mapping meta::test::TestMapping1\n" +
+                        "(\n" +
+                        ")\n" +
+                        "\n" +
+                        "###Mapping\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Mapping meta::test::TestMapping2\n" +
+                        "(\n" +
+                        ")\n",
+                importGroup("import__platform_mapping_mappingTestWithManySections_pure_1", sourceId, 0, 0, 0, 0),
+                importGroup("import__platform_mapping_mappingTestWithManySections_pure_2", sourceId, 2, 1, 3, 38, "meta::pure::metamodel::constraints", "meta::pure::metamodel::types"),
+                importGroup("import__platform_mapping_mappingTestWithManySections_pure_3", sourceId, 10, 1, 10, 38, "meta::pure::metamodel::types")
+        );
+    }
+
+    @Test
+    public void testMixedSections()
+    {
+        String sourceId = "/platform/mapping/mappingTestWithMixedSections.pure";
+        testImportGroups(
+                sourceId,
+                "###Mapping\n" +
+                        "import meta::pure::metamodel::constraints::*;\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Mapping meta::test::TestMapping1\n" +
+                        "(\n" +
+                        ")\n" +
+                        "\n" +
+                        "###Pure\n" +
+                        "import meta::pure::metamodel::constraints::*;\n" +
+                        "\n" +
+                        "Class meta::test::TestClass\n" +
+                        "{\n" +
+                        "}\n" +
+                        "\n" +
+                        "###Mapping\n" +
+                        "import meta::pure::metamodel::types::*;\n" +
+                        "\n" +
+                        "Mapping meta::test::TestMapping2\n" +
+                        "(\n" +
+                        ")\n",
+                importGroup("import__platform_mapping_mappingTestWithMixedSections_pure_1", sourceId, 0, 0, 0, 0),
+                importGroup("import__platform_mapping_mappingTestWithMixedSections_pure_2", sourceId, 2, 1, 3, 38, "meta::pure::metamodel::constraints", "meta::pure::metamodel::types"),
+                importGroup("import__platform_mapping_mappingTestWithMixedSections_pure_3", sourceId, 10, 1, 10, 44, "meta::pure::metamodel::constraints"),
+                importGroup("import__platform_mapping_mappingTestWithMixedSections_pure_4", sourceId, 17, 1, 17, 38, "meta::pure::metamodel::types")
+        );
+    }
+}

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/profile/TestPureRuntimeStereotypeCompiled.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/profile/TestPureRuntimeStereotypeCompiled.java
@@ -29,8 +29,6 @@ import org.finos.legend.pure.runtime.java.compiled.CompiledMetadataStateVerifier
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
 
 public class TestPureRuntimeStereotypeCompiled extends TestPureRuntimeStereotype
 {
@@ -42,18 +40,10 @@ public class TestPureRuntimeStereotypeCompiled extends TestPureRuntimeStereotype
 
     protected static RichIterable<? extends CodeRepository> getCodeRepositories()
     {
-        MutableList<CodeRepository> repositories = org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
+        MutableList<CodeRepository> repositories = Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
         CodeRepository system = GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform");
         repositories.add(system);
         return repositories;
-    }
-
-    @Override
-    @Test
-    @Ignore
-    public void testPureRuntimeProfileWithEnumWithReferenceToEnum() throws Exception
-    {
-        super.testPureRuntimeProfileWithEnumWithReferenceToEnum();
     }
 
     protected static FunctionExecution getFunctionExecution()


### PR DESCRIPTION
Fix an issue where duplicate import groups were being created under certain circumstances. This was happening in cases where a DSL (such as Mapping or Diagram) parsed a code section, transformed it into M3 grammar, and then sent that to the M3 parser. In cases like that, both the DSL parser and the M3 parser would create an import group for the same section. Now the M3 parser only creates an import group if it cannot find one that already exists for the section.

Add tests to ensure there are no duplicate import groups and that import groups had the expected imports.