### PR TITLE
Set classifierGenericType for Profiles

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
@@ -3379,6 +3379,7 @@ public class AntlrContextToM3CoreInstance
         profile.setSourceInformation(this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.qualifiedName().getStop(), ctx.getStop()));
         buildAndSetPackage(profile, ctx.qualifiedName().packagePath(), this.repository, this.sourceInformation);
         return profile._name(profileName)
+                ._classifierGenericType(GenericTypeInstance.createPersistent(this.repository)._rawType((Type) this.processorSupport.package_getByUserPath(M3Paths.Profile)))
                 ._p_stereotypes(buildStereoTypes(ctx.stereotypeDefinitions(), profile))
                 ._p_tags(buildTags(ctx.tagDefinitions(), profile));
     }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/binary/TestBinaryModelSourceSerializer.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/binary/TestBinaryModelSourceSerializer.java
@@ -38,7 +38,7 @@ import org.finos.legend.pure.m3.serialization.runtime.PureRuntime;
 import org.finos.legend.pure.m3.serialization.runtime.PureRuntimeBuilder;
 import org.finos.legend.pure.m3.serialization.runtime.Source;
 import org.finos.legend.pure.m3.serialization.runtime.binary.reference.ExternalReferenceSerializerLibrary;
-import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.serialization.binary.BinaryReaders;
 import org.finos.legend.pure.m4.serialization.binary.BinaryWriters;
@@ -51,7 +51,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.Collection;
 import java.util.Set;
 
-public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCompiledPlatform
+public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCompiled
 {
     @BeforeClass
     public static void setUp()
@@ -118,7 +118,7 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
                         "    tags: [tag1];\n" +
                         "}\n");
         SetIterable<String> expectedInstances = Sets.mutable.with("test::profiles::MyProfile", "system::imports::import__test_model_testSource_pure_1");
-        SetIterable<String> expectedReferences = Sets.mutable.with("meta::pure::metamodel::extension::Profile", "meta::pure::metamodel::extension::Stereotype", "meta::pure::metamodel::extension::Tag", "meta::pure::metamodel::import::ImportGroup");
+        SetIterable<String> expectedReferences = Sets.mutable.with("meta::pure::metamodel::extension::Profile", "meta::pure::metamodel::extension::Stereotype", "meta::pure::metamodel::extension::Tag", "meta::pure::metamodel::import::ImportGroup", "meta::pure::metamodel::type::generics::GenericType");
 
         Pair<SourceSerializationResult, byte[]> serializationResult = serializeSource("/test/model/testSource.pure");
         SourceSerializationResult result = serializationResult.getOne();
@@ -505,7 +505,7 @@ public class TestBinaryModelSourceSerializer extends AbstractPureTestWithCoreCom
         if (missing.notEmpty())
         {
             StringBuilder message = new StringBuilder("Missing ").append(description == null ? "elements" : description).append(": ");
-            Iterate.collect(missing, Object::toString, Lists.mutable.empty()).sortThis().appendString(message, ", ");
+            missing.collect(Object::toString).sortThis().appendString(message, ", ");
             Assert.fail(message.toString());
         }
     }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/profile/TestProfile.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/profile/TestProfile.java
@@ -16,13 +16,12 @@ package org.finos.legend.pure.m3.tests.elements.profile;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ListIterable;
-import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.test.Verify;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Stereotype;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Tag;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
@@ -70,25 +69,15 @@ public class TestProfile extends AbstractPureTestWithCoreCompiledPlatform
         Profile profile = (Profile) runtime.getCoreInstance("test::myProfile");
         Assert.assertNotNull(profile);
 
+        Assert.assertEquals(M3Paths.Profile, GenericType.print(profile._classifierGenericType(), true, processorSupport));
+
         ListIterable<? extends Stereotype> stereotypes = ListHelper.wrapListIterable(profile._p_stereotypes());
-        Verify.assertSize(2, stereotypes);
-        MutableSet<String> stereotypeValues = Sets.mutable.empty();
-        for (Stereotype stereotype : stereotypes)
-        {
-            Assert.assertSame(profile, stereotype._profile());
-            stereotypeValues.add(stereotype._value());
-        }
-        Verify.assertSetsEqual(Sets.mutable.with("st1", "st2"), stereotypeValues);
+        Assert.assertEquals(Lists.mutable.with("st1", "st2"), stereotypes.collect(Stereotype::_value));
+        stereotypes.forEach(st -> Assert.assertSame(st._value(), profile, st._profile()));
 
         ListIterable<? extends Tag> tags = ListHelper.wrapListIterable(profile._p_tags());
-        Verify.assertSize(3, tags);
-        MutableSet<String> tagValues = Sets.mutable.empty();
-        for (Tag tag : tags)
-        {
-            Assert.assertSame(profile, tag._profile());
-            tagValues.add(tag._value());
-        }
-        Verify.assertSetsEqual(Sets.mutable.with("t1", "t2", "t3"), tagValues);
+        Assert.assertEquals(Lists.mutable.with("t1", "t2", "t3"), tags.collect(Tag::_value));
+        tags.forEach(t -> Assert.assertSame(t._value(), profile, t._profile()));
     }
 
     @Test
@@ -104,7 +93,7 @@ public class TestProfile extends AbstractPureTestWithCoreCompiledPlatform
         Assert.assertNotNull(profile);
 
         ListIterable<? extends Stereotype> stereotypes = ListHelper.wrapListIterable(profile._p_stereotypes());
-        Verify.assertSize(3, stereotypes);
+        Assert.assertEquals(Lists.mutable.with("st1", "st2", "st3"), stereotypes.collect(Stereotype::_value));
 
         Stereotype st1 = (Stereotype) org.finos.legend.pure.m3.navigation.profile.Profile.findStereotype(profile, "st1");
         Assert.assertNotNull(st1);
@@ -139,7 +128,7 @@ public class TestProfile extends AbstractPureTestWithCoreCompiledPlatform
         Assert.assertNotNull(profile);
 
         ListIterable<? extends Tag> tags = ListHelper.wrapListIterable(profile._p_tags());
-        Verify.assertSize(3, tags);
+        Assert.assertEquals(Lists.mutable.with("t1", "t2", "t3"), tags.collect(Tag::_value));
 
         Tag t1 = (Tag) org.finos.legend.pure.m3.navigation.profile.Profile.findTag(profile, "t1");
         Assert.assertNotNull(t1);


### PR DESCRIPTION
Set the classifierGenericType for Profiles. In passing, abstract out the building and setting of packages in AntlrContextToM3CoreInstance.