### PR TITLE
Fix a bug with RelationalInstanceSetImplementationProcessor

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/CompiledStateIntegrityTestTools.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/CompiledStateIntegrityTestTools.java
@@ -660,6 +660,20 @@ public class CompiledStateIntegrityTestTools
                         {
                             sourceInfo.appendMessage(message.append(" (")).append(')');
                         }
+                        ResolvedGraphPath path = findPathToInstance(instance, processorSupport);
+                        if (path != null)
+                        {
+                            if (sourceInfo == null)
+                            {
+                                message.append(" (");
+                            }
+                            else
+                            {
+                                message.setLength(message.length() - 1);
+                                message.append(", ");
+                            }
+                            path.getGraphPath().writeDescription(message).append(')');
+                        }
                         message.append("; property: ").append(propertyName);
                         message.append("; value: ").append(value);
                         message.append("; index: ").append(i);

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/main/java/org/finos/legend/pure/m2/relational/serialization/grammar/v1/processor/RelationalInstanceSetImplementationProcessor.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/main/java/org/finos/legend/pure/m2/relational/serialization/grammar/v1/processor/RelationalInstanceSetImplementationProcessor.java
@@ -16,32 +16,28 @@ package org.finos.legend.pure.m2.relational.serialization.grammar.v1.processor;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
-import org.eclipse.collections.api.block.function.Function2;
-import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.block.factory.Functions;
-import org.eclipse.collections.impl.list.mutable.FastList;
-import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.finos.legend.pure.m2.relational.M2RelationalPaths;
 import org.finos.legend.pure.m2.relational.M2RelationalProperties;
-import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.compiler.postprocessing.PostProcessor;
 import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.Processor;
-import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
-import org.finos.legend.pure.m3.navigation.type.Type;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMapping;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMappingAccessor;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.ModelElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.mapping.EmbeddedRelationalInstanceSetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.mapping.GroupByMapping;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.mapping.RelationalInstanceSetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.mapping.RelationalPropertyMapping;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.mapping.RootRelationalInstanceSetImplementation;
+import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.AliasAccessor;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Column;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Database;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.RelationalOperationElement;
@@ -53,83 +49,21 @@ import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.relation.
 import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.relation.Relation;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.relation.Table;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.relation.View;
+import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
+import org.finos.legend.pure.m3.navigation.type.Type;
 import org.finos.legend.pure.m3.tools.matcher.Matcher;
