### PR TITLE
Assorted fixes and code clean-up

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreParser.g4
+++ b/legend-pure-core/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreParser.g4
@@ -43,31 +43,31 @@ classDefinition: CLASS stereotypes? taggedValues? qualifiedName typeParametersWi
        )
 ;
 
-measureDefinition: MEASURE qualifiedName
+measureDefinition: MEASURE stereotypes? taggedValues? qualifiedName
                    measureBody
 ;
 
 measureBody: CURLY_BRACKET_OPEN
              (
                 (
-                    measureExpr* canonicalExpr measureExpr*
+                    unitExpr* canonicalUnitExpr unitExpr*
                 )
                 |
-                nonConvertibleMeasureExpr+
+                nonConvertibleUnitExpr+
              )
              CURLY_BRACKET_CLOSE
 ;
 
-canonicalExpr: STAR measureExpr
+canonicalUnitExpr: STAR unitExpr
 ;
 
-measureExpr: qualifiedName COLON unitExpr
+unitExpr: identifier COLON unitConversionExpr
 ;
 
-nonConvertibleMeasureExpr : qualifiedName END_LINE
+nonConvertibleUnitExpr : identifier END_LINE
 ;
 
-unitExpr: identifier ARROW codeBlock
+unitConversionExpr: identifier ARROW codeBlock
 ;
 
 mapping : (MAPPING_SRC qualifiedName)? (MAPPING_FILTER combinedExpression)? mappingLine (COMMA mappingLine)*

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/M3PropertyPaths.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/M3PropertyPaths.java
@@ -41,11 +41,12 @@ public class M3PropertyPaths
     public static final ImmutableList<String> multiplicityArguments = makePropertyPath(M3Paths.GenericType, M3Properties.multiplicityArguments);
     public static final ImmutableList<String> multiplicityParameters = makePropertyPath(M3Paths.Class, M3Properties.multiplicityParameters);
     public static final ImmutableList<String> name = makePropertyPath(M3Paths.ModelElement, M3Properties.name);
+    public static final ImmutableList<String> name_Enum = makePropertyPath(M3Paths.Enum, M3Properties.name);
     public static final ImmutableList<String> offset_ReferenceUsage = makePropertyPath(M3Paths.ReferenceUsage, M3Properties.offset);
+    public static final ImmutableList<String> originalMilestonedProperties = makePropertyPath(M3Paths.Class, M3Properties.originalMilestonedProperties);
     public static final ImmutableList<String> owner_ReferenceUsage = makePropertyPath(M3Paths.ReferenceUsage, M3Properties.owner);
     public static final ImmutableList<String> _package = makePropertyPath(M3Paths.PackageableElement, M3Properties._package);
     public static final ImmutableList<String> properties = makePropertyPath(M3Paths.Class, M3Properties.properties);
-    public static final ImmutableList<String> originalMilestonedProperties = makePropertyPath(M3Paths.Class, M3Properties.originalMilestonedProperties);
     public static final ImmutableList<String> propertiesFromAssociations = makePropertyPath(M3Paths.Class, M3Properties.propertiesFromAssociations);
     public static final ImmutableList<String> propertyName_ReferenceUsage = makePropertyPath(M3Paths.ReferenceUsage, M3Properties.propertyName);
     public static final ImmutableList<String> qualifiedProperties = makePropertyPath(M3Paths.Class, M3Properties.qualifiedProperties);
@@ -57,8 +58,8 @@ public class M3PropertyPaths
     public static final ImmutableList<String> typeArguments = makePropertyPath(M3Paths.GenericType, M3Properties.typeArguments);
     public static final ImmutableList<String> typeParameter = makePropertyPath(M3Paths.GenericType, M3Properties.typeParameter);
     public static final ImmutableList<String> typeParameters = makePropertyPath(M3Paths.Class, M3Properties.typeParameters);
