### PR TITLE
Fixes and improvements for default values in dynamicNew

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreParser.g4
+++ b/legend-pure-core/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreParser.g4
@@ -239,7 +239,7 @@ taggedValue: qualifiedName DOT identifier EQUAL STRING (PLUS STRING)*
 defaultValue: EQUAL defaultValueExpression
 ;
 
-defaultValueExpression: (instanceReference)(propertyExpression) | expressionInstance | instanceLiteralToken | defaultValueExpressionsArray
+defaultValueExpression: (instanceReference)(propertyExpression) | expressionInstance | instanceLiteral | defaultValueExpressionsArray
 ;
 
 defaultValueExpressionsArray: BRACKET_OPEN ( defaultValueExpression (COMMA defaultValueExpression)* )? BRACKET_CLOSE

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
@@ -3433,9 +3433,9 @@ public class AntlrContextToM3CoreInstance
     {
         CoreInstance result = null;
 
-        if (ctx.instanceLiteralToken() != null)
+        if (ctx.instanceLiteral() != null)
         {
-            result = this.instanceLiteralToken(ctx.instanceLiteralToken(), true);
+            result = doWrap(instanceLiteral(ctx.instanceLiteral()), ctx.instanceLiteral().getStart());
         }
         else if (ctx.instanceReference() != null)
         {

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/creation/dynamicNew.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/creation/dynamicNew.pure
@@ -56,6 +56,11 @@ Class meta::pure::functions::lang::tests::dynamicNew::ClassWithDefault
   list : List<String>[1] = ^List<String>(values=['default', 'strings']);
 }
 
+Class meta::pure::functions::lang::tests::dynamicNew::SubClassWithDefault extends ClassWithDefault
+{
+  age : Integer[1] = -1;
+}
+
 function meta::pure::functions::lang::tests::dynamicNew::getterOverrideToMany(o:Any[1], property:Property<Nil,Any|*>[1]):Any[*]
 {
  [^D_D(name = $o->cast(@D_A).a + $o->getHiddenPayload()->cast(@String)->toOne()), ^D_D(name = $o->cast(@D_A).b->toOne() + $o->getHiddenPayload()->cast(@String)->toOne())]
@@ -81,6 +86,11 @@ function <<test.Test>> meta::pure::functions::lang::tests::dynamicNew::testDynam
     let c_any = ClassWithDefault->cast(@Class<Any>);
     assertEquals('default_X_Y', dynamicNew($c_any, [^KeyValue(key='other',value='rrr')])->cast(@ClassWithDefault).name);
     assertEquals(list(['default', 'strings']), dynamicNew($c_any, [^KeyValue(key='other',value='rrr')])->cast(@ClassWithDefault).list);
+
+    let subClass = SubClassWithDefault;
+    assertEquals('default_X_Y', dynamicNew($subClass, [^KeyValue(key='other',value='rrr')])->cast(@SubClassWithDefault).name);
+    assertEquals(list(['default', 'strings']), dynamicNew($subClass, [^KeyValue(key='other',value='rrr')])->cast(@SubClassWithDefault).list);
+    assertEquals(-1, dynamicNew($subClass, [^KeyValue(key='other',value='rrr')])->cast(@SubClassWithDefault).age);
 }
 
 function <<test.Test>> meta::pure::functions::lang::tests::dynamicNew::testDynamicNewWithDefaultAndSet():Boolean[1]
@@ -104,6 +114,11 @@ function <<test.Test>> meta::pure::functions::lang::tests::dynamicNew::testDynam
     let c_any = ClassWithDefault->cast(@Class<Any>);
     assertEquals('NewVal', dynamicNew($c_any, [^KeyValue(key='other',value='rrr'), ^KeyValue(key='name',value='NewVal')])->cast(@ClassWithDefault).name);
     assertEquals(list(['not', 'the', 'default', 'strings']), dynamicNew($c_any, [^KeyValue(key='other',value='rrr'), ^KeyValue(key='name',value='NewVal'), ^KeyValue(key='list',value=list(['not', 'the', 'default', 'strings']))])->cast(@ClassWithDefault).list);
+
+    let subClass = SubClassWithDefault;
+    assertEquals('NewVal', dynamicNew($subClass, [^KeyValue(key='other',value='rrr'), ^KeyValue(key='name',value='NewVal')])->cast(@SubClassWithDefault).name);
+    assertEquals(list(['not', 'the', 'default', 'strings']), dynamicNew($subClass, [^KeyValue(key='other',value='rrr'), ^KeyValue(key='name',value='NewVal'), ^KeyValue(key='list',value=list(['not', 'the', 'default', 'strings']))])->cast(@SubClassWithDefault).list);
+    assertEquals(36, dynamicNew($subClass, [^KeyValue(key='other',value='rrr'), ^KeyValue(key='name',value='NewVal'), ^KeyValue(key='age',value=36)])->cast(@SubClassWithDefault).age);
 }
 
 function <<test.Test>> meta::pure::functions::lang::tests::dynamicNew::testSimpleDynamicNew():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/creation/dynamicNew.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/creation/dynamicNew.pure
