### PR TITLE
Initialize compiled state integrity tests from caches when possible

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/ParserLibrary.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/ParserLibrary.java
@@ -54,12 +54,19 @@ public class ParserLibrary
         return this.parsers.valuesView();
     }
 
+    /**
+     * Get the named parser from the library.
+     *
+     * @param name parser name
+     * @return parser
+     * @throws UnknownParserException if the parser cannot be found
+     */
     public Parser getParser(String name)
     {
         Parser parser = this.parsers.get(name);
         if (parser == null)
         {
-            throw new RuntimeException("'" + name + "' is not a known parser. Known parsers are: " + this.parsers.keysView().toSortedList().makeString(", "));
+            throw new UnknownParserException(name, this.parsers);
         }
         return this.parsers.get(name).newInstance(this);
     }
@@ -105,6 +112,22 @@ public class ParserLibrary
             throw new RuntimeException("Found 0 or more than one (" + res.size() + ") handlers for resolving the element Accessor " + element.getName() + " " + path.makeString("."));
         }
         return res.get(0);
+    }
+
+    public static class UnknownParserException extends RuntimeException
+    {
+        private final String name;
+
+        private UnknownParserException(String name, ImmutableMap<String, Parser> parsers)
+        {
+            super("'" + name + "' is not a known parser. Known parsers are: " + parsers.keysView().toSortedList().makeString(", "));
+            this.name = name;
+        }
+
+        public String getName()
+        {
+            return this.name;
+        }
     }
 
     public static class InvalidParserLibraryException extends Exception

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/BinarySourceSerializer.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/BinarySourceSerializer.java
@@ -188,10 +188,6 @@ public class BinarySourceSerializer
                 {
                     String parserName = parserNames[reader.readInt()];
                     Parser parser = library.getParser(parserName);
-                    if (parser == null)
-                    {
-                        throw new RuntimeException("Unknown parser: " + parserName);
-                    }
                     elementsByParser.putAll(parser, readCoreInstancesById(reader, instancesById));
                 }
             }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/PureRuntime.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/PureRuntime.java
@@ -114,6 +114,11 @@ public class PureRuntime
         this.options = options;
     }
 
+    public void initialize()
+    {
+        initialize(null);
+    }
+
     public void initialize(Message message)
     {
         synchronized (this.initializationLock)
@@ -125,7 +130,10 @@ public class PureRuntime
                 this.initializationError = false;
                 try
                 {
-                    message.setMessage("Initializing...");
+                    if (message != null)
+                    {
+                        message.setMessage("Initializing...");
+                    }
                     this.loadAndCompileCore(message);
                     try
                     {
@@ -136,7 +144,10 @@ public class PureRuntime
                     {
                         this.initialized = true;
                     }
-                    message.setMessage("...");
+                    if (message != null)
+                    {
+                        message.setMessage("...");
+                    }
                 }
                 catch (RuntimeException | Error e)
                 {

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/antlr/AggregationAwareGraphBuilder.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/antlr/AggregationAwareGraphBuilder.java
@@ -160,7 +160,7 @@ public class AggregationAwareGraphBuilder extends AggregationAwareParserBaseVisi
         {
             parser = this.parserLibrary.getParser(parserName);
         }
-        catch (RuntimeException e)
+        catch (ParserLibrary.UnknownParserException e)
         {
             throw new PureParserException(sourceInfo, e.getMessage(), e);
         }

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/antlr/MappingGraphBuilder.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/antlr/MappingGraphBuilder.java
@@ -166,7 +166,7 @@ public class MappingGraphBuilder extends MappingParserBaseVisitor<String>
         {
             parser = this.parserLibrary.getParser(parserName);
         }
-        catch (RuntimeException e)
+        catch (ParserLibrary.UnknownParserException e)
         {
             throw new PureParserException(this.sourceInformation.getPureSourceInformation(ctx.mappingInstance().CURLY_BRACKET_OPEN().getSymbol()), e.getMessage(), e);
         }


### PR DESCRIPTION
Initialize compiled state integrity tests from caches when possible. In passing, add a specific exception to ParserLibrary for unknown parsers.