-    public static final ImmutableList<String> stereotypes = makePropertyPath(M3Paths.Class, M3Properties.stereotypes);
-    public static final ImmutableList<String> taggedValues = makePropertyPath(M3Paths.Class, M3Properties.taggedValues);
+    public static final ImmutableList<String> stereotypes = makePropertyPath(M3Paths.ElementWithStereotypes, M3Properties.stereotypes);
+    public static final ImmutableList<String> taggedValues = makePropertyPath(M3Paths.ElementWithTaggedValues, M3Properties.taggedValues);
 
     @SuppressWarnings("unchecked")
     public static final ImmutableSet<ImmutableList<String>> BACK_REFERENCE_PROPERTY_PATHS = Sets.immutable.with(

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/function/FunctionType.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/function/FunctionType.java
@@ -23,6 +23,7 @@ import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
+import org.finos.legend.pure.m4.coreinstance.AbstractCoreInstanceWrapper;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.tools.SafeAppendable;
 
@@ -30,8 +31,15 @@ public class FunctionType
 {
     public static boolean isFunctionType(CoreInstance instance, ProcessorSupport processorSupport)
     {
-        return (instance instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType) ||
-                (!(instance instanceof Any) && processorSupport.instance_instanceOf(instance, M3Paths.FunctionType));
+        if (instance == null)
+        {
+            return false;
+        }
+        if (instance instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType)
+        {
+            return true;
+        }
+        return (!(instance instanceof Any) || (instance instanceof AbstractCoreInstanceWrapper)) && processorSupport.instance_instanceOf(instance, M3Paths.FunctionType);
     }
 
     public static boolean functionTypesEqual(CoreInstance functionType1, CoreInstance functionType2, ProcessorSupport processorSupport)

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/relation/_RelationType.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/relation/_RelationType.java
@@ -40,6 +40,7 @@ import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation._package._Package;
 import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
+import org.finos.legend.pure.m4.coreinstance.AbstractCoreInstanceWrapper;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
@@ -49,9 +50,15 @@ public class _RelationType
 {
     public static boolean isRelationType(CoreInstance type, ProcessorSupport processorSupport)
     {
-        return (type != null) &&
-                ((type instanceof RelationType) ||
-                        (!(type instanceof Any) && processorSupport.instance_instanceOf(type, M3Paths.RelationType)));
+        if (type == null)
+        {
+            return false;
+        }
+        if (type instanceof RelationType)
+        {
+            return true;
+        }
+        return (!(type instanceof Any) || (type instanceof AbstractCoreInstanceWrapper)) && processorSupport.instance_instanceOf(type, M3Paths.RelationType);
     }
 
     public static String print(CoreInstance relationType, ProcessorSupport processorSupport)

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/type/Type.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/type/Type.java
@@ -15,10 +15,10 @@
 package org.finos.legend.pure.m3.navigation.type;
 
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.SetIterable;
-import org.eclipse.collections.impl.factory.Sets;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Any;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.PrimitiveType;
 import org.finos.legend.pure.m3.navigation.Instance;
@@ -26,6 +26,7 @@ import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation.linearization.C3Linearization;
+import org.finos.legend.pure.m4.coreinstance.AbstractCoreInstanceWrapper;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 
@@ -61,9 +62,15 @@ public class Type
      */
     public static boolean isPrimitiveType(CoreInstance type, ProcessorSupport processorSupport)
     {
-        return (type != null) &&
-                ((type instanceof PrimitiveType) ||
-                        (!(type instanceof Any) && processorSupport.type_subTypeOf(type.getClassifier(), processorSupport.package_getByUserPath(M3Paths.PrimitiveType))));
+        if (type == null)
+        {
+            return false;
+        }
+        if (type instanceof PrimitiveType)
+        {
+            return true;
+        }
+        return (!(type instanceof Any) || (type instanceof AbstractCoreInstanceWrapper)) && processorSupport.instance_instanceOf(type, M3Paths.PrimitiveType);
     }
 
     /**

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
@@ -21,7 +21,6 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.block.function.Function0;
-import org.eclipse.collections.api.block.predicate.Predicate2;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.factory.Sets;
@@ -32,7 +31,7 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.list.mutable.ListAdapter;
+import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.Iterate;
@@ -133,7 +132,6 @@ import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.As
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.AtomicExpressionContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.BooleanPartContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.BuildMilestoningVariableExpressionContext;
-import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.CanonicalExprContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.ClassDefinitionContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.CodeBlockContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.CombinedArithmeticOnlyContext;
@@ -179,10 +177,10 @@ import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.Le
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.MappingContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.MappingLineContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.MeasureDefinitionContext;
-import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.MeasureExprContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.MultiplicityArgumentContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.MultiplicityArgumentsContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.NativeFunctionContext;
+import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.NonConvertibleUnitExprContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.NotExpressionContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.PackagePathContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.ProfileContext;
@@ -215,6 +213,7 @@ import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.Ty
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.TypeParameterContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.TypeParametersWithContravarianceAndMultiplicityParametersContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.TypeWithOperationContext;
+import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.UnitExprContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.VariableContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.inlinedsl.InlineDSL;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.inlinedsl.InlineDSLLibrary;
@@ -231,6 +230,7 @@ import org.finos.legend.pure.m4.serialization.grammar.antlr.AntlrSourceInformati
 import org.finos.legend.pure.m4.serialization.grammar.antlr.PureParserException;
 
 import java.util.List;
+import java.util.Optional;
 
 public class AntlrContextToM3CoreInstance
 {
@@ -385,72 +385,55 @@ public class AntlrContextToM3CoreInstance
         {
             for (MeasureDefinitionContext dCtx : ctx.measureDefinition())
             {
+                Measure measure;
                 if (hasImportChanged)
                 {
-                    result = this.measureParser(dCtx, importId);
+                    measure = measureParser(dCtx, importId);
                 }
                 else
                 {
                     String importGroupID = importId._name();
                     String newContent = normalizeContent(dCtx.start.getInputStream().getText(new Interval(dCtx.start.getStartIndex(), dCtx.stop.getStopIndex())));
                     MutableList<CoreInstance> oldInstances = this.oldInstances.select(i -> this.oldState.instanceImportGroupInSourceEqualsNewImportGroup(i, importGroupID) && this.oldState.instanceContentInSourceEqualsNewContent(i, newContent), Lists.mutable.empty());
-
-                    Predicate2<CoreInstance, SourceInformation> matchesOldInstance = (oldMeasureInstance, newSourceInfo) ->
+                    if (oldInstances.size() == 1)
                     {
-                        if (newSourceInfo == null || oldMeasureInstance.getSourceInformation().getStartColumn() == newSourceInfo.getStartColumn())
-                        {
-                            if (newSourceInfo != null)
-                            {
-                                offsetSourceInformationForInstanceAndChildren(oldMeasureInstance, newSourceInfo.getStartLine() - oldMeasureInstance.getSourceInformation().getStartLine());
-                            }
-                            Function<String, IdentifierContext> newIdentifierContext = s -> new IdentifierContext(null, 1)
-                            {
-                                @Override
-                                public String getText()
-                                {
-                                    return s;
-                                }
-                            };
-                            Package packageInstance = buildPackage(Lists.mutable.with(newIdentifierContext.valueOf(oldMeasureInstance.getValueForMetaPropertyToOne(M3Properties._package).getName())));
-                            ((PackageableElement) oldMeasureInstance)._package(packageInstance);
-                            packageInstance._childrenAdd((PackageableElement) oldMeasureInstance);
-                            return true;
-                        }
-                        return false;
-                    };
-
-                    CoreInstance oldMeasureInstance = ListIterate.detect(oldInstances, i -> Instance.instanceOf(i, M3Paths.Measure, this.processorSupport));
-
-                    if (oldMeasureInstance != null)
-                    {
-                        this.oldInstances.remove(oldMeasureInstance);
+                        CoreInstance thisInstance = oldInstances.get(0);
+                        this.oldInstances.remove(thisInstance);
                         SourceInformation newSourceInfo = this.sourceInformation.getPureSourceInformation(dCtx.getStart(), dCtx.qualifiedName().identifier().getStart(), dCtx.getStop());
-                        if (matchesOldInstance.accept(oldMeasureInstance, newSourceInfo))
+                        if (thisInstance.getSourceInformation().getStartColumn() == newSourceInfo.getStartColumn())
                         {
-                            Measure mI = (Measure) oldMeasureInstance;
-                            result = mI;
+                            measure = (Measure) thisInstance;
+                            offsetSourceInformationForInstanceAndChildren(thisInstance, newSourceInfo.getStartLine() - thisInstance.getSourceInformation().getStartLine());
+                            Package packageInstance = buildPackage(dCtx.qualifiedName().packagePath());
+                            measure._package(packageInstance);
+                            packageInstance._childrenAdd(measure);
 
-                            for (Unit unit : Lists.mutable.with(mI._canonicalUnit()).withAll(mI._nonCanonicalUnits()))
+                            Unit canonicalUnit = measure._canonicalUnit();
+                            if (canonicalUnit != null)
                             {
-                                Package packageInstance = buildPackage(Lists.mutable.withAll(dCtx.qualifiedName().packagePath() == null ? Lists.mutable.empty() : ListAdapter.adapt(dCtx.qualifiedName().packagePath().identifier())));
+                                canonicalUnit._package(packageInstance);
+                                packageInstance._childrenAdd(canonicalUnit);
+                            }
+                            measure._nonCanonicalUnits().forEach(unit ->
+                            {
                                 unit._package(packageInstance);
                                 packageInstance._childrenAdd(unit);
-                            }
+                            });
                         }
                         else
                         {
-                            result = this.measureParser(dCtx, importId);
+                            measure = measureParser(dCtx, importId);
                         }
                     }
                     else
                     {
-                        result = this.measureParser(dCtx, importId);
+                        measure = measureParser(dCtx, importId);
                     }
                 }
-                Measure mI = (Measure) result;
-                this.coreInstancesResult.add(result);
-                this.coreInstancesResult.addAllIterable(mI._nonCanonicalUnits());
-                this.coreInstancesResult.add(mI._canonicalUnit());
+                result = measure;
+                this.coreInstancesResult.add(measure);
+                Optional.ofNullable(measure._canonicalUnit()).ifPresent(this.coreInstancesResult::add);
+                this.coreInstancesResult.addAllIterable(measure._nonCanonicalUnits());
             }
         }
         if (ctx.association() != null)
@@ -1805,11 +1788,16 @@ public class AntlrContextToM3CoreInstance
         return wrapperIv;
     }
 
-    private String getUnitNameWithMeasure(org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.UnitNameContext ctx)
+    private String getUnitNameWithMeasure(M3Parser.UnitNameContext ctx)
     {
         QualifiedNameContext measureQualifiedName = ctx.qualifiedName();
-        String nameWithoutPath = measureQualifiedName.identifier().getText().concat(this.tilde).concat(ctx.identifier().getText());
-        return measureQualifiedName.packagePath() != null ? this.packageToString(measureQualifiedName.packagePath()).concat("::").concat(nameWithoutPath) : nameWithoutPath;
+        StringBuilder builder = new StringBuilder();
+        if (measureQualifiedName.packagePath() != null)
+        {
+            appendPackage(builder, measureQualifiedName.packagePath()).append("::");
+        }
+        builder.append(measureQualifiedName.identifier().getText()).append(this.tilde).append(ctx.identifier().getText());
+        return builder.toString();
     }
 
     private SimpleFunctionExpression expressionInstanceParser(ExpressionInstanceContext ctx, MutableList<String> typeParametersNames, LambdaContext lambdaContext, ImportGroup importId, boolean addLines, String space)
@@ -2290,100 +2278,39 @@ public class AntlrContextToM3CoreInstance
      * Parses the measure given its definition context.
      * Returns the parsed measure as a CoreInstance.
      */
-    private CoreInstance measureParser(MeasureDefinitionContext ctx, ImportGroup importId) throws PureParserException
+    private Measure measureParser(MeasureDefinitionContext ctx, ImportGroup importId) throws PureParserException
     {
-        UnitInstance canonicalUnit;
-        MutableList<UnitInstance> nonCanonicalUnits;
-
-        MutableList<GenericType> superTypesGenericTypes = Lists.mutable.empty();
-        MutableList<String> typeParameterNames = Lists.mutable.empty();
-        MutableList<Boolean> contravariants = Lists.mutable.empty();
-        MutableList<String> multiplicityParameterNames = Lists.mutable.empty();
-        ListIterable<CoreInstance> stereotypes = Lists.mutable.empty();
-        ListIterable<TaggedValue> tags = Lists.mutable.empty();
-        MeasureInstance measureInstance;
+        checkExists(ctx.qualifiedName().packagePath(), ctx.qualifiedName().identifier(), null);
 
         String measureName = ctx.qualifiedName().identifier().getText();
-        measureInstance = MeasureInstance.createPersistent(this.repository, measureName);
+        Measure measureInstance = MeasureInstance.createPersistent(this.repository, measureName, this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.qualifiedName().identifier().getStart(), ctx.getStop()))
+                ._name(measureName)
+                ._classifierGenericType(GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Measure)));
+
         Package packageInstance = buildPackage(ctx.qualifiedName().packagePath());
         measureInstance._package(packageInstance);
         packageInstance._childrenAdd(measureInstance);
 
-        measureInstance.setSourceInformation(this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.qualifiedName().identifier().getStart(), ctx.getStop()));
-
-        if (superTypesGenericTypes.isEmpty())
-        {
-            GenericTypeInstance genericTypeInstance = GenericTypeInstance.createPersistent(this.repository);
-            genericTypeInstance._rawTypeCoreInstance(this.processorSupport.package_getByUserPath(M3Paths.Any));
-            superTypesGenericTypes.add(genericTypeInstance);
-        }
-
-        GenericTypeInstance classifierGT = GenericTypeInstance.createPersistent(this.repository);
-        ClassInstance measureType = (ClassInstance) this.processorSupport.package_getByUserPath(M3Paths.Measure);
-        classifierGT._rawTypeCoreInstance(measureType);
-
-
-        measureInstance._classifierGenericType(classifierGT);
-
-        if (!typeParameterNames.isEmpty())
-        {
-            MutableList<TypeParameter> typeParameters = Lists.mutable.of();
-            MutableList<Pair<String, Boolean>> tps = typeParameterNames.zip(contravariants);
-            for (Pair<String, Boolean> typeParam : tps)
-            {
-                TypeParameterInstance tp = TypeParameterInstance.createPersistent(this.repository, typeParam.getOne());
-                tp._contravariant(typeParam.getTwo());
-                typeParameters.add(tp);
-            }
-
-            MutableList<GenericType> typeArgs = Lists.mutable.of();
-            for (String typeParamName : typeParameterNames)
-            {
-                TypeParameterInstance tp = TypeParameterInstance.createPersistent(this.repository, typeParamName);
-                GenericTypeInstance gt = GenericTypeInstance.createPersistent(this.repository);
-                gt._typeParameter(tp);
-                typeArgs.add(gt);
-            }
-
-        }
-
-        if (!multiplicityParameterNames.isEmpty())
-        {
-            MutableList<Multiplicity> multParameters = Lists.mutable.of();
-
-            for (String multiplicityParam : multiplicityParameterNames)
-            {
-                MultiplicityInstance mult = MultiplicityInstance.createPersistent(this.repository, null, null);
-                mult._multiplicityParameter(multiplicityParam);
-                multParameters.add(mult);
-            }
-        }
-
-        measureInstance._name(ctx.qualifiedName().identifier().getText());
-        if (!stereotypes.isEmpty())
+        ListIterable<CoreInstance> stereotypes = (ctx.stereotypes() == null) ? Lists.immutable.empty() : stereotypes(ctx.stereotypes(), importId);
+        if (stereotypes.notEmpty())
         {
             measureInstance._stereotypesCoreInstance(stereotypes);
         }