-import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
+
+import java.util.function.Consumer;
 
 public class RelationalInstanceSetImplementationProcessor extends Processor<RootRelationalInstanceSetImplementation>
 {
-    private static final Function<PropertyMapping, Store> STORE = new Function<PropertyMapping, Store>()
-    {
-        @Override
-        public Store valueOf(PropertyMapping propertyMapping)
-        {
-            return propertyMapping._store();
-        }
-    };
-
-    private static final Function<PropertyMapping, RichIterable<RelationalOperationElement>> PROPERTY_MAPPING_TO_RELATIONAL_OPERATION_ELEMENT_FN = new Function<PropertyMapping, RichIterable<RelationalOperationElement>>()
-    {
-        @Override
-        public RichIterable<RelationalOperationElement> valueOf(PropertyMapping propertyMapping)
-        {
-            if (propertyMapping instanceof RelationalPropertyMapping)
-            {
-                return FastList.newListWith(((RelationalPropertyMapping)propertyMapping)._relationalOperationElement());
-            }
-            else if (propertyMapping instanceof EmbeddedRelationalInstanceSetImplementation)
-            {
-                return ((EmbeddedRelationalInstanceSetImplementation)propertyMapping)._propertyMappings().flatCollect(PROPERTY_MAPPING_TO_RELATIONAL_OPERATION_ELEMENT_FN);
-            }
-            else
-            {
-                return FastList.newList();
-            }
-        }
-    };
-
-    private static final Function<RelationalOperationElement, RelationalOperationElement> TAC_TO_COLUMN = new Function<RelationalOperationElement, RelationalOperationElement>()
-    {
-
-        @Override
-        public RelationalOperationElement valueOf(RelationalOperationElement roe)
-        {
-            if (roe instanceof TableAliasColumn)
-            {
-                return ((TableAliasColumn)roe)._column();
-            }
-            return roe;
-        }
-    };
-
-    public static final Function<TableAlias, RelationalOperationElement> TABLE_ALIAS_TO_RELATIONAL_OPERATION_ELEMENT_FN = new Function<TableAlias, RelationalOperationElement>()
-    {
-        @Override
-        public RelationalOperationElement valueOf(TableAlias tableAlias)
-        {
-            return tableAlias._relationalElement();
-        }
-    };
-
-    private static final Function2<TableAlias, ProcessorSupport, Database> TABLE_ALIAS_TO_DATABASE_FN = new Function2<TableAlias, ProcessorSupport, Database>()
-    {
-        @Override
-        public Database value(TableAlias tableAlias, ProcessorSupport processorSupport)
-        {
-            return (Database)ImportStub.withImportStubByPass(tableAlias._databaseCoreInstance(), processorSupport);
-        }
-    };
-
-    private static final Predicate<RelationalOperationElement> RELATIONAL_OPERATION_ELEMENT_PK_PREDICATE = new Predicate<RelationalOperationElement>()
-    {
-        @Override
-        public boolean accept(RelationalOperationElement instance)
-        {
-            return !(instance instanceof RelationalOperationElementWithJoin) || ((RelationalOperationElementWithJoin)instance)._relationalOperationElement() != null;
-        }
-    };
+    @Deprecated
+    public static final Function<TableAlias, RelationalOperationElement> TABLE_ALIAS_TO_RELATIONAL_OPERATION_ELEMENT_FN = AliasAccessor::_relationalElement;
 
     @Override
     public String getClassName()
@@ -140,12 +74,12 @@ public class RelationalInstanceSetImplementationProcessor extends Processor<Root
     @Override
     public void process(RootRelationalInstanceSetImplementation implementation, ProcessorState state, Matcher matcher, final ModelRepository repository, final Context context, final ProcessorSupport processorSupport)
     {
-        // No need to cross reference... ClassMapping is responsible for that
-        ModelElement cls = (ModelElement)ImportStub.withImportStubByPass(implementation._classCoreInstance(), processorSupport);
+        // No need to cross-reference... ClassMapping is responsible for that
+        ModelElement cls = (ModelElement) ImportStub.withImportStubByPass(implementation._classCoreInstance(), processorSupport);
 
-        GenericType instanceGenericType = cls._classifierGenericType() == null ? (GenericType)Type.wrapGenericType(processorSupport.getClassifier(cls), processorSupport) : cls._classifierGenericType();
+        GenericType instanceGenericType = cls._classifierGenericType() == null ? (GenericType) Type.wrapGenericType(processorSupport.getClassifier(cls), processorSupport) : cls._classifierGenericType();
 
-        CoreInstance propertyReturnGenericType = org.finos.legend.pure.m3.navigation.generictype.GenericType.resolvePropertyReturnType((implementation._classifierGenericType() == null ? (GenericType)Type.wrapGenericType(processorSupport.getClassifier(implementation), processorSupport) : implementation._classifierGenericType()), implementation.getKeyByName(M3Properties._class), processorSupport);
+        CoreInstance propertyReturnGenericType = org.finos.legend.pure.m3.navigation.generictype.GenericType.resolvePropertyReturnType((implementation._classifierGenericType() == null ? (GenericType) Type.wrapGenericType(processorSupport.getClassifier(implementation), processorSupport) : implementation._classifierGenericType()), implementation.getKeyByName(M3Properties._class), processorSupport);
 
         if (!org.finos.legend.pure.m3.navigation.generictype.GenericType.subTypeOf(instanceGenericType, propertyReturnGenericType, processorSupport))
         {
@@ -158,15 +92,15 @@ public class RelationalInstanceSetImplementationProcessor extends Processor<Root
 
         if (implementation._id().equals(implementation._superSetImplementationId()))
         {
-            throw new PureCompilationException(implementation.getSourceInformation(), "Extend mapping id cannot reference self \'" + implementation._id() + "\'");
+            throw new PureCompilationException(implementation.getSourceInformation(), "Extend mapping id cannot reference self '" + implementation._id() + "'");
         }
 
         TableAlias mainTableAlias;
         TableAlias userDefinedMainTable = implementation._mainTableAlias();
         if (userDefinedMainTable == null)
         {
-            MutableSet<RelationalOperationElement> tables = tableAliases.collect(TABLE_ALIAS_TO_RELATIONAL_OPERATION_ELEMENT_FN);
-            MutableSet<Database> databases = tableAliases.collectWith(TABLE_ALIAS_TO_DATABASE_FN, processorSupport);
+            MutableSet<RelationalOperationElement> tables = tableAliases.collect(AliasAccessor::_relationalElement);
+            MutableSet<Database> databases = tableAliases.collect(tableAlias -> (Database) ImportStub.withImportStubByPass(tableAlias._databaseCoreInstance(), processorSupport));
 
             if (implementation._superSetImplementationId() != null)
             {
@@ -183,26 +117,27 @@ public class RelationalInstanceSetImplementationProcessor extends Processor<Root
                 throw new PureCompilationException(implementation.getSourceInformation(), "Can't find the main table for class '" + cls._name() + "'. Inconsistent database definitions for the mapping");
             }
 
-            mainTableAlias = (TableAlias)processorSupport.newAnonymousCoreInstance(null, M2RelationalPaths.TableAlias);
-            mainTableAlias._name(repository.newStringCoreInstance_cached("").getName());
-            mainTableAlias._relationalElement(tables.toList().getFirst());
-            mainTableAlias._databaseCoreInstance(databases.toList().getFirst());
+            Database database = databases.getAny();
+            PostProcessor.processElement(matcher, database, state, processorSupport);
+
+            mainTableAlias = (TableAlias) processorSupport.newAnonymousCoreInstance(null, M2RelationalPaths.TableAlias);
+            mainTableAlias._name("");
+            mainTableAlias._relationalElement(tables.getAny());
+            mainTableAlias._databaseCoreInstance(database);
             implementation._mainTableAlias(mainTableAlias);
+        }
+        else if (implementation._superSetImplementationId() == null)
+        {
+            mainTableAlias = userDefinedMainTable;
+            Database database = (Database) ImportStub.withImportStubByPass(mainTableAlias._databaseCoreInstance(), processorSupport);
+            PostProcessor.processElement(matcher, database, state, processorSupport);
+            NamedRelation table = (NamedRelation) DatabaseProcessor.findTableForAlias(database, mainTableAlias, processorSupport);
+            mainTableAlias._relationalElement(table);
+            mainTableAlias._setMappingOwner(implementation);
         }
         else
         {
-            if (implementation._superSetImplementationId() == null)
-            {
-                mainTableAlias = userDefinedMainTable;
-                Database database = (Database)ImportStub.withImportStubByPass(mainTableAlias._databaseCoreInstance(), processorSupport);
-                NamedRelation table = (NamedRelation)DatabaseProcessor.findTableForAlias(database, mainTableAlias, processorSupport);
-                mainTableAlias._relationalElement(table);
-                mainTableAlias._setMappingOwner(implementation);
-            }
-            else
-            {
-                throw new PureCompilationException(implementation.getSourceInformation(), "Cannot specify main table explicitly for extended mapping [" + implementation._id() + "]");
-            }
+            throw new PureCompilationException(implementation.getSourceInformation(), "Cannot specify main table explicitly for extended mapping [" + implementation._id() + "]");
         }
 
         RelationalOperationElement mainTable = mainTableAlias._relationalElement();
@@ -222,42 +157,35 @@ public class RelationalInstanceSetImplementationProcessor extends Processor<Root
         }
         else if (distinct)
         {
-            RichIterable<RelationalOperationElement> pks = propertyMappings.flatCollect(PROPERTY_MAPPING_TO_RELATIONAL_OPERATION_ELEMENT_FN);
-            RichIterable<RelationalOperationElement> pksWithDistinctColumns = pks.groupBy(TAC_TO_COLUMN).keyMultiValuePairsView().collect(Functions.<RichIterable<RelationalOperationElement>>secondOfPair()).collect(new Function<RichIterable<RelationalOperationElement>, RelationalOperationElement>()
-            {
-                @Override
-                public RelationalOperationElement valueOf(RichIterable<RelationalOperationElement> roes)
-                {
-                    return roes.getFirst();
-                }
-            });
+            RichIterable<RelationalOperationElement> pks = propertyMappingsToRelationalOperationElements(propertyMappings);
+            RichIterable<RelationalOperationElement> pksWithDistinctColumns = pks.groupBy(roe -> (roe instanceof TableAliasColumn) ? ((TableAliasColumn) roe)._column() : roe).keyMultiValuePairsView().collect(pair -> pair.getTwo().getFirst());
 
-            implementation._primaryKey(pksWithDistinctColumns.select(RELATIONAL_OPERATION_ELEMENT_PK_PREDICATE));
+            implementation._primaryKey(pksWithDistinctColumns.select(pk -> !(pk instanceof RelationalOperationElementWithJoin) || ((RelationalOperationElementWithJoin) pk)._relationalOperationElement() != null));
         }
         else if (implementation._primaryKey().isEmpty())
         {
-            Relation relation = (Relation)mainTableAlias._relationalElement();
+            Relation relation = (Relation) mainTableAlias._relationalElement();
             final TableAlias finalMainTable = mainTableAlias;
             DatabaseProcessor.processTable(relation, matcher, state, processorSupport);
-            RichIterable<? extends Column> columns = FastList.newList();
+            RichIterable<? extends Column> columns;
             if (relation instanceof Table)
             {
-                columns = ((Table)relation)._primaryKey();
+                columns = ((Table) relation)._primaryKey();
             }
             else if (relation instanceof View)
             {
-                columns = ((View)relation)._primaryKey();
+                columns = ((View) relation)._primaryKey();
             }
-            RichIterable<TableAliasColumn> primaryKey = columns.collect(new Function<Column, TableAliasColumn>()
+            else
             {
-                @Override
-                public TableAliasColumn valueOf(Column column)
-                {
-                    TableAliasColumn tableAliasColumn = (TableAliasColumn)repository.newEphemeralAnonymousCoreInstance(null, processorSupport.package_getByUserPath(M2RelationalPaths.TableAliasColumn));
-                    tableAliasColumn._column(column);
-                    tableAliasColumn._alias(finalMainTable);
-                    return tableAliasColumn;
-                }
+                columns = Lists.mutable.empty();
+            }
+            RichIterable<TableAliasColumn> primaryKey = columns.collect(column ->
+            {
+                TableAliasColumn tableAliasColumn = (TableAliasColumn) repository.newEphemeralAnonymousCoreInstance(null, processorSupport.package_getByUserPath(M2RelationalPaths.TableAliasColumn));
+                tableAliasColumn._column(column);
+                tableAliasColumn._alias(finalMainTable);
+                return tableAliasColumn;
             });
             implementation._primaryKey(primaryKey);
         }
@@ -270,7 +198,7 @@ public class RelationalInstanceSetImplementationProcessor extends Processor<Root
             processUserDefinedPrimaryKey(implementation, implementation, matcher, state, repository, processorSupport);
         }
 
-        implementation._stores(implementation._propertyMappings().collect(STORE).toSet().with(implementation._mainTableAlias()._database()).without(null));
+        implementation._stores(implementation._propertyMappings().collect(PropertyMappingAccessor::_store, Sets.mutable.empty()).with(implementation._mainTableAlias()._database()).without(null));
         MilestoningPropertyMappingProcessor.processMilestoningPropertyMapping(implementation, implementation, processorSupport);
     }
 
@@ -300,7 +228,7 @@ public class RelationalInstanceSetImplementationProcessor extends Processor<Root
         RichIterable<? extends RelationalOperationElement> primaryKeys = implementation._primaryKey();
         for (RelationalOperationElement primaryKey : primaryKeys)
         {
-            RelationalOperationElementProcessor.processColumnExpr(primaryKey, implementation, mappingOwner, UnifiedSet.<TableAlias>newSet(), matcher, state, repository, processorSupport);
+            RelationalOperationElementProcessor.processColumnExpr(primaryKey, implementation, mappingOwner, Sets.mutable.empty(), matcher, state, repository, processorSupport);
         }
         // TODO figure out why we are setting the property values back to the same list
         implementation._primaryKey(primaryKeys);
@@ -310,7 +238,7 @@ public class RelationalInstanceSetImplementationProcessor extends Processor<Root
     {
         if (implementation instanceof RelationalInstanceSetImplementation)
         {
-            for (RelationalOperationElement primaryKey : ((RelationalInstanceSetImplementation)implementation)._primaryKey())
+            for (RelationalOperationElement primaryKey : ((RelationalInstanceSetImplementation) implementation)._primaryKey())
             {
                 RelationalOperationElementProcessor.populateColumnExpressionReferenceUsages(primaryKey, repository, processorSupport);
             }
@@ -325,11 +253,11 @@ public class RelationalInstanceSetImplementationProcessor extends Processor<Root
 
     private static RootRelationalInstanceSetImplementation getSuperMapping(RootRelationalInstanceSetImplementation implementation, ProcessorSupport processorSupport)
     {
-        Mapping parentMapping = (Mapping)ImportStub.withImportStubByPass(implementation._parentCoreInstance(), processorSupport);
+        Mapping parentMapping = (Mapping) ImportStub.withImportStubByPass(implementation._parentCoreInstance(), processorSupport);
         SetImplementation superMapping = org.finos.legend.pure.m2.dsl.mapping.Mapping.getClassMappingById(parentMapping, implementation._superSetImplementationId(), processorSupport);
         if (superMapping instanceof RootRelationalInstanceSetImplementation)
         {
-            return (RootRelationalInstanceSetImplementation)superMapping;
+            return (RootRelationalInstanceSetImplementation) superMapping;
         }
         throw new PureCompilationException(implementation.getSourceInformation(), "Invalid superMapping for mapping [" + implementation._id() + "]");
     }
@@ -339,8 +267,27 @@ public class RelationalInstanceSetImplementationProcessor extends Processor<Root
         RelationalOperationElement superImplementationMainTable = superImplementation._mainTableAlias()._relationalElement();
         tables.add(superImplementationMainTable);
 
-        Database superImplementationDatabase = (Database)ImportStub.withImportStubByPass(superImplementation._mainTableAlias()._databaseCoreInstance(), processorSupport);
+        Database superImplementationDatabase = (Database) ImportStub.withImportStubByPass(superImplementation._mainTableAlias()._databaseCoreInstance(), processorSupport);
         Database superImplementationDatabaseAfterSubstitutions = DatabaseSubstitutionHandler.getDatabaseAfterStoreSubstitution(implementation, superImplementation, superImplementationDatabase);
         databases.add(superImplementationDatabaseAfterSubstitutions);
+    }
+
+    private static RichIterable<RelationalOperationElement> propertyMappingsToRelationalOperationElements(Iterable<? extends PropertyMapping> propertyMappings)
+    {
+        MutableList<RelationalOperationElement> result = Lists.mutable.empty();
+        propertyMappings.forEach(pm -> forEachRelationalOperationElement(pm, result::add));
+        return result;
+    }
+
+    private static void forEachRelationalOperationElement(PropertyMapping propertyMapping, Consumer<? super RelationalOperationElement> consumer)
+    {
+        if (propertyMapping instanceof RelationalPropertyMapping)
+        {
+            consumer.accept(((RelationalPropertyMapping) propertyMapping)._relationalOperationElement());
+        }
+        else if (propertyMapping instanceof EmbeddedRelationalInstanceSetImplementation)
+        {
+            ((EmbeddedRelationalInstanceSetImplementation) propertyMapping)._propertyMappings().forEach(pm -> forEachRelationalOperationElement(pm, consumer));
+        }
     }
 }

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/main/java/org/finos/legend/pure/m2/relational/serialization/grammar/v1/processor/ViewProcessing.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/main/java/org/finos/legend/pure/m2/relational/serialization/grammar/v1/processor/ViewProcessing.java
@@ -31,6 +31,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.Pair
 import org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.TreeNode;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.mapping.ColumnMapping;
+import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.AliasAccessor;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Column;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Database;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.DynaFunction;
@@ -127,7 +128,7 @@ public class ViewProcessing extends RelationalMappingSpecificationProcessing
     private static void processGroupByMapping(View view, Matcher matcher, ProcessorState processorState, ModelRepository repository, CoreInstance mainTable, ProcessorSupport processorSupport)
     {
         MutableSet<TableAlias> groupByTableAliases = processGroupByMapping(view, null, processorState, matcher, repository, processorSupport).getTwo();
-        SetIterable<RelationalOperationElement> groupByTables = groupByTableAliases.collect(RelationalInstanceSetImplementationProcessor.TABLE_ALIAS_TO_RELATIONAL_OPERATION_ELEMENT_FN, Sets.mutable.empty());
+        SetIterable<RelationalOperationElement> groupByTables = groupByTableAliases.collect(AliasAccessor::_relationalElement, Sets.mutable.empty());
         for (RelationalOperationElement groupByTable : groupByTables)
         {
             if (groupByTable != mainTable)

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/test/java/org/finos/legend/pure/m2/relational/TestMilestoningPropertyMapping.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/test/java/org/finos/legend/pure/m2/relational/TestMilestoningPropertyMapping.java
@@ -14,10 +14,10 @@
 
 package org.finos.legend.pure.m2.relational;
 
-import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.pure.m3.compiler.postprocessing.processor.milestoning.MilestoningFunctions;
-import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.PropertyMapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property;
@@ -30,7 +30,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Relationa
 import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.SQLNull;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.TableAliasColumn;
 import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.relation.Table;
-import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,14 +43,14 @@ import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTest
 import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.EMBEDDED_MODEL_CODE;
 import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.EMBEDDED_MODEL_ID;
 import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.EXTENDED_MAPPING_CODE;
-import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.EXTENDED_MAPPING_ID;
 import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.EXTENDED_MAPPING_CODE_WITH_MILESTONING_PROPERTY_EXPLICITLY_MAPPED;
+import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.EXTENDED_MAPPING_ID;
 import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.EXTENDED_MODEL_ID;
 import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.INLINE_EMBEDDED_MAPPING_CODE;
 import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.INLINE_EMBEDDED_MAPPING_CODE_WITH_MILESTONING_PROPERTY_EXPLICITLY_MAPPED;
 import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.MAPPING_CODE;
-import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.MAPPING_ID;
 import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.MAPPING_CODE_WITH_MILESTONING_PROPERTY_EXPLICITLY_MAPPED;
+import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.MAPPING_ID;
 import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.MILESTONED_STORE_CODE;
 import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.MODEL_ID;
 import static org.finos.legend.pure.m2.relational.MilestoningPropertyMappingTestSourceCodes.NON_MILESTONED_STORE_CODE;
@@ -63,19 +63,19 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
     @Test
     public void testProcessingMilestoningPropertyMapping()
     {
-        this.runtime.createInMemorySource(MODEL_ID, PROCESSING_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
-        this.runtime.compile();
+        runtime.createInMemorySource(MODEL_ID, PROCESSING_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
+        runtime.compile();
 
-        Mapping mapping = (Mapping)this.runtime.getCoreInstance("milestoning::Amap");
-        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = mapping._classMappings().selectInstancesOf(RootRelationalInstanceSetImplementation.class).getFirst();
+        Mapping mapping = (Mapping) runtime.getCoreInstance("milestoning::Amap");
+        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = (RootRelationalInstanceSetImplementation) mapping._classMappings().detect(RootRelationalInstanceSetImplementation.class::isInstance);
 
-        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)rootRelationalInstanceSetImplementation._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstanceSetImplementation._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::A");
 
-        MutableList<RelationalPropertyMapping> relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        ListIterable<RelationalPropertyMapping> relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(2, relationalPropertyMappings.size());
 
         RelationalPropertyMapping inPropertyMapping = relationalPropertyMappings.get(0);
@@ -90,19 +90,19 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
     @Test
     public void testBusinessMilestoningPropertyMapping()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
-        this.runtime.compile();
+        runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
+        runtime.compile();
 
-        Mapping mapping = (Mapping)this.runtime.getCoreInstance("milestoning::Amap");
-        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = mapping._classMappings().selectInstancesOf(RootRelationalInstanceSetImplementation.class).getFirst();
+        Mapping mapping = (Mapping) runtime.getCoreInstance("milestoning::Amap");
+        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = (RootRelationalInstanceSetImplementation) mapping._classMappings().detect(RootRelationalInstanceSetImplementation.class::isInstance);
 
-        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)rootRelationalInstanceSetImplementation._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstanceSetImplementation._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::A");
 
-        MutableList<RelationalPropertyMapping> relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        MutableList<RelationalPropertyMapping> relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(2, relationalPropertyMappings.size());
 
         RelationalPropertyMapping fromPropertyMapping = relationalPropertyMappings.get(0);
@@ -117,19 +117,19 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
     @Test
     public void testBiTemporalMilestoningPropertyMapping()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BI_TEMPORAL_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
-        this.runtime.compile();
+        runtime.createInMemorySource(MODEL_ID, BI_TEMPORAL_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
+        runtime.compile();
 
-        Mapping mapping = (Mapping)this.runtime.getCoreInstance("milestoning::Amap");
-        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = mapping._classMappings().selectInstancesOf(RootRelationalInstanceSetImplementation.class).getFirst();
+        Mapping mapping = (Mapping) runtime.getCoreInstance("milestoning::Amap");
+        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = (RootRelationalInstanceSetImplementation) mapping._classMappings().detect(RootRelationalInstanceSetImplementation.class::isInstance);
 
-        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)rootRelationalInstanceSetImplementation._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstanceSetImplementation._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::A");
 
-        MutableList<RelationalPropertyMapping> relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        MutableList<RelationalPropertyMapping> relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(4, relationalPropertyMappings.size());
 
         RelationalPropertyMapping inPropertyMapping = relationalPropertyMappings.get(0);
@@ -152,19 +152,19 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
     @Test
     public void testProcessingMilestoningPropertyMappingWithNonMilestonedTable()
     {
-        this.runtime.createInMemorySource(MODEL_ID, PROCESSING_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, NON_MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
-        this.runtime.compile();
+        runtime.createInMemorySource(MODEL_ID, PROCESSING_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, NON_MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
+        runtime.compile();
 
-        Mapping mapping = (Mapping)this.runtime.getCoreInstance("milestoning::Amap");
-        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = mapping._classMappings().selectInstancesOf(RootRelationalInstanceSetImplementation.class).getFirst();
+        Mapping mapping = (Mapping) runtime.getCoreInstance("milestoning::Amap");
+        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = (RootRelationalInstanceSetImplementation) mapping._classMappings().detect(RootRelationalInstanceSetImplementation.class::isInstance);
 
-        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)rootRelationalInstanceSetImplementation._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstanceSetImplementation._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::A");
 
-        MutableList<RelationalPropertyMapping> relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        MutableList<RelationalPropertyMapping> relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(2, relationalPropertyMappings.size());
 
         RelationalPropertyMapping inPropertyMapping = relationalPropertyMappings.get(0);
@@ -179,19 +179,19 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
     @Test
     public void testBusinessMilestoningPropertyMappingWithNonMilestonedTable()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, NON_MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
-        this.runtime.compile();
+        runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, NON_MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
+        runtime.compile();
 
-        Mapping mapping = (Mapping)this.runtime.getCoreInstance("milestoning::Amap");
-        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = mapping._classMappings().selectInstancesOf(RootRelationalInstanceSetImplementation.class).getFirst();
+        Mapping mapping = (Mapping) runtime.getCoreInstance("milestoning::Amap");
+        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = (RootRelationalInstanceSetImplementation) mapping._classMappings().detect(RootRelationalInstanceSetImplementation.class::isInstance);
 
-        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)rootRelationalInstanceSetImplementation._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstanceSetImplementation._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::A");
 
-        MutableList<RelationalPropertyMapping> relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        MutableList<RelationalPropertyMapping> relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(2, relationalPropertyMappings.size());
 
         RelationalPropertyMapping fromPropertyMapping = relationalPropertyMappings.get(0);
@@ -206,19 +206,19 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
     @Test
     public void testBiTemporalMilestoningPropertyMappingWithNonMilestonedTable()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BI_TEMPORAL_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, NON_MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
-        this.runtime.compile();
+        runtime.createInMemorySource(MODEL_ID, BI_TEMPORAL_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, NON_MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
+        runtime.compile();
 
-        Mapping mapping = (Mapping)this.runtime.getCoreInstance("milestoning::Amap");
-        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = mapping._classMappings().selectInstancesOf(RootRelationalInstanceSetImplementation.class).getFirst();
+        Mapping mapping = (Mapping) runtime.getCoreInstance("milestoning::Amap");
+        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = (RootRelationalInstanceSetImplementation) mapping._classMappings().detect(RootRelationalInstanceSetImplementation.class::isInstance);
 
-        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)rootRelationalInstanceSetImplementation._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstanceSetImplementation._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::A");
 
-        MutableList<RelationalPropertyMapping> relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        MutableList<RelationalPropertyMapping> relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(4, relationalPropertyMappings.size());
 
         RelationalPropertyMapping inPropertyMapping = relationalPropertyMappings.get(0);
@@ -241,21 +241,21 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
     @Test
     public void testBusinessMilestoningPropertyMappingWithMappingExtends()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(EXTENDED_MODEL_ID, BUSINESS_MILESTONING_EXTENDED_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
-        this.runtime.createInMemorySource(EXTENDED_MAPPING_ID, EXTENDED_MAPPING_CODE);
-        this.runtime.compile();
+        runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(EXTENDED_MODEL_ID, BUSINESS_MILESTONING_EXTENDED_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
+        runtime.createInMemorySource(EXTENDED_MAPPING_ID, EXTENDED_MAPPING_CODE);
+        runtime.compile();
 
-        Mapping mapping = (Mapping)this.runtime.getCoreInstance("milestoning::Amap");
-        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = mapping._classMappings().selectInstancesOf(RootRelationalInstanceSetImplementation.class).getFirst();
+        Mapping mapping = (Mapping) runtime.getCoreInstance("milestoning::Amap");
+        RootRelationalInstanceSetImplementation rootRelationalInstanceSetImplementation = (RootRelationalInstanceSetImplementation) mapping._classMappings().detect(RootRelationalInstanceSetImplementation.class::isInstance);
 
-        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)rootRelationalInstanceSetImplementation._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstanceSetImplementation._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::A");
 
-        MutableList<RelationalPropertyMapping> relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        MutableList<RelationalPropertyMapping> relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(2, relationalPropertyMappings.size());
 
         RelationalPropertyMapping fromPropertyMapping = relationalPropertyMappings.get(0);
@@ -266,31 +266,31 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
         validateProperty(thruPropertyMapping._property(), "thru", "meta::pure::milestoning::BusinessDateMilestoning");
         validateTableAliasColumn(thruPropertyMapping._relationalOperationElement(), "thru_z");
 
-        Mapping subMapping = (Mapping)this.runtime.getCoreInstance("milestoning::Bmap");
-        RootRelationalInstanceSetImplementation subRootRelationalInstanceSetImplementation = subMapping._classMappings().selectInstancesOf(RootRelationalInstanceSetImplementation.class).getFirst();
+        Mapping subMapping = (Mapping) runtime.getCoreInstance("milestoning::Bmap");
+        RootRelationalInstanceSetImplementation subRootRelationalInstanceSetImplementation = (RootRelationalInstanceSetImplementation) subMapping._classMappings().detect(RootRelationalInstanceSetImplementation.class::isInstance);
 
-        EmbeddedRelationalInstanceSetImplementation subMilestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)subRootRelationalInstanceSetImplementation._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        EmbeddedRelationalInstanceSetImplementation subMilestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) subRootRelationalInstanceSetImplementation._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNull(subMilestoningEmbeddedRelationalInstance);
     }
 
     @Test
     public void testBusinessMilestoningPropertyMappingForEmbedded()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(EMBEDDED_MODEL_ID, EMBEDDED_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, EMBEDDED_MAPPING_CODE);
-        this.runtime.compile();
+        runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(EMBEDDED_MODEL_ID, EMBEDDED_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, EMBEDDED_MAPPING_CODE);
+        runtime.compile();
 
-        Mapping mapping = (Mapping)this.runtime.getCoreInstance("milestoning::Bmap");
-        RootRelationalInstanceSetImplementation rootRelationalInstance = mapping._classMappings().selectInstancesOf(RootRelationalInstanceSetImplementation.class).getFirst();
-        EmbeddedRelationalInstanceSetImplementation embeddedRelationalInstance = rootRelationalInstance._propertyMappings().selectInstancesOf(EmbeddedRelationalInstanceSetImplementation.class).getFirst();
+        Mapping mapping = (Mapping) runtime.getCoreInstance("milestoning::Bmap");
+        RootRelationalInstanceSetImplementation rootRelationalInstance = (RootRelationalInstanceSetImplementation) mapping._classMappings().detect(RootRelationalInstanceSetImplementation.class::isInstance);
+        EmbeddedRelationalInstanceSetImplementation embeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstance._propertyMappings().detect(EmbeddedRelationalInstanceSetImplementation.class::isInstance);
 
-        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)embeddedRelationalInstance._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) embeddedRelationalInstance._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::A");
 
-        MutableList<RelationalPropertyMapping> relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        MutableList<RelationalPropertyMapping> relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(2, relationalPropertyMappings.size());
 
         RelationalPropertyMapping fromPropertyMapping = relationalPropertyMappings.get(0);
@@ -305,20 +305,20 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
     @Test
     public void testBusinessMilestoningPropertyMappingForTemporalEmbedded()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(EMBEDDED_MODEL_ID, TEMPORAL_EMBEDDED_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, EMBEDDED_MAPPING_CODE);
-        this.runtime.compile();
+        runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(EMBEDDED_MODEL_ID, TEMPORAL_EMBEDDED_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, EMBEDDED_MAPPING_CODE);
+        runtime.compile();
 
-        Mapping mapping = (Mapping)this.runtime.getCoreInstance("milestoning::Bmap");
-        RootRelationalInstanceSetImplementation rootRelationalInstance = mapping._classMappings().selectInstancesOf(RootRelationalInstanceSetImplementation.class).getFirst();
+        Mapping mapping = (Mapping) runtime.getCoreInstance("milestoning::Bmap");
+        RootRelationalInstanceSetImplementation rootRelationalInstance = (RootRelationalInstanceSetImplementation) mapping._classMappings().detect(RootRelationalInstanceSetImplementation.class::isInstance);
 
-        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)rootRelationalInstance._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstance._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::B");
 
