### PR TITLE
add test connection execution for duck db in pure runtime

### DIFF
--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-compiled-store-relational/pom.xml
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-compiled-store-relational/pom.xml
@@ -167,6 +167,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.duckdb</groupId>
+            <artifactId>duckdb_jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-interpreted-store-relational/pom.xml
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-interpreted-store-relational/pom.xml
@@ -76,6 +76,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.duckdb</groupId>
+            <artifactId>duckdb_jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m2-store-relational-grammar</artifactId>
             <scope>test</scope>

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/ConnectionManager.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/ConnectionManager.java
@@ -21,6 +21,7 @@ import org.eclipse.collections.api.map.ConcurrentMutableMap;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.list.mutable.SynchronizedMutableList;
 import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
+import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.shared.identity.IdentityManager;
@@ -69,6 +70,7 @@ public class ConnectionManager
 
     private static final String TestDatabaseConnection = "meta::external::store::relational::runtime::TestDatabaseConnection";
     private static final TestDatabaseConnect testDatabaseConnect = new TestDatabaseConnect();
+    private static final TestDatabaseConnectDuckDB testDatabaseConnectDuckDB = new TestDatabaseConnectDuckDB();
 
     private ConnectionManager()
     {
@@ -78,7 +80,16 @@ public class ConnectionManager
     {
         if (processorSupport.instance_instanceOf(connectionInformation, TestDatabaseConnection))
         {
-            return testDatabaseConnect.getConnectionWithDataSourceInfo(IdentityManager.getAuthenticatedUserId());
+            CoreInstance dbType = Instance.getValueForMetaPropertyToOneResolved(connectionInformation, "type", processorSupport);
+            String dbTypeStr = dbType.getName();
+            if (dbTypeStr.equals("DuckDB"))
+            {
+                return testDatabaseConnectDuckDB.getConnectionWithDataSourceInfo(IdentityManager.getAuthenticatedUserId());
+            }
+            else    // default to H2
+            {
+                return testDatabaseConnect.getConnectionWithDataSourceInfo(IdentityManager.getAuthenticatedUserId());
+            }
         }
 
         throw new RuntimeException(connectionInformation + " is not supported for execution!!");

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/DuckDBConnectionWrapper.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/DuckDBConnectionWrapper.java
@@ -1,0 +1,56 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.extension.store.relational.shared.connectionManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class DuckDBConnectionWrapper extends ConnectionWrapper
+{
+    Logger logger = LoggerFactory.getLogger(DuckDBConnectionWrapper.class);
+
+    private int borrowedCounter;
+    String user;
+
+    public DuckDBConnectionWrapper(Connection connection, String user)
+    {
+        super(connection);
+        this.user = user;
+    }
+
+    public void incrementBorrowedCounter()
+    {
+        borrowedCounter++;
+    }
+
+    private void decrementBorrowedCounter()
+    {
+        borrowedCounter--;
+    }
+
+    @Override
+    public void close() throws SQLException
+    {
+        this.decrementBorrowedCounter();
+        //never actually close duck db connection and re-use same connection over
+//        if (borrowedCounter <= 0)
+//        {
+//            this.closeConnection();
+//        }
+    }
+}

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/DuckDBConnectionWrapper.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/DuckDBConnectionWrapper.java
@@ -24,7 +24,6 @@ public class DuckDBConnectionWrapper extends ConnectionWrapper
 {
     Logger logger = LoggerFactory.getLogger(DuckDBConnectionWrapper.class);
 
-    private int borrowedCounter;
     String user;
 
     public DuckDBConnectionWrapper(Connection connection, String user)
@@ -33,24 +32,11 @@ public class DuckDBConnectionWrapper extends ConnectionWrapper
         this.user = user;
     }
 
-    public void incrementBorrowedCounter()
-    {
-        borrowedCounter++;
-    }
-
-    private void decrementBorrowedCounter()
-    {
-        borrowedCounter--;
-    }
 
     @Override
     public void close() throws SQLException
     {
-        this.decrementBorrowedCounter();
+        //needed to hijack jdbc connection close method
         //never actually close duck db connection and re-use same connection over
-//        if (borrowedCounter <= 0)
-//        {
-//            this.closeConnection();
-//        }
     }
 }

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
@@ -69,7 +69,7 @@ public class TestDatabaseConnect extends PerThreadPoolableConnectionProvider
         }
         catch (SQLException ex)
         {
-            throw new PureExecutionException("Unable to create TestDatabaseConnection for user: " + user, ex);
+            throw new PureExecutionException("Unable to create TestDatabaseConnection of type: H2 for user: " + user + ", message: " + ex.getMessage(), ex);
         }
 
         pcw.incrementBorrowedCounter();

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnectDuckDB.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnectDuckDB.java
@@ -58,7 +58,6 @@ public class TestDatabaseConnectDuckDB
         {
             throw new PureExecutionException("Unable to create TestDatabaseConnection of type: DuckDB for user: " + user + ", message: " + ex.getMessage(), ex);
         }
