### PR TITLE
Unit/Measure improvements

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
@@ -2338,9 +2338,8 @@ public class AntlrContextToM3CoreInstance
         String unitName = measure._name() + this.tilde + ctx.identifier().getText();
         SourceInformation sourceInfo = this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.identifier().getStart(), ctx.getStop());
         checkExists(measure._package(), unitName, sourceInfo);
-        Unit unitInstance = UnitInstance.createPersistent(this.repository, unitName, sourceInfo)
+        Unit unitInstance = UnitInstance.createPersistent(this.repository, unitName, sourceInfo, measure)
                 ._name(unitName)
-                ._measure(measure)
                 ._classifierGenericType(GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Unit)));
 
         // set unit super type to be its measure (Kilogram -> Mass)
@@ -2382,9 +2381,8 @@ public class AntlrContextToM3CoreInstance
         String unitName = measure._name() + this.tilde + ctx.identifier().getText();
         SourceInformation sourceInfo = this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.identifier().getStart(), ctx.getStop());
         checkExists(measure._package(), unitName, sourceInfo);
-        Unit unitInstance = UnitInstance.createPersistent(this.repository, unitName, sourceInfo)
+        Unit unitInstance = UnitInstance.createPersistent(this.repository, unitName, sourceInfo, measure)
                 ._name(unitName)
-                ._measure(measure)
                 ._classifierGenericType(GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Unit)));
         unitInstance._generalizations(Lists.immutable.with(GeneralizationInstance.createPersistent(this.repository, GenericTypeInstance.createPersistent(this.repository)._rawType(measure), unitInstance)));
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementToPath.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementToPath.pure
@@ -28,7 +28,7 @@ function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::element
 
 function meta::pure::functions::meta::elementToPath(element:Type[1]):String[1]
 {
-    $element->cast(@PackageableElement)->elementToPath('::')
+    $element->elementToPath('::')
 }
 
 function meta::pure::functions::meta::elementToPath(element:Type[1], separator:String[1]):String[1]
@@ -108,6 +108,16 @@ function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testEn
     assertEquals('meta::pure::functions::meta::tests::model', elementToPath(CC_GeographicEntityType->cast(@PackageableElement).package->at(0)));
     assertEquals('meta.pure.functions.meta.tests.model', elementToPath(CC_GeographicEntityType->cast(@PackageableElement).package->at(0), '.'));
     assertEquals('Root&meta&pure&functions&meta&tests&model', elementToPath(CC_GeographicEntityType->cast(@PackageableElement).package->at(0), '&', true));
+}
+
+function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testUnitMeasureToPath():Boolean[1]
+{
+    assertEquals('meta::pure::functions::meta::tests::model::RomanLength', elementToPath(RomanLength));
+    assertEquals('meta::pure::functions::meta::tests::model::RomanLength~Pes', elementToPath(RomanLength~Pes));
+    assertEquals('meta::pure::functions::meta::tests::model::RomanLength~Cubitum', elementToPath(RomanLength~Cubitum));
+    assertEquals('meta::pure::functions::meta::tests::model::RomanLength~Passus', elementToPath(RomanLength~Passus));
+    assertEquals('meta::pure::functions::meta::tests::model::RomanLength~Actus', elementToPath(RomanLength~Actus));
+    assertEquals('meta::pure::functions::meta::tests::model::RomanLength~Stadium', elementToPath(RomanLength~Stadium));
 }
 
 function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testEphemeralPackageableElements():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/pathToElement.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/pathToElement.pure
@@ -73,6 +73,16 @@ function <<test.Test>> meta::pure::functions::meta::tests::pathToElement::testCo
     assertIs(meta::pure::functions::boolean::greaterThan_Number_1__Number_1__Boolean_1_, pathToElement('meta::pure::functions::boolean::greaterThan_Number_1__Number_1__Boolean_1_'));
 }
 
