### PR TITLE
Import group source information validity

### DIFF
--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/SourceInformation.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/SourceInformation.java
@@ -270,11 +270,29 @@ public class SourceInformation implements Comparable<SourceInformation>
      */
     public boolean isValid()
     {
-        return (this.sourceId != null) &&
-                (this.startLine >= 1) &&
-                (this.startColumn >= 1) &&
-                (this.column >= 1) &&
-                (this.endColumn >= 1) &&
+        // Source id must not be null
+        if (this.sourceId == null)
+        {
+            return false;
+        }
+
+        // Source information with 0 for a line or column value occurs with ImportGroups with no Imports. In this case,
+        // all column values should be 0 and all line values should be equal (and may be 0). We check for this unusual
+        // but valid case by checking if the start column is 0.
+        if (this.startColumn == 0)
+        {
+            return (this.startLine >= 0) &&
+                    (this.startLine == this.line) &&
+                    (this.startLine == this.endLine) &&
+                    (this.column == 0) &&
+                    (this.endColumn == 0);
+        }
+
+        // Otherwise, all line and column values must be strictly greater than 0, and the interval must be valid.
+        return (this.startLine > 0) &&
+                (this.startColumn > 0) &&
+                (this.column > 0) &&
+                (this.endColumn > 0) &&
                 isNotBefore(this.line, this.column, this.startLine, this.startColumn) &&
                 isNotBefore(this.endLine, this.endColumn, this.line, this.column);
     }

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/TestSourceInformation.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/TestSourceInformation.java
@@ -45,18 +45,27 @@ public class TestSourceInformation
     public void testIsBefore()
     {
         // equal
+        Assert.assertFalse(SourceInformation.isBefore(0, 0, 0, 0));
+        Assert.assertFalse(SourceInformation.isBefore(1, 0, 1, 0));
         Assert.assertFalse(SourceInformation.isBefore(1, 1, 1, 1));
+        Assert.assertFalse(SourceInformation.isBefore(2, 0, 2, 0));
         Assert.assertFalse(SourceInformation.isBefore(2, 1, 2, 1));
         Assert.assertFalse(SourceInformation.isBefore(10, 17, 10, 17));
         Assert.assertFalse(SourceInformation.isBefore(234510, 17123, 234510, 17123));
 
         // before
+        Assert.assertTrue(SourceInformation.isBefore(0, 0, 1, 0));
+        Assert.assertTrue(SourceInformation.isBefore(1, 0, 1, 1));
+        Assert.assertTrue(SourceInformation.isBefore(1, 0, 2, 1));
         Assert.assertTrue(SourceInformation.isBefore(1, 1, 2, 1));
         Assert.assertTrue(SourceInformation.isBefore(1, 1, 1, 2));
         Assert.assertTrue(SourceInformation.isBefore(1, 2, 1, 3));
         Assert.assertTrue(SourceInformation.isBefore(1, 2, 2, 1));
 
         // after
+        Assert.assertFalse(SourceInformation.isBefore(1, 0, 0, 0));
+        Assert.assertFalse(SourceInformation.isBefore(1, 1, 0, 0));
+        Assert.assertFalse(SourceInformation.isBefore(1, 1, 1, 0));
         Assert.assertFalse(SourceInformation.isBefore(2, 2, 1, 2));
         Assert.assertFalse(SourceInformation.isBefore(2, 2, 1, 3));
         Assert.assertFalse(SourceInformation.isBefore(2, 2, 1, 3));
@@ -67,18 +76,27 @@ public class TestSourceInformation
     public void testIsAfter()
     {
         // equal
+        Assert.assertFalse(SourceInformation.isAfter(0, 0, 0, 0));
+        Assert.assertFalse(SourceInformation.isAfter(1, 0, 1, 0));
         Assert.assertFalse(SourceInformation.isAfter(1, 1, 1, 1));
+        Assert.assertFalse(SourceInformation.isAfter(2, 0, 2, 0));
         Assert.assertFalse(SourceInformation.isAfter(2, 1, 2, 1));
         Assert.assertFalse(SourceInformation.isAfter(10, 17, 10, 17));
         Assert.assertFalse(SourceInformation.isAfter(234510, 17123, 234510, 17123));
 
         // before
+        Assert.assertFalse(SourceInformation.isAfter(0, 0, 1, 0));
+        Assert.assertFalse(SourceInformation.isAfter(1, 0, 1, 1));
+        Assert.assertFalse(SourceInformation.isAfter(1, 0, 2, 1));
         Assert.assertFalse(SourceInformation.isAfter(1, 1, 2, 1));
         Assert.assertFalse(SourceInformation.isAfter(1, 1, 1, 2));
         Assert.assertFalse(SourceInformation.isAfter(1, 2, 1, 3));
         Assert.assertFalse(SourceInformation.isAfter(1, 2, 2, 1));
 
         // after
+        Assert.assertTrue(SourceInformation.isAfter(1, 0, 0, 0));
+        Assert.assertTrue(SourceInformation.isAfter(1, 1, 0, 0));
+        Assert.assertTrue(SourceInformation.isAfter(1, 1, 1, 0));
         Assert.assertTrue(SourceInformation.isAfter(2, 2, 1, 2));
         Assert.assertTrue(SourceInformation.isAfter(2, 2, 1, 3));
         Assert.assertTrue(SourceInformation.isAfter(2, 2, 1, 3));
@@ -89,18 +107,27 @@ public class TestSourceInformation
     public void testIsNotBefore()
     {
         // equal
+        Assert.assertTrue(SourceInformation.isNotBefore(0, 0, 0, 0));
+        Assert.assertTrue(SourceInformation.isNotBefore(1, 0, 1, 0));
         Assert.assertTrue(SourceInformation.isNotBefore(1, 1, 1, 1));
+        Assert.assertTrue(SourceInformation.isNotBefore(2, 0, 2, 0));
         Assert.assertTrue(SourceInformation.isNotBefore(2, 1, 2, 1));
         Assert.assertTrue(SourceInformation.isNotBefore(10, 17, 10, 17));
         Assert.assertTrue(SourceInformation.isNotBefore(234510, 17123, 234510, 17123));
 
         // before
+        Assert.assertFalse(SourceInformation.isNotBefore(0, 0, 1, 0));
+        Assert.assertFalse(SourceInformation.isNotBefore(1, 0, 1, 1));
+        Assert.assertFalse(SourceInformation.isNotBefore(1, 0, 2, 1));
         Assert.assertFalse(SourceInformation.isNotBefore(1, 1, 2, 1));
         Assert.assertFalse(SourceInformation.isNotBefore(1, 1, 1, 2));
         Assert.assertFalse(SourceInformation.isNotBefore(1, 2, 1, 3));
         Assert.assertFalse(SourceInformation.isNotBefore(1, 2, 2, 1));
 
         // after
+        Assert.assertTrue(SourceInformation.isNotBefore(1, 0, 0, 0));
+        Assert.assertTrue(SourceInformation.isNotBefore(1, 1, 0, 0));
+        Assert.assertTrue(SourceInformation.isNotBefore(1, 1, 1, 0));
         Assert.assertTrue(SourceInformation.isNotBefore(2, 2, 1, 2));
         Assert.assertTrue(SourceInformation.isNotBefore(2, 2, 1, 3));
         Assert.assertTrue(SourceInformation.isNotBefore(2, 2, 1, 3));
@@ -111,18 +138,27 @@ public class TestSourceInformation
     public void testIsNotAfter()
     {
         // equal
+        Assert.assertTrue(SourceInformation.isNotAfter(0, 0, 0, 0));
+        Assert.assertTrue(SourceInformation.isNotAfter(1, 0, 1, 0));
         Assert.assertTrue(SourceInformation.isNotAfter(1, 1, 1, 1));
+        Assert.assertTrue(SourceInformation.isNotAfter(2, 0, 2, 0));
         Assert.assertTrue(SourceInformation.isNotAfter(2, 1, 2, 1));
         Assert.assertTrue(SourceInformation.isNotAfter(10, 17, 10, 17));
         Assert.assertTrue(SourceInformation.isNotAfter(234510, 17123, 234510, 17123));
 
         // before
+        Assert.assertTrue(SourceInformation.isNotAfter(0, 0, 1, 0));
+        Assert.assertTrue(SourceInformation.isNotAfter(1, 0, 1, 1));
+        Assert.assertTrue(SourceInformation.isNotAfter(1, 0, 2, 1));
         Assert.assertTrue(SourceInformation.isNotAfter(1, 1, 2, 1));
         Assert.assertTrue(SourceInformation.isNotAfter(1, 1, 1, 2));
         Assert.assertTrue(SourceInformation.isNotAfter(1, 2, 1, 3));
         Assert.assertTrue(SourceInformation.isNotAfter(1, 2, 2, 1));
 
         // after
+        Assert.assertFalse(SourceInformation.isNotAfter(1, 0, 0, 0));
+        Assert.assertFalse(SourceInformation.isNotAfter(1, 1, 0, 0));
+        Assert.assertFalse(SourceInformation.isNotAfter(1, 1, 1, 0));
         Assert.assertFalse(SourceInformation.isNotAfter(2, 2, 1, 2));
         Assert.assertFalse(SourceInformation.isNotAfter(2, 2, 1, 3));
         Assert.assertFalse(SourceInformation.isNotAfter(2, 2, 1, 3));
@@ -148,66 +184,122 @@ public class TestSourceInformation
         String source1 = "/platform/test/source1.pure";
         String source2 = "/platform/test/source2.pure";
 
+        SourceInformation source1_0_0_0_0 = new SourceInformation(source1, 0, 0, 0, 0);
+        SourceInformation source1_1_0_1_0 = new SourceInformation(source1, 1, 0, 1, 0);
         SourceInformation source1_1_1_10_1 = new SourceInformation(source1, 1, 1, 10, 1);
         SourceInformation source1_1_5_1_7 = new SourceInformation(source1, 1, 5, 1, 7);
         SourceInformation source1_1_5_6_1 = new SourceInformation(source1, 1, 5, 6, 1);
+        SourceInformation source1_2_0_2_0 = new SourceInformation(source1, 2, 0, 2, 0);
         SourceInformation source1_2_1_6_1 = new SourceInformation(source1, 2, 1, 6, 1);
+        SourceInformation source1_5_0_5_0 = new SourceInformation(source1, 5, 0, 5, 0);
         SourceInformation source1_5_1_10_1 = new SourceInformation(source1, 5, 1, 10, 1);
         SourceInformation source1_5_3_8_8 = new SourceInformation(source1, 5, 3, 8, 8);
         SourceInformation source2_1_1_10_1 = new SourceInformation(source2, 1, 1, 10, 1);
 
+        assertSubsumes(source1_0_0_0_0, source1_0_0_0_0);
+        assertNotSubsumes(source1_0_0_0_0, source1_1_0_1_0);
+        assertNotSubsumes(source1_0_0_0_0, source1_1_1_10_1);
+        assertNotSubsumes(source1_0_0_0_0, source1_1_5_1_7);
+        assertNotSubsumes(source1_0_0_0_0, source1_1_5_6_1);
+        assertNotSubsumes(source1_0_0_0_0, source1_2_0_2_0);
+        assertNotSubsumes(source1_0_0_0_0, source1_2_1_6_1);
+        assertNotSubsumes(source1_0_0_0_0, source1_5_0_5_0);
+        assertNotSubsumes(source1_0_0_0_0, source1_5_1_10_1);
+        assertNotSubsumes(source1_0_0_0_0, source1_5_3_8_8);
+        assertNotSubsumes(source1_0_0_0_0, source2_1_1_10_1);
+
+        assertNotSubsumes(source1_1_0_1_0, source1_0_0_0_0);
+        assertSubsumes(source1_1_0_1_0, source1_1_0_1_0);
+        assertNotSubsumes(source1_1_0_1_0, source1_1_1_10_1);
+        assertNotSubsumes(source1_1_0_1_0, source1_1_5_1_7);
+        assertNotSubsumes(source1_1_0_1_0, source1_1_5_6_1);
+        assertNotSubsumes(source1_1_0_1_0, source1_2_0_2_0);
+        assertNotSubsumes(source1_1_0_1_0, source1_2_1_6_1);
+        assertNotSubsumes(source1_1_0_1_0, source1_5_0_5_0);
+        assertNotSubsumes(source1_1_0_1_0, source1_5_1_10_1);
+        assertNotSubsumes(source1_1_0_1_0, source1_5_3_8_8);
+        assertNotSubsumes(source1_1_0_1_0, source2_1_1_10_1);
+
+        assertNotSubsumes(source1_1_1_10_1, source1_0_0_0_0);
+        assertNotSubsumes(source1_1_1_10_1, source1_1_0_1_0);
         assertSubsumes(source1_1_1_10_1, source1_1_1_10_1);
         assertSubsumes(source1_1_1_10_1, source1_1_5_1_7);
         assertSubsumes(source1_1_1_10_1, source1_1_5_6_1);
+        assertSubsumes(source1_1_1_10_1, source1_2_0_2_0);
         assertSubsumes(source1_1_1_10_1, source1_2_1_6_1);
+        assertSubsumes(source1_1_1_10_1, source1_5_0_5_0);
         assertSubsumes(source1_1_1_10_1, source1_5_1_10_1);
         assertSubsumes(source1_1_1_10_1, source1_5_3_8_8);
         assertNotSubsumes(source1_1_1_10_1, source2_1_1_10_1);
 
+        assertNotSubsumes(source1_1_5_1_7, source1_0_0_0_0);
+        assertNotSubsumes(source1_1_5_1_7, source1_1_0_1_0);
         assertNotSubsumes(source1_1_5_1_7, source1_1_1_10_1);
         assertSubsumes(source1_1_5_1_7, source1_1_5_1_7);
         assertNotSubsumes(source1_1_5_1_7, source1_1_5_6_1);
+        assertNotSubsumes(source1_1_5_1_7, source1_2_0_2_0);
         assertNotSubsumes(source1_1_5_1_7, source1_2_1_6_1);
+        assertNotSubsumes(source1_1_5_1_7, source1_5_0_5_0);
         assertNotSubsumes(source1_1_5_1_7, source1_5_1_10_1);
         assertNotSubsumes(source1_1_5_1_7, source1_5_3_8_8);
         assertNotSubsumes(source1_1_5_1_7, source2_1_1_10_1);
 
+        assertNotSubsumes(source1_1_5_6_1, source1_0_0_0_0);
+        assertNotSubsumes(source1_1_5_6_1, source1_1_0_1_0);
         assertNotSubsumes(source1_1_5_6_1, source1_1_1_10_1);
         assertSubsumes(source1_1_5_6_1, source1_1_5_1_7);
         assertSubsumes(source1_1_5_6_1, source1_1_5_6_1);
+        assertSubsumes(source1_1_5_6_1, source1_2_0_2_0);
         assertSubsumes(source1_1_5_6_1, source1_2_1_6_1);
+        assertSubsumes(source1_1_5_6_1, source1_5_0_5_0);
         assertNotSubsumes(source1_1_5_6_1, source1_5_1_10_1);
         assertNotSubsumes(source1_1_5_6_1, source1_5_3_8_8);
         assertNotSubsumes(source1_1_5_6_1, source2_1_1_10_1);
 
+        assertNotSubsumes(source1_2_1_6_1, source1_0_0_0_0);
+        assertNotSubsumes(source1_2_1_6_1, source1_1_0_1_0);
         assertNotSubsumes(source1_2_1_6_1, source1_1_1_10_1);
         assertNotSubsumes(source1_2_1_6_1, source1_1_5_1_7);
         assertNotSubsumes(source1_2_1_6_1, source1_1_5_6_1);
+        assertNotSubsumes(source1_2_1_6_1, source1_2_0_2_0);
         assertSubsumes(source1_2_1_6_1, source1_2_1_6_1);
+        assertSubsumes(source1_2_1_6_1, source1_5_0_5_0);
         assertNotSubsumes(source1_2_1_6_1, source1_5_1_10_1);
         assertNotSubsumes(source1_2_1_6_1, source1_5_3_8_8);
         assertNotSubsumes(source1_2_1_6_1, source2_1_1_10_1);
 
+        assertNotSubsumes(source1_5_1_10_1, source1_0_0_0_0);
+        assertNotSubsumes(source1_5_1_10_1, source1_1_0_1_0);
         assertNotSubsumes(source1_5_1_10_1, source1_1_1_10_1);
         assertNotSubsumes(source1_5_1_10_1, source1_1_5_1_7);
         assertNotSubsumes(source1_5_1_10_1, source1_1_5_6_1);
+        assertNotSubsumes(source1_5_1_10_1, source1_2_0_2_0);
         assertNotSubsumes(source1_5_1_10_1, source1_2_1_6_1);
+        assertNotSubsumes(source1_5_1_10_1, source1_5_0_5_0);
         assertSubsumes(source1_5_1_10_1, source1_5_1_10_1);
         assertSubsumes(source1_5_1_10_1, source1_5_3_8_8);
         assertNotSubsumes(source1_5_1_10_1, source2_1_1_10_1);
 
+        assertNotSubsumes(source1_5_3_8_8, source1_0_0_0_0);
+        assertNotSubsumes(source1_5_3_8_8, source1_1_0_1_0);
         assertNotSubsumes(source1_5_3_8_8, source1_1_1_10_1);
         assertNotSubsumes(source1_5_3_8_8, source1_1_5_1_7);
         assertNotSubsumes(source1_5_3_8_8, source1_1_5_6_1);
+        assertNotSubsumes(source1_5_3_8_8, source1_2_0_2_0);
         assertNotSubsumes(source1_5_3_8_8, source1_2_1_6_1);
+        assertNotSubsumes(source1_5_3_8_8, source1_5_0_5_0);
         assertNotSubsumes(source1_5_3_8_8, source1_5_1_10_1);
         assertSubsumes(source1_5_3_8_8, source1_5_3_8_8);
         assertNotSubsumes(source1_5_3_8_8, source2_1_1_10_1);
 
+        assertNotSubsumes(source2_1_1_10_1, source1_0_0_0_0);
+        assertNotSubsumes(source2_1_1_10_1, source1_1_0_1_0);
         assertNotSubsumes(source2_1_1_10_1, source1_1_1_10_1);
         assertNotSubsumes(source2_1_1_10_1, source1_1_5_1_7);
         assertNotSubsumes(source2_1_1_10_1, source1_1_5_6_1);
+        assertNotSubsumes(source2_1_1_10_1, source1_2_0_2_0);
         assertNotSubsumes(source2_1_1_10_1, source1_2_1_6_1);
+        assertNotSubsumes(source2_1_1_10_1, source1_5_0_5_0);
         assertNotSubsumes(source2_1_1_10_1, source1_5_1_10_1);
         assertNotSubsumes(source2_1_1_10_1, source1_5_3_8_8);
         assertSubsumes(source2_1_1_10_1, source2_1_1_10_1);
@@ -219,74 +311,132 @@ public class TestSourceInformation
         String source1 = "/platform/test/source1.pure";
         String source2 = "/platform/test/source2.pure";
 
+        SourceInformation source1_0_0_0_0 = new SourceInformation(source1, 0, 0, 0, 0);
+        SourceInformation source1_1_0_1_0 = new SourceInformation(source1, 1, 0, 1, 0);
         SourceInformation source1_1_1_10_1 = new SourceInformation(source1, 1, 1, 10, 1);
         SourceInformation source1_1_5_1_7 = new SourceInformation(source1, 1, 5, 1, 7);
         SourceInformation source1_1_5_6_1 = new SourceInformation(source1, 1, 5, 6, 1);
         SourceInformation source1_1_8_1_9 = new SourceInformation(source1, 1, 8, 1, 9);
+        SourceInformation source1_2_0_2_0 = new SourceInformation(source1, 2, 0, 2, 0);
         SourceInformation source1_2_1_6_1 = new SourceInformation(source1, 2, 1, 6, 1);
+        SourceInformation source1_5_0_5_0 = new SourceInformation(source1, 5, 0, 5, 0);
         SourceInformation source1_5_1_10_1 = new SourceInformation(source1, 5, 1, 10, 1);
         SourceInformation source1_5_3_8_8 = new SourceInformation(source1, 5, 3, 8, 8);
         SourceInformation source2_1_1_10_1 = new SourceInformation(source2, 1, 1, 10, 1);
 
+        assertIntersects(source1_0_0_0_0, source1_0_0_0_0);
+        assertNotIntersects(source1_0_0_0_0, source1_1_0_1_0);
+        assertNotIntersects(source1_0_0_0_0, source1_1_1_10_1);
+        assertNotIntersects(source1_0_0_0_0, source1_1_5_1_7);
+        assertNotIntersects(source1_0_0_0_0, source1_1_5_6_1);
+        assertNotIntersects(source1_0_0_0_0, source1_1_8_1_9);
+        assertNotIntersects(source1_0_0_0_0, source1_2_0_2_0);
+        assertNotIntersects(source1_0_0_0_0, source1_2_1_6_1);
+        assertNotIntersects(source1_0_0_0_0, source1_5_0_5_0);
+        assertNotIntersects(source1_0_0_0_0, source1_5_1_10_1);
+        assertNotIntersects(source1_0_0_0_0, source1_5_3_8_8);
+        assertNotIntersects(source1_0_0_0_0, source2_1_1_10_1);
+
+        assertNotIntersects(source1_1_0_1_0, source1_0_0_0_0);
+        assertIntersects(source1_1_0_1_0, source1_1_0_1_0);
+        assertNotIntersects(source1_1_0_1_0, source1_1_1_10_1);
+        assertNotIntersects(source1_1_0_1_0, source1_1_5_1_7);
+        assertNotIntersects(source1_1_0_1_0, source1_1_5_6_1);
+        assertNotIntersects(source1_1_0_1_0, source1_1_8_1_9);
+        assertNotIntersects(source1_1_0_1_0, source1_2_0_2_0);
+        assertNotIntersects(source1_1_0_1_0, source1_2_1_6_1);
+        assertNotIntersects(source1_1_0_1_0, source1_5_0_5_0);
+        assertNotIntersects(source1_1_0_1_0, source1_5_1_10_1);
+        assertNotIntersects(source1_1_0_1_0, source1_5_3_8_8);
+        assertNotIntersects(source1_1_0_1_0, source2_1_1_10_1);
+
+        assertNotIntersects(source1_1_1_10_1, source1_0_0_0_0);
+        assertNotIntersects(source1_1_1_10_1, source1_1_0_1_0);
         assertIntersects(source1_1_1_10_1, source1_1_1_10_1);
         assertIntersects(source1_1_1_10_1, source1_1_5_1_7);
         assertIntersects(source1_1_1_10_1, source1_1_5_6_1);
         assertIntersects(source1_1_1_10_1, source1_1_8_1_9);
+        assertIntersects(source1_1_1_10_1, source1_2_0_2_0);
         assertIntersects(source1_1_1_10_1, source1_2_1_6_1);
+        assertIntersects(source1_1_1_10_1, source1_5_0_5_0);
         assertIntersects(source1_1_1_10_1, source1_5_1_10_1);
         assertIntersects(source1_1_1_10_1, source1_5_3_8_8);
         assertNotIntersects(source1_1_1_10_1, source2_1_1_10_1);
 
+        assertNotIntersects(source1_1_5_1_7, source1_0_0_0_0);
+        assertNotIntersects(source1_1_5_1_7, source1_1_0_1_0);
         assertIntersects(source1_1_5_1_7, source1_1_1_10_1);
         assertIntersects(source1_1_5_1_7, source1_1_5_1_7);
         assertIntersects(source1_1_5_1_7, source1_1_5_6_1);
         assertNotIntersects(source1_1_5_1_7, source1_1_8_1_9);
+        assertNotIntersects(source1_1_5_1_7, source1_2_0_2_0);
         assertNotIntersects(source1_1_5_1_7, source1_2_1_6_1);
+        assertNotIntersects(source1_1_5_1_7, source1_5_0_5_0);
         assertNotIntersects(source1_1_5_1_7, source1_5_1_10_1);
         assertNotIntersects(source1_1_5_1_7, source1_5_3_8_8);
         assertNotIntersects(source1_1_5_1_7, source2_1_1_10_1);
 
+        assertNotIntersects(source1_1_5_6_1, source1_0_0_0_0);
+        assertNotIntersects(source1_1_5_6_1, source1_1_0_1_0);
         assertIntersects(source1_1_5_6_1, source1_1_1_10_1);
         assertIntersects(source1_1_5_6_1, source1_1_5_1_7);
         assertIntersects(source1_1_5_6_1, source1_1_5_6_1);
         assertIntersects(source1_1_5_6_1, source1_1_8_1_9);
+        assertIntersects(source1_1_5_6_1, source1_2_0_2_0);
         assertIntersects(source1_1_5_6_1, source1_2_1_6_1);
+        assertIntersects(source1_1_5_6_1, source1_5_0_5_0);
         assertIntersects(source1_1_5_6_1, source1_5_1_10_1);
         assertIntersects(source1_1_5_6_1, source1_5_3_8_8);
         assertNotIntersects(source1_1_5_6_1, source2_1_1_10_1);
 
+        assertNotIntersects(source1_2_1_6_1, source1_0_0_0_0);
+        assertNotIntersects(source1_2_1_6_1, source1_1_0_1_0);
         assertIntersects(source1_2_1_6_1, source1_1_1_10_1);
         assertNotIntersects(source1_2_1_6_1, source1_1_5_1_7);
         assertIntersects(source1_2_1_6_1, source1_1_5_6_1);
         assertNotIntersects(source1_2_1_6_1, source1_1_8_1_9);
+        assertNotIntersects(source1_2_1_6_1, source1_2_0_2_0);
         assertIntersects(source1_2_1_6_1, source1_2_1_6_1);
+        assertIntersects(source1_2_1_6_1, source1_5_0_5_0);
         assertIntersects(source1_2_1_6_1, source1_5_1_10_1);
         assertIntersects(source1_2_1_6_1, source1_5_3_8_8);
         assertNotIntersects(source1_2_1_6_1, source2_1_1_10_1);
 
+        assertNotIntersects(source1_5_1_10_1, source1_0_0_0_0);
+        assertNotIntersects(source1_5_1_10_1, source1_1_0_1_0);
         assertIntersects(source1_5_1_10_1, source1_1_1_10_1);
         assertNotIntersects(source1_5_1_10_1, source1_1_5_1_7);
         assertIntersects(source1_5_1_10_1, source1_1_5_6_1);
         assertNotIntersects(source1_5_1_10_1, source1_1_8_1_9);
+        assertNotIntersects(source1_5_1_10_1, source1_2_0_2_0);
         assertIntersects(source1_5_1_10_1, source1_2_1_6_1);
+        assertNotIntersects(source1_5_1_10_1, source1_5_0_5_0);
         assertIntersects(source1_5_1_10_1, source1_5_1_10_1);
         assertIntersects(source1_5_1_10_1, source1_5_3_8_8);
         assertNotIntersects(source1_5_1_10_1, source2_1_1_10_1);
 
+        assertNotIntersects(source1_5_3_8_8, source1_0_0_0_0);
+        assertNotIntersects(source1_5_3_8_8, source1_1_0_1_0);
         assertIntersects(source1_5_3_8_8, source1_1_1_10_1);
         assertNotIntersects(source1_5_3_8_8, source1_1_5_1_7);
         assertIntersects(source1_5_3_8_8, source1_1_5_6_1);
         assertNotIntersects(source1_5_3_8_8, source1_1_8_1_9);
+        assertNotIntersects(source1_5_3_8_8, source1_2_0_2_0);
         assertIntersects(source1_5_3_8_8, source1_2_1_6_1);
+        assertNotIntersects(source1_5_3_8_8, source1_5_0_5_0);
         assertIntersects(source1_5_3_8_8, source1_5_1_10_1);
         assertIntersects(source1_5_3_8_8, source1_5_3_8_8);
         assertNotIntersects(source1_5_3_8_8, source2_1_1_10_1);
 
+        assertNotIntersects(source2_1_1_10_1, source1_0_0_0_0);
+        assertNotIntersects(source2_1_1_10_1, source1_1_0_1_0);
         assertNotIntersects(source2_1_1_10_1, source1_1_1_10_1);
         assertNotIntersects(source2_1_1_10_1, source1_1_5_1_7);
         assertNotIntersects(source2_1_1_10_1, source1_1_5_6_1);
         assertNotIntersects(source2_1_1_10_1, source1_1_8_1_9);
+        assertNotIntersects(source2_1_1_10_1, source1_2_0_2_0);
         assertNotIntersects(source2_1_1_10_1, source1_2_1_6_1);
+        assertNotIntersects(source2_1_1_10_1, source1_5_0_5_0);
         assertNotIntersects(source2_1_1_10_1, source1_5_1_10_1);
         assertNotIntersects(source2_1_1_10_1, source1_5_3_8_8);
         assertIntersects(source2_1_1_10_1, source2_1_1_10_1);
@@ -303,25 +453,45 @@ public class TestSourceInformation
         Assert.assertTrue(new SourceInformation(sourceId, 5, 1, 7, 7, 16, 3).isValid());
         Assert.assertTrue(new SourceInformation(sourceId, 5, 9, 7, 7, 16, 3).isValid());
 
+        // null source information
         Assert.assertFalse(new SourceInformation(null, 1, 1, 1, 1, 1, 1).isValid());
-        Assert.assertFalse(new SourceInformation(sourceId, 0, 1, 1, 1, 1, 1).isValid());
-        Assert.assertFalse(new SourceInformation(sourceId, -1, 1, 1, 1, 1, 1).isValid());
-        Assert.assertFalse(new SourceInformation(sourceId, 1, 0, 1, 1, 1, 1).isValid());
-        Assert.assertFalse(new SourceInformation(sourceId, 1, -1, 1, 1, 1, 1).isValid());
-        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 0, 1, 1, 1).isValid());
-        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, -1, 1, 1, 1).isValid());
-        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 1, 0, 1, 1).isValid());
-        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 1, -1, 1, 1).isValid());
-        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 1, 1, 0, 1).isValid());
-        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 1, 1, -1, 1).isValid());
-        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 1, 1, 1, 0).isValid());
-        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 1, 1, 1, -1).isValid());
 