@@ -53,6 +53,7 @@ Class meta::pure::functions::lang::tests::dynamicNew::ClassWithDefault
   name : String[1] = 'default_X_Y';
   other : String[1];
   optional : String[0..1];
+  list : List<String>[1] = ^List<String>(values=['default', 'strings']);
 }
 
 function meta::pure::functions::lang::tests::dynamicNew::getterOverrideToMany(o:Any[1], property:Property<Nil,Any|*>[1]):Any[*]
@@ -71,12 +72,15 @@ function <<test.Test>> meta::pure::functions::lang::tests::dynamicNew::testDynam
 
     let x = [^KeyValue(key='other',value='rrr')];
     assertEquals('default_X_Y', dynamicNew(ClassWithDefault, $x)->cast(@ClassWithDefault).name);
+    assertEquals(list(['default', 'strings']), dynamicNew(ClassWithDefault, $x)->cast(@ClassWithDefault).list);
 
     let c = ClassWithDefault;
     assertEquals('default_X_Y', dynamicNew($c, [^KeyValue(key='other',value='rrr')])->cast(@ClassWithDefault).name);
+    assertEquals(list(['default', 'strings']), dynamicNew($c, [^KeyValue(key='other',value='rrr')])->cast(@ClassWithDefault).list);
 
     let c_any = ClassWithDefault->cast(@Class<Any>);
     assertEquals('default_X_Y', dynamicNew($c_any, [^KeyValue(key='other',value='rrr')])->cast(@ClassWithDefault).name);
+    assertEquals(list(['default', 'strings']), dynamicNew($c_any, [^KeyValue(key='other',value='rrr')])->cast(@ClassWithDefault).list);
 }
 
 function <<test.Test>> meta::pure::functions::lang::tests::dynamicNew::testDynamicNewWithDefaultAndSet():Boolean[1]
@@ -86,11 +90,20 @@ function <<test.Test>> meta::pure::functions::lang::tests::dynamicNew::testDynam
     let x = [^KeyValue(key='other',value='rrr'), ^KeyValue(key='name',value='NewVal')];
     assertEquals('NewVal', dynamicNew(ClassWithDefault, $x)->cast(@ClassWithDefault).name);
 
+    let y = [^KeyValue(key='other',value='rrr'), ^KeyValue(key='list',value=list(['not', 'the', 'default', 'strings']))];
+    assertEquals(list(['not', 'the', 'default', 'strings']), dynamicNew(ClassWithDefault, $y)->cast(@ClassWithDefault).list);
+
+    let xy = [^KeyValue(key='other',value='rrr'), ^KeyValue(key='name',value='NewVal'), ^KeyValue(key='list',value=list(['not', 'the', 'default', 'strings']))];
+    assertEquals('NewVal', dynamicNew(ClassWithDefault, $xy)->cast(@ClassWithDefault).name);
+    assertEquals(list(['not', 'the', 'default', 'strings']), dynamicNew(ClassWithDefault, $xy)->cast(@ClassWithDefault).list);
+
     let c = ClassWithDefault;
     assertEquals('NewVal', dynamicNew($c, [^KeyValue(key='other',value='rrr'), ^KeyValue(key='name',value='NewVal')])->cast(@ClassWithDefault).name);