+function <<test.Test>> meta::pure::functions::meta::tests::pathToElement::testUnitMeasurePathToElement():Boolean[1]
+{
+    assertIs(RomanLength, pathToElement('meta::pure::functions::meta::tests::model::RomanLength'));
+    assertEquals(RomanLength~Pes, pathToElement('meta::pure::functions::meta::tests::model::RomanLength~Pes'));
+    assertEquals(RomanLength~Cubitum, pathToElement('meta::pure::functions::meta::tests::model::RomanLength~Cubitum'));
+    assertEquals(RomanLength~Passus, pathToElement('meta::pure::functions::meta::tests::model::RomanLength~Passus'));
+    assertEquals(RomanLength~Actus, pathToElement('meta::pure::functions::meta::tests::model::RomanLength~Actus'));
+    assertEquals(RomanLength~Stadium, pathToElement('meta::pure::functions::meta::tests::model::RomanLength~Stadium'));
+}
+
 // To be removed
 function <<test.Test, meta::pure::profiles::doc.deprecated>> meta::pure::functions::boolean::tests::testIsNativeFunctions():Boolean[1]
 {

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/testModel.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/testModel.pure
@@ -61,3 +61,12 @@ Association meta::pure::functions::meta::tests::model::AddressLocation
     location : CC_Location[0..1];
     addresses: CC_Address[*];
 }
+
+Measure meta::pure::functions::meta::tests::model::RomanLength
+{
+    *Pes: x -> $x;
+    Cubitum: x -> $x * 1.5;
+    Passus: x -> $x * 5;
+    Actus: x -> $x * 120;
+    Stadium: x -> $x * 625;
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/m3.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/m3.pure
@@ -880,7 +880,7 @@
                                                             {
                                                                 Root.children[meta].children[pure].children[metamodel].children[type].children[generics].children[GenericType].properties[rawType] : Root.children[meta].children[pure].children[metamodel].children[type].children[Measure]
                                                             },
-                                    Root.children[meta].children[pure].children[metamodel].children[function].children[property].children[AbstractProperty].properties[multiplicity] : Root.children[meta].children[pure].children[metamodel].children[multiplicity].children[ZeroOne],
+                                    Root.children[meta].children[pure].children[metamodel].children[function].children[property].children[AbstractProperty].properties[multiplicity] : Root.children[meta].children[pure].children[metamodel].children[multiplicity].children[PureOne],
                                     Root.children[meta].children[pure].children[metamodel].children[type].children[Any].properties[classifierGenericType] : ^Root.children[meta].children[pure].children[metamodel].children[type].children[generics].children[GenericType]
                                                             {
                                                                 Root.children[meta].children[pure].children[metamodel].children[type].children[generics].children[GenericType].properties[rawType] : Root.children[meta].children[pure].children[metamodel].children[function].children[property].children[Property],
@@ -895,7 +895,7 @@
                                                                                 Root.children[meta].children[pure].children[metamodel].children[type].children[generics].children[GenericType].properties[rawType] : Root.children[meta].children[pure].children[metamodel].children[type].children[Measure]
                                                                             }
                                                                     ],
-                                                                Root.children[meta].children[pure].children[metamodel].children[type].children[generics].children[GenericType].properties[multiplicityArguments] : Root.children[meta].children[pure].children[metamodel].children[multiplicity].children[ZeroOne]
+                                                                Root.children[meta].children[pure].children[metamodel].children[type].children[generics].children[GenericType].properties[multiplicityArguments] : Root.children[meta].children[pure].children[metamodel].children[multiplicity].children[PureOne]
                                                             }
                                 }
                                 ,

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/navigation/graph/TestGraphPath.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/navigation/graph/TestGraphPath.java
@@ -59,15 +59,6 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                                 "{\n" +
                                 "  prop3 : String[0..1];\n" +
                                 "  4prop : Date[*];\n" +
-                                "}\n" +
-                                "\n" +
-                                "Measure test::domain::RomanLength\n" +
-                                "{\n" +
-                                "   *Pes: x -> $x;\n" +
-                                "   Cubitum: x -> $x * 1.5;\n" +
-                                "   Passus: x -> $x * 5;\n" +
-                                "   Actus: x -> $x * 120;\n" +
-                                "   Stadium: x -> $x * 625;\n" +
                                 "}\n")
         );
     }
@@ -137,20 +128,20 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("Integer", "generalizations", "general", "rawType").getDescription());
 
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum",
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum").getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").getDescription());
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum.measure",
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure").getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").getDescription());
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum.measure.canonicalUnit",
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit").getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit").getDescription());
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum.measure.canonicalUnit.measure",
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").getDescription());
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']",
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getDescription());
     }
 
     @Test
