### PR TITLE
Fix an issue with resolved type parameters for function expressions

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/inference/PrintTypeInferenceObserver.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/inference/PrintTypeInferenceObserver.java
@@ -346,7 +346,7 @@ public class PrintTypeInferenceObserver implements TypeInferenceObserver
         GenericType.print(this.appendable, templateGenType, this.processorState.getProcessorSupport());
         print(" <-> ");
         GenericType.print(this.appendable, genericType, this.processorState.getProcessorSupport());
-        print(" in ").print(typeInferenceContext.getId()).print("/").print(targetGenericsContext.getId()).print("   ");
+        print(" in ").print(typeInferenceContext.getId()).print("/").print(targetGenericsContext.getId());
         return printNewline();
     }
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/inference/TestTypeInferenceObserver.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/inference/TestTypeInferenceObserver.java
@@ -17,6 +17,10 @@ package org.finos.legend.pure.m3.compiler.postprocessing.inference;
 import org.eclipse.collections.api.factory.Stacks;
 import org.eclipse.collections.api.stack.MutableStack;
 import org.finos.legend.pure.m3.compiler.postprocessing.ProcessorState;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Function;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.TypeParameter;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
@@ -151,6 +155,13 @@ public class TestTypeInferenceObserver implements TypeInferenceObserver
     }
 
     @Override
+    public TypeInferenceObserver tryingRegistration(GenericType templateGenType, GenericType genericType, TypeInferenceContext typeInferenceContext, TypeInferenceContext targetGenericsContext)
+    {
+        activeObserver().tryingRegistration(templateGenType, genericType, typeInferenceContext, targetGenericsContext);
+        return this;
+    }
+
+    @Override
     public TypeInferenceObserver registerMul(CoreInstance templateMul, CoreInstance valueMul, TypeInferenceContext context, TypeInferenceContext targetGenericsContext)
     {
         activeObserver().registerMul(templateMul, valueMul, context, targetGenericsContext);
@@ -231,6 +242,20 @@ public class TestTypeInferenceObserver implements TypeInferenceObserver
     public TypeInferenceObserver finishedProcessingFunctionExpression(CoreInstance functionExpression)
     {
         activeObserver().finishedProcessingFunctionExpression(functionExpression);
+        return this;
+    }
+
+    @Override
+    public TypeInferenceObserver updateFunctionResolvedTypeParameters(Function<?> foundFunction, FunctionType functionType)
+    {
+        activeObserver().updateFunctionResolvedTypeParameters(foundFunction, functionType);
+        return this;
+    }
+
+    @Override
+    public TypeInferenceObserver updateFunctionResolvedTypeParameterValue(TypeParameter typeParameter, CoreInstance value)
+    {
+        activeObserver().updateFunctionResolvedTypeParameterValue(typeParameter, value);
         return this;
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/_package/_Package.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/_package/_Package.java
@@ -19,6 +19,8 @@ import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
+import org.finos.legend.pure.m3.coreinstance.Package;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Any;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.M3PropertyPaths;
@@ -26,11 +28,25 @@ import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement
 import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.AbstractCoreInstanceWrapper;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
 public class _Package
 {
     public static final ImmutableSet<String> SPECIAL_TYPES = PrimitiveUtilities.getPrimitiveTypeNames().newWith(M3Paths.Package);
+
+    public static boolean isPackage(CoreInstance instance, ProcessorSupport processorSupport)
+    {
+        if (instance == null)
+        {
+            return false;
+        }
+        if (instance instanceof Package)
+        {
+            return true;
+        }
+        return (!(instance instanceof Any) || (instance instanceof AbstractCoreInstanceWrapper)) && processorSupport.instance_instanceOf(instance, M3Paths.Package);
+    }
 
     public static CoreInstance getByUserPath(String path, ProcessorSupport processorSupport)
     {

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/graph/GraphPathIterable.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/graph/GraphPathIterable.java
@@ -57,6 +57,26 @@ public class GraphPathIterable extends AbstractLazySpliterable<ResolvedGraphPath
     }
 
     @Override
+    public ResolvedGraphPath getAny()
+    {
+        if (this.startPaths.isEmpty())
+        {
+            return null;
+        }
+        if (this.pathFilter == null)
+        {
+            return this.startPaths.getAny();
+        }
+        return super.getAny();
+    }
+
+    @Override
+    public ResolvedGraphPath getFirst()
+    {
+        return this.startPaths.isEmpty() ? null : super.getFirst();
+    }
+
+    @Override
     public boolean contains(Object object)
     {
         if (!(object instanceof ResolvedGraphPath))

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/tools/GraphStatistics.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/tools/GraphStatistics.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.pure.m3.tools;
 
-import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.factory.Bags;
@@ -27,23 +26,14 @@ import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.SetIterable;
 import org.eclipse.collections.impl.factory.Multimaps;
 import org.eclipse.collections.impl.factory.primitive.ObjectIntMaps;
-import org.finos.legend.pure.m3.coreinstance.Package;
 import org.finos.legend.pure.m3.coreinstance.helper.AnyStubHelper;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
-import org.finos.legend.pure.m3.navigation.ProcessorSupport;
-import org.finos.legend.pure.m3.navigation._package._Package;
-import org.finos.legend.pure.m3.navigation.graph.GraphPath;
-import org.finos.legend.pure.m3.navigation.graph.GraphPathIterable;
-import org.finos.legend.pure.m3.navigation.graph.ResolvedGraphPath;
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.tools.GraphNodeIterable;
-import org.finos.legend.pure.m4.tools.GraphWalkFilterResult;
 
 import java.util.Formatter;
-import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
 public class GraphStatistics
@@ -148,77 +138,5 @@ public class GraphStatistics
                 }
             });
         }
