### PR TITLE
Add test for component instance containment

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/TestM3CoreCompiledStateIntegrity.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/TestM3CoreCompiledStateIntegrity.java
@@ -15,6 +15,7 @@
 package org.finos.legend.pure.m3.tests;
 
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class TestM3CoreCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -22,5 +23,11 @@ public class TestM3CoreCompiledStateIntegrity extends AbstractCompiledStateInteg
     public static void initialize()
     {
         initialize("platform");
+    }
+
+    @Test
+    public void testPackagedElementsContainAllOthers()
+    {
+        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/AbstractTestFunctionDefinitionModify.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/AbstractTestFunctionDefinitionModify.java
@@ -15,7 +15,6 @@
 package org.finos.legend.pure.m3.tests.function;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableRepositoryCodeStorage;
@@ -26,7 +25,6 @@ import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
-
 
 public abstract class AbstractTestFunctionDefinitionModify extends AbstractPureTestWithCoreCompiled
 {
@@ -253,9 +251,7 @@ public abstract class AbstractTestFunctionDefinitionModify extends AbstractPureT
 
     protected static MutableRepositoryCodeStorage getCodeStorage()
     {
-        MutableList<CodeRepository> repositories = org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
-        CodeRepository test = new GenericCodeRepository("test", null, "platform");
-        repositories.add(test);
-        return new CompositeCodeStorage(new ClassLoaderCodeStorage(repositories));
+        return new CompositeCodeStorage(new ClassLoaderCodeStorage(Lists.mutable.<CodeRepository>withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories())
+                .with(new GenericCodeRepository("test", null, "platform"))));
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/lang/AbstractTestCast.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/lang/AbstractTestCast.java
@@ -14,7 +14,7 @@
 
 package org.finos.legend.pure.m3.tests.function.base.lang;
 
-import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
@@ -27,7 +27,6 @@ import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
-
 
 public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 {
@@ -347,9 +346,8 @@ public abstract class AbstractTestCast extends AbstractPureTestWithCoreCompiled
 
     protected static MutableRepositoryCodeStorage getCodeStorage()
     {
-        MutableList<CodeRepository> repositories = org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
-        repositories.add(new GenericCodeRepository("test", null, "platform", "core_functions_unclassified"));
-        return new CompositeCodeStorage(new ClassLoaderCodeStorage(repositories));
+        return new CompositeCodeStorage(new ClassLoaderCodeStorage(Lists.mutable.<CodeRepository>withAll(getCodeRepositories())
+                .with(new GenericCodeRepository("test", null, "platform", "core_functions_unclassified"))));
     }
 
     public static Pair<String, String> getExtra()

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/lang/AbstractTestDynamicNew.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/lang/AbstractTestDynamicNew.java
@@ -15,7 +15,6 @@
 package org.finos.legend.pure.m3.tests.function.base.lang;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.MutableRepositoryCodeStorage;
@@ -317,9 +316,7 @@ public abstract class AbstractTestDynamicNew extends AbstractPureTestWithCoreCom
 
     protected static MutableRepositoryCodeStorage getCodeStorage()
     {
-        MutableList<CodeRepository> repositories = Lists.mutable.withAll(org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories()));
-        CodeRepository test = new GenericCodeRepository("test", null, "platform", "core_functions_unclassified");
-        repositories.add(test);
-        return new CompositeCodeStorage(new ClassLoaderCodeStorage(repositories));
+        return new CompositeCodeStorage(new ClassLoaderCodeStorage(Lists.mutable.<CodeRepository>withAll(getCodeRepositories())
+                .with(new GenericCodeRepository("test", null, "platform", "core_functions_unclassified"))));
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/lang/AbstractTestNewAtRuntime.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/lang/AbstractTestNewAtRuntime.java
@@ -15,7 +15,6 @@
 package org.finos.legend.pure.m3.tests.function.base.lang;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
@@ -408,12 +407,9 @@ public abstract class AbstractTestNewAtRuntime extends AbstractPureTestWithCoreC
     @Test
     public abstract void testNewWithInheritenceAndOverriddenAssociationEndWithReverseOneToManyProperty();
 
-
     protected static MutableRepositoryCodeStorage getCodeStorage()
     {
-        MutableList<CodeRepository> repositories = org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
-        CodeRepository test = new GenericCodeRepository("test", null, "platform", "core_functions_unclassified");
-        repositories.add(test);
-        return new CompositeCodeStorage(new ClassLoaderCodeStorage(repositories));
+        return new CompositeCodeStorage(new ClassLoaderCodeStorage(Lists.mutable.<CodeRepository>withAll(getCodeRepositories())
+                .with(new GenericCodeRepository("test", null, "platform", "core_functions_unclassified"))));
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/string/AbstractTestChunk.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/string/AbstractTestChunk.java
@@ -15,7 +15,6 @@
 package org.finos.legend.pure.m3.tests.function.base.string;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.test.Verify;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
@@ -29,7 +28,6 @@ import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
-
 
 public abstract class AbstractTestChunk extends AbstractPureTestWithCoreCompiled
 {
@@ -92,9 +90,7 @@ public abstract class AbstractTestChunk extends AbstractPureTestWithCoreCompiled
 
     protected static MutableRepositoryCodeStorage getCodeStorage()
     {
-        MutableList<CodeRepository> repositories = org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
-        CodeRepository test = new GenericCodeRepository("test", null, "platform", "core_functions_unclassified");
-        repositories.add(test);
-        return new CompositeCodeStorage(new ClassLoaderCodeStorage(repositories));
+        return new CompositeCodeStorage(new ClassLoaderCodeStorage(Lists.mutable.<CodeRepository>withAll(getCodeRepositories())
+                .with(new GenericCodeRepository("test", null, "platform", "core_functions_unclassified"))));
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/AbstractTestIncrementalCompilation.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/AbstractTestIncrementalCompilation.java
@@ -25,7 +25,6 @@ import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -33,16 +32,11 @@ public abstract class AbstractTestIncrementalCompilation extends AbstractPureTes
 {
     protected static MutableRepositoryCodeStorage getCodeStorage()
     {
-        MutableList<CodeRepository> repositories = org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
-        CodeRepository platform = repositories.detect(x -> x.getName().equals("platform"));
-        CodeRepository core = new GenericCodeRepository("x_core", null, "platform");
-        CodeRepository system = new GenericCodeRepository("system", null, "platform", "x_core");
-        CodeRepository model = new GenericCodeRepository("model", null, "platform", "x_core", "system");
-        CodeRepository other = new GenericCodeRepository("datamart_other", null, "platform", "x_core", "system", "model");
-        repositories.add(core);
-        repositories.add(system);
-        repositories.add(model);
-        repositories.add(other);
+        MutableList<CodeRepository> repositories = Lists.mutable.<CodeRepository>withAll(getCodeRepositories())
+                .with(new GenericCodeRepository("x_core", null, "platform"))
+                .with(new GenericCodeRepository("system", null, "platform", "x_core"))
+                .with(new GenericCodeRepository("model", null, "platform", "x_core", "system"))
+                .with(new GenericCodeRepository("datamart_other", null, "platform", "x_core", "system", "model"));
         return new CompositeCodeStorage(new ClassLoaderCodeStorage(repositories));
     }
 
@@ -756,7 +750,6 @@ public abstract class AbstractTestIncrementalCompilation extends AbstractPureTes
     }
 
     @Test
-    @Ignore("Inconsistency of new operator in compiled vs interpreted mode")
     public void test14()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId1.pure", "Class my::enterprise::Vehicle\n" +
@@ -1148,7 +1141,6 @@ public abstract class AbstractTestIncrementalCompilation extends AbstractPureTes
     }
 
     @Test
-    @Ignore("Inconsistency of new operator in compiled vs interpreted mode")
     public void test20()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("/system/tests/sourceId1.pure", "Class A\n" +
@@ -1219,7 +1211,6 @@ public abstract class AbstractTestIncrementalCompilation extends AbstractPureTes
     }
 
     @Test
-    @Ignore("Inconsistency of new operator in compiled vs interpreted mode")
     public void test21()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("/system/tests/sourceId1.pure", "Class A\n" +

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_AsFunctionReturn.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_AsFunctionReturn.java
@@ -15,8 +15,8 @@
 package org.finos.legend.pure.m3.tests.incremental._class;
 
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
-import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Properties;
@@ -26,7 +26,6 @@ import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeR
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
@@ -36,22 +35,19 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
     {
-        setUpRuntime(getFunctionExecution(), new CompositeCodeStorage(new ClassLoaderCodeStorage(getCodeRepositories())), getFactoryRegistryOverride(), getOptions(), getExtra());
+        setUpRuntime(getFunctionExecution(), new CompositeCodeStorage(new ClassLoaderCodeStorage(getCodeRepositories())), getFactoryRegistryOverride());
     }
 
     protected static RichIterable<? extends CodeRepository> getCodeRepositories()
     {
-        MutableList<CodeRepository> repositories = org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
-        CodeRepository system = GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform");
-        CodeRepository test = GenericCodeRepository.build("test", "test(::.*)?", "platform", "system");
-        repositories.add(system);
-        repositories.add(test);
-        return repositories;
+        return Lists.mutable.<CodeRepository>withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories())
+                .with(GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform"))
+                .with(GenericCodeRepository.build("test", "test(::.*)?", "platform", "system"));
     }
 
     @After
@@ -445,5 +441,4 @@ public class TestPureRuntimeClass_AsFunctionReturn extends AbstractPureTestWithC
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
-
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_AsPointer.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_AsPointer.java
@@ -14,7 +14,7 @@
 
 package org.finos.legend.pure.m3.tests.incremental._class;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
@@ -22,7 +22,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeClass_AsPointer extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeClass_AsPointer extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -39,7 +39,7 @@ public class TestPureRuntimeClass_AsPointer extends AbstractPureTestWithCoreComp
     }
 
     @Test
-    public void testPureRuntimeClassPointer() throws Exception
+    public void testPureRuntimeClassPointer()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{}")
                         .createInMemorySource("userId.pure", "function f():Class<Any>[1]{A}" +
@@ -54,7 +54,7 @@ public class TestPureRuntimeClass_AsPointer extends AbstractPureTestWithCoreComp
     }
 
     @Test
-    public void testPureRuntimeClassPointerInArray() throws Exception
+    public void testPureRuntimeClassPointerInArray()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{}")
                         .createInMemorySource("userId.pure", "function f():Class<Any>[*]{[A,A]}" +
@@ -69,7 +69,7 @@ public class TestPureRuntimeClass_AsPointer extends AbstractPureTestWithCoreComp
     }
 
     @Test
-    public void testPureRuntimeClassPointerError() throws Exception
+    public void testPureRuntimeClassPointerError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{}")
                         .createInMemorySource("userId.pure", "function f():Class<Any>[1]{A}" +
@@ -87,7 +87,7 @@ public class TestPureRuntimeClass_AsPointer extends AbstractPureTestWithCoreComp
     }
 
     @Test
-    public void testPureRuntimeClassReferenceUsageCleanUp() throws Exception
+    public void testPureRuntimeClassReferenceUsageCleanUp()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "function f():Class<Any>[1]{A}")
                         .createInMemorySource("userId.pure", "Class A{}")

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_Constraints.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_Constraints.java
@@ -14,7 +14,7 @@
 
 package org.finos.legend.pure.m3.tests.incremental._class;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
@@ -23,7 +23,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeClass_Constraints extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeClass_Constraints extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_FunctionExpressionParam.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_FunctionExpressionParam.java
@@ -14,7 +14,7 @@
 
 package org.finos.legend.pure.m3.tests.incremental._class;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
@@ -22,7 +22,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeClass_FunctionExpressionParam extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeClass_FunctionExpressionParam extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -41,7 +41,7 @@ public class TestPureRuntimeClass_FunctionExpressionParam extends AbstractPureTe
     }
 
     @Test
-    public void testPureRuntimeClassAsFunctionExpressionParameter() throws Exception
+    public void testPureRuntimeClassAsFunctionExpressionParameter()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{}")
                         .createInMemorySource("userId.pure", "function f(c:Class<Any>[1]):String[0..1]{$c.name}" +
@@ -57,7 +57,7 @@ public class TestPureRuntimeClass_FunctionExpressionParam extends AbstractPureTe
 
 
     @Test
-    public void testPureRuntimeClassAsFunctionExpressionParameterError() throws Exception
+    public void testPureRuntimeClassAsFunctionExpressionParameterError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{}")
                         .createInMemorySource("userId.pure", "function f(c:Class<Any>[1]):String[0..1]{$c.name}" +
@@ -74,7 +74,7 @@ public class TestPureRuntimeClass_FunctionExpressionParam extends AbstractPureTe
     }
 
     @Test
-    public void testPureRuntimeClassParameterUsageCleanUp() throws Exception
+    public void testPureRuntimeClassParameterUsageCleanUp()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "function f(c:Class<Any>[1]):Any[1]{$c} function k():Nil[0]{f(A);[];}")
                         .createInMemorySource("userId.pure", "Class A{}")
@@ -104,7 +104,7 @@ public class TestPureRuntimeClass_FunctionExpressionParam extends AbstractPureTe
     }
 
     @Test
-    public void testPureRuntimeClassUsedInNew() throws Exception
+    public void testPureRuntimeClassUsedInNew()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("other.pure", "Class XX{ok:String[1];}")
                         .createInMemorySource("sourceId.pure", "function test():Nil[0]{^XX(ok='1');[];}" +
@@ -119,7 +119,7 @@ public class TestPureRuntimeClass_FunctionExpressionParam extends AbstractPureTe
     }
 
     @Test
-    public void testPureRuntimeClassUsedInNewReverse() throws Exception
+    public void testPureRuntimeClassUsedInNewReverse()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("other.pure", "Class XX{ok:String[1];}")
                         .createInMemorySource("sourceId.pure", "function test():Nil[0]{^XX(ok='1');[];}" +
@@ -135,7 +135,7 @@ public class TestPureRuntimeClass_FunctionExpressionParam extends AbstractPureTe
     }
 
     @Test
-    public void testPureRuntimeClassUsedInNewOther() throws Exception
+    public void testPureRuntimeClassUsedInNewOther()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("other.pure", "function test():Nil[0]{^XX(ok='1');[];}")
                         .createInMemorySource("sourceId.pure", "Class XX{ok:String[1];}\n" +
@@ -161,7 +161,7 @@ public class TestPureRuntimeClass_FunctionExpressionParam extends AbstractPureTe
     }
 
     @Test
-    public void testPureRuntimeClassProperty_GenericsLambdaModify() throws Exception
+    public void testPureRuntimeClassProperty_GenericsLambdaModify()
     {
         String sourceId2 = "import meta::relational::tests::mapping::enumeration::model::domain::*;\n" +
                 "function go():Any[*]\n" +
@@ -187,7 +187,7 @@ public class TestPureRuntimeClass_FunctionExpressionParam extends AbstractPureTe
 
 
     @Test
-    public void testPureRuntimeClassProperty_NestedGenericsModify() throws Exception
+    public void testPureRuntimeClassProperty_NestedGenericsModify()
     {
         String sourceId2 = "import meta::relational::tests::mapping::enumeration::model::domain::*;\n" +
                 "\n" +
@@ -236,7 +236,7 @@ public class TestPureRuntimeClass_FunctionExpressionParam extends AbstractPureTe
 
 
     @Test
-    public void testPureRuntimeClassProperty_NestedGenericsModifyProject() throws Exception
+    public void testPureRuntimeClassProperty_NestedGenericsModifyProject()
     {
         String sourceId2 = "import meta::relational::tests::mapping::enumeration::model::domain::*;\n" +
                 "Class meta::pure::tds::TabularDataSet\n" +

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_FunctionParamType.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_FunctionParamType.java
@@ -19,7 +19,7 @@ import org.eclipse.collections.api.map.ImmutableMap;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation._class._Class;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
@@ -29,7 +29,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeClass_FunctionParamType extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeClass_FunctionParamType extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_InCast.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_InCast.java
@@ -14,14 +14,14 @@
 
 package org.finos.legend.pure.m3.tests.incremental._class;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeClass_InCast extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeClass_InCast extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -49,7 +49,6 @@ public class TestPureRuntimeClass_InCast extends AbstractPureTestWithCoreCompile
                         .createInMemorySource("sourceId.pure", "Class A{name:String[1];} Class B extends A{}")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
-
     }
 
     @Test

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_InCopy.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_InCopy.java
@@ -14,14 +14,14 @@
 
 package org.finos.legend.pure.m3.tests.incremental._class;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeClass_InCopy extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeClass_InCopy extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -38,7 +38,7 @@ public class TestPureRuntimeClass_InCopy extends AbstractPureTestWithCoreCompile
     }
 
     @Test
-    public void testPureRuntimeClassUsedInCopy() throws Exception
+    public void testPureRuntimeClassUsedInCopy()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{name:String[1];} function getA():A[1]{^A(name='ok')}")
                         .createInMemorySource("userId.pure", "function test():String[1]{let a = getA(); ^$a(name='test'); 'tst';}")
@@ -52,7 +52,7 @@ public class TestPureRuntimeClass_InCopy extends AbstractPureTestWithCoreCompile
     }
 
     @Test
-    public void testPureRuntimeClassUsedInCopyWithWrongProperty() throws Exception
+    public void testPureRuntimeClassUsedInCopyWithWrongProperty()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{name:String[1];} function getA():A[1]{^A(name='ok')}")
                         .createInMemorySource("userId.pure", "function test():String[1]{let a = getA();^$a(name='test'); 'tst';}")

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_InGeneralization.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_InGeneralization.java
@@ -15,7 +15,7 @@
 package org.finos.legend.pure.m3.tests.incremental._class;
 
 import org.finos.legend.pure.m3.exception.PureUnmatchedFunctionException;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.finos.legend.pure.m3.tools.test.ToFix;
@@ -24,7 +24,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-public class TestPureRuntimeClass_InGeneralization extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeClass_InGeneralization extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -42,7 +42,7 @@ public class TestPureRuntimeClass_InGeneralization extends AbstractPureTestWithC
     }
 
     @Test
-    public void testPureRuntimeClassGeneralization() throws Exception
+    public void testPureRuntimeClassGeneralization()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class B{}")
                         .createInMemorySource("userId.pure", "Class A extends B{}" +
@@ -80,7 +80,7 @@ public class TestPureRuntimeClass_InGeneralization extends AbstractPureTestWithC
 
 
     @Test
-    public void testPureRuntimeClassGeneralizationError() throws Exception
+    public void testPureRuntimeClassGeneralizationError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class B{}")
                         .createInMemorySource("userId.pure", "Class A extends B{}" +
@@ -98,7 +98,7 @@ public class TestPureRuntimeClass_InGeneralization extends AbstractPureTestWithC
 
 
     @Test
-    public void testPureRuntimeClassGeneralizationPropertyError() throws Exception
+    public void testPureRuntimeClassGeneralizationPropertyError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class test::B{property:String[1];}")
                         .createInMemorySource("userId.pure", "import test::*;\n" +
@@ -116,7 +116,7 @@ public class TestPureRuntimeClass_InGeneralization extends AbstractPureTestWithC
     }
 
     @Test
-    public void testPureRuntimeClassGeneralizationFunctionMatchingParameter() throws Exception
+    public void testPureRuntimeClassGeneralizationFunctionMatchingParameter()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A extends B{}")
                         .createInMemorySource("userId.pure", "Class B{}" +
@@ -133,7 +133,7 @@ public class TestPureRuntimeClass_InGeneralization extends AbstractPureTestWithC
 
 
     @Test
-    public void testPureRuntimeClassGeneralizationFunctionMatchingParameterError() throws Exception
+    public void testPureRuntimeClassGeneralizationFunctionMatchingParameterError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A extends B{}")
                         .createInMemorySource("userId.pure", "Class B{}" +
@@ -155,7 +155,7 @@ public class TestPureRuntimeClass_InGeneralization extends AbstractPureTestWithC
 
 
     @Test
-    public void testPureRuntimeClassGeneralizationFunctionMatchingReturn() throws Exception
+    public void testPureRuntimeClassGeneralizationFunctionMatchingReturn()
     {
 
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class B extends C{}")
@@ -175,7 +175,7 @@ public class TestPureRuntimeClass_InGeneralization extends AbstractPureTestWithC
 
 
     @Test
-    public void testPureRuntimeClassGeneralizationFunctionMatchingOtherReturnError() throws Exception
+    public void testPureRuntimeClassGeneralizationFunctionMatchingOtherReturnError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class B extends C{}")
                         .createInMemorySource("userId.pure", "Class D{}" +

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_InNew.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_InNew.java
@@ -14,14 +14,14 @@
 
 package org.finos.legend.pure.m3.tests.incremental._class;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeClass_InNew extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeClass_InNew extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -111,5 +111,4 @@ public class TestPureRuntimeClass_InNew extends AbstractPureTestWithCoreCompiled
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
-
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_Property_UsedInAutoCollect.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_class/TestPureRuntimeClass_Property_UsedInAutoCollect.java
@@ -14,14 +14,14 @@
 
 package org.finos.legend.pure.m3.tests.incremental._class;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeClass_Property_UsedInAutoCollect extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeClass_Property_UsedInAutoCollect extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -38,7 +38,7 @@ public class TestPureRuntimeClass_Property_UsedInAutoCollect extends AbstractPur
     }
 
     @Test
-    public void testPureRuntimeClass_Property() throws Exception
+    public void testPureRuntimeClass_Property()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class A{name:String[1];}")
                         .createInMemorySource("userId.pure", "function test():String[*]{A.all().name}")
@@ -51,9 +51,8 @@ public class TestPureRuntimeClass_Property_UsedInAutoCollect extends AbstractPur
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
-
     @Test
-    public void testPureRuntimeClass_QualifiedProperty() throws Exception
+    public void testPureRuntimeClass_QualifiedProperty()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class my::A{name(prefix:String[1]){ $prefix + ' Bob';}:String[1];}")
                         .createInMemorySource("userId.pure", "function test():String[*]{my::A.all().name('Mr')}")
@@ -66,7 +65,7 @@ public class TestPureRuntimeClass_Property_UsedInAutoCollect extends AbstractPur
     }
 
     @Test
-    public void testPureRuntimeClass_QualifiedPropertyOpenVariable() throws Exception
+    public void testPureRuntimeClass_QualifiedPropertyOpenVariable()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class my::A{name(prefix:String[1]){ $prefix + ' Bob';}:String[1];}")
                         .createInMemorySource("userId.pure", "function test():String[*]{ let b = 'Mr'; my::A.all().name($b);}")
@@ -79,7 +78,7 @@ public class TestPureRuntimeClass_Property_UsedInAutoCollect extends AbstractPur
     }
 
     @Test
-    public void testPureRuntimeClass_QualifiedPropertyOpenVariableForceUnbindAndReprocess() throws Exception
+    public void testPureRuntimeClass_QualifiedPropertyOpenVariableForceUnbindAndReprocess()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class my::A{name(prefix:String[1]){ $prefix + ' Bob';}:String[1];}")
                         .createInMemorySource("userId.pure", "function test():String[*]{ let b = 'Mr'; my::A.all().name($b);}")
@@ -89,7 +88,5 @@ public class TestPureRuntimeClass_Property_UsedInAutoCollect extends AbstractPur
                         .createInMemorySource("sourceId.pure", "Class my::A{name(prefix:String[1]){ $prefix + ' Bob';}:String[1];}")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
-
     }
-
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_package/TestPureRuntimePackage.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/_package/TestPureRuntimePackage.java
@@ -14,14 +14,14 @@
 
 package org.finos.legend.pure.m3.tests.incremental._package;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimePackage extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimePackage extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -32,7 +32,10 @@ public class TestPureRuntimePackage extends AbstractPureTestWithCoreCompiledPlat
     @After
     public void cleanRuntime()
     {
-        setUp();
+        runtime.delete("source.pure");
+        runtime.delete("source1.pure");
+        runtime.delete("source2.pure");
+        runtime.compile();
     }
 
     @Test
@@ -144,15 +147,8 @@ public class TestPureRuntimePackage extends AbstractPureTestWithCoreCompiledPlat
         Assert.assertNotNull(runtime.getCoreInstance("test_package1::test_package3::testFn__Package_1_"));
 
         runtime.delete("source1.pure");
-        try
-        {
-            runtime.compile();
-            Assert.fail("Expected compile exception");
-        }
-        catch (Exception e)
-        {
-            assertPureException(PureCompilationException.class, "test_package1::test_package2 has not been defined!", "source2.pure", 3, 19, e);
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+        assertPureException(PureCompilationException.class, "test_package1::test_package2 has not been defined!", "source2.pure", 3, 19, e);
     }
 
     @Test

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/association/TestPureRuntimeAssociation_AsPointer.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/association/TestPureRuntimeAssociation_AsPointer.java
@@ -14,14 +14,14 @@
 
 package org.finos.legend.pure.m3.tests.incremental.association;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeAssociation_AsPointer extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeAssociation_AsPointer extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -34,10 +34,11 @@ public class TestPureRuntimeAssociation_AsPointer extends AbstractPureTestWithCo
     {
         runtime.delete("userId.pure");
         runtime.delete("sourceId.pure");
+        runtime.compile();
     }
 
     @Test
-    public void testPureRuntimeAssociation() throws Exception
+    public void testPureRuntimeAssociation()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Association a {a:A[1];b:B[1];}")
                         .createInMemorySource("userId.pure", "Class A{}" +
@@ -52,9 +53,8 @@ public class TestPureRuntimeAssociation_AsPointer extends AbstractPureTestWithCo
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
-
     @Test
-    public void testPureRuntimeAssociationError() throws Exception
+    public void testPureRuntimeAssociationError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Association a {a:A[1];b:B[1];}")
                         .createInMemorySource("userId.pure", "Class A{}" +

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/association/TestPureRuntimeAssociation_UseProperty.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/association/TestPureRuntimeAssociation_UseProperty.java
@@ -14,14 +14,14 @@
 
 package org.finos.legend.pure.m3.tests.incremental.association;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeAssociation_UseProperty extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeAssociation_UseProperty extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -34,10 +34,11 @@ public class TestPureRuntimeAssociation_UseProperty extends AbstractPureTestWith
     {
         runtime.delete("userId.pure");
         runtime.delete("sourceId.pure");
+        runtime.compile();
     }
 
     @Test
-    public void testPureRuntimeAssociation_UseProperty() throws Exception
+    public void testPureRuntimeAssociation_UseProperty()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Association a {a:test::A[0..1];b:test::B[0..1];}")
                         .createInMemorySource("userId.pure", "import test::*;\n" +
@@ -51,12 +52,11 @@ public class TestPureRuntimeAssociation_UseProperty extends AbstractPureTestWith
                         .createInMemorySource("sourceId.pure", "Association a {a:test::A[0..1];b:test::B[0..1];}")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
-
     }
 
 
     @Test
-    public void testPureRuntimeAssociation_UsePropertyError() throws Exception
+    public void testPureRuntimeAssociation_UsePropertyError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Association a {a:test::A[0..1];b:test::B[0..1];}")
                         .createInMemorySource("userId.pure", "import test::*;\n" +
@@ -72,6 +72,5 @@ public class TestPureRuntimeAssociation_UseProperty extends AbstractPureTestWith
                         .updateSource("sourceId.pure", "Association a {a:test::A[0..1];b:test::B[0..1];}")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
-
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/enumeration/AbstractPureRuntimeEnumerationTest.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/enumeration/AbstractPureRuntimeEnumerationTest.java
@@ -17,12 +17,21 @@ package org.finos.legend.pure.m3.tests.incremental.enumeration;
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
+import org.junit.After;
 import org.junit.Test;
 
 public abstract class AbstractPureRuntimeEnumerationTest extends AbstractPureTestWithCoreCompiled
 {
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete("userId.pure");
+        runtime.delete("sourceId.pure");
+        runtime.compile();
+    }
+
     @Test
-    public void testPureRuntimeEnumerationAsReference() throws Exception
+    public void testPureRuntimeEnumerationAsReference()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Enum myEnum{VAL1, VAL2}")
                         .createInMemorySource("userId.pure", "function test():Any[1]{myEnum.VAL1;}")
@@ -32,11 +41,11 @@ public abstract class AbstractPureRuntimeEnumerationTest extends AbstractPureTes
                         .compileWithExpectedCompileFailure("myEnum has not been defined!", "userId.pure", 1, 24)
                         .createInMemorySource("sourceId.pure", "Enum myEnum{VAL1, VAL2}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
-    public void testPureRuntimeEnumerationAsReferenceValueError() throws Exception
+    public void testPureRuntimeEnumerationAsReferenceValueError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Enum test::myEnum{VAL1, VAL2}")
                         .createInMemorySource("userId.pure", "function test():Any[1]{test::myEnum.VAL1;}")
@@ -48,11 +57,11 @@ public abstract class AbstractPureRuntimeEnumerationTest extends AbstractPureTes
                         .compileWithExpectedCompileFailure("The enum value 'VAL1' can't be found in the enumeration test::myEnum", "userId.pure", 1, 37)
                         .updateSource("sourceId.pure", "Enum test::myEnum{VAL1, VAL2}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
-    public void testPureRuntimeEnumerationAsReferenceTypeError() throws Exception
+    public void testPureRuntimeEnumerationAsReferenceTypeError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Enum myEnum{VAL1, VAL2}")
                         .createInMemorySource("userId.pure", "function test():Any[1]{myEnum.VAL1;}")
@@ -64,11 +73,11 @@ public abstract class AbstractPureRuntimeEnumerationTest extends AbstractPureTes
                         .compileWithExpectedCompileFailure("myEnum has not been defined!", "userId.pure", 1, 24)
                         .updateSource("sourceId.pure", "Enum myEnum{VAL1, VAL2}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
-    public void testPureRuntimeEnumerationAsReturn() throws Exception
+    public void testPureRuntimeEnumerationAsReturn()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Enum myEnum{VAL1, VAL2}")
                         .createInMemorySource("userId.pure", "function func():myEnum[1]{myEnum.VAL2}" +
@@ -79,11 +88,11 @@ public abstract class AbstractPureRuntimeEnumerationTest extends AbstractPureTes
                         .compileWithExpectedCompileFailure("myEnum has not been defined!", "userId.pure", 1, 17)
                         .createInMemorySource("sourceId.pure", "Enum myEnum{VAL1, VAL2}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
-    public void testPureRuntimeEnumerationAsReturnError() throws Exception
+    public void testPureRuntimeEnumerationAsReturnError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Enum test::myEnum{VAL1, VAL2}")
                         .createInMemorySource("userId.pure", "function func():test::myEnum[1]{test::myEnum.VAL2}\n" +
@@ -96,12 +105,12 @@ public abstract class AbstractPureRuntimeEnumerationTest extends AbstractPureTes
                         .compileWithExpectedCompileFailure("The enum value 'VAL2' can't be found in the enumeration test::myEnum", "userId.pure", 1, 46)
                         .updateSource("sourceId.pure", "Enum test::myEnum{VAL1, VAL2}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
 
     @Test
-    public void testPureRuntimeEnumerationAsParameter() throws Exception
+    public void testPureRuntimeEnumerationAsParameter()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Enum myEnum{VAL1, VAL2}")
                         .createInMemorySource("userId.pure", "function func(f:myEnum[1]):Boolean[1]{true}" +
@@ -112,13 +121,13 @@ public abstract class AbstractPureRuntimeEnumerationTest extends AbstractPureTes
                         .compileWithExpectedCompileFailure("myEnum has not been defined!", "userId.pure", 1, 17)
                         .createInMemorySource("sourceId.pure", "Enum myEnum{VAL1, VAL2}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
 
     }
 
 
     @Test
-    public void testPureRuntimeEnumerationAsParameterError() throws Exception
+    public void testPureRuntimeEnumerationAsParameterError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Enum test::myEnum{VAL1, VAL2}")
                         .createInMemorySource("userId.pure", "function func(f:test::myEnum[1]):Boolean[1]{true}\n" +
@@ -131,11 +140,11 @@ public abstract class AbstractPureRuntimeEnumerationTest extends AbstractPureTes
                         .compileWithExpectedCompileFailure("The enum value 'VAL1' can't be found in the enumeration test::myEnum", "userId.pure", 2, 42)
                         .updateSource("sourceId.pure", "Enum test::myEnum{VAL1, VAL2}")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
-    public void testPureRuntimeDeleteEnumeration() throws Exception
+    public void testPureRuntimeDeleteEnumeration()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder(),
                 new RuntimeTestScriptBuilder()
@@ -145,22 +154,20 @@ public abstract class AbstractPureRuntimeEnumerationTest extends AbstractPureTes
                         .deleteSource("sourceId.pure")
                         .deleteSource("userId.pure")
                         .compile(),
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
-
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
     @Test
-    public void testPureRuntimeModifyEnumerationWithTaggedValue() throws Exception
+    public void testPureRuntimeModifyEnumerationWithTaggedValue()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Enum myEnum{ {testProfile.t1='bb'} VAL1, VAL2}")
-                .createInMemorySource("userId.pure", "Profile testProfile{tags:[t1,t2];}")
-                .compile(),
+                        .createInMemorySource("userId.pure", "Profile testProfile{tags:[t1,t2];}")
+                        .compile(),
                 new RuntimeTestScriptBuilder()
                         .updateSource("sourceId.pure", "////Some comment\n" +
                                 "Enum myEnum{ {testProfile.t1='bb'} VAL1, VAL2}")
                         .compile(),
 
-                this.runtime, this.functionExecution, this.getAdditionalVerifiers());
-
+                runtime, functionExecution, this.getAdditionalVerifiers());
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/extendedPrimitive/TestPureRuntimeExtendedPrimitive_InCast.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/extendedPrimitive/TestPureRuntimeExtendedPrimitive_InCast.java
@@ -14,14 +14,14 @@
 
 package org.finos.legend.pure.m3.tests.incremental.extendedPrimitive;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeExtendedPrimitive_InCast extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeExtendedPrimitive_InCast extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -49,7 +49,6 @@ public class TestPureRuntimeExtendedPrimitive_InCast extends AbstractPureTestWit
                         .createInMemorySource("sourceId.pure", "Primitive x::SmallInt(x:Integer[1]) extends Integer [$this < $x]")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
-
     }
 
     @Test
@@ -64,6 +63,5 @@ public class TestPureRuntimeExtendedPrimitive_InCast extends AbstractPureTestWit
                         .createInMemorySource("sourceId.pure", "function test():String[1]{1->cast(@x::SmallInt(2));'ok';}")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
-
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/function/TestPureRuntimeFunction_All.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/function/TestPureRuntimeFunction_All.java
@@ -15,20 +15,19 @@
 package org.finos.legend.pure.m3.tests.incremental.function;
 
 import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeFunction_All extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeFunction_All extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -38,12 +37,9 @@ public class TestPureRuntimeFunction_All extends AbstractPureTestWithCoreCompile
 
     protected static RichIterable<? extends CodeRepository> getCodeRepositories()
     {
-        MutableList<CodeRepository> repositories = org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
-        CodeRepository system = GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform", "core_functions_unclassified");
-        CodeRepository test = GenericCodeRepository.build("test", "test(::.*)?", "platform", "system", "core_functions_unclassified");
-        repositories.add(system);
-        repositories.add(test);
-        return repositories;
+        return Lists.mutable.<CodeRepository>withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories())
+                .with(GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform", "core_functions_unclassified"))
+                .with(GenericCodeRepository.build("test", "test(::.*)?", "platform", "system", "core_functions_unclassified"));
     }
 
     @After
@@ -95,7 +91,6 @@ public class TestPureRuntimeFunction_All extends AbstractPureTestWithCoreCompile
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
-
     @Test
     public void testPureRuntimeFunctionAllFunctionsIncludingLambdaInNew()
     {
@@ -113,7 +108,6 @@ public class TestPureRuntimeFunction_All extends AbstractPureTestWithCoreCompile
                         .createInMemorySource("sourceId.pure", source)
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
-
     }
 
     @Test
@@ -129,7 +123,6 @@ public class TestPureRuntimeFunction_All extends AbstractPureTestWithCoreCompile
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
-
 
     @Test
     public void testPureRuntimeFunctionLambdaWithinIf()

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/function/TestPureRuntimeFunction_Constraint.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/function/TestPureRuntimeFunction_Constraint.java
@@ -14,7 +14,7 @@
 
 package org.finos.legend.pure.m3.tests.incremental.function;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
@@ -23,7 +23,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeFunction_Constraint extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeFunction_Constraint extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/imports/TestPureRuntimeImport.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/imports/TestPureRuntimeImport.java
@@ -14,14 +14,14 @@
 
 package org.finos.legend.pure.m3.tests.incremental.imports;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeImport extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeImport extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -35,6 +35,7 @@ public class TestPureRuntimeImport extends AbstractPureTestWithCoreCompiledPlatf
         runtime.delete("other.pure");
         runtime.delete("userId.pure");
         runtime.delete("sourceId.pure");
+        runtime.compile();
     }
 
     @Test
@@ -58,7 +59,6 @@ public class TestPureRuntimeImport extends AbstractPureTestWithCoreCompiledPlatf
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
-
 
     @Test
     public void testPureRuntimeImport_Delete()

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/milestoning/TestMilestoning.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/milestoning/TestMilestoning.java
@@ -16,14 +16,12 @@ package org.finos.legend.pure.m3.tests.incremental.milestoning;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
@@ -31,22 +29,19 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestMilestoning extends AbstractPureTestWithCoreCompiledPlatform
+public class TestMilestoning extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
     {
-        setUpRuntime(getFunctionExecution(), new CompositeCodeStorage(new ClassLoaderCodeStorage(getCodeRepositories())), getFactoryRegistryOverride(), getOptions(), getExtra());
+        setUpRuntime(getFunctionExecution(), new CompositeCodeStorage(new ClassLoaderCodeStorage(getCodeRepositories())), getFactoryRegistryOverride());
     }
 
     protected static RichIterable<? extends CodeRepository> getCodeRepositories()
     {
-        MutableList<CodeRepository> repositories = org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
-        CodeRepository system = GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform");
-        CodeRepository test = GenericCodeRepository.build("test", "test(::.*)?", "platform", "system");
-        repositories.add(test);
-        repositories.add(system);
-        return repositories;
+        return Lists.mutable.<CodeRepository>withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories())
+                .with(GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform"))
+                .with(GenericCodeRepository.build("test", "test(::.*)?", "platform", "system"));
     }
 
     @After

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/profile/TestPureRuntimeStereotype.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/profile/TestPureRuntimeStereotype.java
@@ -14,7 +14,7 @@
 
 package org.finos.legend.pure.m3.tests.incremental.profile;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
@@ -22,7 +22,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeStereotype extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeStereotype extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/profile/TestPureRuntimeTaggedValue.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/profile/TestPureRuntimeTaggedValue.java
@@ -14,14 +14,14 @@
 
 package org.finos.legend.pure.m3.tests.incremental.profile;
 
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeTaggedValue extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeTaggedValue extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -34,10 +34,11 @@ public class TestPureRuntimeTaggedValue extends AbstractPureTestWithCoreCompiled
     {
         runtime.delete("userId.pure");
         runtime.delete("sourceId.pure");
+        runtime.compile();
     }
 
     @Test
-    public void testPureRuntimeProfileTaggedValueClass() throws Exception
+    public void testPureRuntimeProfileTaggedValueClass()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Profile testProfile{tags:[t1,t2];}")
                         .createInMemorySource("userId.pure", "Class {testProfile.t1='bb'} A{}")
@@ -51,7 +52,7 @@ public class TestPureRuntimeTaggedValue extends AbstractPureTestWithCoreCompiled
     }
 
     @Test
-    public void testPureRuntimeProfileTaggedValueClassError() throws Exception
+    public void testPureRuntimeProfileTaggedValueClassError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Profile testProfile{tags:[t1,t2];}")
                         .createInMemorySource("userId.pure", "Class {testProfile.t1='bb'} A{}")
@@ -64,12 +65,11 @@ public class TestPureRuntimeTaggedValue extends AbstractPureTestWithCoreCompiled
                         .updateSource("sourceId.pure", "Profile testProfile{tags:[t1,t2];}")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
-
     }
 
 
     @Test
-    public void testPureRuntimeProfileStereotypeClassValueError() throws Exception
+    public void testPureRuntimeProfileStereotypeClassValueError()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Profile testProfile{tags:[t1,t2];}")
                         .createInMemorySource("userId.pure", "Class {testProfile.t1='bb'} A{}")
@@ -85,7 +85,7 @@ public class TestPureRuntimeTaggedValue extends AbstractPureTestWithCoreCompiled
     }
 
     @Test
-    public void testPureRuntimeProfileTaggedValueClassInverse() throws Exception
+    public void testPureRuntimeProfileTaggedValueClassInverse()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Class {testProfile.t1='bb'} A{}")
                         .createInMemorySource("userId.pure", "Profile testProfile{tags:[t1,t2];}")
@@ -98,9 +98,8 @@ public class TestPureRuntimeTaggedValue extends AbstractPureTestWithCoreCompiled
                 runtime, functionExecution, this.getAdditionalVerifiers());
     }
 
-
     @Test
-    public void testPureRuntimeProfileTaggedValueEnumeration() throws Exception
+    public void testPureRuntimeProfileTaggedValueEnumeration()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Profile testProfile{tags:[t1,t2];}")
                         .createInMemorySource("userId.pure", "Enum {testProfile.t1='bb'} A{ VAL1 }")
@@ -111,11 +110,10 @@ public class TestPureRuntimeTaggedValue extends AbstractPureTestWithCoreCompiled
                         .createInMemorySource("sourceId.pure", "Profile testProfile{tags:[t1,t2];}")
                         .compile(),
                 runtime, functionExecution, this.getAdditionalVerifiers());
-
     }
 
     @Test
-    public void testPureRuntimeProfileTaggedValueEnum() throws Exception
+    public void testPureRuntimeProfileTaggedValueEnum()
     {
         RuntimeVerifier.verifyOperationIsStable(new RuntimeTestScriptBuilder().createInMemorySource("sourceId.pure", "Profile testProfile{tags:[t1,t2];}")
                         .createInMemorySource("userId.pure", "Enum A{ {testProfile.t1='bb'} VAL1 }")

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/projection/TestPureRuntimeProjection.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/projection/TestPureRuntimeProjection.java
@@ -17,7 +17,7 @@ package org.finos.legend.pure.m3.tests.incremental.projection;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.execution.VoidFunctionExecution;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.finos.legend.pure.m3.tests.TrackingTransactionObserver;
@@ -33,7 +33,7 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
-public class TestPureRuntimeProjection extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeProjection extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/treepath/TestPureRuntimeTreePath.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/incremental/treepath/TestPureRuntimeTreePath.java
@@ -17,14 +17,14 @@ package org.finos.legend.pure.m3.tests.incremental.treepath;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeTestScriptBuilder;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPureRuntimeTreePath extends AbstractPureTestWithCoreCompiledPlatform
+public class TestPureRuntimeTreePath extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()

--- a/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-pure/src/test/java/org/finos/legend/pure/m2/dsl/diagram/TestM2DiagramCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-pure/src/test/java/org/finos/legend/pure/m2/dsl/diagram/TestM2DiagramCompiledStateIntegrity.java
@@ -16,6 +16,7 @@ package org.finos.legend.pure.m2.dsl.diagram;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class TestM2DiagramCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -23,5 +24,11 @@ public class TestM2DiagramCompiledStateIntegrity extends AbstractCompiledStateIn
     public static void initialize()
     {
         initialize("platform_dsl_diagram");
+    }
+
+    @Test
+    public void testPackagedElementsContainAllOthers()
+    {
+        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-m2-dsl-graph-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/graph/TestM2GraphCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-m2-dsl-graph-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/graph/TestM2GraphCompiledStateIntegrity.java
@@ -16,6 +16,7 @@ package org.finos.legend.pure.m2.inlinedsl.graph;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class TestM2GraphCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -23,5 +24,11 @@ public class TestM2GraphCompiledStateIntegrity extends AbstractCompiledStateInte
     public static void initialize()
     {
         initialize("platform_dsl_graph");
+    }
+
+    @Test
+    public void testPackagedElementsContainAllOthers()
+    {
+        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-pure/src/test/java/org/finos/legend/pure/m2/dsl/mapping/TestM2MappingCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-pure/src/test/java/org/finos/legend/pure/m2/dsl/mapping/TestM2MappingCompiledStateIntegrity.java
@@ -16,6 +16,7 @@ package org.finos.legend.pure.m2.dsl.mapping;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class TestM2MappingCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -23,5 +24,11 @@ public class TestM2MappingCompiledStateIntegrity extends AbstractCompiledStateIn
     public static void initialize()
     {
         initialize("platform_dsl_mapping");
+    }
+
+    @Test
+    public void testPackagedElementsContainAllOthers()
+    {
+        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-path/legend-pure-m2-dsl-path-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/path/TestM2PathCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-path/legend-pure-m2-dsl-path-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/path/TestM2PathCompiledStateIntegrity.java
@@ -16,6 +16,7 @@ package org.finos.legend.pure.m2.inlinedsl.path;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class TestM2PathCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -23,5 +24,11 @@ public class TestM2PathCompiledStateIntegrity extends AbstractCompiledStateInteg
     public static void initialize()
     {
         initialize("platform_dsl_path");
+    }
+
+    @Test
+    public void testPackagedElementsContainAllOthers()
+    {
+        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-pure/src/test/java/org/finos/legend/pure/m2/dsl/store/TestM2StoreCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-pure/src/test/java/org/finos/legend/pure/m2/dsl/store/TestM2StoreCompiledStateIntegrity.java
@@ -16,6 +16,7 @@ package org.finos.legend.pure.m2.dsl.store;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class TestM2StoreCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -23,5 +24,11 @@ public class TestM2StoreCompiledStateIntegrity extends AbstractCompiledStateInte
     public static void initialize()
     {
         initialize("platform_dsl_store");
+    }
+
+    @Test
+    public void testPackagedElementsContainAllOthers()
+    {
+        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/tds/TestM2TDSCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/tds/TestM2TDSCompiledStateIntegrity.java
@@ -16,6 +16,7 @@ package org.finos.legend.pure.m2.inlinedsl.tds;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class TestM2TDSCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -23,5 +24,11 @@ public class TestM2TDSCompiledStateIntegrity extends AbstractCompiledStateIntegr
     public static void initialize()
     {
         initialize("platform_dsl_tds");
+    }
+
+    @Test
+    public void testPackagedElementsContainAllOthers()
+    {
+        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/TestIncrementalCompilationCompiled.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/TestIncrementalCompilationCompiled.java
@@ -24,6 +24,8 @@ import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledMetadataState
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
 
 public class TestIncrementalCompilationCompiled extends AbstractTestIncrementalCompilation
 {
@@ -36,6 +38,22 @@ public class TestIncrementalCompilationCompiled extends AbstractTestIncrementalC
     protected static FunctionExecution getFunctionExecution()
     {
         return new FunctionExecutionCompiledBuilder().build();
+    }
+
+    @Test
+    @Ignore("Inconsistency of new operator in compiled vs interpreted mode")
+    @Override
+    public void test14()
+    {
+        super.test14();
+    }
+
+    @Test
+    @Ignore("Inconsistency of new operator in compiled vs interpreted mode")
+    @Override
+    public void test21()
+    {
+        super.test21();
     }
 
     @Override

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/TestPureRuntimeEnumerationCompiled.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/TestPureRuntimeEnumerationCompiled.java
@@ -14,17 +14,15 @@
 
 package org.finos.legend.pure.runtime.java.compiled.incremental;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.impl.factory.Lists;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.finos.legend.pure.m3.tests.incremental.enumeration.AbstractPureRuntimeEnumerationTest;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
-import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledClassloaderStateVerifier;
-import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledMetadataStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
-import org.junit.After;
+import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledClassloaderStateVerifier;
+import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledMetadataStateVerifier;
 import org.junit.BeforeClass;
 
 public class TestPureRuntimeEnumerationCompiled extends AbstractPureRuntimeEnumerationTest
@@ -35,26 +33,10 @@ public class TestPureRuntimeEnumerationCompiled extends AbstractPureRuntimeEnume
         setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
     }
 
-    @After
-    public void cleanRuntime()
-    {
-        runtime.delete("sourceId.pure");
-        runtime.delete("userId.pure");
-        try
-        {
-            runtime.compile();
-        }
-        catch (PureCompilationException e)
-        {
-            setUp();
-        }
-    }
-
     @Override
     protected ListIterable<RuntimeVerifier.FunctionExecutionStateVerifier> getAdditionalVerifiers()
     {
-        return Lists.fixedSize.<RuntimeVerifier.FunctionExecutionStateVerifier>of(new CompiledMetadataStateVerifier(),
-                new CompiledClassloaderStateVerifier());
+        return Lists.immutable.of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
     }
 
     protected static FunctionExecution getFunctionExecution()

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/_class/TestPureRuntimeClass_AsFunctionReturnCompiled.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/_class/TestPureRuntimeClass_AsFunctionReturnCompiled.java
@@ -16,33 +16,22 @@ package org.finos.legend.pure.runtime.java.compiled.incremental._class;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.api.tuple.Pair;
+import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
-import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.incremental._class.TestPureRuntimeClass_AsFunctionReturn;
+import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledClassloaderStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledMetadataStateVerifier;
-import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
-import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
 
 public class TestPureRuntimeClass_AsFunctionReturnCompiled extends TestPureRuntimeClass_AsFunctionReturn
 {
     @BeforeClass
     public static void setUp()
     {
-        setUpRuntime(getFunctionExecution(), new CompositeCodeStorage(new ClassLoaderCodeStorage(getCodeRepositories())), JavaModelFactoryRegistryLoader.loader(), getOptions(), getExtra());
-    }
-
-    @Test
-    @Ignore
-    public void testPureRuntimeClassAsQualifiedPropertyReturn()
-    {
-        testPureRuntimeClassAsQualifiedPropertyReturn();
+        setUpRuntime(getFunctionExecution(), new CompositeCodeStorage(new ClassLoaderCodeStorage(getCodeRepositories())), getFactoryRegistryOverride());
     }
 
     protected static FunctionExecution getFunctionExecution()
@@ -54,10 +43,5 @@ public class TestPureRuntimeClass_AsFunctionReturnCompiled extends TestPureRunti
     protected ListIterable<RuntimeVerifier.FunctionExecutionStateVerifier> getAdditionalVerifiers()
     {
         return Lists.fixedSize.of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
-    }
-
-    public static Pair<String, String> getExtra()
-    {
-        return null;
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/_class/TestPureRuntimeClass_ConstraintsCompiled.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/_class/TestPureRuntimeClass_ConstraintsCompiled.java
@@ -43,5 +43,4 @@ public class TestPureRuntimeClass_ConstraintsCompiled extends TestPureRuntimeCla
     {
         return Lists.fixedSize.of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
     }
-
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/_package/TestPureRuntimePackageCompiled.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/_package/TestPureRuntimePackageCompiled.java
@@ -19,10 +19,9 @@ import org.eclipse.collections.api.list.ListIterable;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.finos.legend.pure.m3.tests.incremental._package.TestPureRuntimePackage;
-import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledClassloaderStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
-import org.junit.After;
+import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledClassloaderStateVerifier;
 import org.junit.BeforeClass;
 
 public class TestPureRuntimePackageCompiled extends TestPureRuntimePackage
@@ -31,12 +30,6 @@ public class TestPureRuntimePackageCompiled extends TestPureRuntimePackage
     public static void setUp()
     {
         setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
-    }
-
-    @After
-    public void cleanRuntime()
-    {
-        setUp();
     }
 
     protected static FunctionExecution getFunctionExecution()

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/function/TestPureRuntimeFunction_ConstraintCompiled.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/function/TestPureRuntimeFunction_ConstraintCompiled.java
@@ -19,12 +19,11 @@ import org.eclipse.collections.api.list.ListIterable;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier.FunctionExecutionStateVerifier;
 import org.finos.legend.pure.m3.tests.incremental.function.TestPureRuntimeFunction_Constraint;
-import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledClassloaderStateVerifier;
-import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledMetadataStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
+import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledClassloaderStateVerifier;
+import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledMetadataStateVerifier;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestPureRuntimeFunction_ConstraintCompiled extends TestPureRuntimeFunction_Constraint
 {
@@ -32,13 +31,6 @@ public class TestPureRuntimeFunction_ConstraintCompiled extends TestPureRuntimeF
     public static void setUp()
     {
         setUpRuntime(getFunctionExecution(), JavaModelFactoryRegistryLoader.loader());
-    }
-
-    @Override
-    @Test
-    public void testPureRuntimeFunctionConstraint() throws Exception
-    {
-        super.testPureRuntimeFunctionConstraint();
     }
 
     protected static FunctionExecution getFunctionExecution()

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/profile/TestPureRuntimeStereotypeCompiled.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/incremental/profile/TestPureRuntimeStereotypeCompiled.java
@@ -17,17 +17,15 @@ package org.finos.legend.pure.runtime.java.compiled.incremental.profile;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.finos.legend.pure.m3.tests.incremental.profile.TestPureRuntimeStereotype;
-import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledClassloaderStateVerifier;
-import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledMetadataStateVerifier;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
 import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
+import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledClassloaderStateVerifier;
+import org.finos.legend.pure.runtime.java.compiled.runtime.CompiledMetadataStateVerifier;
 import org.junit.BeforeClass;
 
 public class TestPureRuntimeStereotypeCompiled extends TestPureRuntimeStereotype
@@ -40,10 +38,8 @@ public class TestPureRuntimeStereotypeCompiled extends TestPureRuntimeStereotype
 
     protected static RichIterable<? extends CodeRepository> getCodeRepositories()
     {
-        MutableList<CodeRepository> repositories = Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
-        CodeRepository system = GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform");
-        repositories.add(system);
-        return repositories;
+        return Lists.mutable.<CodeRepository>withAll(TestPureRuntimeStereotype.getCodeRepositories())
+                .with(GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform"));
     }
 
     protected static FunctionExecution getFunctionExecution()
@@ -54,6 +50,6 @@ public class TestPureRuntimeStereotypeCompiled extends TestPureRuntimeStereotype
     @Override
     protected ListIterable<RuntimeVerifier.FunctionExecutionStateVerifier> getAdditionalVerifiers()
     {
-        return Lists.fixedSize.of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
+        return Lists.immutable.of(new CompiledMetadataStateVerifier(), new CompiledClassloaderStateVerifier());
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/modeling/_class/TestQualifiedProperty.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/modeling/_class/TestQualifiedProperty.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.runtime.java.compiled.runtime.modeling._class;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
@@ -212,11 +211,8 @@ public class TestQualifiedProperty extends AbstractPureTestWithCoreCompiled
 
     protected static RichIterable<? extends CodeRepository> getCodeRepositories()
     {
-        MutableList<CodeRepository> repositories = org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
-        CodeRepository system = GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform");
-        CodeRepository test = GenericCodeRepository.build("test", "test(::.*)?", "platform", "system");
-        repositories.add(system);
-        repositories.add(test);
-        return repositories;
+        return Lists.mutable.<CodeRepository>withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories())
+                .with(GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform"))
+                .with(GenericCodeRepository.build("test", "test(::.*)?", "platform", "system"));
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/modeling/function/TestLambdaAsInstanceValue.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/modeling/function/TestLambdaAsInstanceValue.java
@@ -16,14 +16,13 @@ package org.finos.legend.pure.runtime.java.compiled.runtime.modeling.function;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
-import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
@@ -118,11 +117,8 @@ public class TestLambdaAsInstanceValue extends AbstractPureTestWithCoreCompiled
 
     protected static RichIterable<? extends CodeRepository> getCodeRepositories()
     {
-        MutableList<CodeRepository> repositories = org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
-        CodeRepository system = GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform");
-        CodeRepository test = GenericCodeRepository.build("test", "test(::.*)?", "platform", "system");
-        repositories.add(system);
-        repositories.add(test);
-        return repositories;
+        return Lists.mutable.<CodeRepository>withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories())
+                .with(GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform"))
+                .with(GenericCodeRepository.build("test", "test(::.*)?", "platform", "system"));
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/modeling/function/TestLambdasWithTypeParameters.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/modeling/function/TestLambdasWithTypeParameters.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.runtime.java.compiled.runtime.modeling.function;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
@@ -96,11 +95,8 @@ public class TestLambdasWithTypeParameters extends AbstractPureTestWithCoreCompi
 
     protected static RichIterable<? extends CodeRepository> getCodeRepositories()
     {
-        MutableList<CodeRepository> repositories = org.eclipse.collections.impl.factory.Lists.mutable.withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories());
-        CodeRepository system = GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform");
-        CodeRepository test = GenericCodeRepository.build("test", "test(::.*)?", "platform", "system");
-        repositories.add(system);
-        repositories.add(test);
-        return repositories;
+        return Lists.mutable.<CodeRepository>withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories())
+                .with(GenericCodeRepository.build("system", "((meta)|(system)|(apps::pure))(::.*)?", "platform"))
+                .with(GenericCodeRepository.build("test", "test(::.*)?", "platform", "system"));
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/incremental/TestIncrementalCompilationInterpreted.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/incremental/TestIncrementalCompilationInterpreted.java
@@ -18,7 +18,6 @@ import org.finos.legend.pure.m3.execution.FunctionExecution;
 import org.finos.legend.pure.m3.tests.incremental.AbstractTestIncrementalCompilation;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestIncrementalCompilationInterpreted extends AbstractTestIncrementalCompilation
 {
@@ -26,27 +25,6 @@ public class TestIncrementalCompilationInterpreted extends AbstractTestIncrement
     public static void setUp()
     {
         setUpRuntime(getFunctionExecution(), getCodeStorage());
-    }
-
-    @Test
-    @Override
-    public void test14()
-    {
-        super.test14();
-    }
-
-    @Test
-    @Override
-    public void test20()
-    {
-        super.test20();
-    }
-
-    @Test
-    @Override
-    public void test21()
-    {
-        super.test21();
     }
 
     protected static FunctionExecution getFunctionExecution()

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/incremental/enumeration/TestPureRuntimeEnumeration.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/incremental/enumeration/TestPureRuntimeEnumeration.java
@@ -15,8 +15,6 @@
 package org.finos.legend.pure.runtime.java.interpreted.incremental.enumeration;
 
 import org.finos.legend.pure.m3.tests.incremental.enumeration.AbstractPureRuntimeEnumerationTest;
-import org.finos.legend.pure.m4.exception.PureCompilationException;
-import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestPureRuntimeEnumeration extends AbstractPureRuntimeEnumerationTest
@@ -25,20 +23,5 @@ public class TestPureRuntimeEnumeration extends AbstractPureRuntimeEnumerationTe
     public static void setUp()
     {
         setUpRuntime();
-    }
-
-    @After
-    public void cleanRuntime()
-    {
-        runtime.delete("sourceId.pure");
-        runtime.delete("userId.pure");
-        try
-        {
-            runtime.compile();
-        }
-        catch (PureCompilationException e)
-        {
-            setUp();
-        }
     }
 }


### PR DESCRIPTION
Add a test to ensure that the source information of each component instance is contained (subsumed by) the source information of its owning element (in the package tree). For example, that the source information of a Property is contained within the source information of the Class or Association that owns it. The test is currently ignored by default, but is enabled in all subclasses in legend-pure.

In passing, clean up a number of tests.