### PR TITLE
Fix type parsing for Relational local mapping properties

### DIFF
--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/test/java/org/finos/legend/pure/m2/dsl/mapping/test/TestModelMapping.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/test/java/org/finos/legend/pure/m2/dsl/mapping/test/TestModelMapping.java
@@ -949,4 +949,60 @@ public class TestModelMapping extends AbstractPureMappingTestWithCoreCompiled
                 "Merge validation function for class: Person has an invalid parameter. All parameters must be a src class of a merged set",
                 "mapping.pure", 24, 5, 24, 14, 27, 12, e);
     }
+
+    @Test
+    public void testLocalPropertyWithInvalidType()
+    {
+        runtime.createInMemorySource("model.pure",
+                "Class Firm\n" +
+                        "{\n" +
+                        "  legalName : String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class FirmSource\n" +
+                        "{\n" +
+                        "  allNames : String[1..*];\n" +
+                        "}\n");
+        runtime.createInMemorySource("mapping.pure",
+                "###Mapping\n" +
+                        "Mapping test::TestMapping\n" +
+                        "(\n" +
+                        "  Firm : Pure\n" +
+                        "  {\n" +
+                        "    ~src FirmSource\n" +
+                        "    legalName : $src.allNames->at(0),\n" +
+                        "    +otherNames:Strixng[*] : $src.allNames->tail()\n" +
+                        "  }\n" +
+                        ")");
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+        assertPureException(PureCompilationException.class, "Strixng has not been defined!", "mapping.pure", 8, 17, 8, 17, 8, 23, e);
+    }
+
+    @Test
+    public void testLocalPropertyTypeError()
+    {
+        runtime.createInMemorySource("model.pure",
+                "Class Firm\n" +
+                        "{\n" +
+                        "  legalName : String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class FirmSource\n" +
+                        "{\n" +
+                        "  allNames : String[1..*];\n" +
+                        "}\n");
+        runtime.createInMemorySource("mapping.pure",
+                "###Mapping\n" +
+                        "Mapping test::TestMapping\n" +
+                        "(\n" +
+                        "  Firm : Pure\n" +
+                        "  {\n" +
+                        "    ~src FirmSource\n" +
+                        "    legalName : $src.allNames->at(0),\n" +
+                        "    +otherNames:String[*] : $src.allNames->size()\n" +
+                        "  }\n" +
+                        ")");
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+        assertPureException(PureCompilationException.class, "Type Error: 'Integer' not a subtype of 'String'", "mapping.pure", 8, 44, e);
+    }
 }

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/test/java/org/finos/legend/pure/m2/relational/TestSimpleGrammar.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/test/java/org/finos/legend/pure/m2/relational/TestSimpleGrammar.java
@@ -2317,6 +2317,37 @@ public class TestSimpleGrammar extends AbstractPureRelationalTestWithCoreCompile
 
 
     @Test