-    }
-
-    public static LazyIterable<GraphPath> allPathsBetween(String startNodePath, CoreInstance endNode, ProcessorSupport processorSupport)
-    {
-        return allPathsBetween(Sets.immutable.with(startNodePath), endNode, processorSupport);
-    }
-
-    public static LazyIterable<GraphPath> allPathsBetween(String startNodePath, CoreInstance endNode, int maxPathLength, ProcessorSupport processorSupport)
-    {
-        return allPathsBetween(Sets.immutable.with(startNodePath), endNode, maxPathLength, processorSupport);
-    }
-
-    public static LazyIterable<GraphPath> allPathsBetween(Iterable<String> startNodePaths, CoreInstance endNode, ProcessorSupport processorSupport)
-    {
-        return allPathsBetween(startNodePaths, endNode, -1, processorSupport);
-    }
-
-    public static LazyIterable<GraphPath> allPathsBetween(Iterable<String> startNodePaths, CoreInstance endNode, int maxPathLength, ProcessorSupport processorSupport)
-    {
-        return allPathsBetween(startNodePaths, endNode::equals, maxPathLength, processorSupport);
-    }
-
-    public static LazyIterable<GraphPath> allPathsBetween(String startNodePath, Iterable<? extends CoreInstance> endNodes, ProcessorSupport processorSupport)
-    {
-        return allPathsBetween(Sets.immutable.with(startNodePath), endNodes, processorSupport);
-    }
-
-    public static LazyIterable<GraphPath> allPathsBetween(String startNodePath, Iterable<? extends CoreInstance> endNodes, int maxPathLength, ProcessorSupport processorSupport)
-    {
-        return allPathsBetween(Sets.immutable.with(startNodePath), endNodes, maxPathLength, processorSupport);
-    }
-
-    public static LazyIterable<GraphPath> allPathsBetween(Iterable<String> startNodePaths, Iterable<? extends CoreInstance> endNodes, ProcessorSupport processorSupport)
-    {
-        return allPathsBetween(startNodePaths, endNodes, -1, processorSupport);
-    }
-
-    public static LazyIterable<GraphPath> allPathsBetween(Iterable<String> startNodePaths, Iterable<? extends CoreInstance> endNodes, int maxPathLength, ProcessorSupport processorSupport)
-    {
-        Set<?> endNodesSet = (endNodes instanceof Set) ? (Set<?>) endNodes : Sets.mutable.withAll(endNodes);
-        return allPathsBetween(startNodePaths, endNodesSet::contains, maxPathLength, processorSupport);
-    }
-
-    private static LazyIterable<GraphPath> allPathsBetween(Iterable<String> startNodePaths, Predicate<? super CoreInstance> isEndNode, int maxPathLength, ProcessorSupport processorSupport)
-    {
-        return GraphPathIterable.builder(processorSupport)
-                .withStartNodePaths(startNodePaths)
-                .withPathFilter(rgp ->
-                {
-                    int len = rgp.getGraphPath().getEdgeCount();
-                    if (len > maxPathLength)
-                    {
-                        return GraphWalkFilterResult.REJECT_AND_STOP;
-                    }
-                    if ((len == maxPathLength) || isEndNode.test(rgp.getLastResolvedNode()))
-                    {
-                        return GraphWalkFilterResult.ACCEPT_AND_STOP;
-                    }
-                    return GraphWalkFilterResult.ACCEPT_AND_CONTINUE;
-                })
-                .build()
-                .select(path -> isEndNode.test(path.getLastResolvedNode()))
-                .collect(ResolvedGraphPath::getGraphPath);
-    }
-
-    public static LazyIterable<String> allTopLevelAndPackagedElementPaths(ProcessorSupport processorSupport)
-    {
-        LazyIterable<String> packagedElements = PackageTreeIterable.newRootPackageTreeIterable(processorSupport)
-                .flatCollect(Package::_children)
-                .reject(c -> c instanceof Package)
-                .collect(PackageableElement::getUserPathForPackageableElement);
-        return _Package.SPECIAL_TYPES.asLazy().concatenate(packagedElements);
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/tools/GraphTools.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/tools/GraphTools.java
@@ -1,0 +1,273 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.tools;
+
+import org.eclipse.collections.api.LazyIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.utility.LazyIterate;
+import org.finos.legend.pure.m3.coreinstance.PackageAccessor;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.M3PropertyPaths;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation._package._Package;
+import org.finos.legend.pure.m3.navigation.graph.GraphPathIterable;
+import org.finos.legend.pure.m3.navigation.graph.ResolvedGraphPath;
+import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+import org.finos.legend.pure.m4.tools.GraphNodeIterable;
+import org.finos.legend.pure.m4.tools.GraphWalkFilterResult;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+
+public class GraphTools
+{
+    public static LazyIterable<String> getTopLevelAndPackagedElementPaths(ModelRepository repository)
+    {
+        return repository.getTopLevels().asLazy().collect(CoreInstance::getName)
+                .concatenate(PackageTreeIterable.newRootPackageTreeIterable(repository)
+                        .flatCollect(PackageAccessor::_children)
+                        .collect(PackageableElement::getUserPathForPackageableElement));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static LazyIterable<String> getTopLevelAndPackagedElementPaths(ProcessorSupport processorSupport)
+    {
+        return LazyIterate.concatenate(
+                PrimitiveUtilities.getPrimitiveTypeNames().asLazy(),
+                Lists.immutable.with(M3Paths.Package, M3Paths.Root),
+                PackageTreeIterable.newRootPackageTreeIterable(processorSupport).flatCollect(PackageAccessor::_children).collect(PackageableElement::getUserPathForPackageableElement));
+    }
+
+    public static LazyIterable<CoreInstance> getTopLevelAndPackagedElements(ModelRepository repository)
+    {
+        return repository.getTopLevels()
+                .asLazy()
+                .concatenate(PackageTreeIterable.newRootPackageTreeIterable(repository)
+                        .flatCollect(PackageAccessor::_children)
+                        .collect(e -> (CoreInstance) e));
+    }
+
+    public static LazyIterable<CoreInstance> getTopLevelAndPackagedElements(ProcessorSupport processorSupport)
+    {
+        return PrimitiveUtilities.getPrimitiveTypes(processorSupport, Lists.mutable.ofInitialCapacity(PrimitiveUtilities.getPrimitiveTypeNames().size() + 2))
+                .with(processorSupport.repository_getTopLevel(M3Paths.Package))
+                .with(processorSupport.repository_getTopLevel(M3Paths.Root))
+                .asLazy()
+                .concatenate(PackageTreeIterable.newRootPackageTreeIterable(processorSupport)
+                        .flatCollect(PackageAccessor::_children)
+                        .collect(e -> (CoreInstance) e));
+    }
+
+    public static LazyIterable<CoreInstance> getComponentInstances(CoreInstance element, ProcessorSupport processorSupport)
+    {
+        Objects.requireNonNull(element.getSourceInformation(), "element source information may not be null");
+        return GraphNodeIterable.builder()
+                .withStartingNode(element)
+                .withKeyFilter(GraphTools::internalPropertyFilter)
+                .withNodeFilter(node -> internalNodeFilter(element, node, processorSupport))
+                .build();
+    }
+
+    public static GraphPathIterable internalGraphPaths(CoreInstance element, ProcessorSupport processorSupport)
+    {
+        Objects.requireNonNull(element.getSourceInformation(), "element source information may not be null");
+        return GraphPathIterable.builder(processorSupport)
+                .withStartNode(element)
+                .withPropertyFilter(GraphTools::internalPropertyFilter)
+                .withPathFilter(rgp -> internalPathFilter(element, rgp, processorSupport))
+                .build();
+    }
+
+    public static ResolvedGraphPath findPathToInstance(CoreInstance instance, ProcessorSupport processorSupport)
+    {
+        return findPathToInstance(instance, processorSupport, false);
+    }
+
+    public static ResolvedGraphPath findPathToInstance(CoreInstance instance, ProcessorSupport processorSupport, boolean allowPathToExternalInstance)
+    {
+        return getTopLevelAndPackagedElements(processorSupport)
+                .flatCollect(e -> Lists.immutable.with(findPathToInstanceWithinElement(e, instance, processorSupport, allowPathToExternalInstance)))
+                .detect(Objects::nonNull);
+    }
+
+    public static ResolvedGraphPath findPathToInstanceWithinElement(CoreInstance element, CoreInstance instance, ProcessorSupport processorSupport)
+    {
+        return findPathToInstanceWithinElement(element, instance, processorSupport, false);
+    }
+
+    public static ResolvedGraphPath findPathToInstanceWithinElement(CoreInstance element, CoreInstance instance, ProcessorSupport processorSupport, boolean allowPathToExternalInstance)
+    {
+        if (element == instance)
+        {
+            return GraphPathIterable.builder(processorSupport)
+                    .withStartNode(element)
+                    .withPropertyFilter((rgp, prop) -> false)
+                    .build()
+                    .getAny();
+        }
+        if ((element.getSourceInformation() == null) || (!allowPathToExternalInstance && isExternalNode(element, instance, processorSupport)))
+        {
+            return null;
+        }
+        MutableSet<CoreInstance> visited = Sets.mutable.empty();
+        return GraphPathIterable.builder(processorSupport)
+                .withStartNode(element)
+                .withPropertyFilter(GraphTools::internalPropertyFilter)
+                .withPathFilter(rgp ->
+                {
+                    CoreInstance node = rgp.getLastResolvedNode();
+                    return (node == instance) ?
+                           GraphWalkFilterResult.ACCEPT_AND_STOP :
+                           GraphWalkFilterResult.reject(visited.add(node) && !isExternalNode(element, node, processorSupport));
+                })
+                .build()
+                .getAny();
+    }
+
+    public static GraphPathIterable getPathsToInstanceWithinElement(CoreInstance element, CoreInstance instance, ProcessorSupport processorSupport)
+    {
+        return getPathsToInstanceWithinElement(element, instance, processorSupport, false);
+    }
+
+    public static GraphPathIterable getPathsToInstanceWithinElement(CoreInstance element, CoreInstance instance, ProcessorSupport processorSupport, boolean allowPathsToExternalInstance)
+    {
+        if (element == instance)
+        {
+            return GraphPathIterable.builder(processorSupport)
+                    .withStartNode(element)
+                    .withPropertyFilter((rgp, prop) -> false)
+                    .build();
+        }
+        if ((element.getSourceInformation() == null) || (!allowPathsToExternalInstance && isExternalNode(element, instance, processorSupport)))
+        {
+            return GraphPathIterable.builder(processorSupport).build();
+        }
+        return GraphPathIterable.builder(processorSupport)
+                .withStartNode(element)
+                .withPropertyFilter(GraphTools::internalPropertyFilter)
+                .withPathFilter(rgp ->
+                {
+                    CoreInstance node = rgp.getLastResolvedNode();
+                    return (node == instance) ?
+                           GraphWalkFilterResult.ACCEPT_AND_STOP :
+                           GraphWalkFilterResult.reject(!isExternalNode(element, node, processorSupport));
+                })
+                .build();
+    }
+
+    private static boolean isExternalNode(CoreInstance element, CoreInstance node, ProcessorSupport processorSupport)
+    {
+        if (node == element)
+        {
+            return false;
+        }
+
+        SourceInformation nodeSourceInfo = node.getSourceInformation();
+        return ((nodeSourceInfo == null) ? _Package.isPackage(node, processorSupport) : !element.getSourceInformation().subsumes(nodeSourceInfo));
+    }
+
+    private static boolean internalPropertyFilter(CoreInstance node, String key)
+    {
+        switch (key)
+        {
+            case M3Properties._package:
+            {
+                return !M3PropertyPaths._package.equals(node.getRealKeyByName(key));
+            }
+            case M3Properties.children:
+            {
+                return !M3PropertyPaths.children.equals(node.getRealKeyByName(key));
+            }
+            default:
+            {
+                return true;
+            }
+        }
+    }
+
+    private static boolean internalPropertyFilter(ResolvedGraphPath resolvedGraphPath, String property)
+    {
+        return internalPropertyFilter(resolvedGraphPath.getLastResolvedNode(), property);
+    }
+
+    private static GraphWalkFilterResult internalNodeFilter(CoreInstance element, CoreInstance node, ProcessorSupport processorSupport)
+    {
+        return isExternalNode(element, node, processorSupport) ? GraphWalkFilterResult.REJECT_AND_STOP : GraphWalkFilterResult.ACCEPT_AND_CONTINUE;
+    }
+
+    private static GraphWalkFilterResult internalPathFilter(CoreInstance element, ResolvedGraphPath resolvedGraphPath, ProcessorSupport processorSupport)
+    {
+        return internalNodeFilter(element, resolvedGraphPath.getLastResolvedNode(), processorSupport);
+    }
+
+    public static GraphPathIterable allPathsBetween(String startNodePath, CoreInstance endNode, ProcessorSupport processorSupport)
+    {
+        return allPathsBetween(Sets.immutable.with(startNodePath), endNode, processorSupport);
+    }
+
+    public static GraphPathIterable allPathsBetween(String startNodePath, CoreInstance endNode, int maxPathLength, ProcessorSupport processorSupport)
+    {
+        return allPathsBetween(Sets.immutable.with(startNodePath), endNode, maxPathLength, processorSupport);
+    }
+
+    public static GraphPathIterable allPathsBetween(Iterable<String> startNodePaths, CoreInstance endNode, ProcessorSupport processorSupport)
+    {
+        return allPathsBetween(startNodePaths, endNode, -1, processorSupport);
+    }
+
+    public static GraphPathIterable allPathsBetween(Iterable<String> startNodePaths, CoreInstance endNode, int maxPathLength, ProcessorSupport processorSupport)
+    {
+        return allPathsBetween(startNodePaths, endNode::equals, maxPathLength, processorSupport);
+    }
+
+    public static GraphPathIterable allPathsBetween(String startNodePath, Iterable<? extends CoreInstance> endNodes, ProcessorSupport processorSupport)
+    {
+        return allPathsBetween(Sets.immutable.with(startNodePath), endNodes, processorSupport);
+    }
+
+    public static GraphPathIterable allPathsBetween(String startNodePath, Iterable<? extends CoreInstance> endNodes, int maxPathLength, ProcessorSupport processorSupport)
+    {
+        return allPathsBetween(Sets.immutable.with(startNodePath), endNodes, maxPathLength, processorSupport);
+    }
+
+    public static GraphPathIterable allPathsBetween(Iterable<String> startNodePaths, Iterable<? extends CoreInstance> endNodes, ProcessorSupport processorSupport)
+    {
+        return allPathsBetween(startNodePaths, endNodes, -1, processorSupport);
+    }
+
+    public static GraphPathIterable allPathsBetween(Iterable<String> startNodePaths, Iterable<? extends CoreInstance> endNodes, int maxPathLength, ProcessorSupport processorSupport)
+    {
+        Set<?> endNodesSet = (endNodes instanceof Set) ? (Set<?>) endNodes : Sets.mutable.withAll(endNodes);
+        return allPathsBetween(startNodePaths, endNodesSet::contains, maxPathLength, processorSupport);
+    }
+
+    private static GraphPathIterable allPathsBetween(Iterable<String> startNodePaths, Predicate<? super CoreInstance> isEndNode, int maxPathLength, ProcessorSupport processorSupport)
+    {
+        return GraphPathIterable.builder(processorSupport)
+                .withStartNodePaths(startNodePaths)
+                .withPathFilter(rgp -> isEndNode.test(rgp.getLastResolvedNode()) ?
+                                       GraphWalkFilterResult.ACCEPT_AND_STOP :
+                                       GraphWalkFilterResult.reject(rgp.getGraphPath().getEdgeCount() < maxPathLength))
+                .build();
+    }
+}

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/tools/GraphWalkFilterResult.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/tools/GraphWalkFilterResult.java
@@ -83,8 +83,26 @@ public enum GraphWalkFilterResult
 
     public static GraphWalkFilterResult get(boolean accept, boolean cont)
     {
-        return accept ?
-               (cont ? ACCEPT_AND_CONTINUE : ACCEPT_AND_STOP) :
-               (cont ? REJECT_AND_CONTINUE : REJECT_AND_STOP);
+        return accept ? accept(cont) : reject(cont);
+    }
+
+    public static GraphWalkFilterResult accept(boolean cont)
+    {
+        return cont ? ACCEPT_AND_CONTINUE : ACCEPT_AND_STOP;
+    }
+
+    public static GraphWalkFilterResult reject(boolean cont)
+    {
+        return cont ? REJECT_AND_CONTINUE : REJECT_AND_STOP;
+    }
+
+    public static GraphWalkFilterResult cont(boolean accept)
+    {
+        return accept ? ACCEPT_AND_CONTINUE : REJECT_AND_CONTINUE;
+    }
+
+    public static GraphWalkFilterResult stop(boolean accept)
+    {
+        return accept ? ACCEPT_AND_STOP : REJECT_AND_STOP;
     }
 }


### PR DESCRIPTION
Fix an issue with resolved type parameters for function expressions where the generic type might have source information from an inappropriate location. In passing, improve some compiled state integrity failure messages, improve type inference observer output, and clean up some related code.