-        MutableList<RelationalPropertyMapping> relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        MutableList<RelationalPropertyMapping> relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(2, relationalPropertyMappings.size());
 
         RelationalPropertyMapping fromPropertyMapping = relationalPropertyMappings.get(0);
@@ -329,13 +329,13 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
         validateProperty(thruPropertyMapping._property(), "thru", "meta::pure::milestoning::BusinessDateMilestoning");
         validateTableAliasColumn(thruPropertyMapping._relationalOperationElement(), "thru_z");
 
-        EmbeddedRelationalInstanceSetImplementation embeddedRelationalInstance = rootRelationalInstance._propertyMappings().selectInstancesOf(EmbeddedRelationalInstanceSetImplementation.class).getFirst();
+        EmbeddedRelationalInstanceSetImplementation embeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstance._propertyMappings().detect(EmbeddedRelationalInstanceSetImplementation.class::isInstance);
 
-        milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)embeddedRelationalInstance._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) embeddedRelationalInstance._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::A");
 
-        relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(2, relationalPropertyMappings.size());
 
         fromPropertyMapping = relationalPropertyMappings.get(0);
@@ -350,21 +350,21 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
     @Test
     public void testBusinessMilestoningPropertyMappingForInlineEmbedded()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(EMBEDDED_MODEL_ID, EMBEDDED_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, INLINE_EMBEDDED_MAPPING_CODE);
