### PR TITLE
Extend MetadataAccessor API

### DIFF
--- a/legend-pure-core/legend-pure-m3-precisePrimitives/pom.xml
+++ b/legend-pure-core/legend-pure-m3-precisePrimitives/pom.xml
@@ -57,5 +57,17 @@
             <groupId>org.finos.legend.pure</groupId>
             <artifactId>legend-pure-m3-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/legend-pure-core/legend-pure-m3-precisePrimitives/src/test/java/org/finos/legend/pure/code/core/TestPrecisePrimitivesCompiledStateIntegrity.java
+++ b/legend-pure-core/legend-pure-m3-precisePrimitives/src/test/java/org/finos/legend/pure/code/core/TestPrecisePrimitivesCompiledStateIntegrity.java
@@ -1,0 +1,27 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.code.core;
+
+import org.finos.legend.pure.m3.tests.AbstractCompiledStateIntegrityTest;
+import org.junit.BeforeClass;
+
+public class TestPrecisePrimitivesCompiledStateIntegrity extends AbstractCompiledStateIntegrityTest
+{
+    @BeforeClass
+    public static void initialize()
+    {
+        initialize("platform_precise_primitives");
+    }
+}

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
@@ -19,8 +19,6 @@ import org.finos.legend.pure.m4.ModelRepository;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.chrono.IsoChronology;
 import java.util.Calendar;
 import java.util.Date;
@@ -180,7 +178,7 @@ public class DateFunctions extends TimeFunctions
 
     public static DateTime fromInstant(Instant instant, int subsecondPrecision)
     {
-        return DateWithSubsecond.fromLocalDateTime(LocalDateTime.ofInstant(instant, ZoneOffset.UTC), subsecondPrecision);
+        return DateWithSubsecond.fromInstant(instant, subsecondPrecision);
     }
 
     /**

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithSubsecond.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithSubsecond.java
@@ -17,7 +17,7 @@ package org.finos.legend.pure.m4.coreinstance.primitive.date;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
@@ -60,7 +60,7 @@ public class DateWithSubsecond extends AbstractDateWithSubsecond
 
     public static DateTime fromInstant(Instant instant, int subsecondPrecision)
     {
-        return fromLocalDateTime(LocalDateTime.from(instant.atZone(ZoneId.of("UTC"))), subsecondPrecision);
+        return fromLocalDateTime(LocalDateTime.ofInstant(instant, ZoneOffset.UTC), subsecondPrecision);
     }
 
     static DateTime fromLocalDateTime(LocalDateTime time, int subsecondPrecision)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataAccessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataAccessor.java
@@ -14,10 +14,15 @@
 
 package org.finos.legend.pure.runtime.java.compiled.metadata;
 
+import org.finos.legend.pure.m3.coreinstance.Package;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.NativeFunction;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Any;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Nil;
@@ -29,23 +34,29 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
  */
 public interface MetadataAccessor
 {
-    Class<?> getClass(String fullPath);
+    Class<?> getClass(String path);
 
-    Measure getMeasure(String fullPath);
+    Measure getMeasure(String path);
 
-    Unit getUnit(String fullPath);
+    Unit getUnit(String path);
 
-    Enumeration<?> getEnumeration(String fullPath);
+    Enumeration<?> getEnumeration(String path);
+
+    Enum getEnum(String enumerationName, String enumName);
 
     PrimitiveType getPrimitiveType(String name);
 
-    ConcreteFunctionDefinition<?> getConcreteFunctionDefinition(String name);
+    ConcreteFunctionDefinition<?> getConcreteFunctionDefinition(String path);
+
+    NativeFunction<?> getNativeFunction(String path);
 
     LambdaFunction<?> getLambdaFunction(String id);
 
-    org.finos.legend.pure.m3.coreinstance.Package getPackage(String path);
+    Package getPackage(String path);
 
-    org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum getEnum(String enumerationName, String enumName);
+    Association getAssociation(String path);
+
+    Profile getProfile(String path);
 
     @SuppressWarnings("unchecked")
     default Class<Any> getTopType()

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataHolder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataHolder.java
@@ -14,9 +14,14 @@
 
 package org.finos.legend.pure.runtime.java.compiled.metadata;
 
+import org.finos.legend.pure.m3.coreinstance.Package;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.NativeFunction;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.PrimitiveType;
@@ -37,27 +42,33 @@ public class MetadataHolder implements MetadataAccessor
     }
 
     @Override
