### PR TITLE
Units are no longer PackageableElements

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreParser.g4
+++ b/legend-pure-core/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreParser.g4
@@ -151,7 +151,7 @@ functionDescriptor: qualifiedName GROUP_OPEN (functionTypePureType (COMMA functi
 graphPath: graphPathStartNode (DOT graphPathEdge)*
 ;
 
-graphPathStartNode: (PATH_SEPARATOR | qualifiedName | unitName)
+graphPathStartNode: (PATH_SEPARATOR | qualifiedName)
 ;
 
 graphPathEdge: propertyName (BRACKET_OPEN (INTEGER | ((propertyName EQUAL)? STRING)) BRACKET_CLOSE)?

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/MeasureProcessor.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/MeasureProcessor.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2024 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,41 +15,36 @@
 package org.finos.legend.pure.m3.compiler.postprocessing.processor;
 
 import org.finos.legend.pure.m3.compiler.Context;
+import org.finos.legend.pure.m3.compiler.postprocessing.PostProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState;
-import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState.VariableContextScope;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.tools.matcher.Matcher;
 import org.finos.legend.pure.m4.ModelRepository;
 
-/**
- * Post-processor for any Unit.
- */
-public class UnitProcessor extends Processor<Unit>
+public class MeasureProcessor extends Processor<Measure>
 {
     @Override
     public String getClassName()
     {
-        return M3Paths.Unit;
+        return M3Paths.Measure;
     }
 
     @Override
-    public void process(Unit instance, ProcessorState state, Matcher matcher, ModelRepository repository, Context context, ProcessorSupport processorSupport)
+    public void process(Measure measure, ProcessorState state, Matcher matcher, ModelRepository repository, Context context, ProcessorSupport processorSupport)
     {
-        FunctionDefinition<?> conversionFunction = instance._conversionFunction();
-        if (conversionFunction != null)
+        Unit canonicalUnit = measure._canonicalUnit();
+        if (canonicalUnit != null)
         {
-            try (VariableContextScope ignore = state.withNewVariableContext())
-            {
-                FunctionDefinitionProcessor.process(conversionFunction, state, matcher, repository);
-            }
+            PostProcessor.processElement(matcher, canonicalUnit, state, processorSupport);
         }
+        measure._nonCanonicalUnits().forEach(unit -> PostProcessor.processElement(matcher, unit, state, processorSupport));
     }
 
     @Override
-    public void populateReferenceUsages(Unit unit, ModelRepository repository, ProcessorSupport processorSupport)
+    public void populateReferenceUsages(Measure measure, ModelRepository repository, ProcessorSupport processorSupport)
     {
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/coreinstance/BaseM3CoreInstanceFactory.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/coreinstance/BaseM3CoreInstanceFactory.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.pure.m3.coreinstance;
 
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.factory.CoreInstanceFactory;
 
@@ -29,23 +30,6 @@ public abstract class BaseM3CoreInstanceFactory implements CoreInstanceFactory
 
     protected String getClassifierPath(CoreInstance classifier)
     {
-        StringBuilder builder = new StringBuilder(64);
-        writeClassifierPath(builder, classifier);
-        return builder.toString();
-    }
-
-    protected void writeClassifierPath(StringBuilder builder, CoreInstance element)
-    {
-        CoreInstance pkg = element.getValueForMetaPropertyToOne("package");
-        if ((pkg == null) || "Root".equals(pkg.getName()))
-        {
-            builder.append(element.getName());
-        }
-        else
-        {
-            writeClassifierPath(builder, pkg);
-            builder.append("::");
-            builder.append(element.getName());
-        }
+        return PackageableElement.getUserPathForPackageableElement(classifier);
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/PackageableElement/PackageableElement.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/PackageableElement/PackageableElement.java
@@ -18,10 +18,13 @@ import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Any;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation._package._Package;
 import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.AbstractCoreInstanceWrapper;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.tools.SafeAppendable;
 
@@ -46,6 +49,19 @@ public class PackageableElement
         buffer.append(instance.getValueForMetaPropertyToOne(M3Properties.name).getName());
         return buffer.toString();
     };
+
+    public static boolean isPackageableElement(CoreInstance instance, ProcessorSupport processorSupport)
+    {
+        if (instance == null)
+        {
+            return false;
+        }
+        if (instance instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement)
+        {
+            return true;
+        }
+        return (!(instance instanceof Any) || (instance instanceof AbstractCoreInstanceWrapper)) && processorSupport.instance_instanceOf(instance, M3Paths.PackageableElement);
+    }
 
     public static void forEachPackagePathElement(CoreInstance packageableElement, Consumer<? super CoreInstance> firstConsumer, Consumer<? super CoreInstance> restConsumer)
     {

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/generictype/GenericType.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/generictype/GenericType.java
@@ -39,6 +39,7 @@ import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation._class._Class;
 import org.finos.legend.pure.m3.navigation.linearization.C3Linearization;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.navigation.relation._Column;
 import org.finos.legend.pure.m3.navigation.relation._RelationType;
@@ -925,6 +926,10 @@ public class GenericType
         else if (_RelationType.isRelationType(rawType, processorSupport))
         {
             _RelationType.print(appendable, rawType, processorSupport);
+        }
+        else if (Measure.isUnit(rawType, processorSupport))
+        {
+            Measure.printUnit(appendable, rawType, fullPaths);
         }
         else if (fullPaths)
         {

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/importstub/ImportStub.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/importstub/ImportStub.java
@@ -29,6 +29,7 @@ import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation._package._Package;
 import org.finos.legend.pure.m3.navigation.imports.Imports;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m3.navigation.profile.Profile;
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
@@ -38,6 +39,10 @@ import org.finos.legend.pure.m4.tools.SafeAppendable;
 
 public class ImportStub
 {
+    public static final char STEREOTYPE_STUB_DELIM = '@';
+    public static final char TAG_STUB_DELIM = '%';
+    public static final char UNIT_STUB_DELIM = '~';
+
     public static void processImportStub(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportStub importStub, ModelRepository repository, ProcessorSupport processorSupport)
     {
         if (importStub.getValueForMetaPropertyToOne(M3Properties.resolvedNode) == null)
@@ -68,30 +73,65 @@ public class ImportStub
     public static CoreInstance resolveImportStub(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportStub importStub, ModelRepository repository, ProcessorSupport processorSupport)
     {
         String idOrPath = importStub.getValueForMetaPropertyToOne(M3Properties.idOrPath).getName();
-        if (idOrPath.indexOf('@') != -1)
+        int delimiterIndex = findStubDelimiterIndex(idOrPath);
+        if (delimiterIndex != -1)
         {
-            return resolveStereotype(idOrPath, importStub, repository, processorSupport);
-        }
-        if (idOrPath.indexOf('%') != -1)
-        {
-            return resolveTag(idOrPath, importStub, repository, processorSupport);
+            char delimiter = idOrPath.charAt(delimiterIndex);
+            switch (delimiter)
+            {
+                case STEREOTYPE_STUB_DELIM:
+                {
+                    return resolveStereotype(idOrPath, delimiterIndex, importStub, repository, processorSupport);
+                }
+                case TAG_STUB_DELIM:
+                {
+                    return resolveTag(idOrPath, delimiterIndex, importStub, repository, processorSupport);
+                }
+                case UNIT_STUB_DELIM:
+                {
+                    return resolveUnit(idOrPath, delimiterIndex, importStub, repository, processorSupport);
+                }
+                default:
+                {
+                    throw new RuntimeException("Unsupported ImportStub delimiter '" + delimiter + "' at index " + delimiterIndex + " of '" + idOrPath + "'");
+                }
+            }
         }
         return resolvePackageableElement(idOrPath, importStub, repository, processorSupport);
     }
 
+    private static int findStubDelimiterIndex(String idOrPath)
+    {
+        int cp;
+        for (int i = 0, len = idOrPath.length(); i < len; i += Character.charCount(cp))
+        {
+            cp = idOrPath.codePointAt(i);
+            if ((cp == STEREOTYPE_STUB_DELIM) || (cp == TAG_STUB_DELIM) || (cp == UNIT_STUB_DELIM))
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     public static CoreInstance resolveStereotype(String idOrPath, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportStub importStubNode, ModelRepository repository, ProcessorSupport processorSupport)
     {
-        int splitIndex = idOrPath.indexOf('@');
+        int splitIndex = idOrPath.indexOf(STEREOTYPE_STUB_DELIM);
         if (splitIndex == -1)
         {
             throw new IllegalArgumentException("Invalid stereotype id: " + idOrPath);
         }
-        String profileIdOrPath = idOrPath.substring(0, splitIndex);
-        String stereotypeName = idOrPath.substring(splitIndex + 1);
+        return resolveStereotype(idOrPath, splitIndex, importStubNode, repository, processorSupport);
+    }
+
+    private static CoreInstance resolveStereotype(String idOrPath, int delimiterIndex, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportStub importStubNode, ModelRepository repository, ProcessorSupport processorSupport)
+    {
+        String profileIdOrPath = idOrPath.substring(0, delimiterIndex);
+        String stereotypeName = idOrPath.substring(delimiterIndex + 1);
         CoreInstance packageableElement = resolvePackageableElement(profileIdOrPath, importStubNode, repository, processorSupport);
         if ((packageableElement == null) || (packageableElement.getClassifier() != processorSupport.package_getByUserPath(M3Paths.Profile)))
         {
-            throw new PureCompilationException(importStubNode.getSourceInformation(), idOrPath + " : " + profileIdOrPath + " is not a profile!");
+            throw new PureCompilationException(importStubNode.getSourceInformation(), profileIdOrPath + STEREOTYPE_STUB_DELIM + stereotypeName + " : " + profileIdOrPath + " is not a profile!");
         }
 
         CoreInstance result = Profile.findStereotype(packageableElement, stereotypeName);
@@ -102,19 +142,14 @@ public class ImportStub
         return result;
     }
 
-    private static CoreInstance resolveTag(String idOrPath, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportStub importStubNode, ModelRepository repository, ProcessorSupport processorSupport)
+    private static CoreInstance resolveTag(String idOrPath, int delimiterIndex, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportStub importStubNode, ModelRepository repository, ProcessorSupport processorSupport)
     {
-        int splitIndex = idOrPath.indexOf('%');
-        if (splitIndex == -1)
-        {
-            throw new IllegalArgumentException("Invalid tag id: " + idOrPath);
-        }
-        String profileIdOrPath = idOrPath.substring(0, splitIndex);
-        String tagName = idOrPath.substring(splitIndex + 1);
+        String profileIdOrPath = idOrPath.substring(0, delimiterIndex);
+        String tagName = idOrPath.substring(delimiterIndex + 1);
         CoreInstance packageableElement = resolvePackageableElement(profileIdOrPath, importStubNode, repository, processorSupport);
         if ((packageableElement == null) || (packageableElement.getClassifier() != processorSupport.package_getByUserPath(M3Paths.Profile)))
         {
-            throw new PureCompilationException(importStubNode.getSourceInformation(), idOrPath + " : " + profileIdOrPath + " is not a profile!");
+            throw new PureCompilationException(importStubNode.getSourceInformation(), profileIdOrPath + TAG_STUB_DELIM + tagName + " : " + profileIdOrPath + " is not a profile!");
         }
 
         CoreInstance result = Profile.findTag(packageableElement, tagName);
@@ -123,7 +158,24 @@ public class ImportStub
             throw new PureCompilationException(importStubNode.getSourceInformation(), "The tag '" + tagName + "' can't be found in profile '" + profileIdOrPath + "'");
         }
         return result;
+    }
 
+    private static CoreInstance resolveUnit(String idOrPath, int delimiterIndex, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportStub importStubNode, ModelRepository repository, ProcessorSupport processorSupport)
+    {
+        String measureIdOrPath = idOrPath.substring(0, delimiterIndex);
+        String unitName = idOrPath.substring(idOrPath.lastIndexOf(':', delimiterIndex) + 1);
+        CoreInstance packageableElement = resolvePackageableElement(measureIdOrPath, importStubNode, repository, processorSupport);
+        if ((packageableElement == null) || (packageableElement.getClassifier() != processorSupport.package_getByUserPath(M3Paths.Measure)))
+        {
+            throw new PureCompilationException(importStubNode.getSourceInformation(), measureIdOrPath + UNIT_STUB_DELIM + unitName + " : " + measureIdOrPath + " is not a measure!");
+        }
+
+        CoreInstance result = Measure.findUnit(packageableElement, unitName);
+        if (result == null)
+        {
+            throw new PureCompilationException(importStubNode.getSourceInformation(), "The unit '" + unitName + "' can't be found in measure '" + measureIdOrPath + "'");
+        }
+        return result;
     }
 
     private static CoreInstance resolvePackageableElement(String idOrPath, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportStub importStubNode, ModelRepository repository, ProcessorSupport processorSupport)

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/importstub/ImportStub.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/importstub/ImportStub.java
@@ -163,7 +163,7 @@ public class ImportStub
     private static CoreInstance resolveUnit(String idOrPath, int delimiterIndex, org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportStub importStubNode, ModelRepository repository, ProcessorSupport processorSupport)
     {
         String measureIdOrPath = idOrPath.substring(0, delimiterIndex);
-        String unitName = idOrPath.substring(idOrPath.lastIndexOf(':', delimiterIndex) + 1);
+        String unitName = idOrPath.substring(delimiterIndex + 1);
         CoreInstance packageableElement = resolvePackageableElement(measureIdOrPath, importStubNode, repository, processorSupport);
         if ((packageableElement == null) || (packageableElement.getClassifier() != processorSupport.package_getByUserPath(M3Paths.Measure)))
         {

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/measure/Measure.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/measure/Measure.java
@@ -207,14 +207,8 @@ public class Measure
     public static <T extends Appendable> T writeSystemPathForUnit(T appendable, CoreInstance unit, String separator)
     {
         CoreInstance measure = unit.getValueForMetaPropertyToOne(M3Properties.measure);
-        CoreInstance pkg = measure.getValueForMetaPropertyToOne(M3Properties._package);
-        SafeAppendable safeAppendable = SafeAppendable.wrap(appendable);
-        if (pkg != null)
-        {
-            PackageableElement.writeSystemPathForPackageableElement(safeAppendable, pkg)
-                    .append((separator == null) ? PackageableElement.DEFAULT_PATH_SEPARATOR : separator);
-        }
-        safeAppendable.append(unit.getName());
+        PackageableElement.writeSystemPathForPackageableElement(SafeAppendable.wrap(appendable), measure, separator)
+                .append('~').append(unit.getName());
         return appendable;
     }
 
@@ -226,14 +220,8 @@ public class Measure
     public static <T extends Appendable> T writeUserPathForUnit(T appendable, CoreInstance unit, String separator)
     {
         CoreInstance measure = unit.getValueForMetaPropertyToOne(M3Properties.measure);
-        CoreInstance pkg = measure.getValueForMetaPropertyToOne(M3Properties._package);
-        SafeAppendable safeAppendable = SafeAppendable.wrap(appendable);
-        if (pkg != null)
-        {
-            PackageableElement.writeUserPathForPackageableElement(safeAppendable, pkg, separator)
-                    .append((separator == null) ? PackageableElement.DEFAULT_PATH_SEPARATOR : separator);
-        }
-        safeAppendable.append(unit.getName());
+        PackageableElement.writeUserPathForPackageableElement(SafeAppendable.wrap(appendable), measure, separator)
+                .append('~').append(unit.getName());
         return appendable;
     }
 
@@ -244,7 +232,8 @@ public class Measure
             return writeUserPathForUnit(appendable, unit);
         }
 
-        SafeAppendable.wrap(appendable).append(unit.getName());
+        CoreInstance measure = unit.getValueForMetaPropertyToOne(M3Properties.measure);
+        SafeAppendable.wrap(appendable).append(measure.getName()).append('~').append(unit.getName());
         return appendable;
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
@@ -2265,51 +2265,52 @@ public class AntlrContextToM3CoreInstance
     {
         checkExists(ctx.qualifiedName().packagePath(), ctx.qualifiedName().identifier(), null);
 
+        SourceInformation sourceInfo = this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.qualifiedName().identifier().getStart(), ctx.getStop());
         String measureName = ctx.qualifiedName().identifier().getText();
-        Measure measureInstance = MeasureInstance.createPersistent(this.repository, measureName, this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.qualifiedName().identifier().getStart(), ctx.getStop()))
+        Measure measure = MeasureInstance.createPersistent(this.repository, measureName, sourceInfo)
                 ._name(measureName)
-                ._classifierGenericType(GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Measure)));
+                ._classifierGenericType(GenericTypeInstance.createPersistent(this.repository, sourceInfo)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Measure)));
 
         Package packageInstance = buildPackage(ctx.qualifiedName().packagePath());
-        measureInstance._package(packageInstance);
-        packageInstance._childrenAdd(measureInstance);
+        measure._package(packageInstance);
+        packageInstance._childrenAdd(measure);
 
         ListIterable<CoreInstance> stereotypes = (ctx.stereotypes() == null) ? Lists.immutable.empty() : stereotypes(ctx.stereotypes(), importId);
         if (stereotypes.notEmpty())
         {
-            measureInstance._stereotypesCoreInstance(stereotypes);
+            measure._stereotypesCoreInstance(stereotypes);
         }
         ListIterable<TaggedValue> taggedValues = (ctx.taggedValues() == null) ? Lists.immutable.empty() : taggedValues(ctx.taggedValues(), importId);
         if (taggedValues.notEmpty())
         {
-            measureInstance._taggedValues(taggedValues);
+            measure._taggedValues(taggedValues);
         }
 
-        measureInstance._generalizations(Lists.immutable.with(GeneralizationInstance.createPersistent(this.repository, GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Any)), measureInstance)));
+        measure._generalizations(Lists.immutable.with(GeneralizationInstance.createPersistent(this.repository, sourceInfo, GenericTypeInstance.createPersistent(this.repository, sourceInfo)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.DataType)), measure)));
 
         M3Parser.MeasureBodyContext measureBodyCtx = ctx.measureBody();
         if (measureBodyCtx.canonicalUnitExpr() != null)
         {
             // traditional canonical unit pattern
-            measureInstance._canonicalUnit(unitParser(measureBodyCtx.canonicalUnitExpr().unitExpr(), importId, measureInstance));
+            measure._canonicalUnit(unitParser(measureBodyCtx.canonicalUnitExpr().unitExpr(), importId, measure));
 
-            MutableList<Unit> nonCanonicalUnits = ListIterate.collect(measureBodyCtx.unitExpr(), unitCtx -> unitParser(unitCtx, importId, measureInstance));
+            MutableList<Unit> nonCanonicalUnits = ListIterate.collect(measureBodyCtx.unitExpr(), unitCtx -> unitParser(unitCtx, importId, measure));
             if (nonCanonicalUnits.notEmpty())
             {
-                measureInstance._nonCanonicalUnits(nonCanonicalUnits);
+                measure._nonCanonicalUnits(nonCanonicalUnits);
             }
         }
         else
         {
             // non-convertible unit pattern
-            MutableList<Unit> nonConvertibleUnits = ListIterate.collect(measureBodyCtx.nonConvertibleUnitExpr(), unitCtx -> nonConvertibleUnitParser(unitCtx, measureInstance));
-            measureInstance._canonicalUnit(nonConvertibleUnits.get(0));
+            MutableList<Unit> nonConvertibleUnits = ListIterate.collect(measureBodyCtx.nonConvertibleUnitExpr(), unitCtx -> nonConvertibleUnitParser(unitCtx, measure));
+            measure._canonicalUnit(nonConvertibleUnits.get(0));
             if (nonConvertibleUnits.size() > 1)
             {
-                measureInstance._nonCanonicalUnits(Lists.immutable.withAll(nonConvertibleUnits.subList(1, nonConvertibleUnits.size())));
+                measure._nonCanonicalUnits(Lists.immutable.withAll(nonConvertibleUnits.subList(1, nonConvertibleUnits.size())));
             }
         }
-        return measureInstance;
+        return measure;
     }
 
     /**
@@ -2318,54 +2319,52 @@ public class AntlrContextToM3CoreInstance
     @SuppressWarnings("unchecked")
     private Unit unitParser(UnitExprContext ctx, ImportGroup importId, Measure measure)
     {
-        String unitName = measure._name() + org.finos.legend.pure.m3.navigation.importstub.ImportStub.UNIT_STUB_DELIM + ctx.identifier().getText();
         SourceInformation sourceInfo = this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.identifier().getStart(), ctx.getStop());
-        checkExists(measure._package(), unitName, sourceInfo);
-        Unit unitInstance = UnitInstance.createPersistent(this.repository, unitName, sourceInfo, measure)
+        String unitName = ctx.identifier().getText();
+        Unit unit = UnitInstance.createPersistent(this.repository, unitName, sourceInfo, measure)
                 ._name(unitName)
-                ._classifierGenericType(GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Unit)));
+                ._classifierGenericType(GenericTypeInstance.createPersistent(this.repository, sourceInfo)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Unit)));
 
         // set unit super type to be its measure (Kilogram -> Mass)
-        Generalization generalization = GeneralizationInstance.createPersistent(this.repository, GenericTypeInstance.createPersistent(this.repository)._rawType(measure), unitInstance);
-        unitInstance._generalizations(Lists.immutable.with(generalization));
+        Generalization generalization = GeneralizationInstance.createPersistent(this.repository, sourceInfo, GenericTypeInstance.createPersistent(this.repository, sourceInfo)._rawType(measure), unit);
+        unit._generalizations(Lists.immutable.with(generalization));
         measure._specializationsAdd(generalization);
 
         // prepare lambda instance for the conversion function
 
-        LambdaContext lambdaContext = new LambdaContext(org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.writeUserPathForPackageableElement(new StringBuilder(), measure, "_").append(unitName).toString());
+        LambdaContext lambdaContext = new LambdaContext(org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.writeUserPathForPackageableElement(new StringBuilder(), measure, "_").append('~').append(unitName).toString());
         MutableList<String> typeParametersNames = Lists.mutable.empty();
-        FunctionType signature = FunctionTypeInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.unitConversionExpr().getStart(), ctx.unitConversionExpr().getStart(), ctx.unitConversionExpr().getStop()), null, null);
+        FunctionType conversionFuncType = FunctionTypeInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.unitConversionExpr().getStart(), ctx.unitConversionExpr().getStart(), ctx.unitConversionExpr().getStop()), null, null);
 
         // prepare params
 
         VariableExpression expr = lambdaParam(null, ctx.unitConversionExpr().identifier(), typeParametersNames, "", importId)
                 ._multiplicity(getPureOne())
-                ._functionTypeOwner(signature)
+                ._functionTypeOwner(conversionFuncType)
                 ._genericType(GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Number)));
-        signature._parameters(Lists.immutable.with(expr));
+        conversionFuncType._parameters(Lists.immutable.with(expr));
 
-        GenericType genericTypeInstance = GenericTypeInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.unitConversionExpr().ARROW().getSymbol()))
+        GenericType conversionFuncClassifierGT = GenericTypeInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.unitConversionExpr().ARROW().getSymbol()))
                 ._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.LambdaFunction))
-                ._typeArguments(Lists.immutable.with(GenericTypeInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.unitConversionExpr().ARROW().getSymbol()))._rawType(signature)));
-        LambdaFunction<?> lambdaFunctionInstance = LambdaFunctionInstance.createPersistent(this.repository, lambdaContext.getLambdaFunctionUniqueName(), this.sourceInformation.getPureSourceInformation(ctx.unitConversionExpr().ARROW().getSymbol()))
-                ._classifierGenericType(genericTypeInstance)
+                ._typeArguments(Lists.immutable.with(GenericTypeInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.unitConversionExpr().ARROW().getSymbol()))._rawType(conversionFuncType)));
+        LambdaFunction<?> conversionFunc = LambdaFunctionInstance.createPersistent(this.repository, lambdaContext.getLambdaFunctionUniqueName(), this.sourceInformation.getPureSourceInformation(ctx.unitConversionExpr().ARROW().getSymbol()))
+                ._classifierGenericType(conversionFuncClassifierGT)
                 ._expressionSequence(codeBlock(ctx.unitConversionExpr().codeBlock(), typeParametersNames, Lists.mutable.empty(), importId, lambdaContext, this.addLines, tabs(6)));
-        signature._functionAdd(lambdaFunctionInstance);
+        conversionFuncType._functionAdd(conversionFunc);
 
-        unitInstance._conversionFunction(lambdaFunctionInstance);
+        unit._conversionFunction(conversionFunc);
 
-        return unitInstance;
+        return unit;
     }
 
     private Unit nonConvertibleUnitParser(NonConvertibleUnitExprContext ctx, Measure measure)
     {
-        String unitName = measure._name() + org.finos.legend.pure.m3.navigation.importstub.ImportStub.UNIT_STUB_DELIM + ctx.identifier().getText();
         SourceInformation sourceInfo = this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.identifier().getStart(), ctx.getStop());
-        checkExists(measure._package(), unitName, sourceInfo);
+        String unitName = ctx.identifier().getText();
         Unit unitInstance = UnitInstance.createPersistent(this.repository, unitName, sourceInfo, measure)
                 ._name(unitName)
-                ._classifierGenericType(GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Unit)));
-        Generalization generalization = GeneralizationInstance.createPersistent(this.repository, GenericTypeInstance.createPersistent(this.repository)._rawType(measure), unitInstance);
+                ._classifierGenericType(GenericTypeInstance.createPersistent(this.repository, sourceInfo)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Unit)));
+        Generalization generalization = GeneralizationInstance.createPersistent(this.repository, sourceInfo, GenericTypeInstance.createPersistent(this.repository, sourceInfo)._rawType(measure), unitInstance);
         unitInstance._generalizations(Lists.immutable.with(generalization));
         measure._specializationsAdd(generalization);
         return unitInstance;

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/M3AntlrParser.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/M3AntlrParser.java
@@ -32,6 +32,7 @@ import org.finos.legend.pure.m3.compiler.postprocessing.processor.ElementWithCon
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.EnumerationProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.FunctionDefinitionProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.LambdaFunctionProcessor;
+import org.finos.legend.pure.m3.compiler.postprocessing.processor.MeasureProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.PropertyOwnerProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.PropertyProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.QualifiedPropertyProcessor;
@@ -135,6 +136,7 @@ import org.finos.legend.pure.m3.serialization.runtime.binary.reference.PropertyR
 import org.finos.legend.pure.m3.serialization.runtime.binary.reference.QualifiedPropertyReferenceSerializer;
 import org.finos.legend.pure.m3.serialization.runtime.binary.reference.StereotypeReferenceSerializer;
 import org.finos.legend.pure.m3.serialization.runtime.binary.reference.TagReferenceSerializer;
+import org.finos.legend.pure.m3.serialization.runtime.binary.reference.UnitReferenceSerializer;
 import org.finos.legend.pure.m3.serialization.runtime.navigation.NavigationHandler;
 import org.finos.legend.pure.m3.statelistener.M3M4StateListener;
 import org.finos.legend.pure.m3.tools.matcher.MatchRunner;
@@ -445,6 +447,7 @@ public class M3AntlrParser implements Parser
                 new VariableExpressionProcessor(),
                 new InstanceValueProcessor(),
                 new FunctionExpressionProcessor(),
+                new MeasureProcessor(),
                 new UnitProcessor()
         );
     }
@@ -558,7 +561,8 @@ public class M3AntlrParser implements Parser
                 new PropertyReferenceSerializer(),
                 new QualifiedPropertyReferenceSerializer(),
                 new TagReferenceSerializer(),
-                new StereotypeReferenceSerializer()
+                new StereotypeReferenceSerializer(),
+                new UnitReferenceSerializer()
         );
     }
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/binary/reference/UnitReferenceSerializer.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/binary/reference/UnitReferenceSerializer.java
@@ -1,0 +1,68 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.runtime.binary.reference;
+
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+public class UnitReferenceSerializer implements ExternalReferenceSerializer
+{
+    @Override
+    public String getTypePath()
+    {
+        return M3Paths.Unit;
+    }
+
+    @Override
+    public void serialize(CoreInstance instance, ExternalReferenceSerializationHelper helper)
+    {
+        Unit unit = (Unit) instance;
+        helper.writeElementReference(unit._measure());
+        helper.writeString(unit._name());
+    }
+
+    @Override
+    public Reference deserialize(ExternalReferenceDeserializationHelper helper)
+    {
+        Reference measureReference = helper.readElementReference();
+        String unitName = helper.readString();
+        return new UnitExternalReference(measureReference, unitName);
+    }
+
+    private static class UnitExternalReference extends AbstractReferenceWithOwner
+    {
+        private final String unitName;
+
+        private UnitExternalReference(Reference measureReference, String unitName)
+        {
+            super(measureReference);
+            this.unitName = unitName;
+        }
+
+        @Override
+        protected CoreInstance resolveFromOwner(CoreInstance measure) throws UnresolvableReferenceException
+        {
+            CoreInstance unit = Measure.findUnit(measure, this.unitName);
+            if (unit == null)
+            {
+                setFailureMessage(PackageableElement.writeUserPathForPackageableElement(new StringBuilder("Could not find unit '").append(this.unitName).append("' in "), measure).toString());
+            }
+            return unit;
+        }
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/unit/newUnit.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/unit/newUnit.pure
@@ -40,6 +40,6 @@ function <<test.Test>> meta::pure::functions::meta::tests::newUnit::testNewUnitI
     let cubitumFn = {|RomanLength~Cubitum};
     assertEquals(5 RomanLength~Pes, newUnit(RomanLength.canonicalUnit->toOne(), 5));
     assertEquals(10.5D RomanLength~Cubitum, newUnit($cubitumFn->eval(), 10.5D));
-    assertEquals(-310.72D RomanLength~Stadium, newUnit(RomanLength.nonCanonicalUnits->find(u | $u.name == 'RomanLength~Stadium')->toOne(), -310.72D));
+    assertEquals(-310.72D RomanLength~Stadium, newUnit(RomanLength.nonCanonicalUnits->find(u | $u.name == 'Stadium')->toOne(), -310.72D));
     assertEquals(0 RomanLength~Actus, newUnit($actus, 0));
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementToPath.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementToPath.pure
@@ -35,8 +35,8 @@ function meta::pure::functions::meta::elementToPath(element:Type[1], separator:S
 {
     $element->match(
         [
-            u : Unit[1] | if($u.measure.package->isEmpty(), |$u.name->toOne(), |$u.measure.package->toOne()->elementToPath($separator) + $separator + $u.name->toOne()),
-            p : PackageableElement[1] | $p->elementToPath($separator)
+            p : PackageableElement[1] | $p->elementToPath($separator),
+            u : Unit[1] | if($u.measure.package->isEmpty(), |$u.name->toOne(), |$u.measure.package->toOne()->elementToPath($separator) + $separator + $u.name->toOne())
         ]
     )
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementToPath.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementToPath.pure
@@ -33,7 +33,12 @@ function meta::pure::functions::meta::elementToPath(element:Type[1]):String[1]
 
 function meta::pure::functions::meta::elementToPath(element:Type[1], separator:String[1]):String[1]
 {
-    $element->cast(@PackageableElement)->elementToPath($separator)
+    $element->match(
+        [
+            u : Unit[1] | if($u.measure.package->isEmpty(), |$u.name->toOne(), |$u.measure.package->toOne()->elementToPath($separator) + $separator + $u.name->toOne()),
+            p : PackageableElement[1] | $p->elementToPath($separator)
+        ]
+    )
 }
 
 function meta::pure::functions::meta::elementToPath(element:PackageableElement[1]):String[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementToPath.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementToPath.pure
@@ -36,7 +36,7 @@ function meta::pure::functions::meta::elementToPath(element:Type[1], separator:S
     $element->match(
         [
             p : PackageableElement[1] | $p->elementToPath($separator),
-            u : Unit[1] | if($u.measure.package->isEmpty(), |$u.name->toOne(), |$u.measure.package->toOne()->elementToPath($separator) + $separator + $u.name->toOne())
+            u : Unit[1] | $u.measure->elementToPath($separator) + '~' + $u.name->toOne()
         ]
     )
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/pathToElement.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/pathToElement.pure
@@ -36,6 +36,7 @@ function <<test.Test>> meta::pure::functions::meta::tests::pathToElement::testPa
     assertIs(CC_Person, pathToElement('meta.pure.functions.meta.tests.model.CC_Person', '.'));
     assertIs(CC_Person.package->toOne(), pathToElement('meta::pure::functions::meta::tests::model'));
     assertIs(CC_Person.package->toOne(), pathToElement('meta_pure_functions_meta_tests_model', '_'));
+    assertIs(RomanLength, pathToElement('meta::pure::functions::meta::tests::model::RomanLength'));
 }
 
 function <<test.Test>> meta::pure::functions::meta::tests::pathToElement::testLenientPathToElement():Boolean[1]
@@ -71,16 +72,6 @@ function <<test.Test>> meta::pure::functions::meta::tests::pathToElement::testNa
 function <<test.Test>> meta::pure::functions::meta::tests::pathToElement::testConcreteFunctionDefinitionPathToElement():Boolean[1]
 {
     assertIs(meta::pure::functions::boolean::greaterThan_Number_1__Number_1__Boolean_1_, pathToElement('meta::pure::functions::boolean::greaterThan_Number_1__Number_1__Boolean_1_'));
-}
-
-function <<test.Test>> meta::pure::functions::meta::tests::pathToElement::testUnitMeasurePathToElement():Boolean[1]
-{
-    assertIs(RomanLength, pathToElement('meta::pure::functions::meta::tests::model::RomanLength'));
-    assertEquals(RomanLength~Pes, pathToElement('meta::pure::functions::meta::tests::model::RomanLength~Pes'));
-    assertEquals(RomanLength~Cubitum, pathToElement('meta::pure::functions::meta::tests::model::RomanLength~Cubitum'));
-    assertEquals(RomanLength~Passus, pathToElement('meta::pure::functions::meta::tests::model::RomanLength~Passus'));
-    assertEquals(RomanLength~Actus, pathToElement('meta::pure::functions::meta::tests::model::RomanLength~Actus'));
-    assertEquals(RomanLength~Stadium, pathToElement('meta::pure::functions::meta::tests::model::RomanLength~Stadium'));
 }
 
 // To be removed

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/m3.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/m3.pure
@@ -940,7 +940,7 @@
                                                 },
                  ^Root.children[meta].children[pure].children[metamodel].children[relationship].children[Generalization]
                  {
-                     Root.children[meta].children[pure].children[metamodel].children[relationship].children[Generalization].properties[general] : ^Root.children[meta].children[pure].children[metamodel].children[type].children[generics].children[GenericType]{Root.children[meta].children[pure].children[metamodel].children[type].children[generics].children[GenericType].properties[rawType]:Root.children[meta].children[pure].children[metamodel].children[PackageableElement]},
+                     Root.children[meta].children[pure].children[metamodel].children[relationship].children[Generalization].properties[general] : ^Root.children[meta].children[pure].children[metamodel].children[type].children[generics].children[GenericType]{Root.children[meta].children[pure].children[metamodel].children[type].children[generics].children[GenericType].properties[rawType]:Root.children[meta].children[pure].children[metamodel].children[Referenceable]},
                     Root.children[meta].children[pure].children[metamodel].children[relationship].children[Generalization].properties[specific] : Root.children[meta].children[pure].children[metamodel].children[type].children[Unit]
                  }
             ]

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/navigation/graph/TestGraphPath.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/navigation/graph/TestGraphPath.java
@@ -128,20 +128,23 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("Integer", "generalizations", "general", "rawType").getDescription());
 
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength").getDescription());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure",
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum']",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").getDescription());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit",
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit").getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperty("measure").getDescription());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure",
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit").getDescription());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").getDescription());
+        Assert.assertEquals(
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getDescription());
     }
 
     @Test
@@ -206,20 +209,23 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("Integer", "generalizations", "general", "rawType").getPureExpression());
 
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength").getPureExpression());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure",
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Cubitum')->toOne()",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").getPureExpression());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit",
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit").getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Cubitum')->toOne().measure",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperty("measure").getPureExpression());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure",
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Cubitum')->toOne().measure.canonicalUnit",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit").getPureExpression());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Actus')->toOne()",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Cubitum')->toOne().measure.canonicalUnit.measure",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").getPureExpression());
+        Assert.assertEquals(
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Cubitum')->toOne().measure.canonicalUnit.measure.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Actus')->toOne()",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getPureExpression());
     }
 
     @Test
@@ -284,20 +290,23 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("Integer", "generalizations", "general", "rawType").getStartNodePath());
 
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").getStartNodePath());
+                "meta::pure::functions::meta::tests::model::RomanLength",
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength").getStartNodePath());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").getStartNodePath());
+                "meta::pure::functions::meta::tests::model::RomanLength",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").build().getStartNodePath());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit").getStartNodePath());
+                "meta::pure::functions::meta::tests::model::RomanLength",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperty("measure").build().getStartNodePath());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").getStartNodePath());
+                "meta::pure::functions::meta::tests::model::RomanLength",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit").build().getStartNodePath());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getStartNodePath());
+                "meta::pure::functions::meta::tests::model::RomanLength",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build().getStartNodePath());
+        Assert.assertEquals(
+                "meta::pure::functions::meta::tests::model::RomanLength",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getStartNodePath());
     }
 
     @Test
@@ -349,20 +358,23 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolve(processorSupport));
 
         Assert.assertEquals(
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").resolve(processorSupport));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength").resolve(processorSupport));
+        Assert.assertEquals(
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Cubitum"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").build().resolve(processorSupport));
         Assert.assertEquals(
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").resolve(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperty("measure").build().resolve(processorSupport));
         Assert.assertEquals(
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Pes"),
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit").resolve(processorSupport));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueForMetaPropertyToOne("canonicalUnit"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit").build().resolve(processorSupport));
         Assert.assertEquals(
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").resolve(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build().resolve(processorSupport));
         Assert.assertEquals(
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Actus"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().resolve(processorSupport));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Actus"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().resolve(processorSupport));
     }
 
     @Test
@@ -506,30 +518,38 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 runtime.getCoreInstance("Number"));
 
         assertResolveFully(
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"));
-        assertResolveFully(
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"));
         assertResolveFully(
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Pes"));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Cubitum"));
         assertResolveFully(
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperty("measure").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Pes"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Cubitum"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"));
         assertResolveFully(
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build(),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Pes"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Cubitum"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength~Actus"));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueForMetaPropertyToOne("canonicalUnit"));
+        assertResolveFully(
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build(),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Cubitum"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueForMetaPropertyToOne("canonicalUnit"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"));
+        assertResolveFully(
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build(),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Cubitum"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueForMetaPropertyToOne("canonicalUnit"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Actus"));
     }
 
     private void assertResolveFully(GraphPath path, CoreInstance... nodes)
@@ -678,20 +698,23 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("Integer", "generalizations", "general", "rawType", "name").reduce(processorSupport));
 
         Assert.assertEquals(
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").reduce(processorSupport));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength"),
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength").reduce(processorSupport));
+        Assert.assertEquals(
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").build(),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").build().reduce(processorSupport));
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength"),
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure").reduce(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperty("measure").build().reduce(processorSupport));
         Assert.assertEquals(
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Pes"),
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit").reduce(processorSupport));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength", "canonicalUnit"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit").build().reduce(processorSupport));
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength"),
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure").reduce(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build().reduce(processorSupport));
         Assert.assertEquals(
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Actus"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().reduce(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build(),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().reduce(processorSupport));
     }
 
     @Test
@@ -797,16 +820,16 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                         "Integer.generalizations",
                         "Integer.generalizations.general",
                         "Integer.generalizations.general.rawType",
-                        "meta::pure::functions::meta::tests::model::RomanLength~Cubitum",
-                        "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure",
-                        "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit",
-                        "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure",
-                        "meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']")
+                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum']",
+                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure",
+                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit",
+                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure",
+                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']")
                 .forEach(s -> Assert.assertEquals(s, GraphPath.parse(s).getDescription()));
 
         // excess whitespace is not present when generating the description
         Assert.assertEquals("test::domain::ClassA", GraphPath.parse("\t\ttest::domain::ClassA\n\n").getDescription());
-        Assert.assertEquals("meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']", GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength~Cubitum\n\t.measure\n\t.canonicalUnit\n\t.measure.nonCanonicalUnits[    'RomanLength~Actus'    ]\n").getDescription());
+        Assert.assertEquals("meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']", GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum']\n\t.measure\n\t.canonicalUnit\n\t.measure.nonCanonicalUnits[    'RomanLength~Actus'    ]\n").getDescription());
     }
 
     @Test
@@ -870,8 +893,8 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 Lists.mutable.with("properties / name / prop2", "genericType", "rawType"),
                 GraphPath.parse("test::domain::ClassA.properties['prop2'].genericType.rawType").getEdges().collect(e -> e.visit(visitor)));
         Assert.assertEquals(
-                Lists.mutable.with("measure", "canonicalUnit", "measure", "nonCanonicalUnits / name / RomanLength~Actus"),
-                GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']").getEdges().collect(e -> e.visit(visitor)));
+                Lists.mutable.with("nonCanonicalUnits / name / RomanLength~Cubitum", "measure", "canonicalUnit", "measure", "nonCanonicalUnits / name / RomanLength~Actus"),
+                GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']").getEdges().collect(e -> e.visit(visitor)));
     }
 
     @Test
@@ -917,9 +940,9 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
         toOneEdges.clear();
         toManyIndexEdges.clear();
         toManyKeyEdges.clear();
-        GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength~Cubitum.measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']").forEachEdge(consumer);
+        GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']").forEachEdge(consumer);
         Assert.assertEquals(Lists.mutable.with(new ToOnePropertyEdge("measure"), new ToOnePropertyEdge("canonicalUnit"), new ToOnePropertyEdge("measure")), toOneEdges);
         Assert.assertEquals(Lists.mutable.empty(), toManyIndexEdges);
-        Assert.assertEquals(Lists.mutable.with(new ToManyPropertyWithStringKeyEdge("nonCanonicalUnits", "name", "RomanLength~Actus")), toManyKeyEdges);
+        Assert.assertEquals(Lists.mutable.with(new ToManyPropertyWithStringKeyEdge("nonCanonicalUnits", "name", "RomanLength~Cubitum"), new ToManyPropertyWithStringKeyEdge("nonCanonicalUnits", "name", "RomanLength~Actus")), toManyKeyEdges);
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/navigation/graph/TestGraphPath.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/navigation/graph/TestGraphPath.java
@@ -131,20 +131,20 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 "meta::pure::functions::meta::tests::model::RomanLength",
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength").getDescription());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum']",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum']",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").getDescription());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperty("measure").getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum'].measure",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperty("measure").getDescription());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit").getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum'].measure.canonicalUnit",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit").getDescription());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum'].measure.canonicalUnit.measure",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").getDescription());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getDescription());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['Actus']",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().getDescription());
     }
 
     @Test
@@ -212,20 +212,20 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 "meta::pure::functions::meta::tests::model::RomanLength",
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength").getPureExpression());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Cubitum')->toOne()",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'Cubitum')->toOne()",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").getPureExpression());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Cubitum')->toOne().measure",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperty("measure").getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'Cubitum')->toOne().measure",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperty("measure").getPureExpression());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Cubitum')->toOne().measure.canonicalUnit",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit").getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'Cubitum')->toOne().measure.canonicalUnit",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit").getPureExpression());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Cubitum')->toOne().measure.canonicalUnit.measure",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'Cubitum')->toOne().measure.canonicalUnit.measure",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").getPureExpression());
         Assert.assertEquals(
-                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Cubitum')->toOne().measure.canonicalUnit.measure.nonCanonicalUnits->find(x | $x.name == 'RomanLength~Actus')->toOne()",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getPureExpression());
+                "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits->find(x | $x.name == 'Cubitum')->toOne().measure.canonicalUnit.measure.nonCanonicalUnits->find(x | $x.name == 'Actus')->toOne()",
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().getPureExpression());
     }
 
     @Test
@@ -294,19 +294,19 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength").getStartNodePath());
         Assert.assertEquals(
                 "meta::pure::functions::meta::tests::model::RomanLength",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").build().getStartNodePath());
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").build().getStartNodePath());
         Assert.assertEquals(
                 "meta::pure::functions::meta::tests::model::RomanLength",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperty("measure").build().getStartNodePath());
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperty("measure").build().getStartNodePath());
         Assert.assertEquals(
                 "meta::pure::functions::meta::tests::model::RomanLength",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit").build().getStartNodePath());
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit").build().getStartNodePath());
         Assert.assertEquals(
                 "meta::pure::functions::meta::tests::model::RomanLength",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build().getStartNodePath());
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build().getStartNodePath());
         Assert.assertEquals(
                 "meta::pure::functions::meta::tests::model::RomanLength",
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().getStartNodePath());
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().getStartNodePath());
     }
 
     @Test
@@ -361,20 +361,20 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength").resolve(processorSupport));
         Assert.assertEquals(
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Cubitum"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").build().resolve(processorSupport));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Cubitum"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").build().resolve(processorSupport));
         Assert.assertEquals(
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperty("measure").build().resolve(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperty("measure").build().resolve(processorSupport));
         Assert.assertEquals(
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueForMetaPropertyToOne("canonicalUnit"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit").build().resolve(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit").build().resolve(processorSupport));
         Assert.assertEquals(
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build().resolve(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build().resolve(processorSupport));
         Assert.assertEquals(
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Actus"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().resolve(processorSupport));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Actus"),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().resolve(processorSupport));
     }
 
     @Test
@@ -521,35 +521,35 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"));
         assertResolveFully(
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").build(),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Cubitum"));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Cubitum"));
         assertResolveFully(
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperty("measure").build(),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperty("measure").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Cubitum"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Cubitum"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"));
         assertResolveFully(
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit").build(),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Cubitum"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Cubitum"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueForMetaPropertyToOne("canonicalUnit"));
         assertResolveFully(
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build(),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Cubitum"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Cubitum"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueForMetaPropertyToOne("canonicalUnit"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"));
         assertResolveFully(
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build(),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Cubitum"),
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Cubitum"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueForMetaPropertyToOne("canonicalUnit"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "RomanLength~Actus"));
+                runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Actus"));
     }
 
     private void assertResolveFully(GraphPath path, CoreInstance... nodes)
@@ -596,41 +596,41 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
 
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(0));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().subpath(0));
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-4));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().subpath(-4));
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(1));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().subpath(1));
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-3));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().subpath(-3));
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(2));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().subpath(2));
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-2));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().subpath(-2));
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(3));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().subpath(3));
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength~Cubitum", "measure", "canonicalUnit", "measure"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-1));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().subpath(-1));
         Assert.assertEquals(
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build(),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(4));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build(),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().subpath(4));
         Assert.assertEquals(
                 "Index: 5; size: 4",
                 Assert.assertThrows(
                         IndexOutOfBoundsException.class,
-                        () -> GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(5)).getMessage());
+                        () -> GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().subpath(5)).getMessage());
         Assert.assertEquals(
                 "Index: -5; size: 4",
                 Assert.assertThrows(
                         IndexOutOfBoundsException.class,
-                        () -> GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().subpath(-5)).getMessage());
+                        () -> GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().subpath(-5)).getMessage());
     }
 
     @Test
@@ -701,20 +701,20 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength"),
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength").reduce(processorSupport));
         Assert.assertEquals(
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").build(),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").build().reduce(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").build(),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").build().reduce(processorSupport));
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperty("measure").build().reduce(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperty("measure").build().reduce(processorSupport));
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength", "canonicalUnit"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit").build().reduce(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit").build().reduce(processorSupport));
         Assert.assertEquals(
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build().reduce(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build().reduce(processorSupport));
         Assert.assertEquals(
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build(),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "RomanLength~Actus").build().reduce(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build(),
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().reduce(processorSupport));
     }
 
     @Test
@@ -820,16 +820,16 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                         "Integer.generalizations",
                         "Integer.generalizations.general",
                         "Integer.generalizations.general.rawType",
-                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum']",
-                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure",
-                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit",
-                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure",
-                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']")
+                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum']",
+                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum'].measure",
+                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum'].measure.canonicalUnit",
+                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum'].measure.canonicalUnit.measure",
+                        "meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['Actus']")
                 .forEach(s -> Assert.assertEquals(s, GraphPath.parse(s).getDescription()));
 
         // excess whitespace is not present when generating the description
         Assert.assertEquals("test::domain::ClassA", GraphPath.parse("\t\ttest::domain::ClassA\n\n").getDescription());
-        Assert.assertEquals("meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']", GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum']\n\t.measure\n\t.canonicalUnit\n\t.measure.nonCanonicalUnits[    'RomanLength~Actus'    ]\n").getDescription());
+        Assert.assertEquals("meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['Actus']", GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum']\n\t.measure\n\t.canonicalUnit\n\t.measure.nonCanonicalUnits[    'Actus'    ]\n").getDescription());
     }
 
     @Test
@@ -893,8 +893,8 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 Lists.mutable.with("properties / name / prop2", "genericType", "rawType"),
                 GraphPath.parse("test::domain::ClassA.properties['prop2'].genericType.rawType").getEdges().collect(e -> e.visit(visitor)));
         Assert.assertEquals(
-                Lists.mutable.with("nonCanonicalUnits / name / RomanLength~Cubitum", "measure", "canonicalUnit", "measure", "nonCanonicalUnits / name / RomanLength~Actus"),
-                GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']").getEdges().collect(e -> e.visit(visitor)));
+                Lists.mutable.with("nonCanonicalUnits / name / Cubitum", "measure", "canonicalUnit", "measure", "nonCanonicalUnits / name / Actus"),
+                GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['Actus']").getEdges().collect(e -> e.visit(visitor)));
     }
 
     @Test
@@ -940,9 +940,9 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
         toOneEdges.clear();
         toManyIndexEdges.clear();
         toManyKeyEdges.clear();
-        GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['RomanLength~Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['RomanLength~Actus']").forEachEdge(consumer);
+        GraphPath.parse("meta::pure::functions::meta::tests::model::RomanLength.nonCanonicalUnits['Cubitum'].measure.canonicalUnit.measure.nonCanonicalUnits['Actus']").forEachEdge(consumer);
         Assert.assertEquals(Lists.mutable.with(new ToOnePropertyEdge("measure"), new ToOnePropertyEdge("canonicalUnit"), new ToOnePropertyEdge("measure")), toOneEdges);
         Assert.assertEquals(Lists.mutable.empty(), toManyIndexEdges);
-        Assert.assertEquals(Lists.mutable.with(new ToManyPropertyWithStringKeyEdge("nonCanonicalUnits", "name", "RomanLength~Cubitum"), new ToManyPropertyWithStringKeyEdge("nonCanonicalUnits", "name", "RomanLength~Actus")), toManyKeyEdges);
+        Assert.assertEquals(Lists.mutable.with(new ToManyPropertyWithStringKeyEdge("nonCanonicalUnits", "name", "Cubitum"), new ToManyPropertyWithStringKeyEdge("nonCanonicalUnits", "name", "Actus")), toManyKeyEdges);
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractCompiledStateIntegrityTest.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractCompiledStateIntegrityTest.java
@@ -33,6 +33,7 @@ import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.compiler.ReferenceUsage;
 import org.finos.legend.pure.m3.coreinstance.Package;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
@@ -44,6 +45,7 @@ import org.finos.legend.pure.m3.navigation._package._Package;
 import org.finos.legend.pure.m3.navigation.function.FunctionType;
 import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.navigation.type.Type;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
@@ -1111,6 +1113,10 @@ public abstract class AbstractCompiledStateIntegrityTest
         {
             return FunctionType.print(type, true, processorSupport);
         }
+        if (type instanceof Unit)
+        {
+            return Measure.getUserPathForUnit(type);
+        }
         throw new RuntimeException("Cannot generate string for: " + type);
     }
 
@@ -1125,6 +1131,10 @@ public abstract class AbstractCompiledStateIntegrityTest
         else if (specific instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType)
         {
             FunctionType.print(builder, specific, true, processorSupport);
+        }
+        else if (specific instanceof Unit)
+        {
+            Measure.writeUserPathForUnit(builder, specific);
         }
         else
         {

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractTestMeasure.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractTestMeasure.java
@@ -31,7 +31,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                     "   *Gram: x -> $x;\n" +
                     "   Kilogram: x -> $x*1000;\n" +
                     "   Pound: x -> $x*453.59;\n" +
-                    "}";
+                    "}\n";
 
     private static final String plusFunction =
             "function meta::pure::functions::math::sum(numbers:Number[*]):Number[1]\n" +
@@ -40,7 +40,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                     "}\n" +
                     "function meta::pure::functions::math::plus(masses: Mass[*]):Mass~Gram[1]\n" +
                     "{\n" +
-                    "   let cv = $masses->map(m|let cv = $m->type()->cast(@Unit).conversionFunction->cast(@Function<{Number[1]->Number[1]}>)->toOne()->eval(getUnitValue($m)););\n" +
+                    "   let cv = $masses->map(m|let cv = $m->type()->cast(@Unit).conversionFunction->cast(@Function<{Number[1]->Number[1]}>)->toOne()->eval(getUnitValue($m)));\n" +
                     "   let resultNumeric = $cv->sum();\n" +
                     "   newUnit(Mass~Gram, $resultNumeric)->cast(@Mass~Gram);\n" +
                     "}\n";
@@ -48,7 +48,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
     private static final String minusFunction =
             "function meta::pure::functions::math::minus(masses: Mass[*]):Mass~Gram[1]\n" +
                     "{\n" +
-                    "   let cv = $masses->map(m|let cv = $m->type()->cast(@Unit).conversionFunction->cast(@Function<{Number[1]->Number[1]}>)->toOne()->eval(getUnitValue($m)););\n" +
+                    "   let cv = $masses->map(m|let cv = $m->type()->cast(@Unit).conversionFunction->cast(@Function<{Number[1]->Number[1]}>)->toOne()->eval(getUnitValue($m)));\n" +
                     "   let resultNumeric = $cv->minus();\n" +
                     "   newUnit(Mass~Gram, $resultNumeric)->cast(@Mass~Gram);\n" +
                     "}\n";
@@ -91,7 +91,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   1 Mass~Pound;\n" +
                         "}\n");
         CoreInstance result = execute("testFunc():Mass~Pound[0..1]");
-        Assert.assertEquals("Mass~Pound", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Pound", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("1", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -158,7 +158,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   testUnits(5 Mass~Kilogram);\n" +
                         "}");
         CoreInstance result = execute("testUnitsWrapper():Mass~Kilogram[1]");
-        Assert.assertEquals("Mass~Kilogram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Kilogram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("5", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -206,7 +206,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   testUnits(5 Mass~Kilogram);\n" +
                         "}");
         CoreInstance result = execute("testUnitsWrapper():Mass[1]");
-        Assert.assertEquals("Mass~Kilogram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Kilogram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("5", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -226,7 +226,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   testUnits(5 Mass~Kilogram);\n" +
                         "}");
         CoreInstance result = execute("testUnitsWrapper():Mass[1]");
-        Assert.assertEquals("Mass~Kilogram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Kilogram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("5", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -246,7 +246,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   testUnits(5 Mass~Kilogram);\n" +
                         "}");
         CoreInstance result = execute("testUnitsWrapper():Mass~Kilogram[1]");
-        Assert.assertEquals("Mass~Kilogram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Kilogram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("5", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -261,7 +261,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   5 Mass~Kilogram->cast(@Mass~Kilogram);\n" +
                         "}");
         CoreInstance result = execute("testUnitsWrapper():Mass~Kilogram[1]");
-        Assert.assertEquals("Mass~Kilogram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Kilogram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("5", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -276,7 +276,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   5 Mass~Kilogram->cast(@Mass);\n" +
                         "}");
         CoreInstance result = execute("testUnitsWrapper():Mass[1]");
-        Assert.assertEquals("Mass~Kilogram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Kilogram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("5", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -320,7 +320,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   $teddy;" +
                         "}");
         CoreInstance result = execute("testFunc():Mass~Pound[1]");
-        Assert.assertEquals("Mass~Pound", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Pound", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("10", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -394,7 +394,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   let result2 = $result + 50 Mass~Gram;\n" +
                         "}");
         CoreInstance result = execute("testFunc():Any[1]");
-        Assert.assertEquals("Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("5550", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -416,7 +416,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   $y + 5 Mass~Kilogram;\n" +
                         "}");
         CoreInstance result = execute("testParamsWrapper():Mass~Gram[1]");
-        Assert.assertEquals("Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("5907.18", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -435,7 +435,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   let result2 = $result - 50 Mass~Gram;\n" +
                         "}");
         CoreInstance result = execute("testFunc():Any[1]");
-        Assert.assertEquals("Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("4650", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -452,7 +452,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   $a.lb;\n" +
                         "}");
         CoreInstance lb = execute("testKilogramInstanceAsClassProperty():Mass~Pound[1]");
-        Assert.assertEquals("Mass~Pound", GenericType.print(lb.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Pound", GenericType.print(lb.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("5", lb.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -478,7 +478,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   $newA.doStuff();\n" +
                         "}\n");
         CoreInstance result = execute("testQPWrapper():Mass~Gram[1]");
-        Assert.assertEquals("Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("2453.59", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -499,7 +499,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   testParams(3 Mass~Pound, 5 Mass~Kilogram);\n" +
                         "}\n");
         CoreInstance result = execute("testParamsWrapper():Mass~Gram[1]");
-        Assert.assertEquals("Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("6360.77", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -520,7 +520,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   testMult(3 Mass~Kilogram);\n" +
                         "}\n");
         CoreInstance result = execute("testMultWrapper():Mass~Gram[1]");
-        Assert.assertEquals("Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("9000", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -541,7 +541,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   testDiv(9 Mass~Kilogram);\n" +
                         "}\n");
         CoreInstance result = execute("testDivWrapper():Mass~Gram[1]");
-        Assert.assertEquals("Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("3000.0", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -610,7 +610,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "}\n");
         CoreInstance result = execute("testFunc():Mass~Gram[1]");
         Assert.assertTrue(Measure.isUnitOrMeasureInstance(result, processorSupport));
-        Assert.assertEquals("Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("pkg::Mass~Gram", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("3680.385", result.getValueForMetaPropertyToOne(M3Properties.values).getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractTestMeasure.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractTestMeasure.java
@@ -14,7 +14,9 @@
 
 package org.finos.legend.pure.m3.tests;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
@@ -372,10 +374,10 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                 "import pkg::*;\n" +
                         "function testGetUnitValue():Number[1]\n" +
                         "{\n" +
-                        "getUnitValue(5 Mass~Kilogram);\n" +
+                        "    getUnitValue(5 Mass~Kilogram);\n" +
                         "}\n");
         CoreInstance result = execute("testGetUnitValue():Number[1]");
-        Assert.assertEquals("Integer", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), processorSupport));
+        Assert.assertEquals("Integer", GenericType.print(result.getValueForMetaPropertyToOne(M3Properties.genericType), true, processorSupport));
         Assert.assertEquals("5", result.getValueForMetaPropertyToOne(M3Properties.values).getName());
     }
 
@@ -563,7 +565,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   A.properties->size();\n" +
                         "}\n");
         CoreInstance result = execute("testFunc():Any[*]");
-        Assert.assertEquals("1", result.getValueForMetaPropertyToOne(M3Properties.values).getName());
+        Assert.assertEquals(1, PrimitiveUtilities.getIntegerValue(result.getValueForMetaPropertyToOne(M3Properties.values)));
     }
 
     @Test
@@ -587,7 +589,7 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
                         "   A.properties->size();\n" +
                         "}\n");
         CoreInstance result = execute("testFunc():Any[*]");
-        Assert.assertEquals("4", result.getValueForMetaPropertyToOne(M3Properties.values).getName());
+        Assert.assertEquals(4, PrimitiveUtilities.getIntegerValue(result.getValueForMetaPropertyToOne(M3Properties.values)));
     }
 
     @Test
@@ -641,13 +643,13 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
         compileTestSource("testModel.pure", massDefinition);
         compileTestSource("testFunc.pure",
                 "import pkg::*;\n" +
-                        "function testKilogramMatchesKilogram():Integer[1]\n" +
+                        "function testKilogramMatchesKilogram():Number[1]\n" +
                         "{\n" +
                         "   let x = 5 Mass~Kilogram;\n" +
-                        "   $x->match([m:Mass~Kilogram[1] | 1]);\n" +
+                        "   $x->match([m:Mass~Kilogram[1] | $m->getUnitValue()]);\n" +
                         "}");
-        CoreInstance result = execute("testKilogramMatchesKilogram():Integer[1]");
-        Assert.assertEquals("1", result.getValueForMetaPropertyToOne(M3Properties.values).getName());
+        CoreInstance result = execute("testKilogramMatchesKilogram():Number[1]");
+        Assert.assertEquals(5, PrimitiveUtilities.getIntegerValue(result.getValueForMetaPropertyToOne(M3Properties.values)));
     }
 
     @Test
@@ -656,13 +658,13 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
         compileTestSource("testModel.pure", massDefinition);
         compileTestSource("testFunc.pure",
                 "import pkg::*;\n" +
-                        "function testKilogramMatchesKilogram():Integer[1]\n" +
+                        "function testKilogramMatchesKilogram():Number[*]\n" +
                         "{\n" +
                         "   let x = [5 Mass~Kilogram, 10 Mass~Kilogram];\n" +
-                        "   $x->match([m:Mass~Kilogram[*] | 1]);\n" +
+                        "   $x->match([kgs:Mass~Kilogram[*] | $kgs->map(kg | $kg->getUnitValue())]);\n" +
                         "}");
-        CoreInstance result = execute("testKilogramMatchesKilogram():Integer[1]");
-        Assert.assertEquals("1", result.getValueForMetaPropertyToOne(M3Properties.values).getName());
+        CoreInstance result = execute("testKilogramMatchesKilogram():Number[*]");
+        Assert.assertEquals(Lists.fixedSize.with(5, 10), result.getValueForMetaPropertyToMany(M3Properties.values).collect(PrimitiveUtilities::getIntegerValue));
     }
 
     @Test
@@ -671,13 +673,13 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
         compileTestSource("testModel.pure", massDefinition);
         compileTestSource("testFunc.pure",
                 "import pkg::*;\n" +
-                        "function testKilogramMatchesMass():Integer[1]\n" +
+                        "function testKilogramMatchesMass():Number[1]\n" +
                         "{\n" +
                         "   let x = 5 Mass~Kilogram;\n" +
-                        "   $x->match([m:Mass[1] | 1]);\n" +
+                        "   $x->match([m:Mass[1] | $m->getUnitValue()]);\n" +
                         "}");
-        CoreInstance result = execute("testKilogramMatchesMass():Integer[1]");
-        Assert.assertEquals("1", result.getValueForMetaPropertyToOne(M3Properties.values).getName());
+        CoreInstance result = execute("testKilogramMatchesMass():Number[1]");
+        Assert.assertEquals(5, PrimitiveUtilities.getIntegerValue(result.getValueForMetaPropertyToOne(M3Properties.values)));
     }
 
     @Test
@@ -686,12 +688,12 @@ public abstract class AbstractTestMeasure extends AbstractPureTestWithCoreCompil
         compileTestSource("testModel.pure", massDefinition);
         compileTestSource("testFunc.pure",
                 "import pkg::*;\n" +
-                        "function testKilogramMatchesMass():Integer[1]\n" +
+                        "function testKilogramMatchesMass():Number[*]\n" +
                         "{\n" +
                         "   let x = [5 Mass~Kilogram, 10 Mass~Kilogram];\n" +
-                        "   $x->match([m:Mass[*] | 1]);\n" +
+                        "   $x->match([masses:Mass[*] | $masses->map(m | $m->getUnitValue())]);\n" +
                         "}");
-        CoreInstance result = execute("testKilogramMatchesMass():Integer[1]");
-        Assert.assertEquals("1", result.getValueForMetaPropertyToOne(M3Properties.values).getName());
+        CoreInstance result = execute("testKilogramMatchesMass():Number[*]");
+        Assert.assertEquals(Lists.fixedSize.with(5, 10), result.getValueForMetaPropertyToMany(M3Properties.values).collect(PrimitiveUtilities::getIntegerValue));
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/measure/TestMeasureGraphCorrectness.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/measure/TestMeasureGraphCorrectness.java
@@ -29,20 +29,6 @@ import org.junit.Test;
 
 public class TestMeasureGraphCorrectness extends AbstractPureTestWithCoreCompiled
 {
-    @BeforeClass
-    public static void setUp()
-    {
-        setUpRuntime(getFunctionExecution());
-    }
-
-    @After
-    public void clearRuntime()
-    {
-        runtime.delete("testModel.pure");
-        runtime.delete("testSource.pure");
-        runtime.compile();
-    }
-
     private static final String massDefinition =
             "Measure pkg::Mass\n" +
                     "{\n" +
@@ -81,6 +67,20 @@ public class TestMeasureGraphCorrectness extends AbstractPureTestWithCoreCompile
                     "   EUR;\n" +
                     "}\n";
 
+    @BeforeClass
+    public static void setUp()
+    {
+        setUpRuntime(getFunctionExecution());
+    }
+
+    @After
+    public void clearRuntime()
+    {
+        runtime.delete("testModel.pure");
+        runtime.delete("testSource.pure");
+        runtime.compile();
+    }
+
     @Test
     public void testMeasureBuildsCorrectlyInGraph()
     {
@@ -118,7 +118,7 @@ public class TestMeasureGraphCorrectness extends AbstractPureTestWithCoreCompile
     public void testUnitBuildsCorrectlyInGraph()
     {
         compileTestSource("testModel.pure", massDefinition);
-        CoreInstance kilogramCoreInstance = runtime.getCoreInstance("pkg::Mass~Kilogram");
+        CoreInstance kilogramCoreInstance = org.finos.legend.pure.m3.navigation.measure.Measure.findUnit(runtime.getCoreInstance("pkg::Mass"), "Mass~Kilogram");
         Assert.assertEquals("Mass~Kilogram", kilogramCoreInstance.getName());
         Assert.assertTrue(kilogramCoreInstance instanceof Unit);
         Assert.assertEquals("Unit", kilogramCoreInstance.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToOne(M3Properties.rawType).getName());
@@ -126,15 +126,13 @@ public class TestMeasureGraphCorrectness extends AbstractPureTestWithCoreCompile
         CoreInstance myMeasure = kilogramCoreInstance.getValueForMetaPropertyToOne(M3Properties.measure);
         Assert.assertEquals("Mass", myMeasure.getName());
         Assert.assertTrue(myMeasure instanceof Measure);
-        CoreInstance myPackage = kilogramCoreInstance.getValueForMetaPropertyToOne(M3Properties._package);
-        Assert.assertEquals("pkg", myPackage.getName());
     }
 
     @Test
     public void testNonConvertibleUnitBuildsCorrectlyInGraph()
     {
         compileTestSource("testModel.pure", currencyDefinition);
-        CoreInstance dollarCoreInstance = runtime.getCoreInstance("pkg::Currency~USD");
+        CoreInstance dollarCoreInstance = org.finos.legend.pure.m3.navigation.measure.Measure.findUnit(runtime.getCoreInstance("pkg::Currency"), "Currency~USD");
         Assert.assertEquals("Currency~USD", dollarCoreInstance.getName());
         Assert.assertTrue(dollarCoreInstance instanceof Unit);
         Assert.assertEquals("Unit", dollarCoreInstance.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToOne(M3Properties.rawType).getName());
@@ -142,8 +140,6 @@ public class TestMeasureGraphCorrectness extends AbstractPureTestWithCoreCompile
         CoreInstance myMeasure = dollarCoreInstance.getValueForMetaPropertyToOne(M3Properties.measure);
         Assert.assertEquals("Currency", myMeasure.getName());
         Assert.assertTrue(myMeasure instanceof Measure);
-        CoreInstance myPackage = dollarCoreInstance.getValueForMetaPropertyToOne(M3Properties._package);
-        Assert.assertEquals("pkg", myPackage.getName());
     }
 
     @Test

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/measure/TestMeasureGraphCorrectness.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/measure/TestMeasureGraphCorrectness.java
@@ -14,11 +14,12 @@
 
 package org.finos.legend.pure.m3.tests.function.base.measure;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
+import org.finos.legend.pure.m3.coreinstance.Package;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
-import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.serialization.grammar.antlr.PureParserException;
@@ -67,10 +68,17 @@ public class TestMeasureGraphCorrectness extends AbstractPureTestWithCoreCompile
                     "   EUR;\n" +
                     "}\n";
 
+    private static CoreInstance measureClass;
+    private static CoreInstance unitClass;
+
     @BeforeClass
     public static void setUp()
     {
         setUpRuntime(getFunctionExecution());
+        measureClass = runtime.getCoreInstance(M3Paths.Measure);
+        unitClass = runtime.getCoreInstance(M3Paths.Unit);
+        Assert.assertNotNull(measureClass);
+        Assert.assertNotNull(unitClass);
     }
 
     @After
@@ -85,61 +93,40 @@ public class TestMeasureGraphCorrectness extends AbstractPureTestWithCoreCompile
     public void testMeasureBuildsCorrectlyInGraph()
     {
         compileTestSource("testModel.pure", massDefinition);
-        CoreInstance massCoreInstance = runtime.getCoreInstance("pkg::Mass");
-        Assert.assertEquals("Mass", massCoreInstance.getName());
-        Assert.assertTrue(massCoreInstance instanceof Measure);
-        Assert.assertEquals("Measure", massCoreInstance.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToOne(M3Properties.rawType).getName());
-        CoreInstance canonicalUnit = massCoreInstance.getValueForMetaPropertyToOne("canonicalUnit");
-        Assert.assertEquals("Mass~Gram", canonicalUnit.getName());
-        Assert.assertTrue(canonicalUnit instanceof Unit);
-        ListIterable<? extends CoreInstance> nonCanonicalUnits = massCoreInstance.getValueForMetaPropertyToMany("nonCanonicalUnits");
-        Assert.assertEquals("Mass~Kilogram", nonCanonicalUnits.get(0).getName());
-        Assert.assertTrue(nonCanonicalUnits.get(0) instanceof Unit);
-        Assert.assertEquals("Mass~Pound", nonCanonicalUnits.get(1).getName());
-        Assert.assertTrue(nonCanonicalUnits.get(1) instanceof Unit);
-        Assert.assertEquals("pkg", massCoreInstance.getValueForMetaPropertyToOne(M3Properties._package).getName());
+        Measure mass = getAndAssertMeasure("pkg::Mass");
+
+        assertUnit(mass, "Gram", true, mass._canonicalUnit());
+
+        ListIterable<? extends Unit> nonCanonicalUnits = mass._nonCanonicalUnits().toList();
+        assertUnit(mass, "Kilogram", true, nonCanonicalUnits.get(0));
+        assertUnit(mass, "Pound", true, nonCanonicalUnits.get(1));
+        Assert.assertEquals(2, nonCanonicalUnits.size());
     }
 
     @Test
     public void testMeasureWithOnlyCanonicalUnitBuildsCorrectlyInGraph()
     {
         compileTestSource("testModel.pure", distanceDefinition);
-        CoreInstance distanceCoreInstance = runtime.getCoreInstance("pkg::Distance");
-        Assert.assertEquals("Distance", distanceCoreInstance.getName());
-        Assert.assertTrue(distanceCoreInstance instanceof Measure);
-        Assert.assertEquals("Measure", distanceCoreInstance.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToOne(M3Properties.rawType).getName());
-        CoreInstance canonicalUnit = distanceCoreInstance.getValueForMetaPropertyToOne("canonicalUnit");
-        Assert.assertEquals("Distance~Meter", canonicalUnit.getName());
-        Assert.assertTrue(canonicalUnit instanceof Unit);
-        Assert.assertEquals("pkg", distanceCoreInstance.getValueForMetaPropertyToOne(M3Properties._package).getName());
-    }
+        Measure distance = getAndAssertMeasure("pkg::Distance");
 
-    @Test
-    public void testUnitBuildsCorrectlyInGraph()
-    {
-        compileTestSource("testModel.pure", massDefinition);
-        CoreInstance kilogramCoreInstance = org.finos.legend.pure.m3.navigation.measure.Measure.findUnit(runtime.getCoreInstance("pkg::Mass"), "Mass~Kilogram");
-        Assert.assertEquals("Mass~Kilogram", kilogramCoreInstance.getName());
-        Assert.assertTrue(kilogramCoreInstance instanceof Unit);
-        Assert.assertEquals("Unit", kilogramCoreInstance.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToOne(M3Properties.rawType).getName());
-        Assert.assertTrue(kilogramCoreInstance.getValueForMetaPropertyToOne(M3Properties.conversionFunction) instanceof LambdaFunction);
-        CoreInstance myMeasure = kilogramCoreInstance.getValueForMetaPropertyToOne(M3Properties.measure);
-        Assert.assertEquals("Mass", myMeasure.getName());
-        Assert.assertTrue(myMeasure instanceof Measure);
+        assertUnit(distance, "Meter", true, distance._canonicalUnit());
+
+        Assert.assertEquals(Lists.fixedSize.empty(), distance._nonCanonicalUnits().toList());
     }
 
     @Test
     public void testNonConvertibleUnitBuildsCorrectlyInGraph()
     {
         compileTestSource("testModel.pure", currencyDefinition);
-        CoreInstance dollarCoreInstance = org.finos.legend.pure.m3.navigation.measure.Measure.findUnit(runtime.getCoreInstance("pkg::Currency"), "Currency~USD");
-        Assert.assertEquals("Currency~USD", dollarCoreInstance.getName());
-        Assert.assertTrue(dollarCoreInstance instanceof Unit);
-        Assert.assertEquals("Unit", dollarCoreInstance.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToOne(M3Properties.rawType).getName());
-        Assert.assertNull(dollarCoreInstance.getValueForMetaPropertyToOne(M3Properties.conversionFunction));
-        CoreInstance myMeasure = dollarCoreInstance.getValueForMetaPropertyToOne(M3Properties.measure);
-        Assert.assertEquals("Currency", myMeasure.getName());
-        Assert.assertTrue(myMeasure instanceof Measure);
+
+        Measure currency = getAndAssertMeasure("pkg::Currency");
+
+        assertUnit(currency, "USD", false, currency._canonicalUnit());
+
+        ListIterable<? extends Unit> nonCanonicalUnits = currency._nonCanonicalUnits().toList();
+        assertUnit(currency, "GBP", false, nonCanonicalUnits.get(0));
+        assertUnit(currency, "EUR", false, nonCanonicalUnits.get(1));
+        Assert.assertEquals(2, nonCanonicalUnits.size());
     }
 
     @Test
@@ -154,5 +141,48 @@ public class TestMeasureGraphCorrectness extends AbstractPureTestWithCoreCompile
     {
         PureParserException e = Assert.assertThrows(PureParserException.class, () -> compileTestSource("testSource.pure", currencyDefinitionWithCanonicalUnit));
         assertPureException(PureParserException.class, "expected: ':' found: ';'", 3, 8, e);
+    }
+
+    private Measure getAndAssertMeasure(String path)
+    {
+        CoreInstance rawInstance = runtime.getCoreInstance(path);
+        Assert.assertTrue(path, rawInstance instanceof Measure);
+        Measure measure = (Measure) rawInstance;
+
+        int lastSep = path.lastIndexOf("::");
+        String name = (lastSep == -1) ? path : path.substring(lastSep + 2);
+        String pkg = (lastSep == -1) ? "::" : path.substring(0, lastSep);
+        assertMeasure(name, pkg, measure);
+
+        return measure;
+    }
+
+    private void assertMeasure(String expectedName, String expectedPackage, Measure measure)
+    {
+        Assert.assertEquals(expectedName, measure.getName());
+        Assert.assertEquals(expectedName, measure._name());
+        Assert.assertEquals(expectedName, measureClass, measure.getClassifier());
+        Assert.assertEquals(expectedName, measureClass, measure._classifierGenericType()._rawType());
+
+        CoreInstance pkg = runtime.getCoreInstance(expectedPackage);
+        Assert.assertTrue(expectedPackage, pkg instanceof Package);
+        Assert.assertEquals(pkg, measure._package());
+    }
+
+    private void assertUnit(Measure measure, String name, boolean hasConversionFn, Unit unit)
+    {
+        Assert.assertEquals(name, unit.getName());
+        Assert.assertEquals(name, unit._name());
+        Assert.assertEquals(measure, unit._measure());
+        Assert.assertEquals(name, unitClass, unit.getClassifier());
+        Assert.assertEquals(name, unitClass, unit._classifierGenericType()._rawType());
+        if (hasConversionFn)
+        {
+            Assert.assertNotNull(name, unit._conversionFunction());
+        }
+        else
+        {
+            Assert.assertNull(name, unit._conversionFunction());
+        }
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_FunctionParamType.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_FunctionParamType.java
@@ -48,39 +48,39 @@ public class TestPureRuntimeClass_FunctionParamType extends AbstractPureTestWith
     }
 
     @Test
-    public void testPureRuntimeClassAsFunctionParameterType() throws Exception
+    public void testPureRuntimeClassAsFunctionParameterType()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{name:String[1];}")
-                        .createInMemorySource("userId.pure", "function f(c:A[0]):A[0]{$c}" +
+                        .createInMemorySource("userId.pure", "function f(c:A[*]):Any[*]{$c}" +
                                 "function test():Boolean[1]{assert(f([])->isEmpty(),|'')}")
                         .compile(),
                 new RuntimeTestScriptBuilder()
                         .deleteSource("sourceId.pure")
-                        .compileWithExpectedCompileFailure("A has not been defined!", "userId.pure", 1, 20)
+                        .compileWithExpectedCompileFailure("A has not been defined!", "userId.pure", 1, 14)
                         .createInMemorySource("sourceId.pure", "Class A{name:String[1];}")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
-    public void testPureRuntimeClassAsFunctionParameterTypeError() throws Exception
+    public void testPureRuntimeClassAsFunctionParameterTypeError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{}")
-                        .createInMemorySource("userId.pure", "function f(c:A[0]):A[0]{$c}" +
+                        .createInMemorySource("userId.pure", "function f(c:A[*]):Any[*]{$c}" +
                                 "function test():Boolean[1]{assert(f([])->isEmpty(),|'')}")
                         .compile(),
                 new RuntimeTestScriptBuilder()
                         .deleteSource("sourceId.pure")
-                        .compileWithExpectedCompileFailure("A has not been defined!", "userId.pure", 1, 20)
+                        .compileWithExpectedCompileFailure("A has not been defined!", "userId.pure", 1, 14)
                         .createInMemorySource("sourceId.pure", "Class B{}")
-                        .compileWithExpectedCompileFailure("A has not been defined!", "userId.pure", 1, 20)
+                        .compileWithExpectedCompileFailure("A has not been defined!", "userId.pure", 1, 14)
                         .updateSource("sourceId.pure", "Class A{}")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
-    public void testPureRuntimeClassAsLambdaParameter() throws Exception
+    public void testPureRuntimeClassAsLambdaParameter()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{}")
                         .createInMemorySource("userId.pure", "function test():Nil[0]{f({a:A[1]|[]->cast(@A)}->eval(^A()));}")
@@ -95,7 +95,7 @@ public class TestPureRuntimeClass_FunctionParamType extends AbstractPureTestWith
     }
 
     @Test
-    public void testPureRuntimeClassAsLambdaParameterError() throws Exception
+    public void testPureRuntimeClassAsLambdaParameterError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{}")
                         .createInMemorySource("userId.pure", "function test():Nil[0]{f({a:A[1]|[]->cast(@A)}->eval(^A()));}")
@@ -114,7 +114,7 @@ public class TestPureRuntimeClass_FunctionParamType extends AbstractPureTestWith
 
 
     @Test
-    public void testPureRuntimeClassAsLambdaParameterAndReturn() throws Exception
+    public void testPureRuntimeClassAsLambdaParameterAndReturn()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{}")
                         .createInMemorySource("userId.pure", "function test():Nil[0]{f({a:A[1]|[]->cast(@A)}->eval(^A()));}")
@@ -129,7 +129,7 @@ public class TestPureRuntimeClass_FunctionParamType extends AbstractPureTestWith
     }
 
     @Test
-    public void testPureRuntimeClassAsLambdaParameterAndReturnError() throws Exception
+    public void testPureRuntimeClassAsLambdaParameterAndReturnError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{}")
                         .createInMemorySource("userId.pure", "function test():Nil[0]{f({a:A[1]|$a}->eval(^A()));}")
@@ -147,7 +147,7 @@ public class TestPureRuntimeClass_FunctionParamType extends AbstractPureTestWith
 
 
     @Test
-    public void testPureRuntimeClassAsLambdaParameterWithFuncInside() throws Exception
+    public void testPureRuntimeClassAsLambdaParameterWithFuncInside()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{}")
                         .createInMemorySource("userId.pure", "function test():Nil[0]{^A()->match(a:A[1]|f($a));}")
@@ -162,7 +162,7 @@ public class TestPureRuntimeClass_FunctionParamType extends AbstractPureTestWith
     }
 
     @Test
-    public void testPureRuntimeClassAsLambdaParameterWithFuncInsideError() throws Exception
+    public void testPureRuntimeClassAsLambdaParameterWithFuncInsideError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{} Class B{a:A[1];}")
                         .createInMemorySource("userId.pure", "function test():Nil[0]{^B(a=^A())->match(b:B[1]|f($b.a));}")
@@ -179,7 +179,7 @@ public class TestPureRuntimeClass_FunctionParamType extends AbstractPureTestWith
     }
 
     @Test
-    public void testPureRuntimeClassAsLambda() throws Exception
+    public void testPureRuntimeClassAsLambda()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{} function k(a:Any[1]):Nil[0]{[]}")
                         .createInMemorySource("userId.pure", "function test():Nil[0]{k(a:A[1]|f($a));}")
@@ -194,7 +194,7 @@ public class TestPureRuntimeClass_FunctionParamType extends AbstractPureTestWith
     }
 
     @Test
-    public void testPureRuntimeClassAsFunctionParameterTypeReverse() throws Exception
+    public void testPureRuntimeClassAsFunctionParameterTypeReverse()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("otherId.pure", "Class TK{}")
                         .createInMemorySource("sourceId.pure", "function isContract(p:TK[1]):Nil[0]\n" +
@@ -214,7 +214,7 @@ public class TestPureRuntimeClass_FunctionParamType extends AbstractPureTestWith
     }
 
     @Test
-    public void testPureRuntimeClassAsQualifiedPropertyParameter() throws Exception
+    public void testPureRuntimeClassAsQualifiedPropertyParameter()
     {
         ImmutableMap<String, String> sources = Maps.immutable.with(
                 "sourceId.pure", "Class A{name:String[1];}",

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/measure/TestPureRuntimeMeasure.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/measure/TestPureRuntimeMeasure.java
@@ -23,22 +23,6 @@ import org.junit.Test;
 
 public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlatform
 {
-    @BeforeClass
-    public static void setUp()
-    {
-        setUpRuntime(getExtra());
-    }
-
-    @After
-    public void cleanRuntime()
-    {
-        runtime.delete("userId.pure");
-        runtime.delete("sourceId.pure");
-        runtime.delete("testFunc.pure");
-        runtime.compile();
-    }
-
-
     private final String measureSource = "Measure pkg::Mass \n" +
             "{\n" +
             "   *Gram: x -> $x; \n" +
@@ -65,6 +49,21 @@ public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlat
             "   EUR;\n" +
             "}\n";
 
+    @BeforeClass
+    public static void setUp()
+    {
+        setUpRuntime(getExtra());
+    }
+
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete("userId.pure");
+        runtime.delete("sourceId.pure");
+        runtime.delete("testFunc.pure");
+        runtime.compile();
+    }
+
     @Test
     public void testMeasureAsFunctionParameterTypeIncremental() throws Exception
     {
@@ -89,7 +88,7 @@ public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlat
                         .compile(),
                 new RuntimeTestScriptBuilder()
                         .deleteSource("sourceId.pure")
-                        .compileWithExpectedCompileFailure("pkg::Mass~Kilogram has not been defined!", "testFunc.pure", 1, 60)
+                        .compileWithExpectedCompileFailure("pkg::Mass has not been defined!", "testFunc.pure", 1, 60)
                         .createInMemorySource("sourceId.pure", this.measureSource)
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
@@ -104,9 +103,9 @@ public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlat
                         .compile(),
                 new RuntimeTestScriptBuilder()
                         .deleteSource("sourceId.pure")
-                        .compileWithExpectedCompileFailure("pkg::Mass~Kilogram has not been defined!", "testFunc.pure", 1, 60)
+                        .compileWithExpectedCompileFailure("pkg::Mass has not been defined!", "testFunc.pure", 1, 60)
                         .createInMemorySource("sourceId.pure", this.updatedMeasure)
-                        .compileWithExpectedCompileFailure("pkg::Mass~Kilogram has not been defined!", "testFunc.pure", 1, 60)
+                        .compileWithExpectedCompileFailure("The unit 'Mass~Kilogram' can't be found in measure 'pkg::Mass'", "testFunc.pure", 1, 60)
                         .updateSource("sourceId.pure", this.measureSource)
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
@@ -188,9 +187,9 @@ public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlat
                         .compile(),
                 new RuntimeTestScriptBuilder()
                         .deleteSource("sourceId.pure")
-                        .compileWithExpectedCompileFailure("pkg::Currency~GBP has not been defined!", "testFunc.pure", 1, 64)
+                        .compileWithExpectedCompileFailure("pkg::Currency has not been defined!", "testFunc.pure", 1, 64)
                         .createInMemorySource("sourceId.pure", this.updatedNonConvertibleMeasure)
-                        .compileWithExpectedCompileFailure("pkg::Currency~GBP has not been defined!", "testFunc.pure", 1, 64)
+                        .compileWithExpectedCompileFailure("The unit 'Currency~GBP' can't be found in measure 'pkg::Currency'", "testFunc.pure", 1, 64)
                         .updateSource("sourceId.pure", this.nonConvertibleMeasure)
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/measure/TestPureRuntimeMeasure.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/measure/TestPureRuntimeMeasure.java
@@ -14,14 +14,14 @@
 
 package org.finos.legend.pure.m3.tests.incremental.measure;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiled
 {
     private final String measureSource = "Measure pkg::Mass \n" +
             "{\n" +
@@ -65,22 +65,22 @@ public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlat
     }
 
     @Test
-    public void testMeasureAsFunctionParameterTypeIncremental() throws Exception
+    public void testMeasureAsFunctionParameterTypeIncremental()
     {
-        String testFunc = "function takesInMass(m:pkg::Mass[1]):pkg::Mass[1]{$m}";
+        String testFunc = "function takesInMass(m:pkg::Mass[1]):Any[1]{$m}";
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", this.measureSource)
                         .createInMemorySource("testFunc.pure", testFunc)
                         .compile(),
                 new RuntimeTestScriptBuilder()
                         .deleteSource("sourceId.pure")
-                        .compileWithExpectedCompileFailure("pkg::Mass has not been defined!", "testFunc.pure", 1, 43)
+                        .compileWithExpectedCompileFailure("pkg::Mass has not been defined!", "testFunc.pure", 1, 29)
                         .createInMemorySource("sourceId.pure", this.measureSource)
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
-    public void testUnitAsFunctionExpressionParameterIncremental() throws Exception
+    public void testUnitAsFunctionExpressionParameterIncremental()
     {
         String testFunc = "function instantiateUnit():String[1]{let a  = 10 pkg::Mass~Kilogram;'ok';}";
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", this.measureSource)
@@ -95,7 +95,7 @@ public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlat
     }
 
     @Test
-    public void testDeleteReferencedUnitIncrementalThrowsError() throws Exception
+    public void testDeleteReferencedUnitIncrementalThrowsError()
     {
         String testFunc = "function instantiateUnit():String[1]{let a  = 10 pkg::Mass~Kilogram;'ok';}";
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", this.measureSource)
@@ -105,14 +105,14 @@ public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlat
                         .deleteSource("sourceId.pure")
                         .compileWithExpectedCompileFailure("pkg::Mass has not been defined!", "testFunc.pure", 1, 60)
                         .createInMemorySource("sourceId.pure", this.updatedMeasure)
-                        .compileWithExpectedCompileFailure("The unit 'Mass~Kilogram' can't be found in measure 'pkg::Mass'", "testFunc.pure", 1, 60)
+                        .compileWithExpectedCompileFailure("The unit 'Kilogram' can't be found in measure 'pkg::Mass'", "testFunc.pure", 1, 60)
                         .updateSource("sourceId.pure", this.measureSource)
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
-    public void testDeleteUnreferencedUnitIncremental() throws Exception
+    public void testDeleteUnreferencedUnitIncremental()
     {
         String testFunc = "function instantiateUnit():String[1]{let a  = 10 pkg::Mass~Pound;'ok';}";
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", this.measureSource)
@@ -127,7 +127,7 @@ public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlat
     }
 
     @Test
-    public void testCanUpdateIncremental() throws Exception
+    public void testCanUpdateIncremental()
     {
         String testFunc1 = "function testFunc():Any[0..1]\n" +
                 "{\n" +
@@ -150,7 +150,7 @@ public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlat
     }
 
     @Test
-    public void testUpdateMeasureAsParameterMultiplicityManyIncremental() throws Exception
+    public void testUpdateMeasureAsParameterMultiplicityManyIncremental()
     {
         String updatedConversionFunc = "Measure pkg::Mass \n" +
                 "{\n" +
@@ -179,7 +179,7 @@ public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlat
     }
 
     @Test
-    public void testDeleteReferencedNonConvertibleUnitIncrementalThrowsError() throws Exception
+    public void testDeleteReferencedNonConvertibleUnitIncrementalThrowsError()
     {
         String testFunc = "function instantiateUnit():String[1]{let a  = 10 pkg::Currency~GBP;'ok';}";
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", this.nonConvertibleMeasure)
@@ -189,14 +189,14 @@ public class TestPureRuntimeMeasure extends AbstractPureTestWithCoreCompiledPlat
                         .deleteSource("sourceId.pure")
                         .compileWithExpectedCompileFailure("pkg::Currency has not been defined!", "testFunc.pure", 1, 64)
                         .createInMemorySource("sourceId.pure", this.updatedNonConvertibleMeasure)
-                        .compileWithExpectedCompileFailure("The unit 'Currency~GBP' can't be found in measure 'pkg::Currency'", "testFunc.pure", 1, 64)
+                        .compileWithExpectedCompileFailure("The unit 'GBP' can't be found in measure 'pkg::Currency'", "testFunc.pure", 1, 64)
                         .updateSource("sourceId.pure", this.nonConvertibleMeasure)
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
-    public void testDeleteUnreferencedNonConvertibleUnitIncremental() throws Exception
+    public void testDeleteUnreferencedNonConvertibleUnitIncremental()
     {
         String testFunc = "function instantiateUnit():String[1]{let a  = 10 pkg::Currency~EUR;'ok';}";
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", this.nonConvertibleMeasure)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledExecutionSupport.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledExecutionSupport.java
@@ -75,7 +75,7 @@ public class CompiledExecutionSupport implements ExecutionSupport
         this.sourceRegistry = sourceRegistry;
         this.codeStorage = codeStorage;
         this.incrementalCompiler = incrementalCompiler;
-        this.classCache = (classCache == null) ? new ClassCache(javaCompilerState.getClassLoader()) : ClassCache.reconcileWithClassLoader(classCache, javaCompilerState.getClassLoader());
+        this.classCache = (classCache == null) ? new ClassCache(javaCompilerState.getClassLoader(), processorSupport) : ClassCache.reconcileClassCache(classCache, javaCompilerState.getClassLoader(), processorSupport);
         this.functionCache = (functionCache == null) ? new FunctionCache(this.classCache) : FunctionCache.reconcileFunctionCache(functionCache, this.classCache);
         this.metadataProvider = metadataProvider;
         this.executionActivityListener = (executionActivityListener == null) ? VoidExecutionActivityListener.VOID_EXECUTION_ACTIVITY_LISTENER : executionActivityListener;

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledProcessorSupport.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledProcessorSupport.java
@@ -71,7 +71,7 @@ public class CompiledProcessorSupport implements ProcessorSupport
     public CompiledProcessorSupport(ClassLoader globalClassLoader, Metadata metadata, SetIterable<String> extraSupportedTypes)
     {
         this.globalClassLoader = globalClassLoader;
-        this.classCache = new ClassCache(this.globalClassLoader);
+        this.classCache = new ClassCache(this.globalClassLoader, this);
         this.metadata = metadata;
         this.metadataAccessor = new MetadataHolder(metadata);
         this.extraSupportedTypes = extraSupportedTypes;

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/JavaCompilerEventHandler.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/JavaCompilerEventHandler.java
@@ -64,7 +64,7 @@ public class JavaCompilerEventHandler implements CompilerEventHandler
         this.message = message;
         this.observer = observer;
         this.generateAndCompile = new GenerateAndCompile(this.message, this.observer);
-        this.classCache = new ClassCache(this.generateAndCompile.getPureJavaCompiler().getClassLoader());
+        this.classCache = new ClassCache(this.generateAndCompile.getPureJavaCompiler().getClassLoader(), processorSupport);
         this.sharedFunctionCache = new FunctionCache(this.classCache);
         this.includePureStackTrace = includePureStackTrace;
         this.extensions = extensions;
@@ -103,7 +103,7 @@ public class JavaCompilerEventHandler implements CompilerEventHandler
         this.generateAndCompile.generateAndCompileJavaCodeForSources(compiledSourcesByRepo, this.getJavaSourceCodeGenerator());
         this.javaGeneratedAndCompiled = true;
 
-        this.classCache = new ClassCache(getJavaCompiler().getClassLoader());
+        this.classCache = new ClassCache(getJavaCompiler().getClassLoader(), this.processorSupport);
         this.sharedFunctionCache = new FunctionCache(this.classCache);
     }
 
@@ -112,7 +112,7 @@ public class JavaCompilerEventHandler implements CompilerEventHandler
     {
         this.javaGeneratedAndCompiled = false;
         this.generateAndCompile = new GenerateAndCompile(this.message, this.observer);
-        this.classCache = new ClassCache(getJavaCompiler().getClassLoader());
+        this.classCache = new ClassCache(getJavaCompiler().getClassLoader(), this.processorSupport);
         this.sharedFunctionCache = new FunctionCache(this.classCache);
     }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaPackageAndImportBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaPackageAndImportBuilder.java
@@ -22,6 +22,8 @@ import org.finos.legend.pure.m3.coreinstance.M3PlatformCoreInstanceFactoryRegist
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.tools.SafeAppendable;
 import org.finos.legend.pure.runtime.java.compiled.extension.CompiledExtension;
@@ -153,58 +155,59 @@ public class JavaPackageAndImportBuilder
 
     // Java classes from Pure types
 
-    public static String buildImplClassReferenceFromType(CoreInstance type)
+    public static String buildImplClassReferenceFromType(CoreInstance type, ProcessorSupport processorSupport)
     {
-        return buildImplClassReferenceFromType(new StringBuilder(CODE_GEN_PACKAGE_NAME.length() + 64), type).toString();
+        return buildImplClassReferenceFromType(new StringBuilder(CODE_GEN_PACKAGE_NAME.length() + 64), type, processorSupport).toString();
     }
 
-    public static String buildImplClassReferenceFromType(CoreInstance type, String suffix)
+    public static String buildImplClassReferenceFromType(CoreInstance type, String suffix, ProcessorSupport processorSupport)
     {
-        return buildImplClassNameFromType(new StringBuilder(CODE_GEN_PACKAGE_NAME).append('.'), type, suffix).toString();
+        return buildImplClassNameFromType(new StringBuilder(CODE_GEN_PACKAGE_NAME).append('.'), type, suffix, processorSupport).toString();
     }
 
-    public static String buildImplClassNameFromType(CoreInstance element)
+    public static String buildImplClassNameFromType(CoreInstance element, ProcessorSupport processorSupport)
     {
-        return buildImplClassNameFromType(new StringBuilder(64), element).toString();
+        return buildImplClassNameFromType(new StringBuilder(64), element, processorSupport).toString();
     }
 
-    public static String buildLazyImplClassReferenceFromType(CoreInstance element)
+    public static String buildLazyImplClassReferenceFromType(CoreInstance element, ProcessorSupport processorSupport)
     {
-        return buildLazyImplClassReferenceFromType(new StringBuilder(CODE_GEN_PACKAGE_NAME.length() + 64), element).toString();
+        return buildLazyImplClassReferenceFromType(new StringBuilder(CODE_GEN_PACKAGE_NAME.length() + 64), element, processorSupport).toString();
     }
 
-    public static String buildLazyImplClassNameFromType(CoreInstance element)
+    public static String buildLazyImplClassNameFromType(CoreInstance element, ProcessorSupport processorSupport)
     {
-        return buildLazyImplClassNameFromType(new StringBuilder(64), element).toString();
+        return buildLazyImplClassNameFromType(new StringBuilder(64), element, processorSupport).toString();
     }
 
-    public static String buildImplClassNameFromType(CoreInstance element, String suffix)
+    public static String buildImplClassNameFromType(CoreInstance element, String suffix, ProcessorSupport processorSupport)
     {
-        return buildImplClassNameFromType(new StringBuilder(suffix.length() + 64), element, suffix).toString();
+        return buildImplClassNameFromType(new StringBuilder(suffix.length() + 64), element, suffix, processorSupport).toString();
     }
 
 
-    public static <T extends Appendable> T buildImplClassReferenceFromType(T appendable, CoreInstance element)
+    public static <T extends Appendable> T buildImplClassReferenceFromType(T appendable, CoreInstance element, ProcessorSupport processorSupport)
     {
-        buildImplClassNameFromType(SafeAppendable.wrap(appendable).append(CODE_GEN_PACKAGE_NAME).append('.'), element);
+        buildImplClassNameFromType(SafeAppendable.wrap(appendable).append(CODE_GEN_PACKAGE_NAME).append('.'), element, processorSupport);
         return appendable;
     }
 
-    public static <T extends Appendable> T buildImplClassNameFromType(T appendable, CoreInstance element)
+    public static <T extends Appendable> T buildImplClassNameFromType(T appendable, CoreInstance element, ProcessorSupport processorSupport)
     {
-        return buildImplClassNameFromType(appendable, element, ClassImplProcessor.CLASS_IMPL_SUFFIX);
+        return buildImplClassNameFromType(appendable, element, ClassImplProcessor.CLASS_IMPL_SUFFIX, processorSupport);
     }
 
-    public static <T extends Appendable> T  buildLazyImplClassReferenceFromType(T appendable, CoreInstance type)
+    public static <T extends Appendable> T buildLazyImplClassReferenceFromType(T appendable, CoreInstance type, ProcessorSupport processorSupport)
     {
-        buildLazyImplClassNameFromType(SafeAppendable.wrap(appendable).append(CODE_GEN_PACKAGE_NAME).append('.'), type);
+        buildLazyImplClassNameFromType(SafeAppendable.wrap(appendable).append(CODE_GEN_PACKAGE_NAME).append('.'), type, processorSupport);
         return appendable;
     }
 
-    public static <T extends Appendable> T buildLazyImplClassNameFromType(T appendable, CoreInstance type)
+    public static <T extends Appendable> T buildLazyImplClassNameFromType(T appendable, CoreInstance type, ProcessorSupport processorSupport)
     {
-        return buildImplClassNameFromType(appendable, type, ClassLazyImplProcessor.CLASS_LAZYIMPL_SUFFIX);
+        return buildImplClassNameFromType(appendable, type, ClassLazyImplProcessor.CLASS_LAZYIMPL_SUFFIX, processorSupport);
     }
+
 
     // JAVA INTERFACES
 
@@ -259,30 +262,30 @@ public class JavaPackageAndImportBuilder
 
     // Java interfaces from Pure types
 
-    public static String buildInterfaceReferenceFromType(CoreInstance type)
+    public static String buildInterfaceReferenceFromType(CoreInstance type, ProcessorSupport processorSupport)
     {
-        return buildInterfaceReferenceFromType(new StringBuilder(64), type).toString();
+        return buildInterfaceReferenceFromType(new StringBuilder(64), type, processorSupport).toString();
     }
 
-    public static String buildInterfaceNameFromType(CoreInstance type)
+    public static String buildInterfaceNameFromType(CoreInstance type, ProcessorSupport processorSupport)
     {
-        return buildInterfaceNameFromType(new StringBuilder(64), type).toString();
+        return buildInterfaceNameFromType(new StringBuilder(64), type, processorSupport).toString();
     }
 
-    public static <T extends Appendable> T buildInterfaceReferenceFromType(T appendable, CoreInstance type)
+    public static <T extends Appendable> T buildInterfaceReferenceFromType(T appendable, CoreInstance type, ProcessorSupport processorSupport)
     {
         if (ClassProcessor.isPlatformClass(type))
         {
             return M3ToJavaGenerator.appendFullyQualifiedM3InterfaceForCompiledModel(appendable, type);
         }
 
-        buildInterfaceNameFromType(SafeAppendable.wrap(appendable).append(CODE_GEN_PACKAGE_NAME).append('.'), type);
+        buildInterfaceNameFromType(SafeAppendable.wrap(appendable).append(CODE_GEN_PACKAGE_NAME).append('.'), type, processorSupport);
         return appendable;
     }
 
-    public static <T extends Appendable> T buildInterfaceNameFromType(T appendable, CoreInstance type)
+    public static <T extends Appendable> T buildInterfaceNameFromType(T appendable, CoreInstance type, ProcessorSupport processorSupport)
     {
-        buildClassOrInterfaceNameFromType(SafeAppendable.wrap(appendable), type);
+        buildClassOrInterfaceNameFromType(SafeAppendable.wrap(appendable), type, processorSupport);
         return appendable;
     }
 
@@ -303,29 +306,29 @@ public class JavaPackageAndImportBuilder
         return appendable;
     }
 
-    private static <T extends Appendable> T buildImplClassNameFromType(T appendable, CoreInstance type, String suffix)
+    private static <T extends Appendable> T buildImplClassNameFromType(T appendable, CoreInstance type, String suffix, ProcessorSupport processorSupport)
     {
-        buildClassOrInterfaceNameFromType(SafeAppendable.wrap(appendable), type).append(suffix);
+        buildClassOrInterfaceNameFromType(SafeAppendable.wrap(appendable), type, processorSupport).append(suffix);
         return appendable;
     }
 
-    private static SafeAppendable buildClassOrInterfaceNameFromType(SafeAppendable appendable, CoreInstance type)
+    private static SafeAppendable buildClassOrInterfaceNameFromType(SafeAppendable appendable, CoreInstance type, ProcessorSupport processorSupport)
     {
-        if (isUnitName(type.getName()))
+        if (Measure.isUnit(type, processorSupport))
         {
-            CoreInstance pkg = type.getValueForMetaPropertyToOne(M3Properties.measure).getValueForMetaPropertyToOne(M3Properties._package);
-            if (pkg != null)
-            {
-                PackageableElement.writeSystemPathForPackageableElement(appendable, pkg, "_").append('_');
-            }
-            return appendable.append(convertUnitName(type.getName()));
+            return buildClassOrInterfaceNameForUnit(appendable, type);
         }
-        return PackageableElement.writeSystemPathForPackageableElement(appendable, type, "_");
+        if (PackageableElement.isPackageableElement(type, processorSupport))
+        {
+            return PackageableElement.writeSystemPathForPackageableElement(appendable, type, "_");
+        }
+        throw new IllegalArgumentException("Unsupported type: " + type);
     }
 
-    private static boolean isUnitName(String name)
+    private static SafeAppendable buildClassOrInterfaceNameForUnit(SafeAppendable appendable, CoreInstance unit)
     {
-        return (name != null) && (name.indexOf('~') != -1);
+        CoreInstance measure = unit.getValueForMetaPropertyToOne(M3Properties.measure);
+        return PackageableElement.writeSystemPathForPackageableElement(appendable, measure, "_").append('$').append(unit.getName());
     }
 
     private static String convertUnitName(String unitName)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaPackageAndImportBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaPackageAndImportBuilder.java
@@ -313,7 +313,7 @@ public class JavaPackageAndImportBuilder
     {
         if (isUnitName(type.getName()))
         {
-            CoreInstance pkg = type.getValueForMetaPropertyToOne(M3Properties._package);
+            CoreInstance pkg = type.getValueForMetaPropertyToOne(M3Properties.measure).getValueForMetaPropertyToOne(M3Properties._package);
             if (pkg != null)
             {
                 PackageableElement.writeSystemPathForPackageableElement(appendable, pkg, "_").append('_');

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
@@ -688,7 +688,7 @@ public final class JavaSourceCodeGenerator
     private String toFactoryRegistryEntry(String path, CoreInstance _class)
     {
         String factory = ClassProcessor.requiresCompilationImpl(this.processorSupport, _class) ?
-                         JavaPackageAndImportBuilder.buildImplClassReferenceFromType(_class, ClassImplIncrementalCompilationProcessor.CLASS_IMPL_SUFFIX) :
+                         JavaPackageAndImportBuilder.buildImplClassReferenceFromType(_class, ClassImplIncrementalCompilationProcessor.CLASS_IMPL_SUFFIX, this.processorSupport) :
                          M3ToJavaGenerator.getFullyQualifiedM3ImplForCompiledModel(_class);
         String factoryInterface = M3ToJavaGenerator.getFullyQualifiedM3InterfaceForCompiledModel(_class);
         return "            .withType(\"" + path + "\", " + factory + ".FACTORY, " + factoryInterface + ".class)\n";

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
@@ -228,9 +228,9 @@ public final class JavaSourceCodeGenerator
 
             return javaClasses;
         }
-        catch (Throwable t)
+        catch (Exception e)
         {
-            throw new RuntimeException("Error generating Java code for " + source.getId(), t);
+            throw new RuntimeException("Error generating Java code for " + source.getId(), e);
         }
     }
 
@@ -419,14 +419,11 @@ public final class JavaSourceCodeGenerator
     {
         if (Instance.instanceOf(coreInstance, M3Paths.Package, this.processorSupport))
         {
-            for (CoreInstance element : coreInstance.getValueForMetaPropertyToMany(M3Properties.children))
-            {
-                this.toJava(element, codeRepository, allTypes, processorContext);
-            }
+            coreInstance.getValueForMetaPropertyToMany(M3Properties.children).forEach(e -> toJava(e, codeRepository, allTypes, processorContext));
         }
         if (codeRepository == null || (coreInstance.getSourceInformation() != null && coreInstance.getSourceInformation().getSourceId().startsWith("/" + codeRepository.getName())))
         {
-            if (allTypes == null || (allTypes != null && allTypes.contains(PackageableElement.getUserPathForPackageableElement(coreInstance))))
+            if (allTypes == null || allTypes.contains(PackageableElement.getUserPathForPackageableElement(coreInstance)))
             {
                 try
                 {
@@ -465,18 +462,16 @@ public final class JavaSourceCodeGenerator
                 {
                     throw e;
                 }
-                catch (Throwable t)
+                catch (Exception e)
                 {
-                    PureException pe = PureException.findPureException(t);
+                    PureException pe = PureException.findPureException(e);
                     if (pe == null)
                     {
-                        throw new PureCompilationException(coreInstance.getSourceInformation(), "Error generating Java code for " + coreInstance, t);
+                        throw new PureCompilationException(coreInstance.getSourceInformation(), "Error generating Java code for " + coreInstance, e);
                     }
-                    else
-                    {
-                        String info = pe.getInfo();
-                        throw new PureCompilationException(coreInstance.getSourceInformation(), info == null ? "Error generating Java code for " + coreInstance : info, pe);
-                    }
+
+                    String info = pe.getInfo();
+                    throw new PureCompilationException(coreInstance.getSourceInformation(), info == null ? "Error generating Java code for " + coreInstance : info, pe);
                 }
             }
         }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/ClassJsonFactoryProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/ClassJsonFactoryProcessor.java
@@ -90,7 +90,7 @@ public class ClassJsonFactoryProcessor
         if (!processedClasses.contains(_class) && !processorSupport.instance_instanceOf(_class, M3Paths.DataType))
         {
             processedClasses.add(_class);
-            String className = TypeProcessor.javaInterfaceForType(_class);
+            String className = TypeProcessor.javaInterfaceForType(_class, processorSupport);
             String userDefinedClassName = PackageableElement.getUserPathForPackageableElement(_class);
             String typeParams = typeParameters(_class);
             // Factory to create objects from Json
@@ -140,7 +140,7 @@ public class ClassJsonFactoryProcessor
                                             CoreInstance rawType = Instance.getValueForMetaPropertyToOneResolved(returnType, M3Properties.rawType, processorSupport);
                                             String classFullName = rawType == null ? null : PackageableElement.getSystemPathForPackageableElement(rawType, "::");
                                             String classFullUserPath = rawType == null ? null : PackageableElement.getUserPathForPackageableElement(rawType);
-                                            String classFullName2 = rawType == null ? null : TypeProcessor.javaInterfaceNameForType(rawType);
+                                            String classFullName2 = rawType == null ? null : TypeProcessor.javaInterfaceNameForType(rawType, processorSupport);
 
                                             boolean isToOne = Multiplicity.isToOne(multiplicity, false);
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/IdBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/IdBuilder.java
@@ -26,6 +26,7 @@ import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m3.navigation.type.Type;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.CodeStorageTools;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.RepositoryCodeStorage;
@@ -156,6 +157,13 @@ public class IdBuilder
         return PackageableElement.writeUserPathForPackageableElement(new StringBuilder(), annotation.getValueForMetaPropertyToOne(M3Properties.profile))
                 .append('.').append(annotation.getName())
                 .toString();
+    }
+
+    // Unit
+
+    private static String buildIdForUnit(CoreInstance unit)
+    {
+        return Measure.getSystemPathForUnit(unit);
     }
 
     // PackageableElement
@@ -327,6 +335,7 @@ public class IdBuilder
             addIdBuilder(M3Paths.PackageableElement, IdBuilder::buildIdForPackageableElement);
             addIdBuilder(M3Paths.Property, IdBuilder::buildIdForProperty);
             addIdBuilder(M3Paths.QualifiedProperty, IdBuilder::buildIdForQualifiedProperty);
+            addIdBuilder(M3Paths.Unit, IdBuilder::buildIdForUnit);
             CompiledExtensionLoader.extensions().flatCollect(x -> x.getExtraIdBuilders(this.processorSupport)).forEach(x -> addIdBuilder(x.getOne(), x.getTwo()));
         }
     }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/essentials/lang/unit/NewUnit.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/essentials/lang/unit/NewUnit.java
@@ -38,7 +38,7 @@ public class NewUnit extends AbstractNative
         CoreInstance unit = Instance.getValueForMetaPropertyToOneResolved(functionExpression.getValueForMetaPropertyToMany(M3Properties.parametersValues).getFirst(), M3Properties.values, processorContext.getSupport());
         return Measure.isUnit(unit, processorContext.getSupport()) ?
                // concretely specified unit: we can generate the Java instantiation directly
-               ("new " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(unit) + "(" + transformedParams.get(1) + ", es)") :
+               ("new " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(unit, processorContext.getSupport()) + "(" + transformedParams.get(1) + ", es)") :
                // unit comes from a variable or function expression or something like that: we have to instantiate reflectively
                ("CompiledSupport.newUnitInstance(" + transformedParams.get(0) + ", " + transformedParams.get(1) + ", es)");
     }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/essentials/meta/reflect/Deactivate.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/essentials/meta/reflect/Deactivate.java
@@ -38,7 +38,7 @@ public class Deactivate extends AbstractNative
         ListIterable<? extends CoreInstance> parametersValues = Instance.getValueForMetaPropertyToManyResolved(functionExpression, M3Properties.parametersValues, processorSupport);
 
         CoreInstance valueSpecification = parametersValues.get(0);
-        String type = TypeProcessor.javaInterfaceForType(processorSupport.getClassifier(valueSpecification));
+        String type = TypeProcessor.javaInterfaceForType(processorSupport.getClassifier(valueSpecification), processorSupport);
         return "((" + type + ")((CompiledExecutionSupport)es).getMetadata(\"" + MetadataJavaPaths.buildMetadataKeyFromType(processorSupport.getClassifier(valueSpecification)) + "\",\"" + processorContext.getIdBuilder().buildId(valueSpecification) + "\"))";
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/grammar/lang/creation/InstantiationHelpers.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/grammar/lang/creation/InstantiationHelpers.java
@@ -141,7 +141,7 @@ public class InstantiationHelpers
             CoreInstance rawType = Instance.getValueForMetaPropertyToOneResolved(genericType, M3Properties.rawType, processorSupport);
             ListIterable<? extends CoreInstance> typeArguments = Instance.getValueForMetaPropertyToManyResolved(genericType, M3Properties.typeArguments, processorSupport);
             String rawTypeStr = "(" + FullJavaPaths.Type + ")((CompiledExecutionSupport)es).getMetadata(\"" + MetadataJavaPaths.buildMetadataKeyFromType(processorSupport.getClassifier(rawType)) + "\", \"" + processorContext.getIdBuilder().buildId(rawType) + "\")";
-            String base = "new " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(processorSupport.getClassifier(genericType)) + "(\"Anonymous_NoCounter\")._rawType(" + rawTypeStr + ")";
+            String base = "new " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(processorSupport.getClassifier(genericType), processorSupport) + "(\"Anonymous_NoCounter\")._rawType(" + rawTypeStr + ")";
             if (typeArguments.notEmpty())
             {
                 base += "._typeArguments(Lists.fixedSize.of(" + typeArguments.collect(gt -> buildGenericType(gt, processorContext)).makeString(",") + "))";
@@ -157,7 +157,7 @@ public class InstantiationHelpers
         {
             CoreInstance typeParameter = Instance.getValueForMetaPropertyToOneResolved(genericType, M3Properties.typeParameter, processorSupport);
             String typeParam = "new org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_generics_TypeParameter_Impl(\"Anonymous_NoCounter\")._name(\"" + typeParameter.getValueForMetaPropertyToOne(M3Properties.name).getName() + "\")";
-            return "new " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(processorSupport.getClassifier(genericType)) + "(\"Anonymous_NoCounter\")._typeParameter(" + typeParam + ")";
+            return "new " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(processorSupport.getClassifier(genericType), processorSupport) + "(\"Anonymous_NoCounter\")._typeParameter(" + typeParam + ")";
         }
     }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/grammar/lang/creation/New.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/grammar/lang/creation/New.java
@@ -53,7 +53,7 @@ public class New extends AbstractNative
         else
         {
             String newId = InstantiationHelpers.manageId(parametersValues, processorSupport);
-            return "new " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(_class) + (addGenericType ? TypeProcessor.buildTypeArgumentsString(genericType, false, processorSupport) : "")
+            return "new " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(_class, processorSupport) + (addGenericType ? TypeProcessor.buildTypeArgumentsString(genericType, false, processorSupport) : "")
                     + "(\"" + newId + "\")" + (addGenericType ? "._classifierGenericType("
                     + InstantiationHelpers.buildGenericType(genericType, processorContext) + ")" : "") + (_Class.computeConstraintsInHierarchy(_class, processorSupport).isEmpty() ? "" : "._validate(false, " + SourceInfoProcessor.sourceInfoToString(functionExpression.getSourceInformation()) + ", es)")
                     + DefaultValue.manageDefaultValues(this::formatDefaultValueString, Instance.getValueForMetaPropertyToOneResolved(genericType, M3Properties.rawType, processorSupport), false, processorContext).makeString("");

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/grammar/lang/creation/NewWithKeyExpr.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/grammar/lang/creation/NewWithKeyExpr.java
@@ -48,7 +48,7 @@ public class NewWithKeyExpr extends AbstractNative
         CoreInstance genericType = Instance.getValueForMetaPropertyToOneResolved(parametersValues.get(0), M3Properties.genericType, M3Properties.typeArguments, processorSupport);
         boolean addGenericType = Instance.getValueForMetaPropertyToManyResolved(genericType, M3Properties.typeArguments, processorSupport).notEmpty();
         CoreInstance _class = Instance.getValueForMetaPropertyToOneResolved(genericType, M3Properties.rawType, processorSupport);
-        return "new " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(_class) + (addGenericType ? TypeProcessor.buildTypeArgumentsString(genericType, false, processorSupport) : "")
+        return "new " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(_class, processorSupport) + (addGenericType ? TypeProcessor.buildTypeArgumentsString(genericType, false, processorSupport) : "")
                 + "(\"" + newId + "\")" + (addGenericType ? "._classifierGenericType("
                 + InstantiationHelpers.buildGenericType(genericType, processorContext) + ")" : "")
                 + DefaultValue.manageDefaultValues(this::formatDefaultValueString, Instance.getValueForMetaPropertyToOneResolved(genericType, M3Properties.rawType, processorSupport), false, processorContext).makeString("")

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/CompiledSupport.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/CompiledSupport.java
@@ -2105,7 +2105,7 @@ public class CompiledSupport
         Class<? extends QuantityCoreInstance> unitImplClass;
         try
         {
-            String javaClassImplName = JavaPackageAndImportBuilder.buildImplClassReferenceFromType(unit);
+            String javaClassImplName = JavaPackageAndImportBuilder.buildImplClassReferenceFromType(unit, executionSupport.getProcessorSupport());
             ClassLoader classLoader = executionSupport.getClassLoader();
             unitImplClass = (Class<? extends QuantityCoreInstance>) classLoader.loadClass(javaClassImplName);
         }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/TypeProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/TypeProcessor.java
@@ -118,7 +118,7 @@ public class TypeProcessor
         {
             return FullJavaPaths.Enum;
         }
-        String finalRawTypeSystemPath = fullyQualify || M3Paths.Package.equals(rawType.getName()) ? fullyQualifiedJavaInterfaceNameForType(rawType) : javaInterfaceForType(rawType);
+        String finalRawTypeSystemPath = fullyQualify || M3Paths.Package.equals(rawType.getName()) ? fullyQualifiedJavaInterfaceNameForType(rawType, processorSupport) : javaInterfaceForType(rawType, processorSupport);
 
         // Manage magical TDS structures
         if ("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.ColSpec".equals(finalRawTypeSystemPath) ||
@@ -149,7 +149,7 @@ public class TypeProcessor
         {
             return "java.lang.Object";
         }
-        String systemPath = fullyQualifiedJavaInterfaceNameForType(rawType);
+        String systemPath = fullyQualifiedJavaInterfaceNameForType(rawType, processorSupport);
         String javaType = pureSystemPathToJava_simpleCases(PackageableElement.getUserPathForPackageableElement(rawType), primitiveIfPossible);
         if (javaType != null)
         {
@@ -163,19 +163,19 @@ public class TypeProcessor
     }
 
 
-    public static String javaInterfaceForType(CoreInstance rawType)
+    public static String javaInterfaceForType(CoreInstance rawType, ProcessorSupport processorSupport)
     {
-        return ClassProcessor.isPlatformClass(rawType) ? fullyQualifiedJavaInterfaceNameForType(rawType) : JavaPackageAndImportBuilder.buildInterfaceNameFromType(rawType);
+        return ClassProcessor.isPlatformClass(rawType) ? fullyQualifiedJavaInterfaceNameForType(rawType, processorSupport) : JavaPackageAndImportBuilder.buildInterfaceNameFromType(rawType, processorSupport);
     }
 
-    public static String javaInterfaceNameForType(CoreInstance rawType)
+    public static String javaInterfaceNameForType(CoreInstance rawType, ProcessorSupport processorSupport)
     {
-        return ClassProcessor.isPlatformClass(rawType) ? rawType.getName() : JavaPackageAndImportBuilder.buildInterfaceNameFromType(rawType);
+        return ClassProcessor.isPlatformClass(rawType) ? rawType.getName() : JavaPackageAndImportBuilder.buildInterfaceNameFromType(rawType, processorSupport);
     }
 
-    public static String fullyQualifiedJavaInterfaceNameForType(CoreInstance element)
+    public static String fullyQualifiedJavaInterfaceNameForType(CoreInstance element, ProcessorSupport processorSupport)
     {
-        return JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(element);
+        return JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(element, processorSupport);
     }
 
     private static String pureSystemPathToJava_simpleCases(String fullUserPath, boolean primitiveIfPossible)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassImplIncrementalCompilationProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassImplIncrementalCompilationProcessor.java
@@ -41,14 +41,14 @@ public class ClassImplIncrementalCompilationProcessor
     {
         processorContext.setClassImplSuffix(CLASS_IMPL_SUFFIX);
         CoreInstance _class = Instance.getValueForMetaPropertyToOneResolved(classGenericType, M3Properties.rawType, processorSupport);
-        String className = JavaPackageAndImportBuilder.buildImplClassNameFromType(_class, CLASS_IMPL_SUFFIX);
+        String className = JavaPackageAndImportBuilder.buildImplClassNameFromType(_class, CLASS_IMPL_SUFFIX, processorSupport);
         String typeParams = ClassProcessor.typeParameters(_class);
         String typeParamsString = typeParams.isEmpty() ? "" : "<" + typeParams + ">";
         String classNamePlusTypeParams = className + typeParamsString;
 
         String _extends = M3ToJavaGenerator.getFullyQualifiedM3ImplForCompiledModel(_class);
         String systemPath = PackageableElement.getSystemPathForPackageableElement(_class, "::");
-        String interfaceName = TypeProcessor.javaInterfaceForType(_class);
+        String interfaceName = TypeProcessor.javaInterfaceForType(_class, processorSupport);
         boolean specialEquals = !_Class.getEqualityKeyProperties(_class, processorContext.getSupport()).isEmpty();
 
         return StringJavaSource.newStringJavaSource(_package, className, ClassImplProcessor.IMPORTS + ClassImplProcessor.FUNCTION_IMPORTS + imports +

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassImplProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassImplProcessor.java
@@ -89,11 +89,11 @@ public class ClassImplProcessor
     {
         processorContext.setClassImplSuffix(CLASS_IMPL_SUFFIX);
         CoreInstance _class = Instance.getValueForMetaPropertyToOneResolved(classGenericType, M3Properties.rawType, processorSupport);
-        String className = JavaPackageAndImportBuilder.buildImplClassNameFromType(_class);
+        String className = JavaPackageAndImportBuilder.buildImplClassNameFromType(_class, processorSupport);
         String typeParams = ClassProcessor.typeParameters(_class);
         String typeParamsString = typeParams.isEmpty() ? "" : "<" + typeParams + ">";
         String classNamePlusTypeParams = className + typeParamsString;
-        String interfaceNamePlusTypeParams = TypeProcessor.javaInterfaceForType(_class) + typeParamsString;
+        String interfaceNamePlusTypeParams = TypeProcessor.javaInterfaceForType(_class, processorSupport) + typeParamsString;
 
         MutableList<String> defaultValueKeys = _Class.getSimpleProperties(_class, processorSupport).collectIf(p -> p.getValueForMetaPropertyToOne(M3Properties.defaultValue) != null, CoreInstance::getName, Lists.mutable.empty());
         ListIterable<String> defaultValues = DefaultValue.manageDefaultValues((name, value) ->
@@ -474,7 +474,7 @@ public class ClassImplProcessor
     public static String buildSimpleProperties(CoreInstance classGenericType, FullPropertyImplementation propertyImpl, ProcessorContext processorContext, ProcessorSupport processorSupport)
     {
         CoreInstance _class = Instance.getValueForMetaPropertyToOneResolved(classGenericType, M3Properties.rawType, processorSupport);
-        String ownerClassName = TypeProcessor.javaInterfaceForType(_class);
+        String ownerClassName = TypeProcessor.javaInterfaceForType(_class, processorSupport);
         String ownerTypeParams = ClassProcessor.typeParameters(_class);
 
         return processorSupport.class_getSimpleProperties(_class).collect(property ->
@@ -506,8 +506,8 @@ public class ClassImplProcessor
     public static String buildCopy(CoreInstance classGenericType, String suffix, boolean copyGetterOverride, ProcessorSupport processorSupport)
     {
         CoreInstance _class = Instance.getValueForMetaPropertyToOneResolved(classGenericType, M3Properties.rawType, processorSupport);
-        String className = TypeProcessor.javaInterfaceForType(_class);
-        String implClassName = JavaPackageAndImportBuilder.buildImplClassNameFromType(_class, suffix);
+        String className = TypeProcessor.javaInterfaceForType(_class, processorSupport);
+        String implClassName = JavaPackageAndImportBuilder.buildImplClassNameFromType(_class, suffix, processorSupport);
         String typeParams = ClassProcessor.typeParameters(_class);
         String classNamePlusTypeParams = className + (typeParams.isEmpty() ? "" : "<" + typeParams + "> ");
 
@@ -562,12 +562,12 @@ public class ClassImplProcessor
     static String buildEquality(CoreInstance classGenericType, String suffix, boolean useMethodForEquals, boolean useMethodForHashcode, boolean lazy, ProcessorContext processorContext, ProcessorSupport processorSupport)
     {
         CoreInstance _class = Instance.getValueForMetaPropertyToOneResolved(classGenericType, M3Properties.rawType, processorSupport);
-        String className = TypeProcessor.javaInterfaceForType(_class);
+        String className = TypeProcessor.javaInterfaceForType(_class, processorSupport);
 
         ListIterable<CoreInstance> equalityProperties = _Class.getEqualityKeyProperties(_class, processorContext.getSupport());
 
         String equalsCompilationClass = ClassProcessor.requiresCompilationImpl(processorContext.getSupport(), _class) ?
-                " && o.getClass() != " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(_class, ClassImplIncrementalCompilationProcessor.CLASS_IMPL_SUFFIX) + ".class" : "";
+                " && o.getClass() != " + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(_class, ClassImplIncrementalCompilationProcessor.CLASS_IMPL_SUFFIX, processorSupport) + ".class" : "";
 
         return equalityProperties.isEmpty() ? "" : "public boolean pureEquals(Object o)\n" +
                 "{\n" +
@@ -575,7 +575,7 @@ public class ClassImplProcessor
                 "    {\n" +
                 "        return true;\n" +
                 "    }\n" +
-                "    if (o == null || " + (lazy ? "(o.getClass() != " + JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(_class) + ".class && o.getClass() !=" + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(_class) + ".class" + equalsCompilationClass + "))" : "getClass() != o.getClass())\n") +
+                "    if (o == null || " + (lazy ? "(o.getClass() != " + JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(_class, processorSupport) + ".class && o.getClass() !=" + JavaPackageAndImportBuilder.buildImplClassReferenceFromType(_class, processorSupport) + ".class" + equalsCompilationClass + "))" : "getClass() != o.getClass())\n") +
                 "    {\n" +
                 "        return false;\n" +
                 "    }\n" +

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassInterfaceProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassInterfaceProcessor.java
@@ -45,7 +45,7 @@ public class ClassInterfaceProcessor
     public static StringJavaSource buildInterface(String _package, String imports, CoreInstance classGenericType, ProcessorContext processorContext, ProcessorSupport processorSupport, boolean useJavaInheritance)
     {
         CoreInstance _class = Instance.getValueForMetaPropertyToOneResolved(classGenericType, M3Properties.rawType, processorSupport);
-        String interfaceName = TypeProcessor.javaInterfaceForType(_class);
+        String interfaceName = TypeProcessor.javaInterfaceForType(_class, processorSupport);
         String typeParams = ClassProcessor.typeParameters(_class);
         String typeParamsString = typeParams.isEmpty() ? "" : "<" + typeParams + ">";
         String interfaceNamePlusTypeParams = interfaceName + typeParamsString;
@@ -136,7 +136,7 @@ public class ClassInterfaceProcessor
         String typeArgsString = typeArgs.isEmpty() ? "" : "<" + typeArgs + ">";
         if (suffix.isEmpty())
         {
-            return TypeProcessor.javaInterfaceForType(rawType) + typeArgsString;
+            return TypeProcessor.javaInterfaceForType(rawType, processorSupport) + typeArgsString;
         }
         else
         {

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassLazyImplProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassLazyImplProcessor.java
@@ -69,8 +69,8 @@ public class ClassLazyImplProcessor
     static StringJavaSource buildImplementation(String _package, String imports, CoreInstance classGenericType, ProcessorContext processorContext, ProcessorSupport processorSupport)
     {
         CoreInstance _class = Instance.getValueForMetaPropertyToOneResolved(classGenericType, M3Properties.rawType, processorSupport);
-        String className = JavaPackageAndImportBuilder.buildImplClassNameFromType(_class, CLASS_LAZYIMPL_SUFFIX);
-        String classInterfaceName = TypeProcessor.javaInterfaceForType(_class);
+        String className = JavaPackageAndImportBuilder.buildImplClassNameFromType(_class, CLASS_LAZYIMPL_SUFFIX, processorSupport);
+        String classInterfaceName = TypeProcessor.javaInterfaceForType(_class, processorSupport);
         String typeParams = ClassProcessor.typeParameters(_class);
         String typeParamsString = typeParams.isEmpty() ? "" : "<" + typeParams + ">";
         String classNamePlusTypeParams = className + typeParamsString;

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/MeasureProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/MeasureProcessor.java
@@ -17,7 +17,7 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.type.m
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
 import org.finos.legend.pure.m3.navigation.M3Properties;
-import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.compiled.compiler.StringJavaSource;
 import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
@@ -45,7 +45,7 @@ public class MeasureProcessor
     private static void processUnit(String packageName, String measureInterfaceName, CoreInstance unit, ProcessorContext processorContext)
     {
         String unitInterfaceName = JavaPackageAndImportBuilder.buildInterfaceNameFromType(unit);
-        processorContext.addJavaSource(buildUnitInterface(packageName, measureInterfaceName, unitInterfaceName, PackageableElement.getUserPathForPackageableElement(unit)));
+        processorContext.addJavaSource(buildUnitInterface(packageName, measureInterfaceName, unitInterfaceName, Measure.getUserPathForUnit(unit)));
 
         String unitImplClassName = JavaPackageAndImportBuilder.buildImplClassNameFromType(unit);
         processorContext.addJavaSource(buildUnitImplClass(packageName, unitInterfaceName, unitImplClassName));

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/MeasureProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/MeasureProcessor.java
@@ -31,7 +31,7 @@ public class MeasureProcessor
     public static void processMeasure(CoreInstance measure, ProcessorContext processorContext)
     {
         String packageName = JavaPackageAndImportBuilder.buildPackageForPackageableElement(measure);
-        String measureInterfaceName = JavaPackageAndImportBuilder.buildInterfaceNameFromType(measure);
+        String measureInterfaceName = JavaPackageAndImportBuilder.buildInterfaceNameFromType(measure, processorContext.getSupport());
         processorContext.addJavaSource(buildMeasureInterface(packageName, measureInterfaceName));
 
         CoreInstance canonicalUnit = measure.getValueForMetaPropertyToOne(M3Properties.canonicalUnit);
@@ -44,10 +44,10 @@ public class MeasureProcessor
 
     private static void processUnit(String packageName, String measureInterfaceName, CoreInstance unit, ProcessorContext processorContext)
     {
-        String unitInterfaceName = JavaPackageAndImportBuilder.buildInterfaceNameFromType(unit);
+        String unitInterfaceName = JavaPackageAndImportBuilder.buildInterfaceNameFromType(unit, processorContext.getSupport());
         processorContext.addJavaSource(buildUnitInterface(packageName, measureInterfaceName, unitInterfaceName, Measure.getUserPathForUnit(unit)));
 
-        String unitImplClassName = JavaPackageAndImportBuilder.buildImplClassNameFromType(unit);
+        String unitImplClassName = JavaPackageAndImportBuilder.buildImplClassNameFromType(unit, processorContext.getSupport());
         processorContext.addJavaSource(buildUnitImplClass(packageName, unitInterfaceName, unitImplClassName));
     }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/valuespecification/ValueSpecificationProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/valuespecification/ValueSpecificationProcessor.java
@@ -114,7 +114,7 @@ public class ValueSpecificationProcessor
                     else
                     {
                         CoreInstance _class = Instance.getValueForMetaPropertyToOneResolved(valueSpecification, M3Properties.genericType, M3Properties.typeArguments, M3Properties.rawType, processorSupport);
-                        return "((" + FullJavaPaths.Class + "<" + TypeProcessor.fullyQualifiedJavaInterfaceNameForType(_class) + ">)((CompiledExecutionSupport)es).getMetadataAccessor(\"" + PackageableElement.getSystemPathForPackageableElement(_class, "::") + "\"))";
+                        return "((" + FullJavaPaths.Class + "<" + TypeProcessor.fullyQualifiedJavaInterfaceNameForType(_class, processorSupport) + ">)((CompiledExecutionSupport)es).getMetadataAccessor(\"" + PackageableElement.getSystemPathForPackageableElement(_class, "::") + "\"))";
                     }
                 }
                 else if (values.size() == 1)
@@ -127,7 +127,7 @@ public class ValueSpecificationProcessor
                     }
                     CoreInstance type = processorSupport.getClassifier(cls);
                     String classifier = MetadataJavaPaths.buildMetadataKeyFromType(type);
-                    return "((" + TypeProcessor.fullyQualifiedJavaInterfaceNameForType(type) + "<" + TypeProcessor.fullyQualifiedJavaInterfaceNameForType(cls) + ">)((CompiledExecutionSupport)es).getMetadata(\"" + classifier + "\",\"" + PackageableElement.getSystemPathForPackageableElement(cls) + "\"))";
+                    return "((" + TypeProcessor.fullyQualifiedJavaInterfaceNameForType(type, processorSupport) + "<" + TypeProcessor.fullyQualifiedJavaInterfaceNameForType(cls, processorSupport) + ">)((CompiledExecutionSupport)es).getMetadata(\"" + classifier + "\",\"" + PackageableElement.getSystemPathForPackageableElement(cls) + "\"))";
                 }
                 else
                 {
@@ -141,9 +141,9 @@ public class ValueSpecificationProcessor
                             cls = Instance.getValueForMetaPropertyToOneResolved(cls, M3Properties.values, processorSupport);
                         }
 
-                        String type = TypeProcessor.fullyQualifiedJavaInterfaceNameForType(cls);
+                        String type = TypeProcessor.fullyQualifiedJavaInterfaceNameForType(cls, processorSupport);
                         types.add(type);
-                        String classifier = TypeProcessor.fullyQualifiedJavaInterfaceNameForType(processorSupport.getClassifier(cls));
+                        String classifier = TypeProcessor.fullyQualifiedJavaInterfaceNameForType(processorSupport.getClassifier(cls), processorSupport);
                         return "((" + classifier + "<? extends " + type + ">)((CompiledExecutionSupport)es).getMetadata(\"" + MetadataJavaPaths.buildMetadataKeyFromType(processorSupport.getClassifier(cls)) + "\",\"" + PackageableElement.getSystemPathForPackageableElement(cls, "::") + "\"))";
                     }).makeString();
                     String typeString = (types.size() > 1) ? ("<" + TypeProcessor.typeToJavaObjectSingle(Instance.getValueForMetaPropertyToOneResolved(valueSpecification, M3Properties.genericType, processorSupport), true, processorSupport) + ">") : "";
@@ -197,7 +197,7 @@ public class ValueSpecificationProcessor
         ProcessorSupport processorSupport = processorContext.getSupport();
         CoreInstance value = Instance.getValueForMetaPropertyToOneResolved(firstValue, M3Properties.values, processorSupport);
         CoreInstance unit = Instance.getValueForMetaPropertyToOneResolved(valueSpecification, M3Properties.genericType, M3Properties.rawType, processorSupport);
-        String unitImplClassReference = JavaPackageAndImportBuilder.buildImplClassReferenceFromType(unit);
+        String unitImplClassReference = JavaPackageAndImportBuilder.buildImplClassReferenceFromType(unit, processorSupport);
         return "new " + unitImplClassReference + "(" + JavaPurePrimitiveTypeMapping.convertPureCoreInstanceToJavaType(value, processorContext) + ", es)";
     }
 
@@ -212,7 +212,7 @@ public class ValueSpecificationProcessor
                 String result = "this";
                 if ((varRawType != null) && processorSupport.type_subTypeOf(topLevelElement, varRawType) && !varRawType.equals(processorSupport.type_TopType()))
                 {
-                    result = JavaPackageAndImportBuilder.buildImplClassNameFromType(topLevelElement, processorContext.getClassImplSuffix()) + "." + result;
+                    result = JavaPackageAndImportBuilder.buildImplClassNameFromType(topLevelElement, processorContext.getClassImplSuffix(), processorSupport) + "." + result;
                 }
                 return result;
             }
@@ -344,7 +344,7 @@ public class ValueSpecificationProcessor
                     String value;
                     if ("this".equals(varName) && Instance.instanceOf(topLevelElement, M3Paths.Class, processorContext.getSupport()))
                     {
-                        value = JavaPackageAndImportBuilder.buildImplClassNameFromType(topLevelElement) + ".this";
+                        value = JavaPackageAndImportBuilder.buildImplClassNameFromType(topLevelElement, processorContext.getSupport()) + ".this";
                     }
                     else
                     {
@@ -355,7 +355,7 @@ public class ValueSpecificationProcessor
             }
             else
             {
-                openVarsInitializer = vars.asLazy().collect(var -> "        .withKeyValue(\"" + var.getName() + "\", " + ("this".equals(var.getName()) ? JavaPackageAndImportBuilder.buildImplClassNameFromType(topLevelElement) + ".this" : "_" + var.getName()) + ")")
+                openVarsInitializer = vars.asLazy().collect(var -> "        .withKeyValue(\"" + var.getName() + "\", " + ("this".equals(var.getName()) ? JavaPackageAndImportBuilder.buildImplClassNameFromType(topLevelElement, processorContext.getSupport()) + ".this" : "_" + var.getName()) + ")")
                         .makeString("private final MutableMap<String, Object> __vars = Maps.mutable.<String, Object>ofInitialCapacity(" + vars.size() + ")\n", "\n", ";\n");
             }
         }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaPackageAndImportBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaPackageAndImportBuilder.java
@@ -19,7 +19,6 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
@@ -120,23 +119,23 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
     @Test
     public void testBuildImplClassNameFromType()
     {
-        Assert.assertEquals("Root_test_generation_compiled_SimpleClass_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement("test::generation::compiled::SimpleClass")));
-        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement("test::generation::compiled::extra::ExtraClass")));
-        Assert.assertEquals("Root_meta_pure_metamodel_type_Class_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement(M3Paths.Class)));
-        Assert.assertEquals("Root_meta_pure_metamodel_type_Enumeration_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement(M3Paths.Enumeration)));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("Root_test_generation_compiled_SimpleClass_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement("test::generation::compiled::SimpleClass"), processorSupport));
+        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement("test::generation::compiled::extra::ExtraClass"), processorSupport));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Class_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement(M3Paths.Class), processorSupport));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Enumeration_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement(M3Paths.Enumeration), processorSupport));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes"), processorSupport));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium"), processorSupport));
     }
 
     @Test
     public void testBuildLazyImplClassNameFromType()
     {
-        Assert.assertEquals("Root_test_generation_compiled_SimpleClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement("test::generation::compiled::SimpleClass")));
-        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement("test::generation::compiled::extra::ExtraClass")));
-        Assert.assertEquals("Root_meta_pure_metamodel_type_Class_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement(M3Paths.Class)));
-        Assert.assertEquals("Root_meta_pure_metamodel_type_Enumeration_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement(M3Paths.Enumeration)));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("Root_test_generation_compiled_SimpleClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement("test::generation::compiled::SimpleClass"), processorSupport));
+        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement("test::generation::compiled::extra::ExtraClass"), processorSupport));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Class_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement(M3Paths.Class), processorSupport));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Enumeration_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement(M3Paths.Enumeration), processorSupport));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes"), processorSupport));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium"), processorSupport));
     }
 
     @Test
@@ -146,30 +145,30 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
         Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromUserPath("test::generation::compiled::extra::ExtraClass"));
         Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromUserPath(M3Paths.Class));
         Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromUserPath(M3Paths.Enumeration));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium"), processorSupport));
     }
 
     @Test
     public void testBuildImplClassReferenceFromType()
     {
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement("test::generation::compiled::SimpleClass")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement("test::generation::compiled::extra::ExtraClass")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement(M3Paths.Class)));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement(M3Paths.Enumeration)));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement("test::generation::compiled::SimpleClass"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement("test::generation::compiled::extra::ExtraClass"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement(M3Paths.Class), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement(M3Paths.Enumeration), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium"), processorSupport));
     }
 
     @Test
     public void testBuildLazyImplClassReferenceFromType()
     {
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement("test::generation::compiled::SimpleClass")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement("test::generation::compiled::extra::ExtraClass")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement(M3Paths.Class)));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement(M3Paths.Enumeration)));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement("test::generation::compiled::SimpleClass"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement("test::generation::compiled::extra::ExtraClass"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement(M3Paths.Class), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement(M3Paths.Enumeration), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium"), processorSupport));
     }
 
     @Test
@@ -200,24 +199,24 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
     @Test
     public void testBuildInterfaceNameFromType()
     {
-        Assert.assertEquals("Root_test_generation_compiled_SimpleClass", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement("test::generation::compiled::SimpleClass")));
-        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement("test::generation::compiled::extra::ExtraClass")));
-        Assert.assertEquals("Root_meta_pure_metamodel_type_Enum", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement(M3Paths.Enum)));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength")));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Pes", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("Root_test_generation_compiled_SimpleClass", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement("test::generation::compiled::SimpleClass"), processorSupport));
+        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement("test::generation::compiled::extra::ExtraClass"), processorSupport));
+        Assert.assertEquals("Root_meta_pure_metamodel_type_Enum", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement(M3Paths.Enum), processorSupport));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength"), processorSupport));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Pes", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes"), processorSupport));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium"), processorSupport));
     }
 
     @Test
     public void testBuildInterfaceReferenceFromType()
     {
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement("test::generation::compiled::SimpleClass")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement("test::generation::compiled::extra::ExtraClass")));
-        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement(M3Paths.Class)));
-        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement(M3Paths.Enumeration)));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement("test::generation::compiled::SimpleClass"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement("test::generation::compiled::extra::ExtraClass"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement(M3Paths.Class), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement(M3Paths.Enumeration), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium"), processorSupport));
     }
 
     @SuppressWarnings("unchecked")
@@ -230,9 +229,7 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
 
     private static Unit getUnit(String unitPath)
     {
-        String measurePath = unitPath.substring(0, unitPath.indexOf('~'));
-        Measure measure = getElement(measurePath);
-        Unit unit = (Unit) org.finos.legend.pure.m3.navigation.measure.Measure.findUnit(measure, unitPath.substring(unitPath.lastIndexOf(':') + 1));
+        Unit unit = (Unit) org.finos.legend.pure.m3.navigation.measure.Measure.getUnitByUserPath(unitPath, processorSupport);
         Assert.assertNotNull(unitPath, unit);
         return unit;
     }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaPackageAndImportBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaPackageAndImportBuilder.java
@@ -19,6 +19,8 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
@@ -122,8 +124,8 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
         Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement("test::generation::compiled::extra::ExtraClass")));
         Assert.assertEquals("Root_meta_pure_metamodel_type_Class_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement(M3Paths.Class)));
         Assert.assertEquals("Root_meta_pure_metamodel_type_Enumeration_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement(M3Paths.Enumeration)));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_Impl", JavaPackageAndImportBuilder.buildImplClassNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
     }
 
     @Test
@@ -133,8 +135,8 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
         Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement("test::generation::compiled::extra::ExtraClass")));
         Assert.assertEquals("Root_meta_pure_metamodel_type_Class_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement(M3Paths.Class)));
         Assert.assertEquals("Root_meta_pure_metamodel_type_Enumeration_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement(M3Paths.Enumeration)));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
     }
 
     @Test
@@ -144,8 +146,8 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
         Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromUserPath("test::generation::compiled::extra::ExtraClass"));
         Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromUserPath(M3Paths.Class));
         Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromUserPath(M3Paths.Enumeration));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
     }
 
     @Test
@@ -155,8 +157,8 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
         Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement("test::generation::compiled::extra::ExtraClass")));
         Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement(M3Paths.Class)));
         Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement(M3Paths.Enumeration)));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_Impl", JavaPackageAndImportBuilder.buildImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
     }
 
     @Test
@@ -166,8 +168,8 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
         Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement("test::generation::compiled::extra::ExtraClass")));
         Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Class_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement(M3Paths.Class)));
         Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enumeration_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement(M3Paths.Enumeration)));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium_LazyImpl", JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
     }
 
     @Test
@@ -202,8 +204,8 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
         Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement("test::generation::compiled::extra::ExtraClass")));
         Assert.assertEquals("Root_meta_pure_metamodel_type_Enum", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement(M3Paths.Enum)));
         Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength")));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Pes", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Pes", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
+        Assert.assertEquals("Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium", JavaPackageAndImportBuilder.buildInterfaceNameFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
     }
 
     @Test
@@ -214,8 +216,8 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
         Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement(M3Paths.Class)));
         Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement(M3Paths.Enumeration)));
         Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getElement("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Pes", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Pes")));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_meta_pure_functions_meta_tests_model_RomanLength$Stadium", JavaPackageAndImportBuilder.buildInterfaceReferenceFromType(getUnit("meta::pure::functions::meta::tests::model::RomanLength~Stadium")));
     }
 
     @SuppressWarnings("unchecked")
@@ -224,5 +226,14 @@ public class TestJavaPackageAndImportBuilder extends AbstractPureTestWithCoreCom
         CoreInstance element = runtime.getCoreInstance(userPath);
         Assert.assertNotNull(userPath, element);
         return (T) element;
+    }
+
+    private static Unit getUnit(String unitPath)
+    {
+        String measurePath = unitPath.substring(0, unitPath.indexOf('~'));
+        Measure measure = getElement(measurePath);
+        Unit unit = (Unit) org.finos.legend.pure.m3.navigation.measure.Measure.findUnit(measure, unitPath.substring(unitPath.lastIndexOf(':') + 1));
+        Assert.assertNotNull(unitPath, unit);
+        return unit;
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/TestTypeProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/TestTypeProcessor.java
@@ -61,34 +61,34 @@ public class TestTypeProcessor extends AbstractPureTestWithCoreCompiled
     @Test
     public void testJavaInterfaceForType()
     {
-        Assert.assertEquals("Root_test_generation_compiled_SimpleClass", TypeProcessor.javaInterfaceForType(getElement("test::generation::compiled::SimpleClass")));
-        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass", TypeProcessor.javaInterfaceForType(getElement("test::generation::compiled::extra::ExtraClass")));
-        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class", TypeProcessor.javaInterfaceForType(getElement(M3Paths.Class)));
-        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association", TypeProcessor.javaInterfaceForType(getElement(M3Paths.Association)));
-        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration", TypeProcessor.javaInterfaceForType(getElement(M3Paths.Enumeration)));
-        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum", TypeProcessor.javaInterfaceForType(getElement(M3Paths.Enum)));
+        Assert.assertEquals("Root_test_generation_compiled_SimpleClass", TypeProcessor.javaInterfaceForType(getElement("test::generation::compiled::SimpleClass"), processorSupport));
+        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass", TypeProcessor.javaInterfaceForType(getElement("test::generation::compiled::extra::ExtraClass"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class", TypeProcessor.javaInterfaceForType(getElement(M3Paths.Class), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association", TypeProcessor.javaInterfaceForType(getElement(M3Paths.Association), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration", TypeProcessor.javaInterfaceForType(getElement(M3Paths.Enumeration), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum", TypeProcessor.javaInterfaceForType(getElement(M3Paths.Enum), processorSupport));
     }
 
     @Test
     public void testJavaInterfaceNameForType()
     {
-        Assert.assertEquals("Root_test_generation_compiled_SimpleClass", TypeProcessor.javaInterfaceNameForType(getElement("test::generation::compiled::SimpleClass")));
-        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass", TypeProcessor.javaInterfaceNameForType(getElement("test::generation::compiled::extra::ExtraClass")));
-        Assert.assertEquals("Class", TypeProcessor.javaInterfaceNameForType(getElement(M3Paths.Class)));
-        Assert.assertEquals("Association", TypeProcessor.javaInterfaceNameForType(getElement(M3Paths.Association)));
-        Assert.assertEquals("Enumeration", TypeProcessor.javaInterfaceNameForType(getElement(M3Paths.Enumeration)));
-        Assert.assertEquals("Enum", TypeProcessor.javaInterfaceNameForType(getElement(M3Paths.Enum)));
+        Assert.assertEquals("Root_test_generation_compiled_SimpleClass", TypeProcessor.javaInterfaceNameForType(getElement("test::generation::compiled::SimpleClass"), processorSupport));
+        Assert.assertEquals("Root_test_generation_compiled_extra_ExtraClass", TypeProcessor.javaInterfaceNameForType(getElement("test::generation::compiled::extra::ExtraClass"), processorSupport));
+        Assert.assertEquals("Class", TypeProcessor.javaInterfaceNameForType(getElement(M3Paths.Class), processorSupport));
+        Assert.assertEquals("Association", TypeProcessor.javaInterfaceNameForType(getElement(M3Paths.Association), processorSupport));
+        Assert.assertEquals("Enumeration", TypeProcessor.javaInterfaceNameForType(getElement(M3Paths.Enumeration), processorSupport));
+        Assert.assertEquals("Enum", TypeProcessor.javaInterfaceNameForType(getElement(M3Paths.Enum), processorSupport));
     }
 
     @Test
     public void testFullyQualifiedJavaInterfaceNameForType()
     {
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement("test::generation::compiled::SimpleClass")));
-        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement("test::generation::compiled::extra::ExtraClass")));
-        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement(M3Paths.Class)));
-        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement(M3Paths.Association)));
-        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement(M3Paths.Enumeration)));
-        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement(M3Paths.Enum)));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_SimpleClass", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement("test::generation::compiled::SimpleClass"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.generated.Root_test_generation_compiled_extra_ExtraClass", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement("test::generation::compiled::extra::ExtraClass"), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement(M3Paths.Class), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement(M3Paths.Association), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement(M3Paths.Enumeration), processorSupport));
+        Assert.assertEquals("org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum", TypeProcessor.fullyQualifiedJavaInterfaceNameForType(getElement(M3Paths.Enum), processorSupport));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Unit no longer extends PackageableElements. Unit still extends Type, but units are no longer in the package tree. Also, the name of a unit no longer includes the name of its owning measure.

The syntax for denoting units remains the same, however. And they remain accessible from measures in the same way as before.