-        if (!tags.isEmpty())
+        ListIterable<TaggedValue> taggedValues = (ctx.taggedValues() == null) ? Lists.immutable.empty() : taggedValues(ctx.taggedValues(), importId);
+        if (taggedValues.notEmpty())
         {
-            measureInstance._taggedValues(tags);
+            measureInstance._taggedValues(taggedValues);
         }
 
-        MutableList<Generalization> generalizations = Lists.mutable.empty();
-        for (GenericType superType : superTypesGenericTypes)
-        {
-            GeneralizationInstance generalizationInstance = GeneralizationInstance.createPersistent(this.repository, superType, measureInstance);
-            generalizations.add(generalizationInstance);
-        }
-        measureInstance._generalizations(generalizations);
+        measureInstance._generalizations(Lists.immutable.with(GeneralizationInstance.createPersistent(this.repository, GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Any)), measureInstance)));
 
-        if (null != ctx.measureBody().canonicalExpr())
+        M3Parser.MeasureBodyContext measureBodyCtx = ctx.measureBody();
+        if (measureBodyCtx.canonicalUnitExpr() != null)
         {
             // traditional canonical unit pattern
-            canonicalUnit = this.canonicalUnitParser(ctx.measureBody().canonicalExpr(), importId, measureInstance, ctx);
-            measureInstance._canonicalUnit(canonicalUnit);
+            measureInstance._canonicalUnit(unitParser(measureBodyCtx.canonicalUnitExpr().unitExpr(), importId, measureInstance));
 
-            nonCanonicalUnits = this.nonCanonicalUnitsParser(ctx.measureBody().measureExpr(), importId, measureInstance, ctx);
+            MutableList<Unit> nonCanonicalUnits = ListIterate.collect(measureBodyCtx.unitExpr(), unitCtx -> unitParser(unitCtx, importId, measureInstance));
             if (nonCanonicalUnits.notEmpty())
             {
                 measureInstance._nonCanonicalUnits(nonCanonicalUnits);
@@ -2392,150 +2319,78 @@ public class AntlrContextToM3CoreInstance
         else
         {
             // non-convertible unit pattern
-            MutableList<UnitInstance> nonConvertibleUnits = Lists.mutable.empty();
-            for (org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.NonConvertibleMeasureExprContext ncctx : ctx.measureBody().nonConvertibleMeasureExpr())
-            {
-                UnitInstance currentUnit = this.nonConvertibleUnitParser(ncctx, measureInstance, ctx);
-                nonConvertibleUnits.add(currentUnit);
-            }
+            MutableList<Unit> nonConvertibleUnits = ListIterate.collect(measureBodyCtx.nonConvertibleUnitExpr(), unitCtx -> nonConvertibleUnitParser(unitCtx, measureInstance));
             measureInstance._canonicalUnit(nonConvertibleUnits.get(0));
             if (nonConvertibleUnits.size() > 1)
             {
-                measureInstance._nonCanonicalUnits(nonConvertibleUnits.subList(1, nonConvertibleUnits.size()));
+                measureInstance._nonCanonicalUnits(Lists.immutable.withAll(nonConvertibleUnits.subList(1, nonConvertibleUnits.size())));
             }
         }
         return measureInstance;
     }
 
     /**
-     * Parse the canonical unit and returns it as a UnitInstance
-     */
-    private UnitInstance canonicalUnitParser(CanonicalExprContext ctx, ImportGroup importId, MeasureInstance measureInstance, MeasureDefinitionContext mctx) throws PureParserException
-    {
-        return this.unitParser(ctx.measureExpr(), importId, measureInstance, mctx);
-    }
-
-    /**
-     * Parses the non-canonical units in a measure and return a MutableList of UnitInstance's.
-     */
-    private MutableList<UnitInstance> nonCanonicalUnitsParser(List<MeasureExprContext> ctxList, ImportGroup importId, MeasureInstance measureInstance, MeasureDefinitionContext mctx) throws PureParserException
-    {
-        return ListIterate.collect(ctxList, ctx -> unitParser(ctx, importId, measureInstance, mctx));
-    }
-
-    /**
      * Helps build the unitInstance for any canonical and non-canonical units and returns the parsed unitInstance.
      */
-    private UnitInstance unitParser(MeasureExprContext ctx, ImportGroup importId, MeasureInstance measureInstance, MeasureDefinitionContext mctx) throws PureParserException
+    @SuppressWarnings("unchecked")
+    private Unit unitParser(UnitExprContext ctx, ImportGroup importId, Measure measure)
     {
-        UnitInstance unitInstance;
+        String unitName = measure._name() + this.tilde + ctx.identifier().getText();
+        SourceInformation sourceInfo = this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.identifier().getStart(), ctx.getStop());
+        checkExists(measure._package(), unitName, sourceInfo);
+        Unit unitInstance = UnitInstance.createPersistent(this.repository, unitName, sourceInfo)
+                ._name(unitName)
+                ._measure(measure)
+                ._classifierGenericType(GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Unit)));
 
-        MutableList<GenericType> superTypesGenericTypes = Lists.mutable.empty();
+        // set unit super type to be its measure (Kilogram -> Mass)
+        unitInstance._generalizations(Lists.immutable.with(GeneralizationInstance.createPersistent(this.repository, GenericTypeInstance.createPersistent(this.repository)._rawType(measure), unitInstance)));
 
-        this.checkExists(ctx.qualifiedName().packagePath(), ctx.qualifiedName().identifier(), null);
-
-        String unitName = mctx.qualifiedName().identifier().getText().concat(this.tilde).concat(ctx.qualifiedName().identifier().getText());
-        unitInstance = UnitInstance.createPersistent(this.repository, unitName);
-
-        Package packageInstance = buildPackage(Lists.mutable.withAll(mctx.qualifiedName().packagePath() == null ? Lists.mutable.empty() : ListAdapter.adapt(mctx.qualifiedName().packagePath().identifier())));
+        Package packageInstance = measure._package();
         unitInstance._package(packageInstance);
         packageInstance._childrenAdd(unitInstance);
 
-        unitInstance.setSourceInformation(this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.qualifiedName().identifier().getStart(), ctx.getStop()));
-
-        GenericTypeInstance classifierGT = GenericTypeInstance.createPersistent(this.repository);
-        ClassInstance unitType = (ClassInstance) this.processorSupport.package_getByUserPath(M3Paths.Unit);
-        classifierGT._rawTypeCoreInstance(unitType);
-
-        unitInstance._classifierGenericType(classifierGT);
-
-        unitInstance._name(unitName);
-
-        if (superTypesGenericTypes.isEmpty())
-        {
-            GenericTypeInstance genericTypeInstance = GenericTypeInstance.createPersistent(this.repository);
-            genericTypeInstance._rawTypeCoreInstance(measureInstance); // set unit super type to be its measure (Kilogram -> Mass)
-            superTypesGenericTypes.add(genericTypeInstance);
-        }
-        MutableList<Generalization> generalizations = Lists.mutable.empty();
-        for (GenericType superType : superTypesGenericTypes)
-        {
-            GeneralizationInstance generalizationInstance = GeneralizationInstance.createPersistent(this.repository, superType, unitInstance);
-            generalizations.add(generalizationInstance);
-        }
-        unitInstance._generalizations(generalizations);
-
-        unitInstance._measure(measureInstance);
-
         // prepare lambda instance for the conversion function
 
-        String fullName = this.getQualifiedNameString(ctx.qualifiedName());
-        LambdaContext lambdaContext = new LambdaContext(fullName.replace("::", "_"));
+        LambdaContext lambdaContext = new LambdaContext(org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.getUserPathForPackageableElement(unitInstance, "_"));
         MutableList<String> typeParametersNames = Lists.mutable.empty();
-        FunctionTypeInstance signature = FunctionTypeInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.unitExpr().getStart(), ctx.unitExpr().getStart(), ctx.unitExpr().getStop()), null, null);
+        FunctionType signature = FunctionTypeInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.unitConversionExpr().getStart(), ctx.unitConversionExpr().getStart(), ctx.unitConversionExpr().getStop()), null, null);
 
         // prepare params
 