-        this.runtime.compile();
+        runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(EMBEDDED_MODEL_ID, EMBEDDED_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, INLINE_EMBEDDED_MAPPING_CODE);
+        runtime.compile();
 
-        Mapping mapping = (Mapping)this.runtime.getCoreInstance("milestoning::Bmap");
-        RootRelationalInstanceSetImplementation rootRelationalInstance = mapping._classMappings().selectInstancesOf(RootRelationalInstanceSetImplementation.class).getFirst();
-        EmbeddedRelationalInstanceSetImplementation embeddedRelationalInstance = rootRelationalInstance._propertyMappings().selectInstancesOf(EmbeddedRelationalInstanceSetImplementation.class).getFirst();
+        Mapping mapping = (Mapping) runtime.getCoreInstance("milestoning::Bmap");
+        RootRelationalInstanceSetImplementation rootRelationalInstance = (RootRelationalInstanceSetImplementation) mapping._classMappings().detect(RootRelationalInstanceSetImplementation.class::isInstance);
+        EmbeddedRelationalInstanceSetImplementation embeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstance._propertyMappings().detect(EmbeddedRelationalInstanceSetImplementation.class::isInstance);
 
-        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)embeddedRelationalInstance._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) embeddedRelationalInstance._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::A");
 
-        MutableList<RelationalPropertyMapping> relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        MutableList<RelationalPropertyMapping> relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(2, relationalPropertyMappings.size());
 
         RelationalPropertyMapping fromPropertyMapping = relationalPropertyMappings.get(0);