@@ -215,20 +206,20 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("Integer", "generalizations", "general", "rawType").getPureExpression());
 
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum",
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum").getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").getPureExpression());
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum.measure",
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure").getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").getPureExpression());
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum.measure.canonicalUnit",
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit").getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit").getPureExpression());
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum.measure.canonicalUnit.measure",
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").getPureExpression());
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Actus')->toOne()",
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Actus')->toOne()",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getPureExpression());
     }
 
     @Test
@@ -293,20 +284,20 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("Integer", "generalizations", "general", "rawType").getStartNodePath());
 
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum",
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum").getStartNodePath());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").getStartNodePath());
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum",
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure").getStartNodePath());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").getStartNodePath());
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum",
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit").getStartNodePath());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit").getStartNodePath());
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum",
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").getStartNodePath());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").getStartNodePath());
         Assert.assertEquals(
-                "test::domain::RomanLength~Cubitum",
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getStartNodePath());
+                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getStartNodePath());
     }
 
     @Test
@@ -358,20 +349,20 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolve(processorSupport));
 
         Assert.assertEquals(
-                runtime.getCoreInstance("test::domain::RomanLength~Cubitum"),
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum").resolve(processorSupport));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").resolve(processorSupport));
         Assert.assertEquals(
-                runtime.getCoreInstance("test::domain::RomanLength"),
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure").resolve(processorSupport));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").resolve(processorSupport));
         Assert.assertEquals(
-                runtime.getCoreInstance("test::domain::RomanLength~Pes"),
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit").resolve(processorSupport));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Pes"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit").resolve(processorSupport));
         Assert.assertEquals(
-                runtime.getCoreInstance("test::domain::RomanLength"),
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").resolve(processorSupport));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").resolve(processorSupport));
         Assert.assertEquals(
-                runtime.getCoreInstance("test::domain::RomanLength~Actus"),
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().resolve(processorSupport));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Actus"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().resolve(processorSupport));
     }
 
     @Test
@@ -515,30 +506,30 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 runtime.getCoreInstance("Number"));
 
         assertResolveFully(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum"),
-                runtime.getCoreInstance("test::domain::RomanLength~Cubitum"));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"));
         assertResolveFully(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure"),
-                runtime.getCoreInstance("test::domain::RomanLength~Cubitum"),
-                runtime.getCoreInstance("test::domain::RomanLength"));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"));
         assertResolveFully(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit"),
-                runtime.getCoreInstance("test::domain::RomanLength~Cubitum"),
-                runtime.getCoreInstance("test::domain::RomanLength"),
-                runtime.getCoreInstance("test::domain::RomanLength~Pes"));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Pes"));
         assertResolveFully(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit", "measure"),
-                runtime.getCoreInstance("test::domain::RomanLength~Cubitum"),
-                runtime.getCoreInstance("test::domain::RomanLength"),
-                runtime.getCoreInstance("test::domain::RomanLength~Pes"),
-                runtime.getCoreInstance("test::domain::RomanLength"));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Pes"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"));
         assertResolveFully(
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build(),
-                runtime.getCoreInstance("test::domain::RomanLength~Cubitum"),
-                runtime.getCoreInstance("test::domain::RomanLength"),
-                runtime.getCoreInstance("test::domain::RomanLength~Pes"),
-                runtime.getCoreInstance("test::domain::RomanLength"),
-                runtime.getCoreInstance("test::domain::RomanLength~Actus"));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build(),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Pes"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Actus"));
     }
 
     private void assertResolveFully(GraphPath path, CoreInstance... nodes)