-        VariableExpression expr = this.lambdaParam(null, ctx.unitExpr().identifier(), typeParametersNames, "", importId);
-        expr._multiplicity(this.getPureOne());
-        expr._functionTypeOwner(signature);
-        GenericTypeInstance paramGenericType = GenericTypeInstance.createPersistent(this.repository);
-        CoreInstance paramType = this.processorSupport.package_getByUserPath(M3Paths.Number);
-        paramGenericType._rawTypeCoreInstance(paramType);
-        expr._genericType(paramGenericType);
-        signature._parameters(Lists.mutable.with(expr));
+        VariableExpression expr = lambdaParam(null, ctx.unitConversionExpr().identifier(), typeParametersNames, "", importId)
+                ._multiplicity(getPureOne())
+                ._functionTypeOwner(signature)
+                ._genericType(GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Number)));
+        signature._parameters(Lists.immutable.with(expr));
 
-        GenericTypeInstance genericTypeInstance = GenericTypeInstance.createPersistent(this.repository);
-        Type type = (Type) this.processorSupport.package_getByUserPath(M3Paths.LambdaFunction);
-        genericTypeInstance._rawTypeCoreInstance(type);
-        GenericTypeInstance genericTypeInstanceTa = GenericTypeInstance.createPersistent(this.repository);
-        genericTypeInstanceTa._rawTypeCoreInstance(signature);
-        genericTypeInstance._typeArguments(Lists.mutable.<GenericType>of(genericTypeInstanceTa));
-        LambdaFunctionInstance lambdaFunctionInstance = LambdaFunctionInstance.createPersistent(this.repository, lambdaContext.getLambdaFunctionUniqueName(), this.sourceInformation.getPureSourceInformation(ctx.unitExpr().ARROW().getSymbol()));
-        lambdaFunctionInstance._classifierGenericType(genericTypeInstance);
+        GenericType genericTypeInstance = GenericTypeInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.unitConversionExpr().ARROW().getSymbol()))
+                ._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.LambdaFunction))
+                ._typeArguments(Lists.immutable.with(GenericTypeInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.unitConversionExpr().ARROW().getSymbol()))._rawType(signature)));
+        LambdaFunction<?> lambdaFunctionInstance = LambdaFunctionInstance.createPersistent(this.repository, lambdaContext.getLambdaFunctionUniqueName(), this.sourceInformation.getPureSourceInformation(ctx.unitConversionExpr().ARROW().getSymbol()))
+                ._classifierGenericType(genericTypeInstance)
+                ._expressionSequence(codeBlock(ctx.unitConversionExpr().codeBlock(), typeParametersNames, Lists.mutable.empty(), importId, lambdaContext, this.addLines, tabs(6)));
         signature._functionAdd(lambdaFunctionInstance);
-
-        ListIterable<ValueSpecification> block = this.codeBlock(ctx.unitExpr().codeBlock(), typeParametersNames, Lists.mutable.empty(), importId, lambdaContext, this.addLines, tabs(6));
-        lambdaFunctionInstance._expressionSequence(block);
 
         unitInstance._conversionFunction(lambdaFunctionInstance);
 
         return unitInstance;
     }
 
-    private UnitInstance nonConvertibleUnitParser(org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.NonConvertibleMeasureExprContext ctx, MeasureInstance measureInstance, MeasureDefinitionContext mctx) throws PureParserException
+    private Unit nonConvertibleUnitParser(NonConvertibleUnitExprContext ctx, Measure measure)
     {
-        UnitInstance unitInstance;
-        MutableList<GenericType> superTypesGenericTypes = Lists.mutable.empty();
+        String unitName = measure._name() + this.tilde + ctx.identifier().getText();
+        SourceInformation sourceInfo = this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.identifier().getStart(), ctx.getStop());
+        checkExists(measure._package(), unitName, sourceInfo);
+        Unit unitInstance = UnitInstance.createPersistent(this.repository, unitName, sourceInfo)
+                ._name(unitName)
+                ._measure(measure)
+                ._classifierGenericType(GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Unit)));
+        unitInstance._generalizations(Lists.immutable.with(GeneralizationInstance.createPersistent(this.repository, GenericTypeInstance.createPersistent(this.repository)._rawType(measure), unitInstance)));
 
-        this.checkExists(ctx.qualifiedName().packagePath(), ctx.qualifiedName().identifier(), null);
-
-        String unitName = mctx.qualifiedName().identifier().getText().concat(this.tilde).concat(ctx.qualifiedName().identifier().getText());
-        unitInstance = UnitInstance.createPersistent(this.repository, unitName);
-
-        Package packageInstance = buildPackage(Lists.mutable.withAll(mctx.qualifiedName().packagePath() == null ? Lists.mutable.empty() : ListAdapter.adapt(mctx.qualifiedName().packagePath().identifier())));
+        Package packageInstance = measure._package();
         unitInstance._package(packageInstance);
         packageInstance._childrenAdd(unitInstance);
-
-        unitInstance.setSourceInformation(this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.qualifiedName().identifier().getStart(), ctx.getStop()));
-
-        GenericTypeInstance classifierGT = GenericTypeInstance.createPersistent(this.repository);
-        ClassInstance unitType = (ClassInstance) this.processorSupport.package_getByUserPath(M3Paths.Unit);
-        classifierGT._rawTypeCoreInstance(unitType);
-
-        unitInstance._classifierGenericType(classifierGT);
-
-        unitInstance._name(unitName);
-
-        if (superTypesGenericTypes.isEmpty())
-        {
-            GenericTypeInstance genericTypeInstance = GenericTypeInstance.createPersistent(this.repository);
-            genericTypeInstance._rawTypeCoreInstance(measureInstance);
-            superTypesGenericTypes.add(genericTypeInstance);
-        }
-        unitInstance._generalizations(superTypesGenericTypes.collect(superType -> GeneralizationInstance.createPersistent(this.repository, superType, unitInstance)));
-
-        unitInstance._measure(measureInstance);
 
         return unitInstance;
     }
@@ -3479,7 +3334,8 @@ public class AntlrContextToM3CoreInstance
 
     private GenericType processType(QualifiedNameContext classParserPath, MutableList<String> typeParametersNames, ListIterable<GenericType> possibleTypeArguments, ListIterable<Multiplicity> possibleMultiplicityArguments, ImportGroup importId)
     {
-        GenericTypeInstance result = GenericTypeInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(classParserPath.identifier().getStart()));
+        SourceInformation sourceInfo = this.sourceInformation.getPureSourceInformation(classParserPath.identifier().getStart());
+        GenericTypeInstance result = GenericTypeInstance.createPersistent(this.repository, sourceInfo);
 
         MutableList<String> packagePaths = this.qualifiedNameToList(classParserPath);
         if (typeParametersNames.contains(packagePaths.getFirst()))
@@ -3502,10 +3358,9 @@ public class AntlrContextToM3CoreInstance
             }
             else
             {
-                ImportStubInstance is = ImportStubInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(classParserPath.identifier().getStart()), idOrPath, importId);
+                ImportStubInstance is = ImportStubInstance.createPersistent(this.repository, sourceInfo, idOrPath, importId);
                 result._rawTypeCoreInstance(is);
             }
-
         }
         if (!Iterate.isEmpty(possibleTypeArguments))
         {
@@ -3518,26 +3373,12 @@ public class AntlrContextToM3CoreInstance
         return result;
     }
 
-    private GenericType processUnitType(org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.UnitNameContext unitNameContext, ImportGroup importId)
+    private GenericType processUnitType(M3Parser.UnitNameContext unitNameContext, ImportGroup importId)
     {
-        GenericTypeInstance result = GenericTypeInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(unitNameContext.identifier().getStart()));
+        SourceInformation sourceInfo = this.sourceInformation.getPureSourceInformation(unitNameContext.identifier().getStart());
         String idOrPath = getUnitNameWithMeasure(unitNameContext);
-
-        if (_Package.SPECIAL_TYPES.contains(idOrPath))
-        {
-            CoreInstance type = this.repository.getTopLevel(idOrPath);
-            if (type == null)
-            {
-                throw new RuntimeException("Failed to find type");
-            }
-            result._rawTypeCoreInstance(type);
-        }
-        else
-        {
-            ImportStubInstance is = ImportStubInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(unitNameContext.identifier().getStart()), idOrPath, importId);
-            result._rawTypeCoreInstance(is);
-        }
-        return result;
+        return GenericTypeInstance.createPersistent(this.repository, sourceInfo)
+                ._rawTypeCoreInstance(ImportStubInstance.createPersistent(this.repository, sourceInfo, idOrPath, importId));
     }
 
     private ListIterable<CoreInstance> stereotypes(StereotypesContext ctx, ImportGroup importId)
@@ -3631,6 +3472,15 @@ public class AntlrContextToM3CoreInstance
     private String packageToString(PackagePathContext ctx)
     {
         return this.packageToList(ctx).makeString("::");
+    }
+
+    private StringBuilder appendPackage(StringBuilder builder, PackagePathContext ctx)
+    {
+        if (ctx != null)
+        {
+            LazyIterate.collect(ctx.identifier(), RuleContext::getText).appendString(builder, org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.DEFAULT_PATH_SEPARATOR);
+        }
+        return builder;
     }
 
     private String getQualifiedNameString(QualifiedNameContext ctx)
@@ -3848,6 +3698,11 @@ public class AntlrContextToM3CoreInstance
     private Package buildPackage(PackagePathContext paths)
     {
         return buildPackage(paths == null ? Lists.immutable.empty() : paths.identifier());
+    }
+
+    private Package buildPackage(IdentifierContext... paths)
+    {
+        return buildPackage(ArrayAdapter.adapt(paths));
     }
 
     private Package buildPackage(Iterable<? extends IdentifierContext> paths)
