### PR TITLE
Fix type inference on function processing for relation

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/valuespecification/FunctionExpressionProcessor.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/valuespecification/FunctionExpressionProcessor.java
@@ -300,6 +300,11 @@ public class FunctionExpressionProcessor extends Processor<FunctionExpression>
                     String name = functionExpression._propertyName()._valuesCoreInstance().getAny().getName();
                     foundFunctions.add(_RelationType.findColumn((RelationType<?>) sourceGenericType._rawType(), name, functionExpression.getSourceInformation(), processorSupport));
                 }
+                else if (sourceGenericType._typeArguments().notEmpty() && _RelationType.isRelationType(sourceGenericType._typeArguments().getFirst()._rawType(), processorSupport))
+                {
+                    String name = functionExpression._propertyName()._valuesCoreInstance().getAny().getName();
+                    foundFunctions.add(_RelationType.findColumn((RelationType<?>) sourceGenericType._typeArguments().getFirst()._rawType(), name, functionExpression.getSourceInformation(), processorSupport));
+                }
                 else
                 {
                     Multiplicity sourceMultiplicity = source._multiplicity();

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/relation/TestRelationTypeInference.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/relation/TestRelationTypeInference.java
@@ -112,6 +112,25 @@ public class TestRelationTypeInference extends AbstractPureTestWithCoreCompiledP
     }
 
     @Test
+    public void testColumnFunctionCollectionInference2()
+    {
+        compileInferenceTest(
+                "import meta::pure::metamodel::relation::*;\n" +
+                        "Class Firm\n" +
+                        "{\n" +
+                        "   legalName:String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "function f():Relation<(name:String)>[1]\n" +
+                        "{\n" +
+                        "   Firm.all()->project(~[legal:x|$x.legalName])->project(~[name:x|$x.legal]);\n" +
+                        "}\n" +
+                        "\n" +
+                        "native function project<Z,T>(cl:Z[*], x:FuncColSpecArray<{Z[1]->Any[*]},T>[1]):Relation<T>[1];"
+        );
+    }
+
+    @Test
     public void testColumnFunctionCollectionChainedWithNewFunctionInference()
     {
         compileInferenceTest(
@@ -763,8 +782,8 @@ public class TestRelationTypeInference extends AbstractPureTestWithCoreCompiledP
 
     @Test
     @Ignore
-    // Test fails due to bug in type inference, potentially due to incorrect unbind. The type (RelationType) for the 
-    // only expression in the function f() is correctly inferred after first compile. However, the type parameters 
+    // Test fails due to bug in type inference, potentially due to incorrect unbind. The type (RelationType) for the
+    // only expression in the function f() is correctly inferred after first compile. However, the type parameters
     // remain unresolved post unbind and re-compile.
     public void testRelationTypeInferenceIntegrityWithSelect()
     {
@@ -775,22 +794,22 @@ public class TestRelationTypeInference extends AbstractPureTestWithCoreCompiledP
                                 "}";
         String nativeFunctionSource = "import meta::pure::metamodel::relation::*;" +
                                       "native function select<T,X>(x:Relation<X>[1], rel:ColSpecArray<T⊆X>[1]):Relation<T>[1];";
-        
+
         ImmutableMap<String, String> sources = Maps.immutable.of("1.pure", functionSource, "2.pure", nativeFunctionSource);
-        
+
         new RuntimeTestScriptBuilder().createInMemorySources(sources).compile().run(runtime, functionExecution);
 
         RuntimeVerifier.deleteCompileAndReloadMultipleTimesIsStable(
-            runtime, 
+            runtime,
             functionExecution,
-            Lists.fixedSize.of(Tuples.pair("2.pure", nativeFunctionSource)), 
+            Lists.fixedSize.of(Tuples.pair("2.pure", nativeFunctionSource)),
             this.getAdditionalVerifiers()
         );
     }
 
     @Test
     @Ignore
-    // Test fails due to bug in type inference, potentially due to incorrect unbind. The column type for the renamed 
+    // Test fails due to bug in type inference, potentially due to incorrect unbind. The column type for the renamed
     // column in the RelationType returned by the function is set to null post unbind and re-compile.
     public void testRelationTypeInferenceIntegrityWithRename()
     {


### PR DESCRIPTION
Currently for looking up properties where the var type is a relation, it is trying to find the property on type Relation and not the actual relation type