@@ -550,76 +541,76 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
     public void testSubpath()
     {
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum"),
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum").subpath(0));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").subpath(0));
         Assert.assertEquals(
                 "Index: 1; size: 0",
                 Assert.assertThrows(
                         IndexOutOfBoundsException.class,
-                        () -> GraphPath.buildPath("test::domain::RomanLength~Cubitum").subpath(1)).getMessage());
+                        () -> GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").subpath(1)).getMessage());
         Assert.assertEquals(
                 "Index: -1; size: 0",
                 Assert.assertThrows(
                         IndexOutOfBoundsException.class,
-                        () -> GraphPath.buildPath("test::domain::RomanLength~Cubitum").subpath(-1)).getMessage());
+                        () -> GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").subpath(-1)).getMessage());
 
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum"),
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure").subpath(0));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").subpath(0));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum"),
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure").subpath(-1));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").subpath(-1));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure"),
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure").subpath(1));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").subpath(1));
         Assert.assertEquals(
                 "Index: 2; size: 1",
                 Assert.assertThrows(
                         IndexOutOfBoundsException.class,
-                        () -> GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure").subpath(2)).getMessage());
+                        () -> GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").subpath(2)).getMessage());
         Assert.assertEquals(
                 "Index: -2; size: 1",
                 Assert.assertThrows(
                         IndexOutOfBoundsException.class,
-                        () -> GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure").subpath(-2)).getMessage());
+                        () -> GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").subpath(-2)).getMessage());
 
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum"),
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(0));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(0));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum"),
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-4));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-4));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure"),
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(1));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(1));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure"),
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-3));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-3));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit"),
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(2));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(2));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit"),
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-2));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-2));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit", "measure"),
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(3));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(3));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit", "measure"),
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-1));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-1));
         Assert.assertEquals(
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build(),
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(4));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build(),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(4));
         Assert.assertEquals(
                 "Index: 5; size: 4",
                 Assert.assertThrows(
                         IndexOutOfBoundsException.class,
-                        () -> GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(5)).getMessage());
+                        () -> GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(5)).getMessage());
         Assert.assertEquals(
                 "Index: -5; size: 4",
                 Assert.assertThrows(
                         IndexOutOfBoundsException.class,
-                        () -> GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-5)).getMessage());
+                        () -> GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-5)).getMessage());
     }
 
     @Test
@@ -687,20 +678,20 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("Integer", "generalizations", "general", "rawType", "name").reduce(processorSupport));
 
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum"),
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum").reduce(processorSupport));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").reduce(processorSupport));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength"),
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure").reduce(processorSupport));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").reduce(processorSupport));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Pes"),
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit").reduce(processorSupport));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Pes"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit").reduce(processorSupport));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength"),
-                GraphPath.buildPath("test::domain::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").reduce(processorSupport));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").reduce(processorSupport));
         Assert.assertEquals(
-                GraphPath.buildPath("test::domain::RomanLength~Actus"),
-                GraphPath.builder("test::domain::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().reduce(processorSupport));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Actus"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().reduce(processorSupport));
     }
 
     @Test
@@ -806,16 +797,16 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                         "Integer.generalizations",
                         "Integer.generalizations.general",
                         "Integer.generalizations.general.rawType",
-                        "test::domain::RomanLength~Cubitum",
-                        "test::domain::RomanLength~Cubitum.measure",
-                        "test::domain::RomanLength~Cubitum.measure.canonicalUnit",
-                        "test::domain::RomanLength~Cubitum.measure.canonicalUnit.measure",
-                        "test::domain::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']")
+                        "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
+                        "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure",
+                        "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit",
+                        "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure",
+                        "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']")
                 .forEach(s -> Assert.assertEquals(s, GraphPath.parse(s).getDescription()));
 
         // excess whitespace is not present when generating the description
         Assert.assertEquals("test::domain::ClassA", GraphPath.parse("\t\ttest::domain::ClassA\n\n").getDescription());
-        Assert.assertEquals("test::domain::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']", GraphPath.parse("test::domain::RomanLength~Cubitum\n\t.measure\n\t.canonicalUnit\n\t.measure.nonCanonicalUnits[    'RomanLength~Actus'    ]\n").getDescription());
+        Assert.assertEquals("meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']", GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength~Cubitum\n\t.measure\n\t.canonicalUnit\n\t.measure.nonCanonicalUnits[    'RomanLength~Actus'    ]\n").getDescription());
     }
 
     @Test
@@ -880,7 +871,7 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.parse("test::domain::ClassA.properties['prop2'].genericType.rawType").getEdges().collect(e -> e.visit(visitor)));
         Assert.assertEquals(
                 Lists.mutable.with("measure", "canonicalUnit", "measure", "nonCanonicalUnits / name / RomanLength~Actus"),
-                GraphPath.parse("test::domain::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']").getEdges().collect(e -> e.visit(visitor)));
+                GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']").getEdges().collect(e -> e.visit(visitor)));
     }
 
     @Test
@@ -926,7 +917,7 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
         toOneEdges.clear();
         toManyIndexEdges.clear();
         toManyKeyEdges.clear();