@@ -4155,6 +4010,14 @@ public class AntlrContextToM3CoreInstance
                 sourceInfo = this.sourceInformation.getPureSourceInformation(identifierCtx.getStart(), identifierCtx.getStart(), identifierCtx.getStop());
             }
             throw new PureParserException(sourceInfo, "The element '" + identifierCtx.getText() + "' already exists in the package '" + (pkgCtx == null ? "::" : this.getQualifiedNameString(pkgCtx)) + "'");
+        }
+    }
+
+    private void checkExists(Package pkg, String name, SourceInformation sourceInfo)
+    {
+        if (pkg._children().anySatisfy(c -> name.equals(c.getName())))
+        {
+            throw new PureParserException(sourceInfo, "The element '" + name + "' already exists in the package '" + org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.getUserPathForPackageableElement(pkg) + "'");
         }
     }
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/binary/reference/StereotypeReferenceSerializer.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/binary/reference/StereotypeReferenceSerializer.java
@@ -17,7 +17,6 @@ package org.finos.legend.pure.m3.serialization.runtime.binary.reference;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Stereotype;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
-import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.profile.Profile;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
@@ -34,7 +33,7 @@ public class StereotypeReferenceSerializer implements ExternalReferenceSerialize
     {
         Stereotype stereotype = (Stereotype)instance;
         helper.writeElementReference(stereotype._profile());
-        helper.writeString(PrimitiveUtilities.getStringValue(instance));
+        helper.writeString(stereotype._value());
     }
 
     @Override

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractTestMeasure.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractTestMeasure.java
@@ -37,7 +37,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
             "function meta::pure::functions::math::sum(numbers:Number[*]):Number[1]\n" +
                     "{\n" +
                     "    $numbers->plus();\n" +
-                    "}" +
+                    "}\n" +
                     "function meta::pure::functions::math::plus(masses: Mass[*]):Mass~Gram[1]\n" +
                     "{\n" +
                     "   let cv = $masses->map(m|let cv = $m->type()->cast(@Unit).conversionFunction->cast(@Function<{Number[1]->Number[1]}>)->toOne()->eval(getUnitValue($m)););\n" +
@@ -56,7 +56,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
     private static final String multFunction =
             "function meta::pure::unit::massScalarTimes(mass: Mass[1], nums: Number[*]):Mass~Gram[1]\n" +
                     "{\n" +
-                    "   let convertedValue = $mass->type()->cast(@Unit).conversionFunction->cast(@Function<{Number[1]->Number[1]}>)->toOne()->eval(getUnitValue($mass));" +
+                    "   let convertedValue = $mass->type()->cast(@Unit).conversionFunction->cast(@Function<{Number[1]->Number[1]}>)->toOne()->eval(getUnitValue($mass));\n" +
                     "   let numsMultResult = $nums->times();\n" +
                     "   let myValue = [$convertedValue, $numsMultResult]->times();\n" +
                     "   newUnit(Mass~Gram, $myValue)->cast(@Mass~Gram);\n" +
@@ -65,7 +65,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
     private static final String divFunction =
             "function meta::pure::unit::massScalarDivision(mass: Mass[1], nums: Number[*]):Mass~Gram[1]\n" +
                     "{\n" +
-                    "   let convertedValue = $mass->type()->cast(@Unit).conversionFunction->cast(@Function<{Number[1]->Number[1]}>)->toOne()->eval(getUnitValue($mass));" +
+                    "   let convertedValue = $mass->type()->cast(@Unit).conversionFunction->cast(@Function<{Number[1]->Number[1]}>)->toOne()->eval(getUnitValue($mass));\n" +
                     "   let numsMultResult = $nums->times();\n" +
                     "   assert($numsMultResult != 0, 'Cannot divide by zero.');\n" +
                     "   let myValue = $convertedValue->divide($numsMultResult);\n" +
@@ -105,8 +105,8 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                 "import pkg::*;\n" +
                         "function testFunc():Any[*]\n" +
                         "{\n" +
-                        "   let a = 'IamAString' Mass~Pound;" +
-                        "}"));
+                        "   let a = 'IamAString' Mass~Pound;\n" +
+                        "}\n"));
         assertPureException(PureParserException.class, "expected: '}' found: 'Mass'", e);
     }
 
@@ -119,8 +119,8 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                 "import pkg::*;\n" +
                         "function testFunc():Any[*]\n" +
                         "{\n" +
-                        "   let a = false Mass~Pound;" +
-                        "}"));
+                        "   let a = false Mass~Pound;\n" +
+                        "}\n"));
         assertPureException(PureParserException.class, "expected: '}' found: 'Mass'", e);
     }
 
@@ -137,8 +137,8 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "function testFunc():Any[*]\n" +
                         "{\n" +
                         "   let a = ^A(name='className');\n" +
-                        "   let b = $a Mass~Pound;" +
-                        "}"));
+                        "   let b = $a Mass~Pound;\n" +
+                        "}\n"));
         assertPureException(PureParserException.class, "expected: ';' found: 'Mass'", e);
     }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaPackageAndImportBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaPackageAndImportBuilder.java
@@ -19,13 +19,19 @@ import org.eclipse.collections.api.set.SetIterable;
 import org.finos.legend.pure.m3.bootstrap.generator.M3ToJavaGenerator;
 import org.finos.legend.pure.m3.coreinstance.M3CoreInstanceFactoryRegistry;
 import org.finos.legend.pure.m3.coreinstance.M3PlatformCoreInstanceFactoryRegistry;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.tools.SafeAppendable;
 import org.finos.legend.pure.runtime.java.compiled.extension.CompiledExtension;
 import org.finos.legend.pure.runtime.java.compiled.extension.CompiledExtensionLoader;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.type._class.ClassImplProcessor;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.type._class.ClassLazyImplProcessor;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.type._class.ClassProcessor;