-        this.singletonConnection.incrementBorrowedCounter();
         return new ConnectionWithDataSourceInfo(this.singletonConnection, TEST_DATA_SOURCE, this.getClass().getSimpleName());
     }
 

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnectDuckDB.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnectDuckDB.java
@@ -1,0 +1,71 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.extension.store.relational.shared.connectionManager;
+
+import org.finos.legend.pure.m3.exception.PureExecutionException;
+import org.finos.legend.pure.runtime.java.extension.store.relational.shared.ConnectionWithDataSourceInfo;
+import org.finos.legend.pure.runtime.java.extension.store.relational.shared.DataSource;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class TestDatabaseConnectDuckDB
+{
+    private DuckDBConnectionWrapper singletonConnection;         // disabled thread-level and user-level segregation,
+    public static final String TEST_DB_HOST_NAME = "local";
+    private static final String TEST_DB_NAME = "pure-duckDB-test-Db";
+    private static final DataSource TEST_DATA_SOURCE = new DataSource(TEST_DB_HOST_NAME, -1, TEST_DB_NAME, null);
+
+    public TestDatabaseConnectDuckDB()
+    {
+        try
+        {
+            Class.forName("org.duckdb.DuckDBDriver");
+        }
+        catch (ClassNotFoundException ignore)
+        {
+            // ignore exception about not finding the duckDB driver
+        }
+    }
+
+    public ConnectionWithDataSourceInfo getConnectionWithDataSourceInfo(String user)
+    {
+        try
+        {
+            if (this.singletonConnection == null || this.singletonConnection.isClosed())
+            {
+                Connection connection = DriverManager.getConnection(getConnectionURL());
+                //there is no way to configure timezone as jdbc url param or system properties
+                connection.createStatement().execute("SET TimeZone = 'UTC'");
+
+                this.singletonConnection = new DuckDBConnectionWrapper(connection, user);
+            }
+        }
+        catch (SQLException ex)
+        {
+            throw new PureExecutionException("Unable to create TestDatabaseConnection of type: DuckDB for user: " + user + ", message: " + ex.getMessage(), ex);
+        }
+        this.singletonConnection.incrementBorrowedCounter();
+        return new ConnectionWithDataSourceInfo(this.singletonConnection, TEST_DATA_SOURCE, this.getClass().getSimpleName());
+    }
+
+
+    private static String getConnectionURL()
+    {
+        return "jdbc:duckdb:" + TEST_DB_NAME;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <eclipsecollections.version>10.2.0</eclipsecollections.version>
         <guava.version>30.0-jre</guava.version>
         <h2.version>2.1.214</h2.version>
+        <duckdb.version>1.0.0</duckdb.version>
         <jackson.version>2.10.5</jackson.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>
@@ -838,6 +839,11 @@
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>${h2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.duckdb</groupId>
+                <artifactId>duckdb_jdbc</artifactId>
+                <version>${duckdb.version}</version>
             </dependency>
             <!-- DB drivers -->
 


### PR DESCRIPTION
- use dbtype in testdbconnection to switch between h2 and duckDB test connection in legend-pure connection manager
- use singleton connection for duckdb