+    assertEquals(list(['not', 'the', 'default', 'strings']), dynamicNew($c, [^KeyValue(key='other',value='rrr'), ^KeyValue(key='name',value='NewVal'), ^KeyValue(key='list',value=list(['not', 'the', 'default', 'strings']))])->cast(@ClassWithDefault).list);
 
     let c_any = ClassWithDefault->cast(@Class<Any>);
     assertEquals('NewVal', dynamicNew($c_any, [^KeyValue(key='other',value='rrr'), ^KeyValue(key='name',value='NewVal')])->cast(@ClassWithDefault).name);
+    assertEquals(list(['not', 'the', 'default', 'strings']), dynamicNew($c_any, [^KeyValue(key='other',value='rrr'), ^KeyValue(key='name',value='NewVal'), ^KeyValue(key='list',value=list(['not', 'the', 'default', 'strings']))])->cast(@ClassWithDefault).list);
 }
 
 function <<test.Test>> meta::pure::functions::lang::tests::dynamicNew::testSimpleDynamicNew():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/creation/dynamicNew.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/creation/dynamicNew.pure
@@ -58,6 +58,7 @@ Class meta::pure::functions::lang::tests::dynamicNew::ClassWithDefault
 
 Class meta::pure::functions::lang::tests::dynamicNew::SubClassWithDefault extends ClassWithDefault
 {
+  name : String[1] = 'default_Y_Z';
   age : Integer[1] = -1;
 }
 
@@ -88,7 +89,7 @@ function <<test.Test>> meta::pure::functions::lang::tests::dynamicNew::testDynam
     assertEquals(list(['default', 'strings']), dynamicNew($c_any, [^KeyValue(key='other',value='rrr')])->cast(@ClassWithDefault).list);
 
     let subClass = SubClassWithDefault;
-    assertEquals('default_X_Y', dynamicNew($subClass, [^KeyValue(key='other',value='rrr')])->cast(@SubClassWithDefault).name);
+    assertEquals('default_Y_Z', dynamicNew($subClass, [^KeyValue(key='other',value='rrr')])->cast(@SubClassWithDefault).name);
     assertEquals(list(['default', 'strings']), dynamicNew($subClass, [^KeyValue(key='other',value='rrr')])->cast(@SubClassWithDefault).list);
     assertEquals(-1, dynamicNew($subClass, [^KeyValue(key='other',value='rrr')])->cast(@SubClassWithDefault).age);
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/AbstractCompiledCoreInstance.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/AbstractCompiledCoreInstance.java
@@ -16,6 +16,10 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.suppor
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
 import org.finos.legend.pure.m4.coreinstance.AbstractCoreInstance;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
@@ -102,6 +106,27 @@ public abstract class AbstractCompiledCoreInstance extends AbstractCoreInstance 
     public boolean equals(Object obj)
     {
         return this.pureEquals(obj);
+    }
+
+    @Deprecated
+    public MutableList<? extends Pair<? extends String, ? extends RichIterable<?>>> defaultValues(ExecutionSupport es)
+    {
+        ListIterable<String> keys = getDefaultValueKeys();
+        MutableList<Pair<String, RichIterable<?>>> result = Lists.mutable.ofInitialCapacity(keys.size());
+        for (String key : keys)
+        {
+            RichIterable<?> defaultValue = getDefaultValue(key, es);
+            if ((defaultValue != null) && defaultValue.notEmpty())
+            {
+                result.add(Tuples.pair(key, defaultValue));
+            }
+        }
+        return result;
+    }
+
+    public ListIterable<String> getDefaultValueKeys()
+    {
+        return Lists.immutable.empty();
     }
 
     public RichIterable<?> getDefaultValue(String property, ExecutionSupport es)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/AbstractCompiledCoreInstance.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/AbstractCompiledCoreInstance.java
@@ -16,8 +16,6 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.suppor
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.tuple.Pair;
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
 import org.finos.legend.pure.m4.coreinstance.AbstractCoreInstance;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
@@ -106,8 +104,8 @@ public abstract class AbstractCompiledCoreInstance extends AbstractCoreInstance 
         return this.pureEquals(obj);
     }
 