+
+import java.util.function.Predicate;
 
 /**
  * Centralized logic for building package for Java code
@@ -34,24 +40,47 @@ public class JavaPackageAndImportBuilder
 {
     private static final String BASE_PACKAGE_NAME = "org.finos.legend.pure";
     private static final String CODE_GEN_PACKAGE_NAME = BASE_PACKAGE_NAME + ".generated";
-    private static final String CODE_GEN_PACKAGE_PREFIX = CODE_GEN_PACKAGE_NAME + ".";
     private static final String BASE_PACKAGE_FOLDER = CODE_GEN_PACKAGE_NAME.replace('.', '/');
 
     public static final SetIterable<String> M3_CLASSES = Sets.mutable
             .withAll(M3CoreInstanceFactoryRegistry.ALL_PATHS)
             .withAll(M3PlatformCoreInstanceFactoryRegistry.ALL_PATHS)
-            .withAll(CompiledExtensionLoader.extensions().flatCollect(CompiledExtension::getExtraCorePath));
+            .withAll(CompiledExtensionLoader.extensions().flatCollect(CompiledExtension::getExtraCorePath))
+            .asUnmodifiable();
 
     private JavaPackageAndImportBuilder()
     {
     }
+
+    // JAVA PACKAGES
 
     public static String getRootPackage()
     {
         return CODE_GEN_PACKAGE_NAME;
     }
 
-    public static String buildPackageForPackage(CoreInstance element)
+    public static String rootPackage()
+    {
+        return CODE_GEN_PACKAGE_NAME;
+    }
+
+    public static String externalizablePackage()
+    {
+        return BASE_PACKAGE_NAME;
+    }
+
+    public static String platformJavaPackage()
+    {
+        return CODE_GEN_PACKAGE_NAME;
+    }
+
+    @Deprecated
+    public static String rootPackageFolder()
+    {
+        return BASE_PACKAGE_FOLDER;
+    }
+
+    public static String buildPackageForPackage(CoreInstance pkg)
     {
         return CODE_GEN_PACKAGE_NAME;
     }
@@ -71,65 +100,129 @@ public class JavaPackageAndImportBuilder
         return CODE_GEN_PACKAGE_NAME;
     }
 
+    public static String buildImports(CoreInstance element)
+    {
+        return "";
+    }
+
+    // JAVA CLASSES
+
+    // Java classes from Pure user paths
+
     public static String buildImplClassReferenceFromUserPath(String elementPath)
     {
-        return CODE_GEN_PACKAGE_NAME + "." + buildImplClassNameFromUserPath(elementPath);
+        return buildImplClassReferenceFromUserPath(new StringBuilder(elementPath.length() + CODE_GEN_PACKAGE_NAME.length()), elementPath).toString();
     }
 
     public static String buildImplClassNameFromUserPath(String elementPath)
     {
-        return buildImplClassNameFromUserPath(elementPath, ClassImplProcessor.CLASS_IMPL_SUFFIX);
+        return buildImplClassNameFromUserPath(new StringBuilder(elementPath.length()), elementPath).toString();
     }
 
     public static String buildLazyImplClassReferenceFromUserPath(String elementPath)
     {
-        return CODE_GEN_PACKAGE_NAME + "." + buildImplClassNameFromUserPath(elementPath, ClassLazyImplProcessor.CLASS_LAZYIMPL_SUFFIX);
+        return buildLazyImplClassReferenceFromUserPath(new StringBuilder(elementPath.length() + CODE_GEN_PACKAGE_NAME.length()), elementPath).toString();
     }
 
-    private static String buildImplClassNameFromUserPath(String elementPath, String suffix)
+    public static String buildLazyImplClassNameFromUserPath(String elementPath)
     {
-        return (M3Paths.Package.equals(elementPath) ? "" : "Root_") + elementPath.replace("::", "_") + suffix;
+        return buildLazyImplClassNameFromUserPath(new StringBuilder(elementPath.length()), elementPath).toString();
     }
 
-    public static String buildImplClassReferenceFromType(CoreInstance element)
+    public static <T extends Appendable> T  buildLazyImplClassReferenceFromUserPath(T appendable, String elementPath)
     {
-        return CODE_GEN_PACKAGE_NAME + "." + buildImplClassNameFromType(element);
+        buildLazyImplClassNameFromUserPath(SafeAppendable.wrap(appendable).append(CODE_GEN_PACKAGE_NAME).append('.'), elementPath);
+        return appendable;
     }
 
-    public static String buildImplClassReferenceFromType(CoreInstance element, String suffix)
+
+    public static <T extends Appendable> T buildLazyImplClassNameFromUserPath(T appendable, String elementPath)
     {
-        return CODE_GEN_PACKAGE_NAME + "." + buildImplClassNameFromType(element, suffix);
+        return buildImplClassNameFromUserPath(appendable, elementPath, ClassLazyImplProcessor.CLASS_LAZYIMPL_SUFFIX);
+    }
+
+    public static <T extends Appendable> T buildImplClassReferenceFromUserPath(T appendable, String elementPath)
+    {
+        buildImplClassNameFromUserPath(SafeAppendable.wrap(appendable).append(CODE_GEN_PACKAGE_NAME).append('.'), elementPath);
+        return appendable;
+    }
+
+    public static <T extends Appendable> T buildImplClassNameFromUserPath(T appendable, String elementPath)
+    {
+        return buildImplClassNameFromUserPath(appendable, elementPath, ClassImplProcessor.CLASS_IMPL_SUFFIX);
+    }
+
+    // Java classes from Pure types
+
+    public static String buildImplClassReferenceFromType(CoreInstance type)
+    {
+        return buildImplClassReferenceFromType(new StringBuilder(CODE_GEN_PACKAGE_NAME.length() + 64), type).toString();
+    }
+
+    public static String buildImplClassReferenceFromType(CoreInstance type, String suffix)
+    {
+        return buildImplClassNameFromType(new StringBuilder(CODE_GEN_PACKAGE_NAME).append('.'), type, suffix).toString();
     }
 
     public static String buildImplClassNameFromType(CoreInstance element)
     {
-        return buildImplClassNameFromType(element, ClassImplProcessor.CLASS_IMPL_SUFFIX);
+        return buildImplClassNameFromType(new StringBuilder(64), element).toString();
     }
 
     public static String buildLazyImplClassReferenceFromType(CoreInstance element)
     {
-        return CODE_GEN_PACKAGE_NAME + "." + buildLazyImplClassNameFromType(element);
+        return buildLazyImplClassReferenceFromType(new StringBuilder(CODE_GEN_PACKAGE_NAME.length() + 64), element).toString();
     }
 
     public static String buildLazyImplClassNameFromType(CoreInstance element)
     {
-        return PackageableElement.getSystemPathForPackageableElement(element, "_") + ClassLazyImplProcessor.CLASS_LAZYIMPL_SUFFIX;
+        return buildLazyImplClassNameFromType(new StringBuilder(64), element).toString();
     }
 
     public static String buildImplClassNameFromType(CoreInstance element, String suffix)
     {
-        return PackageableElement.getSystemPathForPackageableElement(element, "_") + suffix;
+        return buildImplClassNameFromType(new StringBuilder(suffix.length() + 64), element, suffix).toString();
     }
 
-    public static String buildImplUnitInstanceClassNameFromType(CoreInstance element)
+
+    public static <T extends Appendable> T buildImplClassReferenceFromType(T appendable, CoreInstance element)
     {
-        return buildImplUnitInstanceClassNameFromType(element, ClassImplProcessor.CLASS_IMPL_SUFFIX);
+        buildImplClassNameFromType(SafeAppendable.wrap(appendable).append(CODE_GEN_PACKAGE_NAME).append('.'), element);
+        return appendable;
     }
 
-    public static String buildImplUnitInstanceClassNameFromType(CoreInstance element, String suffix)
+    public static <T extends Appendable> T buildImplClassNameFromType(T appendable, CoreInstance element)
     {
-        return PackageableElement.getSystemPathForPackageableElement(element, "_") + "_Instance" + suffix;
+        return buildImplClassNameFromType(appendable, element, ClassImplProcessor.CLASS_IMPL_SUFFIX);
     }
+
+    public static <T extends Appendable> T  buildLazyImplClassReferenceFromType(T appendable, CoreInstance type)
+    {
+        buildLazyImplClassNameFromType(SafeAppendable.wrap(appendable).append(CODE_GEN_PACKAGE_NAME).append('.'), type);
+        return appendable;
+    }
+
+    public static <T extends Appendable> T buildLazyImplClassNameFromType(T appendable, CoreInstance type)
+    {
+        return buildImplClassNameFromType(appendable, type, ClassLazyImplProcessor.CLASS_LAZYIMPL_SUFFIX);
+    }
+
+    // Java classes for Unit instances
+
+    public static String buildImplUnitInstanceClassNameFromType(CoreInstance unit)
+    {
+        return buildImplUnitInstanceClassNameFromType(unit, ClassImplProcessor.CLASS_IMPL_SUFFIX);
+    }
+
+    public static String buildImplUnitInstanceClassNameFromType(CoreInstance unit, String suffix)
+    {
+        return buildImplUnitInstanceClassNameFromType(new StringBuilder(64), unit, suffix).toString();
+    }
+
+
+    // JAVA INTERFACES
+
+    // Java interfaces from Pure user paths
 
     public static String buildInterfaceReferenceFromUserPath(String elementPath)
     {
@@ -138,48 +231,130 @@ public class JavaPackageAndImportBuilder
 
     public static String buildInterfaceReferenceFromUserPath(String elementPath, SetIterable<String> extraSupportedTypes)
     {
-        if (M3_CLASSES.contains(elementPath) || (extraSupportedTypes != null && extraSupportedTypes.contains(elementPath)))
-        {
-            return buildPlatformInterfaceReferenceFromUserPath(elementPath);
-        }
-        else
-        {
-            return CODE_GEN_PACKAGE_NAME + "." + buildInterfaceFromUserPath(elementPath);
-        }
+        return buildInterfaceReferenceFromUserPath(new StringBuilder(elementPath.length() + CODE_GEN_PACKAGE_NAME.length()), elementPath, (extraSupportedTypes == null) ? null : extraSupportedTypes::contains).toString();
     }
 
+    @Deprecated
     public static String buildPlatformInterfaceReferenceFromUserPath(String elementPath)
     {
         return M3ToJavaGenerator.getFullyQualifiedM3InterfaceForCompiledModel(elementPath);
     }
 
+    /**
+     * Deprecated. Use {@link #buildInterfaceNameFromUserPath(String)} instead.
+     */
+    @Deprecated
     public static String buildInterfaceFromUserPath(String elementPath)
     {
-        return "Root_" + elementPath.replace("::", "_");
+        return buildInterfaceNameFromUserPath(elementPath);
     }
 
-    public static String platformJavaPackage()
+    public static String buildInterfaceNameFromUserPath(String elementPath)
     {
-        return CODE_GEN_PACKAGE_NAME;
+        return buildInterfaceNameFromUserPath(new StringBuilder(elementPath.length()), elementPath).toString();
     }
 
-    public static String rootPackage()
+    public static <T extends Appendable> T buildInterfaceReferenceFromUserPath(T appendable, String elementPath, Predicate<? super String> isExtraSupportedType)
     {
-        return CODE_GEN_PACKAGE_NAME;
+        if (M3_CLASSES.contains(elementPath) || ((isExtraSupportedType != null) && isExtraSupportedType.test(elementPath)))
+        {
+            return M3ToJavaGenerator.appendFullyQualifiedM3InterfaceForCompiledModel(appendable, elementPath);
+        }
+
+        buildInterfaceNameFromUserPath(SafeAppendable.wrap(appendable).append(CODE_GEN_PACKAGE_NAME).append('.'), elementPath);
+        return appendable;
     }
 
-    public static String rootPackageFolder()
+    public static <T extends Appendable> T buildInterfaceNameFromUserPath(T appendable, String elementPath)
     {
-        return BASE_PACKAGE_FOLDER;
+        SafeAppendable.wrap(appendable).append("Root_").append(convertUnitName(elementPath.replace("::", "_")));
+        return appendable;
     }
 
-    public static String externalizablePackage()
+    // Java interfaces from Pure types
+
+    public static String buildInterfaceReferenceFromType(CoreInstance type)
     {
-        return BASE_PACKAGE_NAME;
+        return buildInterfaceReferenceFromType(new StringBuilder(64), type).toString();
     }
 