+        // negative line/column
+        Assert.assertFalse(new SourceInformation(sourceId, -1, 1, 2, 1, 3, 1).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 1, -1, 2, 1, 3, 1).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, -2, 1, 3, 1).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 2, -1, 3, 1).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 2, 1, -3, 1).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 2, 1, 3, -1).isValid());
+
+        // 0 line (only valid if all line/col values are 0)
+        Assert.assertTrue(new SourceInformation(sourceId, 0, 0, 0, 0, 0, 0).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 0, 0, 0, 0, 0, 1).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 0, 1, 0, 1, 0, 1).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 0, 1, 1, 1, 1, 1).isValid());
+
+        // 0 column (only valid if all lines are equal and all cols are 0)
+        Assert.assertTrue(new SourceInformation(sourceId, 1, 0, 1, 0, 1, 0).isValid());
+        Assert.assertTrue(new SourceInformation(sourceId, 2, 0, 2, 0, 2, 0).isValid());
+        Assert.assertTrue(new SourceInformation(sourceId, 5, 0, 5, 0, 5, 0).isValid());
+        Assert.assertTrue(new SourceInformation(sourceId, 17, 0, 17, 0, 17, 0).isValid());
+
+        Assert.assertFalse(new SourceInformation(sourceId, 1, 0, 1, 0, 2, 0).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 1, 0, 2, 0, 2, 0).isValid());
+
+        Assert.assertFalse(new SourceInformation(sourceId, 1, 0, 1, 1, 1, 1).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 0, 1, 1, 1).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 1, 0, 1, 1).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 1, 1, 0, 1).isValid());
+        Assert.assertFalse(new SourceInformation(sourceId, 1, 1, 1, 1, 1, 0).isValid());
+
+        // invalid intervals (end before start, etc)
         Assert.assertFalse(new SourceInformation(sourceId, 5, 1, 4, 1, 7, 1).isValid());
         Assert.assertFalse(new SourceInformation(sourceId, 5, 1, 5, 3, 5, 2).isValid());
         Assert.assertFalse(new SourceInformation(sourceId, 5, 3, 5, 2, 5, 8).isValid());
         Assert.assertFalse(new SourceInformation(sourceId, 5, 3, 5, 5, 4, 8).isValid());
 
+        // miscellaneous
         Assert.assertTrue(new SourceInformation(sourceId, 5, 3, 6, 1, 7, 8).isValid());
         Assert.assertFalse(new SourceInformation(sourceId, 5, 3, 6, 0, 7, 8).isValid());
         Assert.assertFalse(new SourceInformation(sourceId, 5, 3, 6, 1, 7, 0).isValid());


### PR DESCRIPTION
Source information with 0 for a line or column value occurs with ImportGroups with no Imports. In the case of an import group for the initial implicit Pure section of a file with no imports, all line and column values will be 0. In the case of an import group for an explicit section with no imports, all column values will be 0 and line values will be the line of the section declaration (e.g., ###Mapping).

To accommodate this, we allow SourceInformation for these two cases to be valid. These can be characterized as cases where all column values are 0 and all line values are equal and non-negative. Otherwise, validity still requires line and column values to be strictly positive.

Additionally, we have updated our compiled state integrity test to ensure that all PackageableElements, including ImportGroups but excluding Packages, have non-null source information. And we have added a test to ensure that all source information is valid.