@@ -379,20 +379,20 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
     @Test
     public void testBusinessMilestoningPropertyMappingForTemporalInlineEmbedded()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(EMBEDDED_MODEL_ID, TEMPORAL_EMBEDDED_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, INLINE_EMBEDDED_MAPPING_CODE);
-        this.runtime.compile();
+        runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(EMBEDDED_MODEL_ID, TEMPORAL_EMBEDDED_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, INLINE_EMBEDDED_MAPPING_CODE);
+        runtime.compile();
 
-        Mapping mapping = (Mapping)this.runtime.getCoreInstance("milestoning::Bmap");
-        RootRelationalInstanceSetImplementation rootRelationalInstance = mapping._classMappings().selectInstancesOf(RootRelationalInstanceSetImplementation.class).getFirst();
+        Mapping mapping = (Mapping) runtime.getCoreInstance("milestoning::Bmap");
+        RootRelationalInstanceSetImplementation rootRelationalInstance = (RootRelationalInstanceSetImplementation) mapping._classMappings().detect(RootRelationalInstanceSetImplementation.class::isInstance);
 
-        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)rootRelationalInstance._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        EmbeddedRelationalInstanceSetImplementation milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstance._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::B");
 
-        MutableList<RelationalPropertyMapping> relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        MutableList<RelationalPropertyMapping> relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(2, relationalPropertyMappings.size());
 
         RelationalPropertyMapping fromPropertyMapping = relationalPropertyMappings.get(0);