+    public void testLocalPropertyWithInvalidType()
+    {
+        runtime.createInMemorySource("testSource.pure",
+                "Class Person\n" +
+                        "{\n" +
+                        "   lastName : String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "###Mapping\n" +
+                        "Mapping FirmMapping\n" +
+                        "(\n" +
+                        "   Person[e] : Relational\n" +
+                        "   {\n" +
+                        "      +firmId:Strixng[1] : [db]PersonTable.firmId,\n" +
+                        "      lastName : [db]PersonTable.lastName\n" +
+                        "   }\n" +
+                        ")\n" +
+                        "\n" +
+                        "###Relational\n" +
+                        "Database db\n" +
+                        "(\n" +
+                        "   Table FirmTable (id INTEGER, legal_name VARCHAR(200))\n" +
+                        "   Table PersonTable (firmId INTEGER, lastName VARCHAR(200))\n" +
+                        ")");
+
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+        assertPureException(PureCompilationException.class, "Strixng has not been defined!", "testSource.pure", 11, 15, 11, 15, 11, 21, e);
+    }
+
+
+    @Test
     public void testSelfJoin()
     {
         Loader.parseM3("import other::*;\n" +

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/test/java/org/finos/legend/pure/m2/relational/TestXStoreMapping.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/test/java/org/finos/legend/pure/m2/relational/TestXStoreMapping.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.pure.m2.relational;
 
+import org.finos.legend.pure.m4.exception.PureCompilationException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -22,7 +23,7 @@ public class TestXStoreMapping extends AbstractPureRelationalTestWithCoreCompile
     @Test
     public void testXStoreMapping()
     {
-        this.runtime.createInMemorySource("mapping.pure",
+        runtime.createInMemorySource("mapping.pure",
                 "Class Firm\n" +
                         "{\n" +
                         "   legalName : String[1];\n" +
@@ -65,13 +66,13 @@ public class TestXStoreMapping extends AbstractPureRelationalTestWithCoreCompile
                         "   Table FirmTable (id INTEGER, legal_name VARCHAR(200))\n" +
                         "   Table PersonTable (firmId INTEGER, lastName VARCHAR(200))\n" +
                         ")");
-        this.runtime.compile();
+        runtime.compile();
     }
 
     @Test
     public void testXStoreMappingTypeError()
     {
-        this.runtime.createInMemorySource("mapping.pure",
+        runtime.createInMemorySource("mapping.pure",
                 "Class Firm\n" +
                         "{\n" +
                         "   legalName : String[1];\n" +
@@ -114,42 +115,15 @@ public class TestXStoreMapping extends AbstractPureRelationalTestWithCoreCompile
                         "   Table FirmTable (id INTEGER, legal_name VARCHAR(200))\n" +
                         "   Table PersonTable (firmId INTEGER, lastName VARCHAR(200))\n" +
                         ")");
-        try
-        {
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Parser error at (resource:mapping.pure line:14), (Not Found: Strixng) in\n" +
-                    "'\n" +
-                    "Mapping FirmMapping\n" +
-                    "(\n" +
-                    "   Firm[f1] : Relational\n" +
-                    "   {\n" +
-                    "      +id:String[1] : [db]FirmTable.id,\n" +
-                    "      legalName : [db]FirmTable.legal_name\n" +
-                    "   }\n" +
-                    "   \n" +
-                    "   Person[e] : Relational\n" +
-                    "   {\n" +
-                    "      +firmId:Strixng[1] : [db]PersonTable.firmId,\n" +
-                    "      lastName : [db]PersonTable.lastName\n" +
-                    "   }\n" +
-                    "   \n" +
-                    "   Firm_Person : XStore\n" +
-                    "   {\n" +
-                    "      firm[e, f1] : $this.firmId == $that.id,\n" +
-                    "      employees[f1, e] : $this.id == $that.firmId\n" +
-                    "   }\n" +
-                    ")'", e.getMessage());
-        }
+
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+        assertPureException(PureCompilationException.class, "Strixng has not been defined!", "mapping.pure", 27, 15, 27, 15, 27, 21, e);
     }
 
     @Test
     public void testXStoreMappingDiffMul()
     {
-        this.runtime.createInMemorySource("mapping.pure",
+        runtime.createInMemorySource("mapping.pure",
                 "Class Firm\n" +
                         "{\n" +
                         "   legalName : String[1];\n" +
@@ -192,13 +166,13 @@ public class TestXStoreMapping extends AbstractPureRelationalTestWithCoreCompile
                         "   Table FirmTable (id INTEGER, legal_name VARCHAR(200))\n" +
                         "   Table PersonTable (firmId INTEGER, lastName VARCHAR(200))\n" +
                         ")");
-        this.runtime.compile();
+        runtime.compile();
     }
 
     @Test
     public void testXStoreMappingNotSetId()
     {
-        this.runtime.createInMemorySource("mapping.pure",
+        runtime.createInMemorySource("mapping.pure",
                 "Class Firm\n" +
                         "{\n" +
                         "   legalName : String[1];\n" +
@@ -241,13 +215,13 @@ public class TestXStoreMapping extends AbstractPureRelationalTestWithCoreCompile
                         "   Table FirmTable (id INTEGER, legal_name VARCHAR(200))\n" +
                         "   Table PersonTable (firmId INTEGER, lastName VARCHAR(200))\n" +
                         ")");
-        this.runtime.compile();
+        runtime.compile();
     }
 
     @Test
     public void testXStoreMappingNaturalProperty()
     {
-        this.runtime.createInMemorySource("mapping.pure",
+        runtime.createInMemorySource("mapping.pure",
                 "Class Firm\n" +
                         "{\n" +
                         "   id : Integer[1];\n" +
@@ -291,13 +265,13 @@ public class TestXStoreMapping extends AbstractPureRelationalTestWithCoreCompile
                         "   Table FirmTable (id INTEGER, legal_name VARCHAR(200))\n" +
                         "   Table PersonTable (firmId INTEGER, lastName VARCHAR(200))\n" +
                         ")");
-        this.runtime.compile();
+        runtime.compile();
     }
 
     @Test
     public void testXStoreMappingNaturalPropertyError()
     {
-        this.runtime.createInMemorySource("mapping.pure",
+        runtime.createInMemorySource("mapping.pure",
                 "Class Firm\n" +
                         "{\n" +
                         "   id : Integer[1];\n" +
@@ -341,22 +315,14 @@ public class TestXStoreMapping extends AbstractPureRelationalTestWithCoreCompile
                         "   Table FirmTable (id INTEGER, legal_name VARCHAR(200))\n" +
                         "   Table PersonTable (firmId INTEGER, lastName VARCHAR(200))\n" +
                         ")");
-        try
-        {
-            this.runtime.compile();
-            Assert.fail();
-        }
-        catch (Exception e)
-        {
-            Assert.assertEquals("Compilation error at (resource:mapping.pure line:34 column:36), \"Can't find the property 'ixd' in the class Firm\"", e.getMessage());
-        }
-
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, runtime::compile);
+        assertPureException(PureCompilationException.class, "Can't find the property 'ixd' in the class Firm", "mapping.pure", 34, 36, e);
     }
 
     @Test
     public void testXStoreMappingNaturalPropertyUsingInheritance()
     {
-        this.runtime.createInMemorySource("mapping.pure",
+        runtime.createInMemorySource("mapping.pure",
                 "Class SuperFirm" +
                         "{" +
                         "   id : Integer[1];\n" +
@@ -404,15 +370,15 @@ public class TestXStoreMapping extends AbstractPureRelationalTestWithCoreCompile
                         "   Table FirmTable (id INTEGER, legal_name VARCHAR(200))\n" +
                         "   Table PersonTable (firmId INTEGER, lastName VARCHAR(200))\n" +
                         ")");
-        this.runtime.compile();
+        runtime.compile();
     }
 
 
     @Test
     public void testXStoreMappingToMilestonedType()
     {
-        this.runtime.createInMemorySource("mapping.pure",
-                        "Class Firm\n" +
+        runtime.createInMemorySource("mapping.pure",
+                "Class Firm\n" +
                         "{\n" +
                         "   legalName : String[1];\n" +
                         "}\n" +
@@ -454,6 +420,6 @@ public class TestXStoreMapping extends AbstractPureRelationalTestWithCoreCompile
                         "   Table FirmTable (id INTEGER, legal_name VARCHAR(200))\n" +
                         "   Table PersonTable (firmId INTEGER, lastName VARCHAR(200))\n" +
                         ")");
-        this.runtime.compile();
+        runtime.compile();
     }
 }


### PR DESCRIPTION
Fix type parsing for local properties in Relational mappings. In passing, add a test for invalid types in local properties in Pure mappings.