-    public MutableList<? extends Pair<? extends String, ? extends RichIterable>> defaultValues(ExecutionSupport es)
+    public RichIterable<?> getDefaultValue(String property, ExecutionSupport es)
     {
-        return Lists.mutable.empty();
+        return Lists.immutable.empty();
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassImplProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassImplProcessor.java
@@ -44,8 +44,6 @@ import org.finos.legend.pure.runtime.java.compiled.generation.processors.Functio
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.type.TypeProcessor;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.valuespecification.ValueSpecificationProcessor;
 
-import java.util.function.BiFunction;
-
 public class ClassImplProcessor
 {
     //DO NOT ADD WIDE * IMPORTS TO THIS LIST IT IMPACTS COMPILE TIMES
@@ -97,14 +95,11 @@ public class ClassImplProcessor
         String classNamePlusTypeParams = className + typeParamsString;
         String interfaceNamePlusTypeParams = TypeProcessor.javaInterfaceForType(_class) + typeParamsString;
 
-        ListIterable<String> defaultValues = DefaultValue.manageDefaultValues(new BiFunction<String, String, String>()
-        {
-            @Override
-            public String apply(String name, String value)
-            {
-                return "org.eclipse.collections.impl.tuple.Tuples.pair(\"" + name + "\", " + value + ")";
-            }
-        }, _class, true, processorContext).select(s -> !s.isEmpty());
+        ListIterable<String> defaultValues = DefaultValue.manageDefaultValues((name, value) ->
+                "            case \"" + name + "\":\n" +
+                "            {\n" +
+                "                return " + value + ";\n" +
+                "            }\n", _class, true, processorContext);
 
         boolean isGetterOverride = M3Paths.GetterOverride.equals(PackageableElement.getUserPathForPackageableElement(_class)) ||
                 M3Paths.ConstraintsGetterOverride.equals(PackageableElement.getUserPathForPackageableElement(_class));
@@ -159,9 +154,16 @@ public class ClassImplProcessor
                 (ClassProcessor.isPlatformClass(_class) ? "" : validate(_class, className, classGenericType, processorContext, processorSupport.class_getSimpleProperties(_class))) +
                 (defaultValues.isEmpty() ? "" :
                         "    @Override\n" +
-                        "    public MutableList<? extends org.eclipse.collections.api.tuple.Pair<? extends String, ? extends RichIterable>> defaultValues(ExecutionSupport es)\n" +
+                        "    public RichIterable<?> getDefaultValue(String property, ExecutionSupport es)\n" +
                         "    {\n" +
-                        "        return Lists.mutable.with(" + defaultValues.makeString(",") + ");\n" +
+                        "        switch (property)\n" +
+                        "        {\n" +
+                        defaultValues.makeString("") +
+                        "            default:\n" +
+                        "            {\n" +
+                        "                return super.getDefaultValue(property, es);\n" +
+                        "            }\n" +
+                        "        }\n" +
                         "    }") +
                 "}");
     }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/DefaultValue.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/DefaultValue.java
@@ -14,11 +14,14 @@
 
 package org.finos.legend.pure.runtime.java.compiled.generation.processors.type._class;
 
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation._class._Class;
 import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.navigation.property.Property;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