@@ -403,13 +403,13 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
         validateProperty(thruPropertyMapping._property(), "thru", "meta::pure::milestoning::BusinessDateMilestoning");
         validateTableAliasColumn(thruPropertyMapping._relationalOperationElement(), "thru_z");
 
-        EmbeddedRelationalInstanceSetImplementation embeddedRelationalInstance = rootRelationalInstance._propertyMappings().selectInstancesOf(EmbeddedRelationalInstanceSetImplementation.class).getFirst();
+        EmbeddedRelationalInstanceSetImplementation embeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) rootRelationalInstance._propertyMappings().detect(EmbeddedRelationalInstanceSetImplementation.class::isInstance);
 
-        milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation)embeddedRelationalInstance._propertyMappings().detectWith(MILESTONING_PROPERTY_MAPPING, this.processorSupport);
+        milestoningEmbeddedRelationalInstance = (EmbeddedRelationalInstanceSetImplementation) embeddedRelationalInstance._propertyMappings().detect(TestMilestoningPropertyMapping::isMilestoningPropertyMapping);
         Assert.assertNotNull(milestoningEmbeddedRelationalInstance);
         validateProperty(milestoningEmbeddedRelationalInstance._property(), "milestoning", "milestoning::A");
 
-        relationalPropertyMappings = (MutableList<RelationalPropertyMapping>)milestoningEmbeddedRelationalInstance._propertyMappings().toList();
+        relationalPropertyMappings = milestoningEmbeddedRelationalInstance._propertyMappings().collect(RelationalPropertyMapping.class::cast, Lists.mutable.empty());
         Assert.assertEquals(2, relationalPropertyMappings.size());
 
         fromPropertyMapping = relationalPropertyMappings.get(0);
