### PR TITLE
Fix type inference bug with generic type operations

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/ReferenceUsage.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/ReferenceUsage.java
@@ -16,6 +16,7 @@ package org.finos.legend.pure.m3.compiler;
 
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.impl.block.factory.Comparators;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Any;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
@@ -26,6 +27,7 @@ import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
 import org.finos.legend.pure.m3.navigation.type.Type;
 import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.AbstractCoreInstanceWrapper;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 import org.finos.legend.pure.m4.coreinstance.indexing.IndexSpecification;
@@ -42,6 +44,19 @@ public class ReferenceUsage
             return new ReferenceUsageIndexKey(referenceUsage);
         }
     };
+
+    public static boolean isReferenceUsage(CoreInstance instance, ProcessorSupport processorSupport)
+    {
+        if (instance == null)
+        {
+            return false;
+        }
+        if (instance instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.ReferenceUsage)
+        {
+            return true;
+        }
+        return (!(instance instanceof Any) || (instance instanceof AbstractCoreInstanceWrapper)) && processorSupport.instance_instanceOf(instance, M3Paths.ReferenceUsage);
+    }
 
     /**
      * Add a ReferenceUsage to the used instance.

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/M3Properties.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/M3Properties.java
@@ -36,6 +36,7 @@ public class M3Properties
     public static final String _class = "class";
     public static final String classifierGenericType = "classifierGenericType";
     public static final String column = "column";
+    public static final String columns = "columns";
     public static final String constraints = "constraints";
     public static final String constraintsManager = "constraintsManager";
     public static final String contravariant = "contravariant";
@@ -79,6 +80,7 @@ public class M3Properties
     public static final String imports = "imports";
     public static final String instanceValue = "instanceValue";
     public static final String key = "key";
+    public static final String left = "left";
     public static final String line = "line";
     public static final String lowerBound = "lowerBound";
     public static final String mapping = "mapping";
@@ -130,6 +132,7 @@ public class M3Properties
     public static final String resolvedMultiplicityParameters = "resolvedMultiplicityParameters";
     public static final String returnMultiplicity = "returnMultiplicity";
     public static final String returnType = "returnType";
+    public static final String right = "right";
     public static final String root = "root";
     public static final String second = "second";
     public static final String setImplementation = "setImplementation";

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/M3PropertyPaths.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/M3PropertyPaths.java
@@ -37,6 +37,7 @@ public class M3PropertyPaths
     public static final ImmutableList<String> functionName_Function = makePropertyPath(M3Paths.Function, M3Properties.functionName);
     public static final ImmutableList<String> general = makePropertyPath(M3Paths.Generalization, M3Properties.general);
     public static final ImmutableList<String> generalizations = makePropertyPath(M3Paths.Type, M3Properties.generalizations);
+    public static final ImmutableList<String> left = makePropertyPath(M3Paths.GenericTypeOperation, M3Properties.left);
     public static final ImmutableList<String> modelElements = makePropertyPath(M3Paths.Annotation, M3Properties.modelElements);
     public static final ImmutableList<String> multiplicityArguments = makePropertyPath(M3Paths.GenericType, M3Properties.multiplicityArguments);
     public static final ImmutableList<String> multiplicityParameters = makePropertyPath(M3Paths.Class, M3Properties.multiplicityParameters);
@@ -53,12 +54,14 @@ public class M3PropertyPaths
     public static final ImmutableList<String> qualifiedPropertiesFromAssociations = makePropertyPath(M3Paths.Class, M3Properties.qualifiedPropertiesFromAssociations);
     public static final ImmutableList<String> rawType = makePropertyPath(M3Paths.GenericType, M3Properties.rawType);
     public static final ImmutableList<String> referenceUsages = makePropertyPath(M3Paths.Referenceable, M3Properties.referenceUsages);
+    public static final ImmutableList<String> right = makePropertyPath(M3Paths.GenericTypeOperation, M3Properties.right);
     public static final ImmutableList<String> specializations = makePropertyPath(M3Paths.Type, M3Properties.specializations);
     public static final ImmutableList<String> specific = makePropertyPath(M3Paths.Generalization, M3Properties.specific);
+    public static final ImmutableList<String> stereotypes = makePropertyPath(M3Paths.ElementWithStereotypes, M3Properties.stereotypes);
+    public static final ImmutableList<String> type_GenericTypeOperation = makePropertyPath(M3Paths.GenericTypeOperation, M3Properties.type);
     public static final ImmutableList<String> typeArguments = makePropertyPath(M3Paths.GenericType, M3Properties.typeArguments);
     public static final ImmutableList<String> typeParameter = makePropertyPath(M3Paths.GenericType, M3Properties.typeParameter);
     public static final ImmutableList<String> typeParameters = makePropertyPath(M3Paths.Class, M3Properties.typeParameters);
-    public static final ImmutableList<String> stereotypes = makePropertyPath(M3Paths.ElementWithStereotypes, M3Properties.stereotypes);
     public static final ImmutableList<String> taggedValues = makePropertyPath(M3Paths.ElementWithTaggedValues, M3Properties.taggedValues);
 
     @SuppressWarnings("unchecked")

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/graph/GraphPath.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/graph/GraphPath.java
@@ -230,9 +230,19 @@ public class GraphPath
         return extend().addToOneProperty(property).build();
     }
 
+    GraphPath withToOnePropertyUnsafe(String property)
+    {
+        return new GraphPath(this.startNodePath, this.edges.newWith(new ToOnePropertyEdge(property)));
+    }
+
     public GraphPath withToManyPropertyValueAtIndex(String property, int index)
     {
         return extend().addToManyPropertyValueAtIndex(property, index).build();
+    }
+
+    GraphPath withToManyPropertyValueAtIndexUnsafe(String property, int index)
+    {
+        return new GraphPath(this.startNodePath, this.edges.newWith(new ToManyPropertyAtIndexEdge(property, index)));
     }
 
     public GraphPath withToManyPropertyValueWithName(String property, String valueName)
@@ -548,7 +558,12 @@ public class GraphPath
 
         public Builder addToOneProperty(String property)
         {
-            return addEdge(new ToOnePropertyEdge(validateProperty(property)));
+            return addToOnePropertyUnsafe(validateProperty(property));
+        }
+
+        Builder addToOnePropertyUnsafe(String property)
+        {
+            return addEdge(new ToOnePropertyEdge(property));
         }
 
         public Builder addToOneProperties(String... properties)
@@ -565,7 +580,12 @@ public class GraphPath
 
         public Builder addToManyPropertyValueAtIndex(String property, int index)
         {
-            return addEdge(new ToManyPropertyAtIndexEdge(validateProperty(property), validateIndex(index)));
+            return addToManyPropertyValueAtIndexUnsafe(validateProperty(property), validateIndex(index));
+        }
+
+        Builder addToManyPropertyValueAtIndexUnsafe(String property, int index)
+        {
+            return addEdge(new ToManyPropertyAtIndexEdge(property, index));
         }
 
         public Builder addToManyPropertyValueWithName(String property, String valueName)
@@ -575,7 +595,12 @@ public class GraphPath
 
         public Builder addToManyPropertyValueWithKey(String property, String keyProperty, String key)
         {
-            return addEdge(new ToManyPropertyWithStringKeyEdge(validateProperty(property), validateKeyProperty(keyProperty), validateKey(key)));
+            return addToManyPropertyValueWithKeyUnsafe(validateProperty(property), validateKeyProperty(keyProperty), validateKey(key));
+        }
+
+        Builder addToManyPropertyValueWithKeyUnsafe(String property, String keyProperty, String key)
+        {
+            return addEdge(new ToManyPropertyWithStringKeyEdge(property, keyProperty, key));
         }
 
         private Builder addEdge(Edge pathElement)

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/graph/GraphPathIterable.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/graph/GraphPathIterable.java
@@ -201,7 +201,7 @@ public class GraphPathIterable extends AbstractLazySpliterable<ResolvedGraphPath
                         CoreInstance value = values.get(0);
                         if (!pathNodeSet.contains(value))
                         {
-                            possiblyEnqueue(path.withToOneProperty(key), pathNodeList.newWith(value));
+                            possiblyEnqueue(path.withToOnePropertyUnsafe(key), pathNodeList.newWith(value));
                         }
                     }
                     else if (values.notEmpty())
@@ -210,7 +210,7 @@ public class GraphPathIterable extends AbstractLazySpliterable<ResolvedGraphPath
                         {
                             if (!pathNodeSet.contains(value))
                             {
-                                possiblyEnqueue(path.withToManyPropertyValueAtIndex(key, i), pathNodeList.newWith(value));
+                                possiblyEnqueue(path.withToManyPropertyValueAtIndexUnsafe(key, i), pathNodeList.newWith(value));
                             }
                         });
                     }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
@@ -963,7 +963,7 @@ public class AntlrContextToM3CoreInstance
             List<Boolean> nonFunctions = ListIterate.collect(ctx.columnBuilders().oneColSpec(), x -> x.type() != null | x.COLON() == null).distinct();
             if (isArray && nonFunctions.size() > 1)
             {
-                throw new PureCompilationException("Can't mix column types");
+                throw new PureParserException(this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.getStart(), ctx.getStop()), "Can't mix column types");
             }
             boolean nonFunction = nonFunctions.get(0);
 

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/TestM3CoreCompiledStateIntegrity.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/TestM3CoreCompiledStateIntegrity.java
@@ -15,7 +15,6 @@
 package org.finos.legend.pure.m3.tests;
 
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestM3CoreCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -23,11 +22,5 @@ public class TestM3CoreCompiledStateIntegrity extends AbstractCompiledStateInteg
     public static void initialize()
     {
         initialize("platform");
-    }
-
-    @Test
-    public void testPackagedElementsContainAllOthers()
-    {
-        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/relation/TestColumnBuilders.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/relation/TestColumnBuilders.java
@@ -15,12 +15,12 @@
 package org.finos.legend.pure.m3.tests.elements.relation;
 
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m4.exception.PureCompilationException;
+import org.finos.legend.pure.m4.serialization.grammar.antlr.PureParserException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import static org.junit.Assert.fail;
 
 public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
 {
@@ -34,23 +34,23 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     public void clearRuntime()
     {
         runtime.delete("fromString.pure");
+        runtime.compile();
     }
 
     @Test
     public void testSimpleColumnWithInferredType()
     {
         compileTestSource("fromString.pure",
-                "" +
-                        "function infFunc<T,X>(x:meta::pure::metamodel::relation::Relation<T>[1], c:meta::pure::metamodel::relation::ColSpec<X⊆T>[1]):meta::pure::metamodel::relation::Relation<X>[0..1]" +
-                        "{" +
-                        "   [];" +
-                        "}" +
-                        "function test():meta::pure::metamodel::relation::Relation<(colName:String)>[0..1]" +
-                        "{" +
-                        "   infFunc(" +
-                        "               []->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, colName:String)>)->toOne()," +
-                        "               ~colName" +
-                        "           );" +
+                "function infFunc<T,X>(x:meta::pure::metamodel::relation::Relation<T>[1], c:meta::pure::metamodel::relation::ColSpec<X⊆T>[1]):meta::pure::metamodel::relation::Relation<X>[0..1]\n" +
+                        "{\n" +
+                        "   [];\n" +
+                        "}\n" +
+                        "function test():meta::pure::metamodel::relation::Relation<(colName:String)>[0..1]\n" +
+                        "{\n" +
+                        "   infFunc(\n" +
+                        "               []->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, colName:String)>)->toOne(),\n" +
+                        "               ~colName\n" +
+                        "           );\n" +
                         "}");
     }
 
@@ -58,9 +58,9 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     public void testSimpleColumnWithType()
     {
         compileTestSource("fromString.pure",
-                "function test():meta::pure::metamodel::relation::ColSpec<(name:String)>[1]" +
-                        "{" +
-                        "   ~name:String;" +
+                "function test():meta::pure::metamodel::relation::ColSpec<(name:String)>[1]\n" +
+                        "{\n" +
+                        "   ~name:String;\n" +
                         "}");
     }
 
@@ -68,37 +68,35 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     public void testSimpleColumnWithTypeArray()
     {
         compileTestSource("fromString.pure",
-                "function test():meta::pure::metamodel::relation::ColSpecArray<(name:String, id:Integer)>[1]" +
-                        "{" +
-                        "   ~[name:String, id:Integer];" +
+                "function test():meta::pure::metamodel::relation::ColSpecArray<(name:String, id:Integer)>[1]\n" +
+                        "{\n" +
+                        "   ~[name:String, id:Integer];\n" +
                         "}");
     }
 
     @Test
     public void testSimpleColumnWithTypeFail()
     {
-        try
-        {
-            compileTestSource("fromString.pure",
-                    "function test():meta::pure::metamodel::relation::ColSpec<(name:Integer)>[1]" +
-                            "{" +
-                            "   ~name:String;" +
-                            "}");
-            fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Compilation error at (resource:fromString.pure line:1 column:80), \"Return type error in function 'test'; found: meta::pure::metamodel::relation::ColSpec<(name:String)>; expected: meta::pure::metamodel::relation::ColSpec<(name:Integer)>\"", e.getMessage());
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function test():meta::pure::metamodel::relation::ColSpec<(name:Integer)>[1]\n" +
+                        "{\n" +
+                        "   ~name:String;\n" +
+                        "}"));
+        assertPureException(
+                PureCompilationException.class,
+                "Return type error in function 'test'; found: meta::pure::metamodel::relation::ColSpec<(name:String)>; expected: meta::pure::metamodel::relation::ColSpec<(name:Integer)>",
+                "fromString.pure", 3, 4, 3, 4, 3, 4,
+                e);
     }
 
     @Test
     public void testSimpleColumnWithFunction()
     {
         compileTestSource("fromString.pure",
-                "function test<U>():meta::pure::metamodel::relation::FuncColSpec<{U[1]->Any[1]}, (name:String)>[1]" +
-                        "{" +
-                        "   ~name:x|'ok';" +
+                "function test<U>():meta::pure::metamodel::relation::FuncColSpec<{U[1]->Any[1]}, (name:String)>[1]\n" +
+                        "{\n" +
+                        "   ~name:x|'ok';\n" +
                         "}");
     }
 
@@ -107,9 +105,9 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     {
         compileTestSource("fromString.pure",
                 "import meta::pure::metamodel::relation::*;\n" +
-                        "function test<U>():meta::pure::metamodel::relation::FuncColSpec<{Relation<U>[1], _Window<U>[1], U[1]->Any[1]}, (name:String)>[1]" +
-                        "{" +
-                        "   ~name:{p,f,r|'ok'};" +
+                        "function test<U>():meta::pure::metamodel::relation::FuncColSpec<{Relation<U>[1], _Window<U>[1], U[1]->Any[1]}, (name:String)>[1]\n" +
+                        "{\n" +
+                        "   ~name:{p,f,r|'ok'};\n" +
                         "}");
     }
 
@@ -117,9 +115,9 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     public void testSimpleColumnWithFunctionArray()
     {
         compileTestSource("fromString.pure",
-                "function test<U>():meta::pure::metamodel::relation::FuncColSpecArray<{Nil[1]->Any[*]}, (name:String, val:Integer)>[1]" +
-                        "{" +
-                        "   ~[name:x|'ok', val:x|1];" +
+                "function test<U>():meta::pure::metamodel::relation::FuncColSpecArray<{Nil[1]->Any[*]}, (name:String, val:Integer)>[1]\n" +
+                        "{\n" +
+                        "   ~[name:x|'ok', val:x|1];\n" +
                         "}");
     }
 
@@ -128,76 +126,69 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     {
         compileTestSource("fromString.pure",
                 "import meta::pure::metamodel::relation::*;\n" +
-                        "function test<U>():meta::pure::metamodel::relation::FuncColSpecArray<{Relation<U>[1], _Window<U>[1], U[1]->Any[*]}, (name:String, val:Integer)>[1]" +
-                        "{" +
-                        "   ~[name:{w,f,x|'ok'}, val:{w,f,x|1}];" +
+                        "function test<U>():meta::pure::metamodel::relation::FuncColSpecArray<{Relation<U>[1], _Window<U>[1], U[1]->Any[*]}, (name:String, val:Integer)>[1]\n" +
+                        "{\n" +
+                        "   ~[name:{w,f,x|'ok'}, val:{w,f,x|1}];\n" +
                         "}");
     }
 
     @Test
     public void testSimpleColumnWithFunctionArray2ParamsFail()
     {
-        try
-        {
-            compileTestSource("fromString.pure",
-                    "import meta::pure::metamodel::relation::*;\n" +
-                            "function test<U>():meta::pure::metamodel::relation::FuncColSpecArray<{Relation<U>[1], _Window<U>[1], U[1]->Any[*]}, (name:String, val:Integer)>[1]\n" +
-                            "{\n" +
-                            "   ~[name:{p,f,r|'ok'}, val:{x|1}];" +
-                            "}");
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Parser error at (resource:fromString.pure line:4 column:4), All functions used in the col array should be of the same type.", e.getMessage());
-        }
+        PureParserException e = Assert.assertThrows(PureParserException.class, () -> compileTestSource(
+                "fromString.pure",
+                "import meta::pure::metamodel::relation::*;\n" +
+                        "function test<U>():meta::pure::metamodel::relation::FuncColSpecArray<{Relation<U>[1], _Window<U>[1], U[1]->Any[*]}, (name:String, val:Integer)>[1]\n" +
+                        "{\n" +
+                        "   ~[name:{p,f,r|'ok'}, val:{x|1}];\n" +
+                        "}"));
+        assertPureException(
+                PureParserException.class,
+                "All functions used in the col array should be of the same type.",
+                "fromString.pure", 4, 4, 4, 4, 4, 34,
+                e);
     }
 
     @Test
     public void testSimpleColumnWithFunctionFail()
     {
-        try
-        {
-            compileTestSource("fromString.pure",
-                    "function test<U>():meta::pure::metamodel::relation::FuncColSpec<{U[1]->Any[1]}, (name:String)>[1]" +
-                            "{" +
-                            "   ~name:x|1;" +
-                            "}");
-            fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Compilation error at (resource:fromString.pure line:1 column:102), \"Return type error in function 'test'; found: meta::pure::metamodel::relation::FuncColSpec<{U[1]->meta::pure::metamodel::type::Any[1]}, (name:Integer)>; expected: meta::pure::metamodel::relation::FuncColSpec<{U[1]->meta::pure::metamodel::type::Any[1]}, (name:String)>\"", e.getMessage());
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function test<U>():meta::pure::metamodel::relation::FuncColSpec<{U[1]->Any[1]}, (name:String)>[1]\n" +
+                        "{\n" +
+                        "   ~name:x|1;\n" +
+                        "}"));
+        assertPureException(
+                PureCompilationException.class,
+                "Return type error in function 'test'; found: meta::pure::metamodel::relation::FuncColSpec<{U[1]->meta::pure::metamodel::type::Any[1]}, (name:Integer)>; expected: meta::pure::metamodel::relation::FuncColSpec<{U[1]->meta::pure::metamodel::type::Any[1]}, (name:String)>",
+                "fromString.pure", 3, 4, 3, 4, 3, 4,
+                e);
     }
 
     @Test
     public void testMixColumnsFail()
     {
-        try
-        {
-            compileTestSource("fromString.pure",
-                    "function test<U>():meta::pure::metamodel::relation::FuncColSpec<{U[1]->Any[1]}, (name:String)>[1]" +
-                            "{" +
-                            "   ~[name:x|1, id:Integer];" +
-                            "}");
-            fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Parser error at (resource:fromString.pure line:-2), (Compilation error at ??, \"Can't mix column types\") in\n" +
-                    "'\n" +
-                    "function test<U>():meta::pure::metamodel::relation::FuncColSpec<{U[1]->Any[1]}, (name:String)>[1]{   ~[name:x|1, id:Integer];}'", e.getMessage());
-        }
+        PureParserException e = Assert.assertThrows(PureParserException.class, () -> compileTestSource(
+                "fromString.pure",
+                "function test<U>():meta::pure::metamodel::relation::FuncColSpec<{U[1]->Any[1]}, (name:String)>[1]\n" +
+                        "{\n" +
+                        "   ~[name:x|1, id:Integer];\n" +
+                        "}"));
+        assertPureException(
+                PureParserException.class,
+                "Can't mix column types",
+                "fromString.pure", 3, 4, 3, 4, 3, 26,
+                e);
     }
 
     @Test
     public void testColumnWithExtraReduceFunction()
     {
         compileTestSource("fromString.pure",
-                "native function sum(i:Integer[*]):Integer[1];" +
-                        "function test<U>():meta::pure::metamodel::relation::AggColSpec<{U[1]->Integer[0..1]}, {Integer[*]->Integer[0..1]}, (name:Integer)>[1]" +
-                        "{" +
-                        "   ~name: x|1 : y|$y->sum();" +
+                "native function sum(i:Integer[*]):Integer[1];\n" +
+                        "function test<U>():meta::pure::metamodel::relation::AggColSpec<{U[1]->Integer[0..1]}, {Integer[*]->Integer[0..1]}, (name:Integer)>[1]\n" +
+                        "{\n" +
+                        "   ~name: x|1 : y|$y->sum();\n" +
                         "}");
     }
 
@@ -206,10 +197,10 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     {
         compileTestSource("fromString.pure",
                 "import meta::pure::metamodel::relation::*;\n" +
-                        "native function sum(i:Integer[*]):Integer[1];" +
-                        "function test<U>():meta::pure::metamodel::relation::AggColSpec<{Relation<U>[1], _Window<U>[1], U[1]->Integer[0..1]}, {Integer[*]->Integer[0..1]}, (name:Integer)>[1]" +
-                        "{" +
-                        "   ~name: {p,f,r|1} : y|$y->sum();" +
+                        "native function sum(i:Integer[*]):Integer[1];\n" +
+                        "function test<U>():meta::pure::metamodel::relation::AggColSpec<{Relation<U>[1], _Window<U>[1], U[1]->Integer[0..1]}, {Integer[*]->Integer[0..1]}, (name:Integer)>[1]\n" +
+                        "{\n" +
+                        "   ~name: {p,f,r|1} : y|$y->sum();\n" +
                         "}");
     }
 
@@ -217,14 +208,13 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     public void testColumnFunctionInferenceWithExtraReduceFunction()
     {
         compileTestSource("fromString.pure",
-                "native function sum(i:Integer[*]):Integer[1];" +
+                "native function sum(i:Integer[*]):Integer[1];\n" +
                         "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpec<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
                         "\n" +
-                        "" +
-                        "function test():Boolean[1]" +
-                        "{" +
-                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, ok:Integer)>)->toOne()->groupBy(~name: x|$x.ok : y|$y->sum());" +
-                        "   true;" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, ok:Integer)>)->toOne()->groupBy(~name: x|$x.ok : y|$y->sum());\n" +
+                        "   true;\n" +
                         "}");
     }
 
@@ -232,10 +222,10 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     public void testColumnWithExtraReduceFunctionArray()
     {
         compileTestSource("fromString.pure",
-                "native function sum(i:Integer[*]):Integer[1];" +
-                        "function test<U>():meta::pure::metamodel::relation::AggColSpecArray<{Nil[1]->Any[0..1]}, {Nil[*]->Any[0..1]}, (name:Integer, newO:String)>[1]" +
-                        "{" +
-                        "   ~[name: x|1 : y|$y->sum(), newO: z|'a' : y|$y->joinStrings(',')]" +
+                "native function sum(i:Integer[*]):Integer[1];\n" +
+                        "function test<U>():meta::pure::metamodel::relation::AggColSpecArray<{Nil[1]->Any[0..1]}, {Nil[*]->Any[0..1]}, (name:Integer, newO:String)>[1]\n" +
+                        "{\n" +
+                        "   ~[name: x|1 : y|$y->sum(), newO: z|'a' : y|$y->joinStrings(',')]\n" +
                         "}");
     }
 
@@ -244,10 +234,10 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     {
         compileTestSource("fromString.pure",
                 "import meta::pure::metamodel::relation::*;\n" +
-                        "native function sum(i:Integer[*]):Integer[1];" +
-                        "function test<U>():meta::pure::metamodel::relation::AggColSpecArray<{Relation<U>[1], _Window<U>[1], U[1]->Any[0..1]}, {Nil[*]->Any[0..1]}, (name:Integer, newO:String)>[1]" +
-                        "{" +
-                        "   ~[name: {p,f,r|1} : y|$y->sum(), newO: {p,f,r|'a'} : y|$y->joinStrings(',')]" +
+                        "native function sum(i:Integer[*]):Integer[1];\n" +
+                        "function test<U>():meta::pure::metamodel::relation::AggColSpecArray<{Relation<U>[1], _Window<U>[1], U[1]->Any[0..1]}, {Nil[*]->Any[0..1]}, (name:Integer, newO:String)>[1]\n" +
+                        "{\n" +
+                        "   ~[name: {p,f,r|1} : y|$y->sum(), newO: {p,f,r|'a'} : y|$y->joinStrings(',')]\n" +
                         "}");
     }
 
@@ -255,14 +245,13 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     public void testColumnFunctionInferenceWithExtraReduceFunctionArray()
     {
         compileTestSource("fromString.pure",
-                "native function sum(i:Integer[*]):Integer[1];" +
+                "native function sum(i:Integer[*]):Integer[1];\n" +
                         "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
                         "\n" +
-                        "" +
-                        "function test():Boolean[1]" +
-                        "{" +
-                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->sum()]);" +
-                        "   true;" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->sum()]);\n" +
+                        "   true;\n" +
                         "}");
     }
 
@@ -270,14 +259,13 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     public void testColumnFunctionInferenceWithExtraReduceFunctionArrayMultiple()
     {
         compileTestSource("fromString.pure",
-                "native function sum(i:Integer[*]):Integer[1];" +
+                "native function sum(i:Integer[*]):Integer[1];\n" +
                         "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
                         "\n" +
-                        "" +
-                        "function test():Boolean[1]" +
-                        "{" +
-                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:String, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->sum(), otherOne : x|$x.id : y|$y->joinStrings(',')]);" +
-                        "   true;" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:String, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->sum(), otherOne : x|$x.id : y|$y->joinStrings(',')]);\n" +
+                        "   true;\n" +
                         "}");
     }
 
@@ -285,116 +273,102 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     public void testColumnFunctionInferenceWithExtraReduceFunctionArrayMultipleChained()
     {
         compileTestSource("fromString.pure",
-                "native function sum(i:Integer[*]):Integer[1];" +
+                "native function sum(i:Integer[*]):Integer[1];\n" +
                         "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
                         "native function meta::pure::functions::relation::filter<T>(rel:meta::pure::metamodel::relation::Relation<T>[1], f:Function<{T[1]->Boolean[1]}>[1]):meta::pure::metamodel::relation::Relation<T>[1];\n" +
                         "\n" +
-                        "" +
-                        "function test():Boolean[1]" +
-                        "{" +
-                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:String, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->sum(), otherOne : x|$x.id : y|$y->joinStrings(',')])->filter(x|$x.otherOne == 'boom');" +
-                        "   true;" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:String, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->sum(), otherOne : x|$x.id : y|$y->joinStrings(',')])->filter(x|$x.otherOne == 'boom');\n" +
+                        "   true;\n" +
                         "}");
     }
 
     @Test
     public void testColumnFunctionInferenceWithExtraReduceFunctionArrayMultipleChainedError()
     {
-        try
-        {
-            compileTestSource("fromString.pure",
-                    "native function sum(i:Integer[*]):Integer[1];" +
-                            "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
-                            "native function meta::pure::functions::relation::filter<T>(rel:meta::pure::metamodel::relation::Relation<T>[1], f:Function<{T[1]->Boolean[1]}>[1]):meta::pure::metamodel::relation::Relation<T>[1];\n" +
-                            "\n" +
-                            "" +
-                            "function test():Boolean[1]" +
-                            "{" +
-                            "   []->cast(@meta::pure::metamodel::relation::Relation<(id:String, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->sum(), otherOne : x|$x.id : y|$y->joinStrings(',')])->filter(x|$x.otherXne == 'boom');" +
-                            "   true;" +
-                            "}");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Compilation error at (resource:fromString.pure line:4 column:217), \"The system can't find the column otherXne in the Relation (id:String, ok:Integer, name:Integer, otherOne:String)\"", e.getMessage());
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "native function sum(i:Integer[*]):Integer[1];\n" +
+                        "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
+                        "native function meta::pure::functions::relation::filter<T>(rel:meta::pure::metamodel::relation::Relation<T>[1], f:Function<{T[1]->Boolean[1]}>[1]):meta::pure::metamodel::relation::Relation<T>[1];\n" +
+                        "\n" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:String, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->sum(), otherOne : x|$x.id : y|$y->joinStrings(',')])->filter(x|$x.otherXne == 'boom');\n" +
+                        "   true;\n" +
+                        "}"));
+        assertPureException(
+                PureCompilationException.class,
+                "The system can't find the column otherXne in the Relation (id:String, ok:Integer, name:Integer, otherOne:String)",
+                "fromString.pure", 7, 190, 7, 190, 7, 197,
+                e);
     }
 
     @Test
     public void testColumnFunctionInferenceWithExtraReduceFunctionArrayError()
     {
-        try
-        {
-            compileTestSource("fromString.pure",
-                    "native function sum(i:Integer[*]):Integer[1];" +
-                            "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
-                            "\n" +
-                            "" +
-                            "function test():Boolean[1]" +
-                            "{" +
-                            "   []->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.oke : y|$y->sum()]);" +
-                            "   true;" +
-                            "}");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Compilation error at (resource:fromString.pure line:3 column:141), \"The system can't find the column oke in the Relation (id:Integer, ok:Integer)\"", e.getMessage());
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "native function sum(i:Integer[*]):Integer[1];\n" +
+                        "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
+                        "\n" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.oke : y|$y->sum()]);\n" +
+                        "   true;\n" +
+                        "}"));
+        assertPureException(
+                PureCompilationException.class,
+                "The system can't find the column oke in the Relation (id:Integer, ok:Integer)",
+                "fromString.pure", 6, 114, 6, 114, 6, 116,
+                e);
     }
 
     @Test
     public void testColumnFunctionInferenceWithExtraReduceFunctionArrayMultipleError()
     {
-        try
-        {
-            compileTestSource("fromString.pure",
-                    "native function sum(i:Integer[*]):Integer[1];" +
-                            "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
-                            "\n" +
-                            "" +
-                            "function test():Boolean[1]" +
-                            "{" +
-                            "   []->cast(@meta::pure::metamodel::relation::Relation<(id:String, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->sum(), otherOne : x|$x.icd : y|$y->joinStrings(',')]);" +
-                            "   true;" +
-                            "}");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Compilation error at (resource:fromString.pure line:3 column:174), \"The system can't find the column icd in the Relation (id:String, ok:Integer)\"", e.getMessage());
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "native function sum(i:Integer[*]):Integer[1];\n" +
+                        "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
+                        "\n" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:String, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->sum(), otherOne : x|$x.icd : y|$y->joinStrings(',')]);\n" +
+                        "   true;\n" +
+                        "}"));
+        assertPureException(
+                PureCompilationException.class,
+                "The system can't find the column icd in the Relation (id:String, ok:Integer)",
+                "fromString.pure", 6, 147, 6, 147, 6, 149,
+                e);
     }
 
 
     @Test
     public void testColumnFunctionInferenceWithExtraReduceFunctionArrayMultipleAggError()
     {
-        try
-        {
-            compileTestSource("fromString.pure",
-                    "native function sum(i:Integer[*]):Integer[1];" +
-                            "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
-                            "\n" +
-                            "" +
-                            "function test():Boolean[1]" +
-                            "{" +
-                            "   []->cast(@meta::pure::metamodel::relation::Relation<(id:String, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->sum(), otherOne : x|$x.id : y|$y->sum()]);" +
-                            "   true;" +
-                            "}");
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Compilation error at (resource:fromString.pure line:3 column:185), \"The system can't find a match for the function: sum(_:String[*])\n" +
-                    "\n" +
-                    "These functions, in packages already imported, would match the function call if you changed the parameters.\n" +
-                    "\tsum(Integer[*]):Integer[1]\n" +
-                    "\n" +
-                    "No functions, in packages not imported, match the function name.\n" +
-                    "\"", e.getMessage());
-        }
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "fromString.pure",
+                "native function sum(i:Integer[*]):Integer[1];\n" +
+                        "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
+                        "\n" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:String, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->sum(), otherOne : x|$x.id : y|$y->sum()]);\n" +
+                        "   true;\n" +
+                        "}"));
+        assertPureException(
+                PureCompilationException.class,
+                "The system can't find a match for the function: sum(_:String[*])\n" +
+                        "\n" +
+                        "These functions, in packages already imported, would match the function call if you changed the parameters.\n" +
+                        "\tsum(Integer[*]):Integer[1]\n" +
+                        "\n" +
+                        "No functions, in packages not imported, match the function name.\n",
+                "fromString.pure", 6, 158, 6, 158, 6, 160,
+                e);
     }
 
 
@@ -402,15 +376,14 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
     public void testGroupByNullableAggregation()
     {
         compileTestSource("fromString.pure",
-                "native function max(i:Integer[*]):Integer[0..1];" +
+                "native function max(i:Integer[*]):Integer[0..1];\n" +
                         "native function meta::pure::functions::relation::groupBy<U,T,K,R>(r:meta::pure::metamodel::relation::Relation<U>[1], agg:meta::pure::metamodel::relation::AggColSpecArray<{U[1]->T[0..1]},{T[*]->K[0..1]}, R>[1]):meta::pure::metamodel::relation::Relation<U+R>[1];\n" +
-                        "function test():Boolean[1]" +
-                        "{" +
-                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:String, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->max(), otherOne : x|$x.id : y|$y->joinStrings(',')]);" +
-                        "   true;" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   []->cast(@meta::pure::metamodel::relation::Relation<(id:String, ok:Integer)>)->toOne()->groupBy(~[name: x|$x.ok : y|$y->max(), otherOne : x|$x.id : y|$y->joinStrings(',')]);\n" +
+                        "   true;\n" +
                         "}");
     }
-
 
     @Test
     public void testColumnSimpleFunctionInference()
@@ -418,11 +391,10 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
         compileTestSource("fromString.pure",
                 "native function meta::pure::functions::relation::extend<T,Z>(r:meta::pure::metamodel::relation::Relation<T>[1], f:meta::pure::metamodel::relation::FuncColSpec<{T[1]->Any[0..1]},Z>[1]):meta::pure::metamodel::relation::Relation<T+Z>[1];\n" +
                         "\n" +
-                        "" +
-                        "function test():Boolean[1]" +
-                        "{" +
-                        "   []->toOne()->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, ok:Integer)>)->extend(~name:c|$c.id->toOne());" +
-                        "   true;" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   []->toOne()->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, ok:Integer)>)->extend(~name:c|$c.id->toOne());\n" +
+                        "   true;\n" +
                         "}");
     }
 
@@ -433,14 +405,12 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
         compileTestSource("fromString.pure",
                 "native function meta::pure::functions::relation::extend<T,Z>(r:meta::pure::metamodel::relation::Relation<T>[1], f:meta::pure::metamodel::relation::FuncColSpec<{T[1]->Any[0..1]},Z>[1]):meta::pure::metamodel::relation::Relation<T+Z>[1];\n" +
                         "\n" +
-                        "" +
-                        "function test():Boolean[1]" +
-                        "{" +
-                        "   []->toOne()->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, ok:Integer)>)->extend(~name:c|$c.id->toOne());" +
-                        "   true;" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   []->toOne()->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, ok:Integer)>)->extend(~name:c|$c.id->toOne());\n" +
+                        "   true;\n" +
                         "}");
     }
-
 
     @Test
     public void testExtendWithColumnArray()
@@ -448,12 +418,10 @@ public class TestColumnBuilders extends AbstractPureTestWithCoreCompiledPlatform
         compileTestSource("fromString.pure",
                 "native function meta::pure::functions::relation::extend<T,Z>(r:meta::pure::metamodel::relation::Relation<T>[1], f:meta::pure::metamodel::relation::FuncColSpecArray<{T[1]->Any[*]},Z>[1]):meta::pure::metamodel::relation::Relation<T+Z>[1];\n" +
                         "\n" +
-                        "" +
-                        "function test():Boolean[1]" +
-                        "{" +
-                        "   []->toOne()->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, ok:Integer)>)->extend(~[name:c|$c.id->toOne()]);" +
-                        "   true;" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   []->toOne()->cast(@meta::pure::metamodel::relation::Relation<(id:Integer, ok:Integer)>)->extend(~[name:c|$c.id->toOne()]);\n" +
+                        "   true;\n" +
                         "}");
     }
-
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/relation/TestRelationTypeInference.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/relation/TestRelationTypeInference.java
@@ -70,16 +70,18 @@ public class TestRelationTypeInference extends AbstractPureTestWithCoreCompiledP
     public void testColumnFunctionSingleInference()
     {
         compileInferenceTest(
-                "import meta::pure::metamodel::relation::*;" +
-                        "Class Firm{legalName:String[1];}" +
+                "import meta::pure::metamodel::relation::*;\n" +
+                        "Class Firm\n" +
+                        "{\n" +
+                        "   legalName:String[1];\n" +
+                        "}\n" +
                         "\n" +
-                        "function f():Relation<(legal:String)>[1]" +
-                        "{" +
+                        "function f():Relation<(legal:String)>[1]\n" +
+                        "{\n" +
                         "   Firm.all()->project(~legal:x|$x.legalName);\n" +
-                        "}" +
+                        "}\n" +
                         "\n" +
-                        "native function project<Z,T>(cl:Z[*], x:FuncColSpec<{Z[1]->Any[*]},T>[1]):Relation<T>[1];" +
-                        "\n"
+                        "native function project<Z,T>(cl:Z[*], x:FuncColSpec<{Z[1]->Any[*]},T>[1]):Relation<T>[1];"
         );
     }
 
@@ -87,16 +89,18 @@ public class TestRelationTypeInference extends AbstractPureTestWithCoreCompiledP
     public void testColumnFunctionCollectionInference()
     {
         compileInferenceTest(
-                "import meta::pure::metamodel::relation::*;" +
-                        "Class Firm{legalName:String[1];}" +
+                "import meta::pure::metamodel::relation::*;\n" +
+                        "Class Firm\n" +
+                        "{\n" +
+                        "   legalName:String[1];\n" +
+                        "}\n" +
                         "\n" +
-                        "function f():Relation<(legal:String)>[1]" +
-                        "{" +
+                        "function f():Relation<(legal:String)>[1]\n" +
+                        "{\n" +
                         "   Firm.all()->project(~[legal:x|$x.legalName]);\n" +
-                        "}" +
+                        "}\n" +
                         "\n" +
-                        "native function project<Z,T>(cl:Z[*], x:FuncColSpecArray<{Z[1]->Any[*]},T>[1]):Relation<T>[1];" +
-                        "\n"
+                        "native function project<Z,T>(cl:Z[*], x:FuncColSpecArray<{Z[1]->Any[*]},T>[1]):Relation<T>[1];"
         );
     }
 
@@ -608,65 +612,64 @@ public class TestRelationTypeInference extends AbstractPureTestWithCoreCompiledP
     public void testRenameUseCase()
     {
         compileInferenceTest(
-                "import meta::pure::metamodel::relation::*;" +
-                        "Class A<X,Y>{}\n" +
+                "import meta::pure::metamodel::relation::*;\n" +
                         "function f(t:Relation<(value:Integer, name:String)>[1]):Relation<(value:Integer, na:String)>[1]\n" +
                         "{\n" +
                         "    $t->ren(~name, ~na);\n" +
-                        "}" +
+                        "}\n" +
                         "native function meta::pure::functions::relation::ren<T,Z,K,V>(r:Relation<T>[1], old:ColSpec<Z=(?:K)⊆T>[1], new:ColSpec<V=(?:K)>[1]):Relation<T-Z+V>[1];");
-
     }
 
     @Test
     public void testRenameUseCaseWithMap()
     {
         compileInferenceTest(
-                "import meta::pure::metamodel::relation::*;" +
-                        "Class A<X,Y>{}\n" +
+                "import meta::pure::metamodel::relation::*;\n" +
                         "function f(t:Relation<(value:Integer, name:String)>[1]):String[*]\n" +
                         "{\n" +
                         "    $t->ren(~name, ~na)->map(x|$x.na);\n" +
-                        "}" +
-                        "native function map<T,V>(rel:Relation<T>[1], f:Function<{T[1]->V[*]}>[1]):V[*];" +
+                        "}\n" +
+                        "native function map<T,V>(rel:Relation<T>[1], f:Function<{T[1]->V[*]}>[1]):V[*];\n" +
                         "native function meta::pure::functions::relation::ren<T,Z,K,V>(r:Relation<T>[1], old:ColSpec<Z=(?:K)⊆T>[1], new:ColSpec<V=(?:K)>[1]):Relation<T-Z+V>[1];");
-
     }
 
     @Test
     public void testRenameUseCaseWithHardCodedType()
     {
         compileInferenceTest(
-                "import meta::pure::metamodel::relation::*;" +
-                        "Class A<X,Y>{}\n" +
+                "import meta::pure::metamodel::relation::*;\n" +
                         "function f(t:Relation<(value:Integer, name:String)>[1]):Relation<(value:Integer, na:String)>[1]\n" +
                         "{\n" +
                         "    $t->ren(~name, ~na:String);\n" +
-                        "}" +
+                        "}\n" +
                         "native function meta::pure::functions::relation::ren<T,Z,K,V>(r:Relation<T>[1], old:ColSpec<Z=(?:K)⊆T>[1], new:ColSpec<V=(?:K)>[1]):Relation<T-Z+V>[1];");
-
     }
 
     @Test
     public void testRenameWithIndirectCall()
     {
         compileInferenceTest(
-                "import meta::pure::metamodel::relation::*;" +
-                        "Class A<X,Y>{}" +
-                        "Class TDS<T> extends Relation<T>{}\n" +
+                "import meta::pure::metamodel::relation::*;\n" +
+                        "Class TDS<T> extends Relation<T>\n" +
+                        "{\n" +
+                        "}\n" +
+                        "\n" +
                         "function f(t:Relation<(value:Integer, name:String)>[1]):Relation<(value:Integer, na:String)>[1]\n" +
                         "{\n" +
                         "    $t->ren(~name, ~na:String);\n" +
-                        "}" +
+                        "}\n" +
+                        "\n" +
                         "function f2(t:Relation<(value:Integer, name:String)>[1]):Relation<(value:Integer, na:String)>[1]\n" +
                         "{\n" +
                         "    $t->cast(@TDS<(value:Integer, name:String)>)->ren2(~name, ~na:String);\n" +
-                        "}" +
-                        "native function meta::pure::functions::relation::ren<T,Z,K,V>(r:Relation<T>[1], old:ColSpec<Z=(?:K)⊆T>[1], new:ColSpec<V=(?:K)>[1]):Relation<T-Z+V>[1];" +
-                        "function meta::pure::functions::relation::ren2<T,Z,K,V>(r:TDS<T>[1], old:ColSpec<Z=(?:K)⊆T>[1], new:ColSpec<V=(?:K)>[1]):Relation<T-Z+V>[1]" +
-                        "{" +
-                        "   ren($r->cast(@Relation<T>), $old, $new)" +
-                        "}");
+                        "}\n" +
+                        "\n" +
+                        "native function meta::pure::functions::relation::ren<T,Z,K,V>(r:Relation<T>[1], old:ColSpec<Z=(?:K)⊆T>[1], new:ColSpec<V=(?:K)>[1]):Relation<T-Z+V>[1];\n" +
+                        "\n" +
+                        "function meta::pure::functions::relation::ren2<T,Z,K,V>(r:TDS<T>[1], old:ColSpec<Z=(?:K)⊆T>[1], new:ColSpec<V=(?:K)>[1]):Relation<T-Z+V>[1]\n" +
+                        "{\n" +
+                        "   ren($r->cast(@Relation<T>), $old, $new)\n" +
+                        "}\n");
     }
 
     @Test
@@ -750,5 +753,4 @@ public class TestRelationTypeInference extends AbstractPureTestWithCoreCompiledP
         runtime.delete(inferenceTestFileName);
         runtime.compile();
     }
-
 }

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/tools/AbstractLazySpliterable.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/tools/AbstractLazySpliterable.java
@@ -18,6 +18,7 @@ import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.Counter;
 import org.eclipse.collections.impl.lazy.AbstractLazyIterable;
 
 import java.util.Iterator;
@@ -31,6 +32,21 @@ import java.util.stream.StreamSupport;
 
 public abstract class AbstractLazySpliterable<T> extends AbstractLazyIterable<T>
 {
+    @Override
+    public int size()
+    {
+        Counter counter = new Counter();
+        Spliterator<T> spliterator = spliterator();
+        while (spliterator.tryAdvance(n -> counter.increment()))
+        {
+            if (counter.getCount() == Integer.MAX_VALUE)
+            {
+                return Integer.MAX_VALUE;
+            }
+        }
+        return counter.getCount();
+    }
+
     @Override
     public void each(Procedure<? super T> procedure)
     {

--- a/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-pure/src/test/java/org/finos/legend/pure/m2/dsl/diagram/TestM2DiagramCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-pure/src/test/java/org/finos/legend/pure/m2/dsl/diagram/TestM2DiagramCompiledStateIntegrity.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.m2.dsl.diagram;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestM2DiagramCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -24,11 +23,5 @@ public class TestM2DiagramCompiledStateIntegrity extends AbstractCompiledStateIn
     public static void initialize()
     {
         initialize("platform_dsl_diagram");
-    }
-
-    @Test
-    public void testPackagedElementsContainAllOthers()
-    {
-        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-m2-dsl-graph-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/graph/TestM2GraphCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-m2-dsl-graph-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/graph/TestM2GraphCompiledStateIntegrity.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.m2.inlinedsl.graph;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestM2GraphCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -24,11 +23,5 @@ public class TestM2GraphCompiledStateIntegrity extends AbstractCompiledStateInte
     public static void initialize()
     {
         initialize("platform_dsl_graph");
-    }
-
-    @Test
-    public void testPackagedElementsContainAllOthers()
-    {
-        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-pure/src/test/java/org/finos/legend/pure/m2/dsl/mapping/TestM2MappingCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-pure/src/test/java/org/finos/legend/pure/m2/dsl/mapping/TestM2MappingCompiledStateIntegrity.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.m2.dsl.mapping;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestM2MappingCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -24,11 +23,5 @@ public class TestM2MappingCompiledStateIntegrity extends AbstractCompiledStateIn
     public static void initialize()
     {
         initialize("platform_dsl_mapping");
-    }
-
-    @Test
-    public void testPackagedElementsContainAllOthers()
-    {
-        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-path/legend-pure-m2-dsl-path-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/path/TestM2PathCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-path/legend-pure-m2-dsl-path-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/path/TestM2PathCompiledStateIntegrity.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.m2.inlinedsl.path;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestM2PathCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -24,11 +23,5 @@ public class TestM2PathCompiledStateIntegrity extends AbstractCompiledStateInteg
     public static void initialize()
     {
         initialize("platform_dsl_path");
-    }
-
-    @Test
-    public void testPackagedElementsContainAllOthers()
-    {
-        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-pure/src/test/java/org/finos/legend/pure/m2/dsl/store/TestM2StoreCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-pure/src/test/java/org/finos/legend/pure/m2/dsl/store/TestM2StoreCompiledStateIntegrity.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.m2.dsl.store;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestM2StoreCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -24,11 +23,5 @@ public class TestM2StoreCompiledStateIntegrity extends AbstractCompiledStateInte
     public static void initialize()
     {
         initialize("platform_dsl_store");
-    }
-
-    @Test
-    public void testPackagedElementsContainAllOthers()
-    {
-        super.testPackagedElementsContainAllOthers();
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/tds/TestM2TDSCompiledStateIntegrity.java
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-pure/src/test/java/org/finos/legend/pure/m2/inlinedsl/tds/TestM2TDSCompiledStateIntegrity.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.m2.inlinedsl.tds;
 
 import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestM2TDSCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
 {
@@ -24,11 +23,5 @@ public class TestM2TDSCompiledStateIntegrity extends AbstractCompiledStateIntegr
     public static void initialize()
     {
         initialize("platform_dsl_tds");
-    }
-
-    @Test
-    public void testPackagedElementsContainAllOthers()
-    {
-        super.testPackagedElementsContainAllOthers();
     }
 }


### PR DESCRIPTION
Fix a bug in type inference with generic type operations where inappropriate source info was being copied when trying to make generic types as concrete as possible.

This was causing an issue where a generic type owned by a function expression was being misidentified as belonging to the function that it was copied from. To prevent this sort of issue from recurring, a check is added to testPackagedElementsContainAllOthers to verify that the element identified as containing an instance _actually_ contains that instance.

In passing, several other changes:
- several small bug fixes with GraphNodeIterable, especially with computing the closure when there's a node filter
- small performance improvement in GraphPathIterable by avoiding checking validity of property names when we know they're valid
- remove unnecessary overrides for testPackagedElementsContainAllOthers
- fix a parsing error related to column builders