-    public Class<?> getClass(String fullPath)
+    public Class<?> getClass(String path)
     {
-        return (Class<?>) this.metadata.getMetadata(MetadataJavaPaths.Class, fullPath);
+        return (Class<?>) this.metadata.getMetadata(MetadataJavaPaths.Class, path);
     }
 
     @Override
-    public Measure getMeasure(String fullPath)
+    public Measure getMeasure(String path)
     {
-        return (Measure) this.metadata.getMetadata(MetadataJavaPaths.Measure, fullPath);
+        return (Measure) this.metadata.getMetadata(MetadataJavaPaths.Measure, path);
     }
 
     @Override
-    public Unit getUnit(String fullPath)
+    public Unit getUnit(String path)
     {
-        return (Unit) this.metadata.getMetadata(MetadataJavaPaths.Unit, fullPath);
+        return (Unit) this.metadata.getMetadata(MetadataJavaPaths.Unit, path);
     }
 
     @Override
-    public Enumeration<?> getEnumeration(String fullPath)
+    public Enumeration<?> getEnumeration(String path)
     {
-        return (Enumeration<?>) this.metadata.getMetadata(MetadataJavaPaths.Enumeration, fullPath);
+        return (Enumeration<?>) this.metadata.getMetadata(MetadataJavaPaths.Enumeration, path);
+    }
+
+    @Override
+    public Enum getEnum(String enumerationName, String enumName)
+    {
+        return (Enum) this.metadata.getEnum(enumerationName, enumName);
     }
 
     @Override
@@ -67,9 +78,15 @@ public class MetadataHolder implements MetadataAccessor
     }
 
     @Override
-    public ConcreteFunctionDefinition<?> getConcreteFunctionDefinition(String name)
+    public ConcreteFunctionDefinition<?> getConcreteFunctionDefinition(String path)
     {
-        return (ConcreteFunctionDefinition<?>) this.metadata.getMetadata(MetadataJavaPaths.ConcreteFunctionDefinition, name);
+        return (ConcreteFunctionDefinition<?>) this.metadata.getMetadata(MetadataJavaPaths.ConcreteFunctionDefinition, path);
+    }
+
+    @Override
+    public NativeFunction<?> getNativeFunction(String path)
+    {
+        return (NativeFunction<?>) this.metadata.getMetadata(MetadataJavaPaths.NativeFunction, path);
     }
 
     @Override
@@ -79,14 +96,20 @@ public class MetadataHolder implements MetadataAccessor
     }
 
     @Override
-    public org.finos.legend.pure.m3.coreinstance.Package getPackage(String path)
+    public Package getPackage(String path)
     {
-        return (org.finos.legend.pure.m3.coreinstance.Package) this.metadata.getMetadata(M3Paths.Package, path);
+        return (Package) this.metadata.getMetadata(M3Paths.Package, path);
     }
 
     @Override
-    public org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum getEnum(String enumerationName, String enumName)
+    public Association getAssociation(String path)
     {
-        return (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum) this.metadata.getEnum(enumerationName, enumName);
+        return (Association) this.metadata.getMetadata(M3Paths.Association, path);
+    }
+
+    @Override
+    public Profile getProfile(String path)
+    {
+        return (Profile) this.metadata.getMetadata(M3Paths.Profile, path);
     }
 }


### PR DESCRIPTION
Extend MetadataAccessor API with additional methods for getting different element types. In passing, add a compiled state integrity test for platform_precise_primitives and improve DateWithSubsecond.fromInstance.