@@ -424,76 +424,48 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
     @Test
     public void testMilestoningPropertyMappingValidation()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE_WITH_MILESTONING_PROPERTY_EXPLICITLY_MAPPED);
-        try
-        {
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            this.assertOriginatingPureException(PureCompilationException.class, "Class : [milestoning::A] has temporal specification. Hence mapping of property : [milestoning] is reserved and should not be explicit in the mapping", MAPPING_ID, 9, 7, e);
-        }
+        runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE_WITH_MILESTONING_PROPERTY_EXPLICITLY_MAPPED);
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+        assertPureException(PureCompilationException.class, "Class : [milestoning::A] has temporal specification. Hence mapping of property : [milestoning] is reserved and should not be explicit in the mapping", MAPPING_ID, 9, 7, e);
     }
 
     @Test
     public void testMilestoningPropertyMappingValidationOnExtendedMapping()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(EXTENDED_MODEL_ID, BUSINESS_MILESTONING_EXTENDED_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
-        this.runtime.createInMemorySource(EXTENDED_MAPPING_ID, EXTENDED_MAPPING_CODE_WITH_MILESTONING_PROPERTY_EXPLICITLY_MAPPED);
-        try
-        {
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            this.assertOriginatingPureException(PureCompilationException.class, "Class : [milestoning::B] has temporal specification. Hence mapping of property : [milestoning] is reserved and should not be explicit in the mapping", EXTENDED_MAPPING_ID, 10, 7, e);
-        }
+        runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(EXTENDED_MODEL_ID, BUSINESS_MILESTONING_EXTENDED_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, MAPPING_CODE);
+        runtime.createInMemorySource(EXTENDED_MAPPING_ID, EXTENDED_MAPPING_CODE_WITH_MILESTONING_PROPERTY_EXPLICITLY_MAPPED);
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+        assertPureException(PureCompilationException.class, "Class : [milestoning::B] has temporal specification. Hence mapping of property : [milestoning] is reserved and should not be explicit in the mapping", EXTENDED_MAPPING_ID, 10, 7, e);
     }
 
     @Test
     public void testMilestoningPropertyMappingValidationOnEmbeddedMapping()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(EMBEDDED_MODEL_ID, EMBEDDED_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, EMBEDDED_MAPPING_CODE_WITH_MILESTONING_PROPERTY_EXPLICITLY_MAPPED);
