### PR TITLE
Assorted minor fixes and clean-ups

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractCompiledStateIntegrityTest.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractCompiledStateIntegrityTest.java
@@ -472,7 +472,7 @@ public abstract class AbstractCompiledStateIntegrityTest
                                     .forEach(classifierElementsPair ->
                                     {
                                         MutableList<CoreInstance> classifierElements = classifierElementsPair.getTwo();
-                                        builder.append("\n\t\t").append(sourceElementsPair.getOne()).append(" (").append(classifierElements.size()).append(')');
+                                        builder.append("\n\t\t").append(classifierElementsPair.getOne()).append(" (").append(classifierElements.size()).append(')');
                                         classifierElements.sortThisBy(CoreInstance::getSourceInformation).forEach(e ->
                                         {
                                             builder.append("\n\t\t\t").append(e);


### PR DESCRIPTION
Assorted minor fixes and clean-ups:
- improve error handling in PureExecutionException.printPureStackTrace
- fix a typo in AbstractCompiledStateIntegrityTest
- clean up TestRelationTypeInference
- clea up ClassImplProcessor