-    public static String buildImports(CoreInstance element)
+    public static String buildInterfaceNameFromType(CoreInstance type)
     {
-        return "";
+        return buildInterfaceNameFromType(new StringBuilder(64), type).toString();
+    }
+
+    public static <T extends Appendable> T buildInterfaceReferenceFromType(T appendable, CoreInstance type)
+    {
+        if (ClassProcessor.isPlatformClass(type))
+        {
+            return M3ToJavaGenerator.appendFullyQualifiedM3InterfaceForCompiledModel(appendable, type);
+        }
+
+        buildInterfaceNameFromType(SafeAppendable.wrap(appendable).append(CODE_GEN_PACKAGE_NAME).append('.'), type);
+        return appendable;
+    }
+
+    public static <T extends Appendable> T buildInterfaceNameFromType(T appendable, CoreInstance type)
+    {
+        buildClassOrInterfaceNameFromType(SafeAppendable.wrap(appendable), type);
+        return appendable;
+    }
+
+    // HELPERS
+
+    private static <T extends Appendable> T  buildImplClassNameFromUserPath(T appendable, String elementPath, String suffix)
+    {
+        SafeAppendable safeAppendable = SafeAppendable.wrap(appendable);
+        if (M3Paths.Package.equals(elementPath))
+        {
+            safeAppendable.append(elementPath);
+        }
+        else
+        {
+            safeAppendable.append("Root_").append(convertUnitName(elementPath.replace("::", "_")));
+        }
+        safeAppendable.append(suffix);
+        return appendable;
+    }
+
+    private static <T extends Appendable> T buildImplClassNameFromType(T appendable, CoreInstance type, String suffix)
+    {
+        buildClassOrInterfaceNameFromType(SafeAppendable.wrap(appendable), type).append(suffix);
+        return appendable;
+    }
+
+    private static <T extends Appendable> T buildImplUnitInstanceClassNameFromType(T appendable, CoreInstance unit, String suffix)
+    {
+        if (!(unit instanceof Unit))
+        {
+            throw new IllegalArgumentException("Not a Unit: " + unit);
+        }
+        PackageableElement.writeSystemPathForPackageableElement(SafeAppendable.wrap(appendable), ((Unit) unit)._package(), "_")
+                .append('_').append(convertUnitName(((Unit) unit)._name())).append("_Instance").append(suffix);
+        return appendable;
+    }
+
+    private static SafeAppendable buildClassOrInterfaceNameFromType(SafeAppendable appendable, CoreInstance type)
+    {
+        if (isUnitName(type.getName()))
+        {
+            CoreInstance pkg = type.getValueForMetaPropertyToOne(M3Properties._package);
+            if (pkg != null)
+            {
+                PackageableElement.writeSystemPathForPackageableElement(appendable, pkg, "_").append('_');
+            }
+            return appendable.append(convertUnitName(type.getName()));
+        }
+        return PackageableElement.writeSystemPathForPackageableElement(appendable, type, "_");
+    }
+
+    private static boolean isUnitName(String name)
+    {
+        return (name != null) && (name.indexOf('~') != -1);
+    }
+
+    private static String convertUnitName(String unitName)
+    {
+        return unitName.replace("~", "_Tilde_");
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/EnumProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/EnumProcessor.java
@@ -54,7 +54,7 @@ public class EnumProcessor
     public static StringJavaSource processEnumLazy()
     {
         String className = ENUM_LAZY_CLASS_NAME;
-        String superClassName =  JavaPackageAndImportBuilder.buildInterfaceFromUserPath(M3Paths.Enum) + "_LazyImpl";
+        String superClassName =  JavaPackageAndImportBuilder.buildInterfaceNameFromUserPath(M3Paths.Enum) + "_LazyImpl";
         return StringJavaSource.newStringJavaSource(JavaPackageAndImportBuilder.rootPackage(), className,
                 "import " + JavaPackageAndImportBuilder.buildPackageFromUserPath(M3Paths.Enum) + ".*;\n" +
                 "import org.finos.legend.pure.m4.coreinstance.SourceInformation;\n" +

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/TypeProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/TypeProcessor.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.type;
 
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.impl.factory.Lists;
-import org.finos.legend.pure.m3.bootstrap.generator.M3ToJavaGenerator;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.GenericTypeOperation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.navigation.Instance;
@@ -120,7 +119,7 @@ public class TypeProcessor
         {
             return FullJavaPaths.Enum;
         }
-        String finalRawTypeSystemPath = fullyQualify || "Package".equals(rawType.getName()) ? fullyQualifiedJavaInterfaceNameForType(rawType) : javaInterfaceForType(rawType);
+        String finalRawTypeSystemPath = fullyQualify || M3Paths.Package.equals(rawType.getName()) ? fullyQualifiedJavaInterfaceNameForType(rawType) : javaInterfaceForType(rawType);
         if (rawType instanceof Unit)
         {
             return UnitProcessor.convertToJavaCompatibleClassName(finalRawTypeSystemPath) + "_Instance";
@@ -171,17 +170,17 @@ public class TypeProcessor
 
     public static String javaInterfaceForType(CoreInstance rawType)
     {
-        return ClassProcessor.isPlatformClass(rawType) ? fullyQualifiedJavaInterfaceNameForType(rawType) : PackageableElement.getSystemPathForPackageableElement(rawType, "_");
+        return ClassProcessor.isPlatformClass(rawType) ? fullyQualifiedJavaInterfaceNameForType(rawType) : JavaPackageAndImportBuilder.buildInterfaceNameFromType(rawType);
     }
 
     public static String javaInterfaceNameForType(CoreInstance rawType)
     {
-        return ClassProcessor.isPlatformClass(rawType) ? rawType.getName() : PackageableElement.getSystemPathForPackageableElement(rawType, "_");
+        return ClassProcessor.isPlatformClass(rawType) ? rawType.getName() : JavaPackageAndImportBuilder.buildInterfaceNameFromType(rawType);
     }
 
-    public static String fullyQualifiedJavaInterfaceNameForType(final CoreInstance element)
+    public static String fullyQualifiedJavaInterfaceNameForType(CoreInstance element)
     {
-        return ClassProcessor.isPlatformClass(element) ? M3ToJavaGenerator.getFullyQualifiedM3InterfaceForCompiledModel(element) : JavaPackageAndImportBuilder.buildPackageForPackageableElement(element) + "." + PackageableElement.getSystemPathForPackageableElement(element, "_");
+        return JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(element);
     }
 
     private static String pureSystemPathToJava_simpleCases(String fullUserPath, boolean primitiveIfPossible)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaPackageAndImportBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaPackageAndImportBuilder.java
@@ -1,0 +1,221 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.compiled.generation;
+
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableRepositoryCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.empty.EmptyCodeStorage;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCompiled
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        RichIterable<? extends CodeRepository> repositories = AbstractPureTestWithCoreCompiled.getCodeRepositories();
+        MutableRepositoryCodeStorage codeStorage = new CompositeCodeStorage(
+                new ClassLoaderCodeStorage(repositories),
+                new EmptyCodeStorage(new GenericCodeRepository("test", "test::.*", "platform")));
+
+        setUpRuntime(codeStorage, getExtra());
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair(
+                "/test/compiledgen/tests.pure",
+                "Class test::generation::compiled::SimpleClass\n" +
+                        "{\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::generation::compiled::extra::ExtraClass\n" +
+                        "{\n" +
+                        "}\n" +
+                        "\n" +
+                        "Measure test::domain::RomanLength\n" +
+                        "{\n" +
+                        "   *Pes: x -> $x;\n" +
+                        "   Cubitum: x -> $x * 1.5;\n" +
+                        "   Passus: x -> $x * 5;\n" +
+                        "   Actus: x -> $x * 120;\n" +
+                        "   Stadium: x -> $x * 625;\n" +
+                        "}\n"
+        );
+    }
+
+    @Test
+    public void testRootPackage()
+    {
+        Assert.assertEquals("org.finos.legend.pure.generated", JavaPackageAndImportBuilder.rootPackage());
+    }
+
+    @Test
+    public void testPlatformJavaPackage()
+    {
+        Assert.assertEquals("org.finos.legend.pure.generated", JavaPackageAndImportBuilder.platformJavaPackage());
+    }
+
+    @Test
+    public void testExternalizablePackage()
+    {
+        Assert.assertEquals("org.finos.legend.pure", JavaPackageAndImportBuilder.externalizablePackage());
+    }
+
+    @Test
+    public void testBuildImports()
+    {
+        Assert.assertEquals("", JavaPackageAndImportBuilder.buildImports(getElement("test::generation::compiled::SimpleClass")));
+        Assert.assertEquals("", JavaPackageAndImportBuilder.buildImports(getElement("test::generation::compiled::extra::ExtraClass")));
+    }
+
+    @Test
+    public void testBuildPackageFromPath()
+    {
+        Assert.assertEquals("org.finos.legend.pure.generated", JavaPackageAndImportBuilder.buildPackageFromUserPath("test"));
+        Assert.assertEquals("org.finos.legend.pure.generated", JavaPackageAndImportBuilder.buildPackageFromUserPath("test::generation"));
+        Assert.assertEquals("org.finos.legend.pure.generated", JavaPackageAndImportBuilder.buildPackageFromUserPath("test::generation::compiled"));
+        Assert.assertEquals("org.finos.legend.pure.generated", JavaPackageAndImportBuilder.buildPackageFromUserPath("test::generation::compiled::SimpleClass"));
+        Assert.assertEquals("org.finos.legend.pure.generated", JavaPackageAndImportBuilder.buildPackageFromUserPath("test::generation::compiled::extra::ExtraClass"));
+    }
+
+    @Test
+    public void testBuildPackageForPackageableElement()
+    {
+        Assert.assertEquals("org.finos.legend.pure.generated", JavaPackageAndImportBuilder.buildPackageForPackageableElement(getElement("test")));
+        Assert.assertEquals("org.finos.legend.pure.generated", JavaPackageAndImportBuilder.buildPackageForPackageableElement(getElement("test::generation")));
+        Assert.assertEquals("org.finos.legend.pure.generated", JavaPackageAndImportBuilder.buildPackageForPackageableElement(getElement("test::generation::compiled")));
+        Assert.assertEquals("org.finos.legend.pure.generated", JavaPackageAndImportBuilder.buildPackageForPackageableElement(getElement("test::generation::compiled::SimpleClass")));
+        Assert.assertEquals("org.finos.legend.pure.generated", JavaPackageAndImportBuilder.buildPackageForPackageableElement(getElement("test::generation::compiled::extra::ExtraClass")));
+    }
+
+    @Test
+    public void testBuildImplClassNameFromUserPath()
+    {
+        Assert.assertEquals("Root_test_generation_compiled_SimpleClass_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromUserPath("test::generation::compiled::SimpleClass"));
+        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromUserPath("test::generation::compiled::extra::ExtraClass"));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Class_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromUserPath(M3Paths.Class));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Enumeration_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromUserPath(M3Paths.Enumeration));
+    }
+
+    @Test
+    public void testBuildImplClassNameFromType()
+    {
+        Assert.assertEquals("Root_test_generation_compiled_SimpleClass_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement("test::generation::compiled::SimpleClass")));
+        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement("test::generation::compiled::extra::ExtraClass")));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Class_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement(M3Paths.Class)));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Enumeration_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement(M3Paths.Enumeration)));
+    }
+
+    @Test
+    public void testBuildLazyImplClassNameFromType()
+    {
+        Assert.assertEquals("Root_test_generation_compiled_SimpleClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement("test::generation::compiled::SimpleClass")));
+        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement("test::generation::compiled::extra::ExtraClass")));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Class_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement(M3Paths.Class)));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Enumeration_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement(M3Paths.Enumeration)));
+    }
+
+    @Test
+    public void testBuildImplClassReferenceFromUserPath()
+    {
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromUserPath("test::generation::compiled::SimpleClass"));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromUserPath("test::generation::compiled::extra::ExtraClass"));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromUserPath(M3Paths.Class));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromUserPath(M3Paths.Enumeration));
+    }
+
+    @Test
+    public void testBuildImplClassReferenceFromType()
+    {
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement("test::generation::compiled::SimpleClass")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement("test::generation::compiled::extra::ExtraClass")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement(M3Paths.Class)));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement(M3Paths.Enumeration)));
+    }
+
+    @Test
+    public void testBuildLazyImplClassReferenceFromType()
+    {
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement("test::generation::compiled::SimpleClass")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement("test::generation::compiled::extra::ExtraClass")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement(M3Paths.Class)));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement(M3Paths.Enumeration)));
+    }
+
+    @Test
+    public void testBuildInterfaceNameFromUserPath()
+    {
+        Assert.assertEquals("Root_test_generation_compiled_SimpleClass", JavaPackageAndImportBuilder.buildInterfaceNameFromUserPath("test::generation::compiled::SimpleClass"));
+        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass", JavaPackageAndImportBuilder.buildInterfaceNameFromUserPath("test::generation::compiled::extra::ExtraClass"));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Enum", JavaPackageAndImportBuilder.buildInterfaceNameFromUserPath(M3Paths.Enum));
+    }
+
+    @Test
+    public void testBuildInterfaceReferenceFromUserPath()
+    {
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass", JavaPackageAndImportBuilder.buildInterfaceReferenceFromUserPath("test::generation::compiled::SimpleClass"));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass", JavaPackageAndImportBuilder.buildInterfaceReferenceFromUserPath("test::generation::compiled::extra::ExtraClass"));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class", JavaPackageAndImportBuilder.buildInterfaceReferenceFromUserPath(M3Paths.Class));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration", JavaPackageAndImportBuilder.buildInterfaceReferenceFromUserPath(M3Paths.Enumeration));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.test.generation.compiled.SimpleClass", JavaPackageAndImportBuilder.buildInterfaceReferenceFromUserPath("test::generation::compiled::SimpleClass", Sets.immutable.with("test::generation::compiled::SimpleClass", "test::generation::compiled::extra::ExtraClass")));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.test.generation.compiled.extra.ExtraClass", JavaPackageAndImportBuilder.buildInterfaceReferenceFromUserPath("test::generation::compiled::extra::ExtraClass", Sets.immutable.with("test::generation::compiled::SimpleClass", "test::generation::compiled::extra::ExtraClass")));
+    }
+
+    @Test
+    public void testBuildInterfaceNameFromType()
+    {
+        Assert.assertEquals("Root_test_generation_compiled_SimpleClass", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement("test::generation::compiled::SimpleClass")));
+        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement("test::generation::compiled::extra::ExtraClass")));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Enum", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement(M3Paths.Enum)));
+    }
+
+    @Test
+    public void testBuildInterfaceReferenceFromType()
+    {
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement("test::generation::compiled::SimpleClass")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement("test::generation::compiled::extra::ExtraClass")));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement(M3Paths.Class)));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement(M3Paths.Enumeration)));
+    }
+
+    @Test
+    public void testBuildImplUnitInstanceClassNameFromType()
+    {
+        Assert.assertEquals("Root_test_domain_RomanLength_Tilde_Cubitum_Instance_Impl", JavaPackageAndImportBuilder.buildImplUnitInstanceClassNameFromType(getElement("test::domain::RomanLength~Cubitum")));
+        Assert.assertEquals("Root_test_domain_RomanLength_Tilde_Pes_Instance_Impl", JavaPackageAndImportBuilder.buildImplUnitInstanceClassNameFromType(getElement("test::domain::RomanLength~Pes")));
+        Assert.assertEquals("Root_test_domain_RomanLength_Tilde_Actus_Instance_Impl", JavaPackageAndImportBuilder.buildImplUnitInstanceClassNameFromType(getElement("test::domain::RomanLength~Actus")));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends PackageableElement> T getElement(String userPath)
+    {
+        CoreInstance element = runtime.getCoreInstance(userPath);
+        Assert.assertNotNull(userPath, element);
+        return (T) element;
+    }
+}

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/TestTypeProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/TestTypeProcessor.java
@@ -1,0 +1,101 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.compiled.generation.processors.type;
+
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableRepositoryCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.empty.EmptyCodeStorage;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestTypeProcessor extends AbstractPureTestWithCoreCompiled
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        RichIterable<? extends CodeRepository> repositories = AbstractPureTestWithCoreCompiled.getCodeRepositories();
+        MutableRepositoryCodeStorage codeStorage = new CompositeCodeStorage(
+                new ClassLoaderCodeStorage(repositories),
+                new EmptyCodeStorage(new GenericCodeRepository("test", "test::.*", "platform")));
+
+        setUpRuntime(codeStorage, getExtra());
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair(
+                "/test/compiledgen/tests.pure",
+                "Class test::generation::compiled::SimpleClass\n" +
+                        "{\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::generation::compiled::extra::ExtraClass\n" +
+                        "{\n" +
+                        "}\n"
+        );
+    }
+
+    @Test
+    public void testJavaInterfaceForType()
+    {
+        Assert.assertEquals("Root_test_generation_compiled_SimpleClass", TypeProcessor.javaInterfaceForType(getElement("test::generation::compiled::SimpleClass")));
+        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass", TypeProcessor.javaInterfaceForType(getElement("test::generation::compiled::extra::ExtraClass")));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class", TypeProcessor.javaInterfaceForType(getElement(M3Paths.Class)));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association", TypeProcessor.javaInterfaceForType(getElement(M3Paths.Association)));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration", TypeProcessor.javaInterfaceForType(getElement(M3Paths.Enumeration)));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum", TypeProcessor.javaInterfaceForType(getElement(M3Paths.Enum)));
+    }
+
+    @Test
+    public void testJavaInterfaceNameForType()
+    {
+        Assert.assertEquals("Root_test_generation_compiled_SimpleClass", TypeProcessor.javaInterfaceNameForType(getElement("test::generation::compiled::SimpleClass")));
+        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass", TypeProcessor.javaInterfaceNameForType(getElement("test::generation::compiled::extra::ExtraClass")));
+        Assert.assertEquals("Class", TypeProcessor.javaInterfaceNameForType(getElement(M3Paths.Class)));
+        Assert.assertEquals("Association", TypeProcessor.javaInterfaceNameForType(getElement(M3Paths.Association)));
+        Assert.assertEquals("Enumeration", TypeProcessor.javaInterfaceNameForType(getElement(M3Paths.Enumeration)));
+        Assert.assertEquals("Enum", TypeProcessor.javaInterfaceNameForType(getElement(M3Paths.Enum)));
+    }
+
+    @Test
+    public void testFullyQualifiedJavaInterfaceNameForType()
+    {
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement("test::generation::compiled::SimpleClass")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement("test::generation::compiled::extra::ExtraClass")));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement(M3Paths.Class)));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement(M3Paths.Association)));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement(M3Paths.Enumeration)));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement(M3Paths.Enum)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends PackageableElement> T getElement(String userPath)
+    {
+        CoreInstance element = runtime.getCoreInstance(userPath);
+        Assert.assertNotNull(userPath, element);
+        return (T) element;
+    }
+}


### PR DESCRIPTION
Assorted fixes and code clean-up:
- clean up parsing for enums, measures, and units
- clean up PureUnresolvedIdentifierException
- clean up Java class/interface name generation
- fix wrapping handling in some type checks
- fix a minor issue in StereotypeReferenceSerializer