-        GraphPath.parse("test::domain::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']").forEachEdge(consumer);
+        GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']").forEachEdge(consumer);
         Assert.assertEquals(Lists.mutable.with(new ToOnePropertyEdge("measure"), new ToOnePropertyEdge("canonicalUnit"), new ToOnePropertyEdge("measure")), toOneEdges);
         Assert.assertEquals(Lists.mutable.empty(), toManyIndexEdges);
         Assert.assertEquals(Lists.mutable.with(new ToManyPropertyWithStringKeyEdge("nonCanonicalUnits", "name", "RomanLength~Actus")), toManyKeyEdges);

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/TestM3CoreCompiledStateIntegrity.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/TestM3CoreCompiledStateIntegrity.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.m3.tests;
 
 import org.junit.BeforeClass;
 
-
 public class TestM3CoreCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
     @BeforeClass

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/compiler/StringJavaSource.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/compiler/StringJavaSource.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.pure.runtime.java.compiled.compiler;
 
+import javax.tools.SimpleJavaFileObject;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -27,11 +28,10 @@ import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
-import javax.tools.SimpleJavaFileObject;
 
 public abstract class StringJavaSource extends SimpleJavaFileObject
 {
-    private static final Pattern PACKAGE_DECLARATION_PATTERN = Pattern.compile("^\\h*package\\h+[^;\\s]+\\h*;", Pattern.MULTILINE);
+    private static final Pattern PACKAGE_DECLARATION_PATTERN = Pattern.compile("^\\h*+package\\h++[^;\\s]++\\h*+;", Pattern.MULTILINE);
 
     private StringJavaSource(String packageName, String name)
     {
@@ -193,16 +193,16 @@ public abstract class StringJavaSource extends SimpleJavaFileObject
         public InputStream openInputStream()
         {
             return (this.originalLength < 1024) ?
-                    new ByteArrayInputStream(decompressToBytes(this.originalLength, this.compressedCode)) :
-                    new InflaterInputStream(new ByteArrayInputStream(this.compressedCode));
+                   new ByteArrayInputStream(decompressToBytes(this.originalLength, this.compressedCode)) :
+                   new InflaterInputStream(new ByteArrayInputStream(this.compressedCode));
         }
 
         @Override
         public Reader openReader(boolean ignoreEncodingErrors)
         {
             return (this.originalLength < 1024) ?
-                    new StringReader(getCode()) :
-                    new InputStreamReader(new InflaterInputStream(new ByteArrayInputStream(this.compressedCode)), StandardCharsets.UTF_8);
+                   new StringReader(getCode()) :
+                   new InputStreamReader(new InflaterInputStream(new ByteArrayInputStream(this.compressedCode)), StandardCharsets.UTF_8);
         }
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaPackageAndImportBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaPackageAndImportBuilder.java
@@ -19,10 +19,10 @@ import org.eclipse.collections.api.set.SetIterable;
 import org.finos.legend.pure.m3.bootstrap.generator.M3ToJavaGenerator;
 import org.finos.legend.pure.m3.coreinstance.M3CoreInstanceFactoryRegistry;
 import org.finos.legend.pure.m3.coreinstance.M3PlatformCoreInstanceFactoryRegistry;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.tools.SafeAppendable;
 import org.finos.legend.pure.runtime.java.compiled.extension.CompiledExtension;
@@ -325,12 +325,8 @@ public class JavaPackageAndImportBuilder
 
     private static <T extends Appendable> T buildImplUnitInstanceClassNameFromType(T appendable, CoreInstance unit, String suffix)
     {
-        if (!(unit instanceof Unit))
-        {
-            throw new IllegalArgumentException("Not a Unit: " + unit);
-        }
-        PackageableElement.writeSystemPathForPackageableElement(SafeAppendable.wrap(appendable), ((Unit) unit)._package(), "_")
-                .append('_').append(convertUnitName(((Unit) unit)._name())).append("_Instance").append(suffix);
+        PackageableElement.writeSystemPathForPackageableElement(SafeAppendable.wrap(appendable), unit.getValueForMetaPropertyToOne(M3Properties._package), "_")
+                .append('_').append(convertUnitName(PrimitiveUtilities.getStringValue(unit.getValueForMetaPropertyToOne(M3Properties.name)))).append("_Instance").append(suffix);
         return appendable;
     }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaPackageAndImportBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaPackageAndImportBuilder.java
@@ -55,15 +55,6 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
                         "\n" +
                         "Class test::generation::compiled::extra::ExtraClass\n" +
                         "{\n" +
-                        "}\n" +
-                        "\n" +
-                        "Measure test::domain::RomanLength\n" +
-                        "{\n" +
-                        "   *Pes: x -> $x;\n" +
-                        "   Cubitum: x -> $x * 1.5;\n" +
-                        "   Passus: x -> $x * 5;\n" +
-                        "   Actus: x -> $x * 120;\n" +
-                        "   Stadium: x -> $x * 625;\n" +
                         "}\n"
         );
     }
