### PR TITLE
Fix a bug in the compiled mode Java generation for newUnit

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/unit/newUnit.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/unit/newUnit.pure
@@ -33,3 +33,13 @@ function <<test.Test>> meta::pure::functions::meta::tests::newUnit::testNewUnitE
     assertEquals(-310.72D RomanLength~Stadium, newUnit_Unit_1__Number_1__Any_1_->eval(RomanLength~Stadium, -310.72D));
     assertEquals(0 RomanLength~Actus, newUnit_Unit_1__Number_1__Any_1_->eval(RomanLength~Actus, 0));
 }
+
+function <<test.Test>> meta::pure::functions::meta::tests::newUnit::testNewUnitIndirectUnit():Boolean[1]
+{
+    let actus = RomanLength~Actus;
+    let cubitumFn = {|RomanLength~Cubitum};
+    assertEquals(5 RomanLength~Pes, newUnit(RomanLength.canonicalUnit->toOne(), 5));
+    assertEquals(10.5D RomanLength~Cubitum, newUnit($cubitumFn->eval(), 10.5D));
+    assertEquals(-310.72D RomanLength~Stadium, newUnit(RomanLength.nonCanonicalUnits->find(u | $u.name == 'RomanLength~Stadium')->toOne(), -310.72D));
+    assertEquals(0 RomanLength~Actus, newUnit($actus, 0));
+}

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractTestMeasure.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractTestMeasure.java
@@ -325,6 +325,46 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
     }
 
     @Test
+    public void testNewUnitWithUnitParameter()
+    {
+        compileTestSource("testModel.pure", massDefinition);
+        compileTestSource("testFunc.pure",
+                "import pkg::*;\n" +
+                        "function testNewUnit(unit:Unit[1], n:Number[1]):Any[1]\n" +
+                        "{\n" +
+                        "    newUnit($unit, $n)\n" +
+                        "}\n" +
+                        "\n" +
+                        "function testFunc():Mass~Pound[1]\n" +
+                        "{\n" +
+                        "   testNewUnit(Mass~Pound, 10)->cast(@Mass~Pound);\n" +
+                        "}");
+        CoreInstance result = execute("testFunc():Mass~Pound[1]");
+        Assert.assertEquals("Mass~Pound", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("10", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
+    }
+
+    @Test
+    public void testNewUnitWithUnitParameterAndEval()
+    {
+        compileTestSource("testModel.pure", massDefinition);
+        compileTestSource("testFunc.pure",
+                "import pkg::*;\n" +
+                        "function testNewUnit(unit:Unit[1], n:Number[1]):Any[1]\n" +
+                        "{\n" +
+                        "    newUnit($unit, $n)\n" +
+                        "}\n" +
+                        "\n" +
+                        "function testFunc():Mass~Pound[1]\n" +
+                        "{\n" +
+                        "   testNewUnit_Unit_1__Number_1__Any_1_->eval(Mass~Pound, 10)->cast(@Mass~Pound);\n" +
+                        "}");
+        CoreInstance result = execute("testFunc():Mass~Pound[1]");
+        Assert.assertEquals("Mass~Pound", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("10", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
+    }
+
+    @Test
     public void testGetUnitValue()
     {
         compileTestSource("testModel.pure", massDefinition);

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/essentials/lang/unit/NewUnit.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/essentials/lang/unit/NewUnit.java
@@ -18,6 +18,7 @@ import org.eclipse.collections.api.list.ListIterable;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.compiled.generation.JavaPackageAndImportBuilder;
 import org.finos.legend.pure.runtime.java.compiled.generation.ProcessorContext;
@@ -35,8 +36,11 @@ public class NewUnit extends AbstractNative
     public String build(CoreInstance topLevelElement, CoreInstance functionExpression, ListIterable<String> transformedParams, ProcessorContext processorContext)
     {
         CoreInstance unit = Instance.getValueForMetaPropertyToOneResolved(functionExpression.getValueForMetaPropertyToMany(M3Properties.parametersValues).getFirst(), M3Properties.values, processorContext.getSupport());
-        String unitImplClassReference = JavaPackageAndImportBuilder.buildImplClassReferenceFromType(unit);
-        return "new " + unitImplClassReference + "(" + transformedParams.get(1) + ", es)";
+        return Measure.isUnit(unit, processorContext.getSupport()) ?
+               // concretely specified unit: we can generate the Java instantiation directly
+               ("new " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(unit) + "(" + transformedParams.get(1) + ", es)") :
+               // unit comes from a variable or function expression or something like that: we have to instantiate reflectively
+               ("CompiledSupport.newUnitInstance(" + transformedParams.get(0) + ", " + transformedParams.get(1) + ", es)");
     }
 
     @Override


### PR DESCRIPTION
Fix a bug in the compiled mode Java generation for newUnit. It was failing in case the unit was not concretely specified (e.g., it was coming from a variable or function expression). Tests are added for such cases.