-        try
-        {
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            this.assertOriginatingPureException(PureCompilationException.class, "Class : [milestoning::A] has temporal specification. Hence mapping of property : [milestoning] is reserved and should not be explicit in the mapping", MAPPING_ID, 11, 10, e);
-        }
+        runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(EMBEDDED_MODEL_ID, EMBEDDED_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, EMBEDDED_MAPPING_CODE_WITH_MILESTONING_PROPERTY_EXPLICITLY_MAPPED);
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+        assertPureException(PureCompilationException.class, "Class : [milestoning::A] has temporal specification. Hence mapping of property : [milestoning] is reserved and should not be explicit in the mapping", MAPPING_ID, 11, 10, e);
     }
 
     @Test
     public void testMilestoningPropertyMappingValidationOnInlineEmbeddedMapping()
     {
-        this.runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
-        this.runtime.createInMemorySource(EMBEDDED_MODEL_ID, EMBEDDED_MODEL_CODE);
-        this.runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
-        this.runtime.createInMemorySource(MAPPING_ID, INLINE_EMBEDDED_MAPPING_CODE_WITH_MILESTONING_PROPERTY_EXPLICITLY_MAPPED);
-        try
-        {
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            this.assertOriginatingPureException(PureCompilationException.class, "Class : [milestoning::A] has temporal specification. Hence mapping of property : [milestoning] is reserved and should not be explicit in the mapping", MAPPING_ID, 15, 7, e);
-        }
+        runtime.createInMemorySource(MODEL_ID, BUSINESS_MILESTONING_MODEL_CODE);
+        runtime.createInMemorySource(EMBEDDED_MODEL_ID, EMBEDDED_MODEL_CODE);
+        runtime.createInMemorySource(STORE_ID, MILESTONED_STORE_CODE);
+        runtime.createInMemorySource(MAPPING_ID, INLINE_EMBEDDED_MAPPING_CODE_WITH_MILESTONING_PROPERTY_EXPLICITLY_MAPPED);
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+        assertPureException(PureCompilationException.class, "Class : [milestoning::A] has temporal specification. Hence mapping of property : [milestoning] is reserved and should not be explicit in the mapping", MAPPING_ID, 15, 7, e);
     }
 
-    private static void validateProperty(Property property, String propertyName, String owner)
+    private static void validateProperty(Property<?, ?> property, String propertyName, String owner)
     {
         Assert.assertNotNull(property);
         Assert.assertEquals(propertyName, property._name());
@@ -503,26 +475,22 @@ public class TestMilestoningPropertyMapping extends AbstractPureRelationalTestWi
     private static void validateTableAliasColumn(RelationalOperationElement relationalOperationElement, String columnName)
     {
         Assert.assertTrue(relationalOperationElement instanceof TableAliasColumn);
-        Column column = ((TableAliasColumn)relationalOperationElement)._column();
+        Column column = ((TableAliasColumn) relationalOperationElement)._column();
         Assert.assertNotNull(column);
         Assert.assertEquals(columnName, column._name());
-        Assert.assertEquals("myTable", ((Table)column._owner())._name());
-        Assert.assertEquals("default", ((Table)column._owner())._schema()._name());
-        Assert.assertEquals("myDB", ((Table)column._owner())._schema()._database()._name());
+        Assert.assertEquals("myTable", ((Table) column._owner())._name());
+        Assert.assertEquals("default", ((Table) column._owner())._schema()._name());
+        Assert.assertEquals("myDB", ((Table) column._owner())._schema()._database()._name());
     }
 
     private static void validateLiteral(RelationalOperationElement relationalOperationElement)
     {
         Assert.assertTrue(relationalOperationElement instanceof Literal);
-        Assert.assertTrue(((Literal)relationalOperationElement)._value() instanceof SQLNull);
+        Assert.assertTrue(((Literal) relationalOperationElement)._value() instanceof SQLNull);
     }
 
-    private static final Predicate2<PropertyMapping, ProcessorSupport> MILESTONING_PROPERTY_MAPPING = new Predicate2<PropertyMapping, ProcessorSupport>()
+    private static boolean isMilestoningPropertyMapping(PropertyMapping propertyMapping)
     {
-        @Override
-        public boolean accept(PropertyMapping propertyMapping, ProcessorSupport processorSupport)
-        {
-            return MilestoningFunctions.isAutoGeneratedMilestoningNamedDateProperty(propertyMapping._property(), processorSupport);
-        }
-    };
+        return MilestoningFunctions.isAutoGeneratedMilestoningNamedDateProperty(propertyMapping._property(), processorSupport);
+    }
 }


### PR DESCRIPTION
Fix a bug with RelationalInstanceSetImplementationProcessor in which the database of the main table may not be processed before the mapping in question is processed. Failure to process the database before the mapping can yield issues, particularly when there are milestoning columns in the table.

In passing, clean up TestMilestoningPropertyMapping and improve the failure output of the property value type integrity test.