@@ -206,9 +197,9 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
     @Test
     public void testBuildImplUnitInstanceClassNameFromType()
     {
-        Assert.assertEquals("Root_test_domain_RomanLength_Tilde_Cubitum_Instance_Impl", JavaPackageAndImportBuilder.buildImplUnitInstanceClassNameFromType(getElement("test::domain::RomanLength~Cubitum")));
-        Assert.assertEquals("Root_test_domain_RomanLength_Tilde_Pes_Instance_Impl", JavaPackageAndImportBuilder.buildImplUnitInstanceClassNameFromType(getElement("test::domain::RomanLength~Pes")));
-        Assert.assertEquals("Root_test_domain_RomanLength_Tilde_Actus_Instance_Impl", JavaPackageAndImportBuilder.buildImplUnitInstanceClassNameFromType(getElement("test::domain::RomanLength~Actus")));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength_Tilde_Cubitum_Instance_Impl", JavaPackageAndImportBuilder.buildImplUnitInstanceClassNameFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Cubitum")));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength_Tilde_Pes_Instance_Impl", JavaPackageAndImportBuilder.buildImplUnitInstanceClassNameFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength_Tilde_Actus_Instance_Impl", JavaPackageAndImportBuilder.buildImplUnitInstanceClassNameFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Actus")));
     }
 
     @SuppressWarnings("unchecked")

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/FunctionExecutionInterpreted.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/FunctionExecutionInterpreted.java
@@ -465,8 +465,8 @@ public class FunctionExecutionInterpreted implements FunctionExecution
         this.nativeFunctions.put("match_Any_MANY__Function_$1_MANY$__T_m_", new Match(this, repository));
         this.nativeFunctions.put("match_Any_MANY__Function_$1_MANY$__P_o__T_m_", new Match(this, repository));
         //  Unit
-        this.nativeFunctions.put("getUnitValue_Any_1__Number_1_", new GetUnitValue(this, repository));
-        this.nativeFunctions.put("newUnit_Unit_1__Number_1__Any_1_", new NewUnit(this, repository));
+        this.nativeFunctions.put("getUnitValue_Any_1__Number_1_", new GetUnitValue());
+        this.nativeFunctions.put("newUnit_Unit_1__Number_1__Any_1_", new NewUnit(repository));
 
         // Math
         this.nativeFunctions.put("random__Float_1_", new Random(this, repository));

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/essentials/lang/unit/GetUnitValue.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/essentials/lang/unit/GetUnitValue.java
@@ -16,33 +16,33 @@ package org.finos.legend.pure.runtime.java.interpreted.natives.essentials.lang.u
 
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.finos.legend.pure.m3.navigation.M3Properties;
-import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.compiler.Context;
+import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
-import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m3.navigation.ValueSpecificationBootstrap;
 import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.interpreted.ExecutionSupport;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 import org.finos.legend.pure.runtime.java.interpreted.VariableContext;
 import org.finos.legend.pure.runtime.java.interpreted.natives.InstantiationContext;
 import org.finos.legend.pure.runtime.java.interpreted.natives.NativeFunction;
