### PR TITLE
Add subset method for CodeRepositorySet.Builder

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/generator/par/PureJarGenerator.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/generator/par/PureJarGenerator.java
@@ -90,7 +90,7 @@ public class PureJarGenerator
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         RichIterable<CodeRepository> cpRepositories = CodeRepositoryProviderHelper.findCodeRepositories(classLoader, true);
         log.info("  Found repositories (in the classpath): " + cpRepositories.collect(CodeRepository::getName).makeString("[", ",", "]"));
-        CodeRepositorySet.Builder builder = CodeRepositorySet.newBuilder().withCodeRepositories(cpRepositories);
+        CodeRepositorySet.Builder builder = CodeRepositorySet.builder().withCodeRepositories(cpRepositories);
         if (extraRepositories != null)
         {
             extraRepositories.forEach(r -> builder.addCodeRepository(getExtraRepository(classLoader, r)));
@@ -99,8 +99,11 @@ public class PureJarGenerator
         {
             builder.withoutCodeRepositories(excludedRepositories);
         }
-        CodeRepositorySet newRepositories = builder.build();
-        return ((repositories == null) || repositories.isEmpty()) ? newRepositories : newRepositories.subset(repositories);
+        if ((repositories != null) && !repositories.isEmpty())
+        {
+            builder.subset(repositories);
+        }
+        return builder.build();
     }
 
     private static GenericCodeRepository getExtraRepository(ClassLoader classLoader, String extraRepository)

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractCompiledStateIntegrityTest.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractCompiledStateIntegrityTest.java
@@ -97,8 +97,8 @@ public abstract class AbstractCompiledStateIntegrityTest
     {
         CodeRepositorySet repos = CodeRepositorySet.newBuilder()
                 .withCodeRepositories(CodeRepositoryProviderHelper.findCodeRepositories())
-                .build()
-                .subset(repositories);
+                .subset(repositories)
+                .build();
         initialize(new CompositeCodeStorage(new ClassLoaderCodeStorage(repos.getRepositories())));
     }
 

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractImportGroupsTest.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractImportGroupsTest.java
@@ -51,8 +51,8 @@ public abstract class AbstractImportGroupsTest
     {
         CodeRepositorySet repos = CodeRepositorySet.newBuilder()
                 .withCodeRepositories(CodeRepositoryProviderHelper.findCodeRepositories())
-                .build()
-                .subset(repositories);
+                .subset(repositories)
+                .build();
         initialize(new CompositeCodeStorage(new ClassLoaderCodeStorage(repos.getRepositories())));
     }
 


### PR DESCRIPTION
Add subset method for CodeRepositorySet.Builder. This allows building a subset out of a larger set that may not be completely well defined. For example, this could allow building a well defined subset out of a larger set where some dependencies not involved in the subset are missing.

Also, do not automatically add platform repository either to subsets or the builder in general.