@@ -31,8 +34,13 @@ public class DefaultValue
 {
     public static ListIterable<String> manageDefaultValues(BiFunction<String, String, String> formatString, CoreInstance sourceClass, boolean doSingleWrap, ProcessorContext processorContext)
     {
+        return manageDefaultValues(formatString, sourceClass, doSingleWrap, false, processorContext);
+    }
+
+    public static ListIterable<String> manageDefaultValues(BiFunction<String, String, String> formatString, CoreInstance sourceClass, boolean doSingleWrap, boolean includeInheritedProperties, ProcessorContext processorContext)
+    {
         ProcessorSupport processorSupport = processorContext.getSupport();
-        ListIterable<? extends CoreInstance> properties = sourceClass.getValueForMetaPropertyToMany(M3Properties.properties);
+        RichIterable<? extends CoreInstance> properties = includeInheritedProperties ? _Class.getSimpleProperties(sourceClass, processorSupport) : sourceClass.getValueForMetaPropertyToMany(M3Properties.properties);
 
         return properties.collectIf(
                 p -> p.getValueForMetaPropertyToOne(M3Properties.defaultValue) != null,
@@ -56,6 +64,7 @@ public class DefaultValue
                     }
 
                     return formatString.apply(p.getName(), value);
-                });
+                },
+                Lists.mutable.empty());
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/resources/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/core/CoreGen.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/resources/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/core/CoreGen.java
@@ -18,8 +18,9 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.set.MutableSet;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.List;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.Pair;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.functions.lang.KeyExpression;
@@ -195,36 +196,26 @@ public class CoreGen extends CoreHelper
 
     public static RichIterable<? extends Root_meta_pure_functions_lang_KeyValue> processKeyExpressions(java.lang.Class<?> _class, Object instance, RichIterable<? extends Root_meta_pure_functions_lang_KeyValue> keyExpressions, ExecutionSupport es)
     {
-        try
+        MutableList<Root_meta_pure_functions_lang_KeyValue> result = Lists.mutable.empty();
+        MutableSet<String> keys = Sets.mutable.empty();
+        for (Root_meta_pure_functions_lang_KeyValue kv : keyExpressions)
         {
-            MutableList<? extends org.eclipse.collections.api.tuple.Pair<? extends String, ? extends RichIterable>> vals = ((AbstractCompiledCoreInstance)instance).defaultValues(es);
-            MutableMap<String, Root_meta_pure_functions_lang_KeyValue> defaultVals = Maps.mutable.empty();
-            MutableMap<String, Root_meta_pure_functions_lang_KeyValue> given = Maps.mutable.empty();
-
-            MutableList<Root_meta_pure_functions_lang_KeyValue> defaultVals_L = vals.collect(new DefendedFunction<org.eclipse.collections.api.tuple.Pair<? extends String, ? extends RichIterable>, Root_meta_pure_functions_lang_KeyValue>()
+            result.add(kv);
+            keys.add(kv._key());
+        }
+        AbstractCompiledCoreInstance coreInstance = (AbstractCompiledCoreInstance) instance;
+        for (String key : coreInstance.getKeys())
+        {
+            if (!keys.contains(key))
             {
-                @Override
-                public Root_meta_pure_functions_lang_KeyValue valueOf(org.eclipse.collections.api.tuple.Pair<? extends String, ? extends RichIterable> pair)
+                RichIterable<?> defaultValue = coreInstance.getDefaultValue(key, es);
+                if ((defaultValue != null) && !defaultValue.isEmpty())
                 {
-                    return new Root_meta_pure_functions_lang_KeyValue_Impl("")._key(pair.getOne())._value(pair.getTwo());
+                    result.add(new Root_meta_pure_functions_lang_KeyValue_Impl("")._key(key)._value(defaultValue));
                 }
-            });
-            MutableList<? extends Root_meta_pure_functions_lang_KeyValue> givenL = keyExpressions.toList();
-            for (Root_meta_pure_functions_lang_KeyValue kv : defaultVals_L)
-            {
-                defaultVals.put(kv._key(), kv);
             }
-            for (Root_meta_pure_functions_lang_KeyValue kv : givenL)
-            {
-                given.put(kv._key(), kv);
-            }
-            defaultVals.putAll(given);
-            return defaultVals.valuesView();
         }
-        catch (Exception e)
-        {
-            throw new RuntimeException(e);
-        }
+        return result;
     }
 
     public static Object newObject(final Class<?> aClass, RichIterable<? extends Root_meta_pure_functions_lang_KeyValue> keyExpressions, ElementOverride override, Function getterToOne, Function getterToMany, Object payload, PureFunction2 getterToOneExec, PureFunction2 getterToManyExec, ExecutionSupport es)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/resources/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/core/CoreGen.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/resources/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/core/CoreGen.java
@@ -204,7 +204,7 @@ public class CoreGen extends CoreHelper
             keys.add(kv._key());
         }
         AbstractCompiledCoreInstance coreInstance = (AbstractCompiledCoreInstance) instance;
-        for (String key : coreInstance.getKeys())
+        for (String key : coreInstance.getDefaultValueKeys())
         {
             if (!keys.contains(key))
             {


### PR DESCRIPTION
Fixes and improvements for default values in dynamicNew:
- in compiled mode, default values are now computed lazily and only when needed
- in compiled mode, default values for inherited properties are now handled
- in interpreted mode, the native implementation of dynamicNew now handles non-constant default values
- tests for dynamicNew with non-constant default values
- tests for dynamicNew with inherited properties with default values
- fix the parser for default values to allow negative numbers