-import org.finos.legend.pure.runtime.java.interpreted.natives.NumericUtilities;
 import org.finos.legend.pure.runtime.java.interpreted.profiler.Profiler;
 
 import java.util.Stack;
 
 public class GetUnitValue extends NativeFunction
 {
-    private final FunctionExecutionInterpreted functionExecution;
-    private final ModelRepository repository;
+    public GetUnitValue()
+    {
+    }
 
+    @Deprecated
     public GetUnitValue(FunctionExecutionInterpreted functionExecution, ModelRepository repository)
     {
-        this.functionExecution = functionExecution;
-        this.repository = repository;
+        this();
     }
 
     @Override
@@ -53,9 +53,6 @@ public class GetUnitValue extends NativeFunction
         {
             instance = Instance.getValueForMetaPropertyToOneResolved(params.get(0), M3Properties.values, processorSupport);
         }
-        FastList valueList = new FastList();
-        valueList.add(instance);
-        boolean bigDecimalToPureDecimal = valueList.anySatisfy(NumericUtilities.IS_DECIMAL_CORE_INSTANCE(processorSupport));
-        return NumericUtilities.toPureNumberValueExpression(NumericUtilities.toJavaNumber(instance, processorSupport), bigDecimalToPureDecimal, this.repository, processorSupport);
+        return ValueSpecificationBootstrap.wrapValueSpecification(instance, true, processorSupport);
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/essentials/lang/unit/NewUnit.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/essentials/lang/unit/NewUnit.java
@@ -14,20 +14,22 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.natives.essentials.lang.unit;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.impl.list.mutable.FastList;
+import org.finos.legend.pure.m3.compiler.Context;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericTypeInstance;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValueInstance;
+import org.finos.legend.pure.m3.exception.PureExecutionException;
+import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
-import org.finos.legend.pure.m3.exception.PureExecutionException;
-import org.finos.legend.pure.m3.compiler.Context;
-import org.finos.legend.pure.m3.navigation.Instance;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericTypeInstance;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValueInstance;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
-import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.interpreted.ExecutionSupport;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 import org.finos.legend.pure.runtime.java.interpreted.VariableContext;
@@ -39,13 +41,17 @@ import java.util.Stack;
 
 public class NewUnit extends NativeFunction
 {
-    private final FunctionExecutionInterpreted functionExecution;
     private final ModelRepository repository;
 
+    public NewUnit(ModelRepository repository)
+    {
+        this.repository = repository;
+    }
+
+    @Deprecated
     public NewUnit(FunctionExecutionInterpreted functionExecution, ModelRepository repository)
     {
-        this.functionExecution = functionExecution;
-        this.repository = repository;
+        this(repository);
     }
 
     @Override
@@ -53,20 +59,12 @@ public class NewUnit extends NativeFunction
     {
         CoreInstance type = Instance.getValueForMetaPropertyToOneResolved(params.get(0), M3Properties.values, processorSupport);
         CoreInstance value = Instance.getValueForMetaPropertyToOneResolved(params.get(1), M3Properties.values, processorSupport);
-        GenericTypeInstance genericTypeInstance = GenericTypeInstance.createPersistent(this.repository);
-        InstanceValueInstance iv = InstanceValueInstance.createPersistent(this.repository, genericTypeInstance, (Multiplicity)processorSupport.package_getByUserPath(M3Paths.PureOne));
-        FastList valueList = new FastList();
-        valueList.add(value);
-        iv._values(valueList);
-        genericTypeInstance._rawTypeCoreInstance(type);
-        iv._genericType(genericTypeInstance);
 
-        InstanceValueInstance wrapperIv = InstanceValueInstance.createPersistent(this.repository, genericTypeInstance, (Multiplicity)processorSupport.package_getByUserPath(M3Paths.PureOne));
-        FastList wrapperValueList = new FastList();
-        wrapperValueList.add(iv);
-        wrapperIv._values(wrapperValueList);
-        wrapperIv._genericType(genericTypeInstance);
-
-        return wrapperIv;
+        Multiplicity multiplicity = (Multiplicity) processorSupport.package_getByUserPath(M3Paths.PureOne);
+        GenericType genericType = GenericTypeInstance.createPersistent(this.repository)._rawTypeCoreInstance(type);
+        InstanceValue innerInstanceValue = InstanceValueInstance.createPersistent(this.repository, genericType, multiplicity)
+                ._values(Lists.immutable.with(value));
+        return InstanceValueInstance.createPersistent(this.repository, genericType, multiplicity)
+                ._values(Lists.immutable.with(innerInstanceValue));
     }
 }


### PR DESCRIPTION
Improvements to units and measures:

- Make Unit.measure required (i.e., multiplicity 1 instead of 0..1)
- Improve interpreted implementations of getUnitValue and newUnit
- Add unit and measure tests for elementToPath and pathToElement
- Fix handling of units in JavaPackageAndImportBuilder

In passing, improve failure reporting in AbstractCompiledStateIntegrityTest.testSpecializations and the package declaration patter in StringJavaSource.