### PR TITLE
Add reference ids framework

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/pom.xml
+++ b/legend-pure-core/legend-pure-m3-core/pom.xml
@@ -255,6 +255,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
         </dependency>

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/InvalidReferenceIdException.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/InvalidReferenceIdException.java
@@ -1,0 +1,48 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference;
+
+/**
+ * Exception arising when a reference id cannot be resolved because the id is invalid.
+ */
+public class InvalidReferenceIdException extends ReferenceIdResolutionException
+{
+    public InvalidReferenceIdException(String referenceId, String message, Throwable cause)
+    {
+        super(referenceId, message, cause);
+    }
+
+    public InvalidReferenceIdException(String referenceId, String message)
+    {
+        super(referenceId, message);
+    }
+
+    public InvalidReferenceIdException(String referenceId, Throwable cause)
+    {
+        this(referenceId, buildMessage(referenceId), cause);
+    }
+
+    public InvalidReferenceIdException(String referenceId)
+    {
+        this(referenceId, buildMessage(referenceId));
+    }
+
+    private static String buildMessage(String referenceId)
+    {
+        return (referenceId == null) ?
+               "Invalid reference id: null" :
+               ("Invalid reference id: \"" + referenceId + "\"");
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdException.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdException.java
@@ -1,0 +1,36 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference;
+
+/**
+ * Base class for all exceptions related to reference ids.
+ */
+public class ReferenceIdException extends RuntimeException
+{
+    public ReferenceIdException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    public ReferenceIdException(String message)
+    {
+        super(message);
+    }
+
+    public ReferenceIdException(Throwable cause)
+    {
+        super(cause);
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdExtension.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdExtension.java
@@ -1,0 +1,26 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference;
+
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+
+public interface ReferenceIdExtension
+{
+    int version();
+
+    ReferenceIdProvider newProvider(ProcessorSupport processorSupport);
+
+    ReferenceIdResolver newResolver(ProcessorSupport processorSupport);
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdProvider.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdProvider.java
@@ -1,0 +1,45 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference;
+
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+public interface ReferenceIdProvider
+{
+    /**
+     * Version of the {@link ReferenceIdExtension} that this provider is associated with.
+     *
+     * @return extension version
+     */
+    int version();
+
+    /**
+     * Return whether the instance has a reference id.
+     *
+     * @param instance instance
+     * @return whether instance has a reference id
+     */
+    boolean hasReferenceId(CoreInstance instance);
+
+    /**
+     * Get an id for the given reference instance. If no id can be found or computed for the reference instance, then
+     * the implementing class should throw a {@link ReferenceIdProvisionException} with an explanation of why not.
+     *
+     * @param reference reference instance
+     * @return reference id
+     * @throws ReferenceIdProvisionException if no id can be found or computed
+     */
+    String getReferenceId(CoreInstance reference) throws ReferenceIdProvisionException;
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdProvisionException.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdProvisionException.java
@@ -1,0 +1,31 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference;
+
+/**
+ * Exception that arises when a reference id cannot be provided for an instance.
+ */
+public class ReferenceIdProvisionException extends ReferenceIdException
+{
+    public ReferenceIdProvisionException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    public ReferenceIdProvisionException(String message)
+    {
+        super(message);
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdResolutionException.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdResolutionException.java
@@ -1,0 +1,45 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference;
+
+/**
+ * Base class for all exceptions related to reference id resolution.
+ */
+public class ReferenceIdResolutionException extends ReferenceIdException
+{
+    private final String referenceId;
+
+    public ReferenceIdResolutionException(String referenceId, String message, Throwable cause)
+    {
+        super(message, cause);
+        this.referenceId = referenceId;
+    }
+
+    public ReferenceIdResolutionException(String referenceId, String message)
+    {
+        super(message);
+        this.referenceId = referenceId;
+    }
+
+    /**
+     * Get the reference id involved in the exception. Note that this may be null.
+     *
+     * @return reference id (possibly null)
+     */
+    public String getReferenceId()
+    {
+        return this.referenceId;
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdResolver.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdResolver.java
@@ -1,0 +1,39 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference;
+
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+public interface ReferenceIdResolver
+{
+    /**
+     * Version of the {@link ReferenceIdExtension} that this resolver is associated with.
+     *
+     * @return extension version
+     */
+    int version();
+
+    /**
+     * Resolve the reference for the given id. If the id is invalid, the implementing class should throw an
+     * {@link InvalidReferenceIdException}. If the id cannot be resolved, the implementing class should throw an
+     * {@link UnresolvableReferenceIdException}.
+     *
+     * @param referenceId reference id
+     * @return reference instance
+     * @throws InvalidReferenceIdException if the id is invalid
+     * @throws UnresolvableReferenceIdException if the id cannot be resolved
+     */
+    CoreInstance resolveReference(String referenceId) throws InvalidReferenceIdException, UnresolvableReferenceIdException;
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIds.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIds.java
@@ -1,0 +1,355 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference;
+
+import org.eclipse.collections.api.map.primitive.IntObjectMap;
+import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
+import org.eclipse.collections.impl.factory.primitive.IntObjectMaps;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+
+import java.util.Objects;
+import java.util.ServiceLoader;
+
+public abstract class ReferenceIds
+{
+    final ProcessorSupport processorSupport;
+    final int defaultVersion;
+
+    private ReferenceIds(ProcessorSupport processorSupport, int defaultVersion)
+    {
+        this.processorSupport = processorSupport;
+        this.defaultVersion = defaultVersion;
+    }
+
+    public int getDefaultVersion()
+    {
+        return this.defaultVersion;
+    }
+
+    public abstract boolean isVersionAvailable(int version);
+
+    public ReferenceIdExtension getExtension(int version)
+    {
+        return getExtensionCache(version).extension;
+    }
+
+    public ReferenceIdExtension getExtension(Integer version)
+    {
+        return getExtensionCache(version).extension;
+    }
+
+    public ReferenceIdExtension getDefaultExtension()
+    {
+        return getDefaultExtensionCache().extension;
+    }
+
+    public ReferenceIdProvider provider(int version)
+    {
+        return getExtensionCache(version).provider();
+    }
+
+    public ReferenceIdProvider provider(Integer version)
+    {
+        return getExtensionCache(version).provider();
+    }
+
+    public ReferenceIdProvider provider()
+    {
+        return getDefaultExtensionCache().provider();
+    }
+
+    public ReferenceIdResolver resolver(int version)
+    {
+        return getExtensionCache(version).resolver();
+    }
+
+    public ReferenceIdResolver resolver(Integer version)
+    {
+        return getExtensionCache(version).resolver();
+    }
+
+    public ReferenceIdResolver resolver()
+    {
+        return getDefaultExtensionCache().resolver();
+    }
+
+    private ExtensionCache getExtensionCache(Integer version)
+    {
+        return (version == null) ? getDefaultExtensionCache() : getExtensionCache(version.intValue());
+    }
+
+    ExtensionCache getDefaultExtensionCache()
+    {
+        return getExtensionCache(this.defaultVersion);
+    }
+
+    abstract ExtensionCache getExtensionCache(int version);
+
+    class ExtensionCache
+    {
+        private final ReferenceIdExtension extension;
+        private ReferenceIdProvider provider;
+        private ReferenceIdResolver resolver;
+
+        private ExtensionCache(ReferenceIdExtension extension)
+        {
+            this.extension = extension;
+        }
+
+        synchronized ReferenceIdProvider provider()
+        {
+            if (this.provider == null)
+            {
+                this.provider = this.extension.newProvider(ReferenceIds.this.processorSupport);
+            }
+            return this.provider;
+        }
+
+        synchronized ReferenceIdResolver resolver()
+        {
+            if (this.resolver == null)
+            {
+                this.resolver = this.extension.newResolver(ReferenceIds.this.processorSupport);
+            }
+            return this.resolver;
+        }
+    }
+
+    private static class Single extends ReferenceIds
+    {
+        private final ExtensionCache extension;
+
+        private Single(ProcessorSupport processorSupport, ReferenceIdExtension extension)
+        {
+            super(processorSupport, extension.version());
+            this.extension = new ExtensionCache(extension);
+        }
+
+        public boolean isVersionAvailable(int version)
+        {
+            return version == this.defaultVersion;
+        }
+
+        @Override
+        ExtensionCache getDefaultExtensionCache()
+        {
+            return this.extension;
+        }
+
+        @Override
+        ExtensionCache getExtensionCache(int version)
+        {
+            if (!isVersionAvailable(version))
+            {
+                throw new IllegalArgumentException("Unknown extension: " + version);
+            }
+            return this.extension;
+        }
+    }
+
+    private static class Sequence extends ReferenceIds
+    {
+        private final ExtensionCache[] extensions;
+        private final int offset;
+
+        private Sequence(ProcessorSupport processorSupport, int defaultVersion, ReferenceIdExtension[] extensions)
+        {
+            super(processorSupport, defaultVersion);
+            this.extensions = new ExtensionCache[extensions.length];
+            for (int i = 0; i < extensions.length; i++)
+            {
+                this.extensions[i] = new ExtensionCache(extensions[i]);
+            }
+            this.offset = extensions[0].version();
+        }
+
+        @Override
+        public boolean isVersionAvailable(int version)
+        {
+            int index = getIndex(version);
+            return (0 <= index) && (index < this.extensions.length);
+        }
+
+        @Override
+        ExtensionCache getExtensionCache(int version)
+        {
+            try
+            {
+                return this.extensions[getIndex(version)];
+            }
+            catch (IndexOutOfBoundsException e)
+            {
+                throw new IllegalArgumentException("Unknown extension: " + version);
+            }
+        }
+
+        private int getIndex(int version)
+        {
+            return version - this.offset;
+        }
+    }
+
+    private static class General extends ReferenceIds
+    {
+        private final MutableIntObjectMap<ExtensionCache> extensions;
+
+        private General(ProcessorSupport processorSupport, int defaultVersion, IntObjectMap<ReferenceIdExtension> extensions)
+        {
+            super(processorSupport, defaultVersion);
+            this.extensions = IntObjectMaps.mutable.ofInitialCapacity(extensions.size());
+            extensions.forEachKeyValue((version, extension) -> this.extensions.put(version, new ExtensionCache(extension)));
+        }
+
+        public boolean isVersionAvailable(int version)
+        {
+            return this.extensions.containsKey(version);
+        }
+
+        @Override
+        ExtensionCache getExtensionCache(int version)
+        {
+            ExtensionCache extension = this.extensions.get(version);
+            if (extension == null)
+            {
+                throw new IllegalArgumentException("Unknown extension: " + version);
+            }
+            return extension;
+        }
+    }
+
+    public static Builder builder(ProcessorSupport processorSupport)
+    {
+        return new Builder(processorSupport);
+    }
+
+    public static class Builder
+    {
+        private final ProcessorSupport processorSupport;
+        private final MutableIntObjectMap<ReferenceIdExtension> extensions = IntObjectMaps.mutable.empty();
+        private Integer defaultVersion;
+
+        private Builder(ProcessorSupport processorSupport)
+        {
+            this.processorSupport = Objects.requireNonNull(processorSupport, "processor support is required");
+        }
+
+        public void addExtension(ReferenceIdExtension extension)
+        {
+            Objects.requireNonNull(extension, "extension may not be null");
+            if (this.extensions.getIfAbsentPut(extension.version(), extension) != extension)
+            {
+                throw new IllegalArgumentException("There is already an extension for version " + extension.version());
+            }
+        }
+
+        public Builder withExtension(ReferenceIdExtension extension)
+        {
+            addExtension(extension);
+            return this;
+        }
+
+        public void addExtensions(Iterable<? extends ReferenceIdExtension> extensions)
+        {
+            extensions.forEach(this::addExtension);
+        }
+
+        public Builder withExtensions(Iterable<? extends ReferenceIdExtension> extensions)
+        {
+            addExtensions(extensions);
+            return this;
+        }
+
+        public void loadExtensions(ClassLoader classLoader)
+        {
+            addExtensions(ServiceLoader.load(ReferenceIdExtension.class, classLoader));
+        }
+
+        public void loadExtensions()
+        {
+            addExtensions(ServiceLoader.load(ReferenceIdExtension.class));
+        }
+
+        public Builder withAvailableExtensions(ClassLoader classLoader)
+        {
+            loadExtensions(classLoader);
+            return this;
+        }
+
+        public Builder withAvailableExtensions()
+        {
+            loadExtensions();
+            return this;
+        }
+
+        public void setDefaultVersion(int defaultVersion)
+        {
+            this.defaultVersion = defaultVersion;
+        }
+
+        public void clearDefaultVersion()
+        {
+            this.defaultVersion = null;
+        }
+
+        public Builder withDefaultVersion(Integer defaultVersion)
+        {
+            if (defaultVersion == null)
+            {
+                clearDefaultVersion();
+            }
+            else
+            {
+                setDefaultVersion(defaultVersion);
+            }
+            return this;
+        }
+
+        public ReferenceIds build()
+        {
+            if (this.extensions.isEmpty())
+            {
+                throw new IllegalStateException("At least one extension is required");
+            }
+            int resolvedDefaultVersion;
+            if (this.defaultVersion == null)
+            {
+                resolvedDefaultVersion = this.extensions.keySet().max();
+            }
+            else if (this.extensions.containsKey(this.defaultVersion))
+            {
+                resolvedDefaultVersion = this.defaultVersion;
+            }
+            else
+            {
+                throw new IllegalArgumentException("Default version " + this.defaultVersion + " is unknown");
+            }
+
+            if (this.extensions.size() == 1)
+            {
+                return new Single(this.processorSupport, this.extensions.getAny());
+            }
+
+            int minId;
+            if (this.extensions.size() == (this.extensions.keySet().max() - (minId = this.extensions.keySet().min())))
+            {
+                ReferenceIdExtension[] extArray = new ReferenceIdExtension[this.extensions.size()];
+                this.extensions.forEachKeyValue((id, ext) -> extArray[id - minId] = ext);
+                return new Sequence(this.processorSupport, resolvedDefaultVersion, extArray);
+            }
+
+            return new General(this.processorSupport, resolvedDefaultVersion, this.extensions);
+        }
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/UnresolvableReferenceIdException.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/UnresolvableReferenceIdException.java
@@ -1,0 +1,49 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference;
+
+/**
+ * Exception arising when a valid reference id cannot be resolved. For invalid ids, {@link InvalidReferenceIdException}
+ * should be used instead.
+ */
+public class UnresolvableReferenceIdException extends ReferenceIdResolutionException
+{
+    public UnresolvableReferenceIdException(String referenceId, String message, Throwable cause)
+    {
+        super(referenceId, message, cause);
+    }
+
+    public UnresolvableReferenceIdException(String referenceId, String message)
+    {
+        super(referenceId, message);
+    }
+
+    public UnresolvableReferenceIdException(String referenceId, Throwable cause)
+    {
+        this(referenceId, buildMessage(referenceId), cause);
+    }
+
+    public UnresolvableReferenceIdException(String referenceId)
+    {
+        this(referenceId, buildMessage(referenceId));
+    }
+
+    private static String buildMessage(String referenceId)
+    {
+        return (referenceId == null) ?
+               "Unresolvable reference id: null" :
+               ("Unresolvable reference id: \"" + referenceId + "\"");
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ContainingElementIndex.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ContainingElementIndex.java
@@ -1,0 +1,273 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference.v1;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MapIterable;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.set.SetIterable;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation._package._Package;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
+
+class ContainingElementIndex
+{
+    private final MapIterable<String, ImmutableList<CoreInstance>> sourceIndex;
+    private final SetIterable<CoreInstance> virtualPackages;
+
+    private ContainingElementIndex(MapIterable<String, ImmutableList<CoreInstance>> sourceIndex, SetIterable<CoreInstance> virtualPackages)
+    {
+        this.sourceIndex = sourceIndex;
+        this.virtualPackages = virtualPackages;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (this == other)
+        {
+            return true;
+        }
+        if (!(other instanceof ContainingElementIndex))
+        {
+            return false;
+        }
+        ContainingElementIndex that = (ContainingElementIndex) other;
+        return this.sourceIndex.equals(that.sourceIndex) && this.virtualPackages.equals(that.virtualPackages);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return this.sourceIndex.hashCode() + (31 * this.virtualPackages.hashCode());
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder(getClass().getSimpleName()).append('{');
+        this.sourceIndex.forEachKeyValue((source, elements) ->
+        {
+            builder.append(source).append(":[");
+            elements.forEach(element ->
+            {
+                PackageableElement.writeUserPathForPackageableElement(builder, element);
+                element.getSourceInformation().appendIntervalMessage(builder.append(" (")).append("), ");
+            });
+            builder.setLength(builder.length() - 2);
+            builder.append("], ");
+        });
+        if (this.virtualPackages.isEmpty())
+        {
+            builder.setLength(builder.length() - 2);
+            builder.append('}');
+        }
+        else
+        {
+            builder.append("virtual packages:[");
+            this.virtualPackages.forEach(pkg -> PackageableElement.writeUserPathForPackageableElement(builder, pkg).append(", "));
+            builder.setLength(builder.length() - 2);
+            builder.append("]}");
+        }
+        return builder.toString();
+    }
+
+    CoreInstance findContainingElement(CoreInstance instance)
+    {
+        SourceInformation sourceInfo = instance.getSourceInformation();
+        if (sourceInfo != null)
+        {
+            ImmutableList<CoreInstance> sourceElements = this.sourceIndex.get(sourceInfo.getSourceId());
+            if (sourceElements != null)
+            {
+                // Binary search among elements sorted by position in the source
+                int low = 0;
+                int high = sourceElements.size() - 1;
+                while (low <= high)
+                {
+                    int mid = (low + high) >>> 1;
+                    CoreInstance element = sourceElements.get(mid);
+                    if (element == instance)
+                    {
+                        return element;
+                    }
+
+                    SourceInformation elementSourceInfo = element.getSourceInformation();
+                    if (SourceInformation.isBefore(sourceInfo.getEndLine(), sourceInfo.getEndColumn(), elementSourceInfo.getStartLine(), elementSourceInfo.getStartColumn()))
+                    {
+                        // instance ends before element starts
+                        high = mid - 1;
+                    }
+                    else if (SourceInformation.isAfter(sourceInfo.getStartLine(), sourceInfo.getStartColumn(), elementSourceInfo.getEndLine(), elementSourceInfo.getEndColumn()))
+                    {
+                        // instance starts after element ends
+                        low = mid + 1;
+                    }
+                    else
+                    {
+                        // instance and element must intersect, which by assumption means that element contains instance
+                        return element;
+                    }
+                }
+            }
+        }
+        else if (this.virtualPackages.contains(instance))
+        {
+            return instance;
+        }
+        return null;
+    }
+
+    static Builder builder(ProcessorSupport processorSupport)
+    {
+        return new Builder(processorSupport);
+    }
+
+    static class Builder
+    {
+        private final MutableMap<String, MutableList<CoreInstance>> elementsBySource = Maps.mutable.empty();
+        private final MutableList<CoreInstance> virtualPackages = Lists.mutable.empty();
+        private final ProcessorSupport processorSupport;
+
+        private Builder(ProcessorSupport processorSupport)
+        {
+            this.processorSupport = processorSupport;
+        }
+
+        void addElement(CoreInstance element)
+        {
+            SourceInformation sourceInfo = Objects.requireNonNull(element, "element may not be null").getSourceInformation();
+            if (sourceInfo == null)
+            {
+                if (_Package.isPackage(element, this.processorSupport))
+                {
+                    this.virtualPackages.add(element);
+                    return;
+                }
+                throw new IllegalArgumentException("Invalid element, no source information: " + element);
+            }
+            if (!sourceInfo.isValid())
+            {
+                throw new IllegalArgumentException("Element with invalid source information: " + element + ", " + sourceInfo.getMessage());
+            }
+            this.elementsBySource.getIfAbsentPut(sourceInfo.getSourceId(), Lists.mutable::empty).add(element);
+        }
+
+        Builder withElement(CoreInstance element)
+        {
+            addElement(element);
+            return this;
+        }
+
+        void addElements(Iterable<? extends CoreInstance> elements)
+        {
+            elements.forEach(this::addElement);
+        }
+
+        Builder withElements(Iterable<? extends CoreInstance> elements)
+        {
+            addElements(elements);
+            return this;
+        }
+
+        void addAllElements()
+        {
+            addElement(this.processorSupport.repository_getTopLevel(M3Paths.Package));
+            PrimitiveUtilities.forEachPrimitiveType(processorSupport, this::addElement);
+            Deque<CoreInstance> packages = new ArrayDeque<>();
+            packages.add(this.processorSupport.repository_getTopLevel(M3Paths.Root));
+            while (!packages.isEmpty())
+            {
+                CoreInstance pkg = packages.pollFirst();
+                addElement(pkg);
+                pkg.getValueForMetaPropertyToMany(M3Properties.children).forEach(child ->
+                {
+                    if (_Package.isPackage(child, this.processorSupport))
+                    {
+                        packages.addLast(child);
+                    }
+                    else
+                    {
+                        addElement(child);
+                    }
+                });
+            }
+        }
+
+        Builder withAllElements()
+        {
+            addAllElements();
+            return this;
+        }
+
+        ContainingElementIndex build()
+        {
+            MutableMap<String, ImmutableList<CoreInstance>> index = Maps.mutable.ofInitialCapacity(this.elementsBySource.size());
+            this.elementsBySource.forEachKeyValue((source, elements) ->
+            {
+                if (elements.size() > 1)
+                {
+                    elements.sortThis((e1, e2) -> SourceInformation.compareByStartPosition(e1.getSourceInformation(), e2.getSourceInformation()));
+                    CoreInstance[] prev = new CoreInstance[1];
+                    elements.removeIf(current ->
+                    {
+                        CoreInstance previous = prev[0];
+                        if (current == previous)
+                        {
+                            return true;
+                        }
+                        if ((previous != null) && overlaps(current, previous))
+                        {
+                            StringBuilder builder = new StringBuilder("Distinct elements with overlapping source information: ");
+                            PackageableElement.writeUserPathForPackageableElement(builder, previous);
+                            previous.getSourceInformation().appendMessage(builder.append(" (")).append("), ");
+                            PackageableElement.writeUserPathForPackageableElement(builder, current);
+                            current.getSourceInformation().appendMessage(builder.append(" (")).append(")");
+                            throw new IllegalStateException(builder.toString());
+                        }
+                        prev[0] = current;
+                        return false;
+                    });
+                }
+                if (elements.notEmpty())
+                {
+                    index.put(source, elements.toImmutable());
+                }
+            });
+            return new ContainingElementIndex(index, this.virtualPackages.isEmpty() ? Sets.immutable.empty() : Sets.mutable.withAll(this.virtualPackages));
+        }
+
+        private static boolean overlaps(CoreInstance element1, CoreInstance element2)
+        {
+            SourceInformation sourceInfo1 = element1.getSourceInformation();
+            SourceInformation sourceInfo2 = element2.getSourceInformation();
+            return SourceInformation.isNotAfter(sourceInfo1.getStartLine(), sourceInfo1.getStartColumn(), sourceInfo2.getEndLine(), sourceInfo2.getEndColumn()) &&
+                    SourceInformation.isNotBefore(sourceInfo1.getEndLine(), sourceInfo1.getEndColumn(), sourceInfo2.getStartLine(), sourceInfo2.getStartColumn());
+        }
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ReferenceIdExtensionV1.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ReferenceIdExtensionV1.java
@@ -1,0 +1,41 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference.v1;
+
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdExtension;
+import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdProvider;
+import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdResolver;
+
+public class ReferenceIdExtensionV1 implements ReferenceIdExtension
+{
+    @Override
+    public int version()
+    {
+        return 1;
+    }
+
+    @Override
+    public ReferenceIdProvider newProvider(ProcessorSupport processorSupport)
+    {
+        return new ReferenceIdProviderV1(processorSupport);
+    }
+
+    @Override
+    public ReferenceIdResolver newResolver(ProcessorSupport processorSupport)
+    {
+        return new ReferenceIdResolverV1(processorSupport);
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ReferenceIdGenerator.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ReferenceIdGenerator.java
@@ -1,0 +1,681 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference.v1;
+
+import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.map.ConcurrentMutableMap;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MapIterable;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.set.ImmutableSet;
+import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
+import org.finos.legend.pure.m3.coreinstance.Package;
+import org.finos.legend.pure.m3.coreinstance.helper.AnyStubHelper;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Any;
+import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.M3PropertyPaths;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation._package._Package;
+import org.finos.legend.pure.m3.navigation.graph.GraphPath;
+import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
+import org.finos.legend.pure.m3.navigation.property.Property;
+import org.finos.legend.pure.m4.coreinstance.AbstractCoreInstanceWrapper;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+import org.finos.legend.pure.m4.serialization.grammar.StringEscape;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.Objects;
+
+class ReferenceIdGenerator
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceIdGenerator.class);
+
+    private static final ImmutableMap<String, ImmutableList<String>> SKIP_PROPERTY_PATHS = M3PropertyPaths.BACK_REFERENCE_PROPERTY_PATHS
+            .groupByUniqueKey(ImmutableList::getLast, Maps.mutable.ofInitialCapacity(M3PropertyPaths.BACK_REFERENCE_PROPERTY_PATHS.size() + 2))
+            .withKeyValue(M3PropertyPaths._package.getLast(), M3PropertyPaths._package)
+            .withKeyValue(M3PropertyPaths.children.getLast(), M3PropertyPaths.children)
+            .toImmutable();
+
+    private final ProcessorSupport processorSupport;
+    private final TypeCache typeCache;
+
+    ReferenceIdGenerator(ProcessorSupport processorSupport)
+    {
+        this.processorSupport = Objects.requireNonNull(processorSupport, "processorSupport is required");
+        this.typeCache = new TypeCache(this.processorSupport);
+    }
+
+    MapIterable<CoreInstance, String> generateIdsForElement(String path)
+    {
+        CoreInstance element = this.processorSupport.package_getByUserPath(Objects.requireNonNull(path, "path may not be null"));
+        if (element == null)
+        {
+            throw new IllegalArgumentException("Could not find element: \"" + path + "\"");
+        }
+        validateIsPackageableElement(element);
+        return generateIdsForElement(element, path);
+    }
+
+    MapIterable<CoreInstance, String> generateIdsForElement(CoreInstance element)
+    {
+        validateIsPackageableElement(Objects.requireNonNull(element, "element may not be null"));
+        return generateIdsForElement(element, PackageableElement.getUserPathForPackageableElement(element));
+    }
+
+    private MapIterable<CoreInstance, String> generateIdsForElement(CoreInstance element, String path)
+    {
+        long start = System.nanoTime();
+        LOGGER.debug("Generating ids for {}", path);
+        try
+        {
+            MapIterable<CoreInstance, String> result = generateIdsForElementWithPath(element, path);
+            long end = System.nanoTime();
+            LOGGER.debug("Finished generating ids for {} ({} ids) in {}s", path, result.size(), (end - start) / 1_000_000_000.0);
+            return result;
+        }
+        catch (Throwable t)
+        {
+            long end = System.nanoTime();
+            LOGGER.error("Generating ids for {} finished with error in {}s", path, (end - start) / 1_000_000_000.0, t);
+            throw t;
+        }
+    }
+
+    private MapIterable<CoreInstance, String> generateIdsForElementWithPath(CoreInstance element, String path)
+    {
+        // We have already validated that element is a PackageableElement
+        if ((path == null) || path.isEmpty())
+        {
+            throw new IllegalArgumentException("Invalid path: path may not be null or empty");
+        }
+        String elementName = PrimitiveUtilities.getStringValue(element.getValueForMetaPropertyToOne(M3Properties.name));
+        if ((element.getName() == null) || (elementName == null))
+        {
+            throw new IllegalArgumentException("Invalid element '" + path + "': name is null");
+        }
+        if (!element.getName().equals(elementName))
+        {
+            throw new IllegalArgumentException("Invalid element '" + path + "': instance name ('" + StringEscape.escape(element.getName()) + "') does not match name property ('" + StringEscape.escape(elementName) + "')");
+        }
+        if (!(path.equals(elementName) || (path.endsWith(elementName) && (path.charAt(path.length() - elementName.length() - 1) == ':'))))
+        {
+            throw new IllegalArgumentException("Invalid path for element named '" + StringEscape.escape(elementName) + "': '" + path + "'");
+        }
+        if (element.getSourceInformation() == null)
+        {
+            // We allow null source info only for virtual packages
+            if (_Package.isPackage(element, this.processorSupport))
+            {
+                return Maps.immutable.with(element, path);
+            }
+            throw new IllegalArgumentException("No source information for '" + path + "'");
+        }
+        return new Generator(element, path, this.typeCache).generateIds();
+    }
+
+    private void validateIsPackageableElement(CoreInstance element)
+    {
+        if (!PackageableElement.isPackageableElement(element, this.processorSupport))
+        {
+            StringBuilder builder = new StringBuilder("Expected a PackageableElement, got instance of: ");
+            if (element instanceof Any)
+            {
+                String systemPath = ((Any) element).getFullSystemPath();
+                builder.append(systemPath, "Root::".length(), systemPath.length());
+            }
+            else
+            {
+                CoreInstance classifier = this.processorSupport.getClassifier(element);
+                PackageableElement.writeUserPathForPackageableElement(builder, classifier);
+            }
+            throw new IllegalArgumentException(builder.toString());
+        }
+    }
+
+    private static class Generator
+    {
+        private final CoreInstance element;
+        private final Deque<SearchNode> deque = new ArrayDeque<>();
+        private final TypeCache typeCache;
+
+        private Generator(CoreInstance element, String path, TypeCache typeCache)
+        {
+            this.element = element;
+            this.typeCache = typeCache;
+            enqueue(GraphPath.buildPath(path, false), Lists.immutable.with(element), this.typeCache.getClassifier(element));
+        }
+
+        private MapIterable<CoreInstance, String> generateIds()
+        {
+            MapIterable<CoreInstance, GraphPath> paths = generateIdGraphPaths();
+            MutableMap<CoreInstance, String> result = Maps.mutable.ofInitialCapacity(paths.size());
+            paths.forEachKeyValue((k, v) -> result.put(k, v.getDescription()));
+            return result;
+        }
+
+        private MapIterable<CoreInstance, GraphPath> generateIdGraphPaths()
+        {
+            MutableMap<CoreInstance, GraphPath> paths = Maps.mutable.empty();
+            while (!this.deque.isEmpty())
+            {
+                SearchNode searchNode = this.deque.pollFirst();
+                CoreInstance instance = searchNode.pathNodes.getLast();
+                if ((instance.getSourceInformation() == null) || this.typeCache.isStubType(searchNode.finalNodeClassifier))
+                {
+                    // No source information or a Stub instance: no need to record a graph path, but we should still
+                    // advance from the search node.
+                    advanceFromSearchNode(searchNode);
+                }
+                else
+                {
+                    // If we have not recorded a graph path for this instance before, or we have a better path, then
+                    // record the graph path and advance. Otherwise, we have already been to this instance with a better
+                    // graph path, so there is no point in continuing the search from here.
+                    GraphPath oldGraphPath = paths.get(instance);
+                    if ((oldGraphPath == null) || (compareGraphPaths(searchNode.path, oldGraphPath) < 0))
+                    {
+                        paths.put(instance, searchNode.path);
+                        advanceFromSearchNode(searchNode);
+                    }
+                }
+            }
+            return paths;
+        }
+
+        private void advanceFromSearchNode(SearchNode searchNode)
+        {
+            CoreInstance instance = searchNode.pathNodes.getLast();
+            this.typeCache.getClassInfo(searchNode.finalNodeClassifier).forEachPropertyInfo((propertyName, propertyInfo) ->
+            {
+                if (propertyInfo.shouldSkip())
+                {
+                    return;
+                }
+
+                // To-one property handling
+                if (propertyInfo.isToOne())
+                {
+                    CoreInstance value = instance.getValueForMetaPropertyToOne(propertyName);
+                    if ((value != null) && isInternal(value) && !searchNode.pathNodes.contains(value))
+                    {
+                        CoreInstance valueClassifier = this.typeCache.getClassifier(value);
+                        if (!this.typeCache.isPrimitiveType(valueClassifier))
+                        {
+                            GraphPath newGraphPath = searchNode.path.withToOneProperty(propertyName, false);
+                            ImmutableList<CoreInstance> newPathNodes = searchNode.pathNodes.newWith(value);
+                            enqueue(newGraphPath, newPathNodes, valueClassifier);
+                        }
+                    }
+                    return;
+                }
+
+                // To-many property handling
+                ListIterable<? extends CoreInstance> values = instance.getValueForMetaPropertyToMany(propertyName);
+                if (values.notEmpty())
+                {
+                    Collection<CoreInstance> pathNodes = ((values.size() > 1) && (searchNode.pathNodes.size() > 8)) ? Sets.mutable.withAll(searchNode.pathNodes) : searchNode.pathNodes.castToCollection();
+                    PropertyIndex index = tryIndex(propertyInfo, values);
+                    if (index == null)
+                    {
+                        values.forEachWithIndex((value, i) ->
+                        {
+                            if (isInternal(value) && !pathNodes.contains(value))
+                            {
+                                CoreInstance valueClassifier = this.typeCache.getClassifier(value);
+                                if (!this.typeCache.isPrimitiveType(valueClassifier))
+                                {
+                                    GraphPath newGraphPath = searchNode.path.withToManyPropertyValueAtIndex(propertyName, i, false);
+                                    ImmutableList<CoreInstance> newPathNodes = searchNode.pathNodes.newWith(value);
+                                    enqueue(newGraphPath, newPathNodes, valueClassifier);
+                                }
+                            }
+                        });
+                    }
+                    else
+                    {
+                        index.index.forEachKeyValue((name, value) ->
+                        {
+                            if (isInternal(value) && !pathNodes.contains(value))
+                            {
+                                // The fact that we built an index implies these are not primitive values
+                                CoreInstance valueClassifier = this.typeCache.getClassifier(value);
+                                GraphPath newGraphPath = searchNode.path.withToManyPropertyValueWithKey(propertyName, index.property, name, false);
+                                ImmutableList<CoreInstance> newPathNodes = searchNode.pathNodes.newWith(value);
+                                enqueue(newGraphPath, newPathNodes, valueClassifier);
+                            }
+                        });
+                    }
+                }
+            });
+        }
+
+        private void enqueue(GraphPath path, ImmutableList<CoreInstance> pathNodes, CoreInstance finalNodeClassifier)
+        {
+            this.deque.addLast(new SearchNode(path, pathNodes, finalNodeClassifier));
+        }
+
+        private boolean isInternal(CoreInstance instance)
+        {
+            if (instance == this.element)
+            {
+                return true;
+            }
+
+            SourceInformation sourceInfo = instance.getSourceInformation();
+            return (sourceInfo == null) ? !this.typeCache.isPackage(instance) : this.element.getSourceInformation().subsumes(sourceInfo);
+        }
+
+        private PropertyIndex tryIndex(PropertyInfo propertyInfo, ListIterable<? extends CoreInstance> values)
+        {
+            // Figure out which key to index by (if any)
+            for (String keyProp : this.typeCache.getClassInfo(propertyInfo.getRawType()).getIndexKeys())
+            {
+                PropertyIndex index = tryIndex(keyProp, values);
+                if (index != null)
+                {
+                    return index;
+                }
+            }
+            return null;
+        }
+
+        private PropertyIndex tryIndex(String keyProp, ListIterable<? extends CoreInstance> values)
+        {
+            // Try to build an index with the given key property
+            MutableMap<String, CoreInstance> index = Maps.mutable.ofInitialCapacity(values.size());
+            for (CoreInstance value : values)
+            {
+                String key = PrimitiveUtilities.getStringValue(value.getValueForMetaPropertyToOne(keyProp), null);
+                if ((key == null) || (index.put(key, value) != null))
+                {
+                    return null;
+                }
+            }
+            return new PropertyIndex(keyProp, index);
+        }
+
+        private static int compareGraphPaths(GraphPath path1, GraphPath path2)
+        {
+            if (path1 == path2)
+            {
+                return 0;
+            }
+
+            int edgeCount = path1.getEdgeCount();
+            int cmp = Integer.compare(edgeCount, path2.getEdgeCount());
+            for (int i = 0; (cmp == 0) && (i < edgeCount); i++)
+            {
+                cmp = compareEdges(path1.getEdge(i), path2.getEdge(i));
+            }
+            return cmp;
+        }
+
+        private static int compareEdges(GraphPath.Edge edge1, GraphPath.Edge edge2)
+        {
+            // to-one < to-many[key] < to-many[index]
+            return edge1.visit(new GraphPath.EdgeVisitor<Integer>()
+            {
+                @Override
+                public Integer visit(GraphPath.ToOnePropertyEdge e1)
+                {
+                    return (edge2 instanceof GraphPath.ToOnePropertyEdge) ? compareStrings(e1.getProperty(), edge2.getProperty()) : -1;
+                }
+
+                @Override
+                public Integer visit(GraphPath.ToManyPropertyAtIndexEdge e1)
+                {
+                    return edge2.visit(new GraphPath.EdgeVisitor<Integer>()
+                    {
+                        @Override
+                        public Integer visit(GraphPath.ToOnePropertyEdge e2)
+                        {
+                            return 1;
+                        }
+
+                        @Override
+                        public Integer visit(GraphPath.ToManyPropertyAtIndexEdge e2)
+                        {
+                            int cmp = compareStrings(e1.getProperty(), e2.getProperty());
+                            return (cmp != 0) ? cmp : Integer.compare(e1.getIndex(), e2.getIndex());
+                        }
+
+                        @Override
+                        public Integer visit(GraphPath.ToManyPropertyWithStringKeyEdge e2)
+                        {
+                            return 1;
+                        }
+                    });
+                }
+
+                @Override
+                public Integer visit(GraphPath.ToManyPropertyWithStringKeyEdge e1)
+                {
+                    return edge2.visit(new GraphPath.EdgeVisitor<Integer>()
+                    {
+                        @Override
+                        public Integer visit(GraphPath.ToOnePropertyEdge e2)
+                        {
+                            return 1;
+                        }
+
+                        @Override
+                        public Integer visit(GraphPath.ToManyPropertyAtIndexEdge e2)
+                        {
+                            return -1;
+                        }
+
+                        @Override
+                        public Integer visit(GraphPath.ToManyPropertyWithStringKeyEdge e2)
+                        {
+                            int cmp = compareStrings(e1.getProperty(), e2.getProperty());
+                            if (cmp == 0)
+                            {
+                                cmp = compareStrings(e1.getKeyProperty(), e2.getKeyProperty());
+                                if (cmp == 0)
+                                {
+                                    cmp = compareStrings(e1.getKey(), e2.getKey());
+                                }
+                            }
+                            return cmp;
+                        }
+                    });
+                }
+            });
+        }
+
+        private static int compareStrings(String string1, String string2)
+        {
+            int cmp = Integer.compare(string1.length(), string2.length());
+            return (cmp != 0) ? cmp : string1.compareTo(string2);
+        }
+    }
+
+    private static class TypeCache
+    {
+        private final ProcessorSupport processorSupport;
+        private final ImmutableSet<CoreInstance> stubClasses;
+        private final ImmutableSet<CoreInstance> primitiveTypes;
+        private final CoreInstance stringType;
+        private final CoreInstance enumerationClass;
+        private final CoreInstance packageClass;
+        private final CoreInstance qualifiedPropertyClass;
+        private final CoreInstance stereotypeClass;
+        private final CoreInstance tagClass;
+        private final ConcurrentMutableMap<CoreInstance, ClassInfo> classInfos = ConcurrentHashMap.newMap();
+
+        private TypeCache(ProcessorSupport processorSupport)
+        {
+            this.processorSupport = processorSupport;
+            this.stubClasses = Sets.immutable.withAll(AnyStubHelper.getStubClasses(processorSupport));
+            this.primitiveTypes = Sets.immutable.withAll(PrimitiveUtilities.getPrimitiveTypes(processorSupport));
+            this.stringType = this.processorSupport.repository_getTopLevel(M3Paths.String);
+            this.enumerationClass = this.processorSupport.package_getByUserPath(M3Paths.Enumeration);
+            this.packageClass = this.processorSupport.package_getByUserPath(M3Paths.Package);
+            this.qualifiedPropertyClass = this.processorSupport.package_getByUserPath(M3Paths.QualifiedProperty);
+            this.stereotypeClass = this.processorSupport.package_getByUserPath(M3Paths.Stereotype);
+            this.tagClass = this.processorSupport.package_getByUserPath(M3Paths.Tag);
+        }
+
+        CoreInstance getClassifier(CoreInstance instance)
+        {
+            return this.processorSupport.getClassifier(instance);
+        }
+
+        boolean isStubType(CoreInstance instance)
+        {
+            return this.stubClasses.contains(instance);
+        }
+
+        boolean isPrimitiveType(CoreInstance instance)
+        {
+            return this.primitiveTypes.contains(instance);
+        }
+
+        boolean isStringType(CoreInstance instance)
+        {
+            return this.stringType == instance;
+        }
+
+        boolean isPackage(CoreInstance instance)
+        {
+            if (instance == null)
+            {
+                return false;
+            }
+            if (instance instanceof Package)
+            {
+                return true;
+            }
+            return (!(instance instanceof Any) || (instance instanceof AbstractCoreInstanceWrapper)) && (this.packageClass == getClassifier(instance));
+        }
+
+        private ClassInfo getClassInfo(CoreInstance classifier)
+        {
+            return (classifier == null) ?
+                   new ClassInfo(Maps.immutable.empty(), Lists.immutable.empty()) :
+                   this.classInfos.getIfAbsentPutWithKey(classifier, this::computeClassInfo);
+        }
+
+        private ClassInfo computeClassInfo(CoreInstance classifier)
+        {
+            MapIterable<String, CoreInstance> properties = this.processorSupport.class_getSimplePropertiesByName(classifier);
+            if (properties.isEmpty())
+            {
+                return new ClassInfo(Maps.immutable.empty(), Lists.immutable.empty());
+            }
+
+            MutableMap<String, PropertyInfo> map = Maps.mutable.ofInitialCapacity(properties.size());
+            properties.forEachKeyValue((name, prop) -> map.put(name, computePropertyInfo(name, prop)));
+            if (classifier == this.enumerationClass)
+            {
+                // Special handling for Enumeration: the type of values is T, but we know that T will always be a subclass of Enum
+                PropertyInfo propInfo = map.get(M3Properties.values);
+                if ((propInfo != null) && (propInfo.getRawType() == null))
+                {
+                    map.put(M3Properties.values, new ToManyPropertyInfo(this.processorSupport.package_getByUserPath(M3Paths.Enum)));
+                }
+            }
+            return new ClassInfo(map.toImmutable(), getIndexKeys(classifier, map));
+        }
+
+        private PropertyInfo computePropertyInfo(String propertyName, CoreInstance property)
+        {
+            CoreInstance rawType = Instance.getValueForMetaPropertyToOneResolved(property, M3Properties.genericType, M3Properties.rawType, this.processorSupport);
+            CoreInstance multiplicity = Instance.getValueForMetaPropertyToOneResolved(property, M3Properties.multiplicity, this.processorSupport);
+            if (Multiplicity.isToOne(multiplicity, false))
+            {
+                return shouldSkipProperty(propertyName, property) ? new ToOneSkipPropertyInfo(rawType) : new ToOnePropertyInfo(rawType);
+            }
+
+            return ((rawType != null) && (isPrimitiveType(rawType) || shouldSkipProperty(propertyName, property))) ?
+                   new ToManySkipPropertyInfo(rawType) :
+                   new ToManyPropertyInfo(rawType);
+        }
+
+        private boolean shouldSkipProperty(String propertyName, CoreInstance property)
+        {
+            ImmutableList<String> realKeyToSkip = SKIP_PROPERTY_PATHS.get(propertyName);
+            return (realKeyToSkip != null) && realKeyToSkip.equals(Property.calculatePropertyPath(property, this.processorSupport));
+        }
+
+        private ImmutableList<String> getIndexKeys(CoreInstance classifier, MapIterable<String, PropertyInfo> propertyInfos)
+        {
+            if (this.qualifiedPropertyClass == classifier)
+            {
+                return Lists.immutable.with(M3Properties.id);
+            }
+            if ((this.stereotypeClass == classifier) || (this.tagClass == classifier))
+            {
+                return Lists.immutable.with(M3Properties.value);
+            }
+            if (isPossibleIndexKey(propertyInfos.get(M3Properties.name)))
+            {
+                return isPossibleIndexKey(propertyInfos.get(M3Properties.id)) ?
+                       Lists.immutable.with(M3Properties.name, M3Properties.id) :
+                       Lists.immutable.with(M3Properties.name);
+            }
+            if (isPossibleIndexKey(propertyInfos.get(M3Properties.id)))
+            {
+                return Lists.immutable.with(M3Properties.id);
+            }
+            return Lists.immutable.empty();
+        }
+
+        private boolean isPossibleIndexKey(PropertyInfo propertyInfo)
+        {
+            return (propertyInfo != null) && propertyInfo.isToOne() && isStringType(propertyInfo.getRawType());
+        }
+    }
+
+    private static class SearchNode
+    {
+        private final GraphPath path;
+        private final ImmutableList<CoreInstance> pathNodes;
+        private final CoreInstance finalNodeClassifier;
+
+        private SearchNode(GraphPath path, ImmutableList<CoreInstance> pathNodes, CoreInstance finalNodeClassifier)
+        {
+            this.path = path;
+            this.pathNodes = pathNodes;
+            this.finalNodeClassifier = finalNodeClassifier;
+        }
+    }
+
+    private static class ClassInfo
+    {
+        private final MapIterable<String, PropertyInfo> propertyInfos;
+        private final ImmutableList<String> indexKeys;
+
+        private ClassInfo(MapIterable<String, PropertyInfo> propertyInfos, ImmutableList<String> indexKeys)
+        {
+            this.propertyInfos = propertyInfos;
+            this.indexKeys = indexKeys;
+        }
+
+        ImmutableList<String> getIndexKeys()
+        {
+            return this.indexKeys;
+        }
+
+        void forEachPropertyInfo(Procedure2<? super String, ? super PropertyInfo> procedure)
+        {
+            this.propertyInfos.forEachKeyValue(procedure);
+        }
+    }
+
+    private abstract static class PropertyInfo
+    {
+        private final CoreInstance rawType;
+
+        private PropertyInfo(CoreInstance rawType)
+        {
+            this.rawType = rawType;
+        }
+
+        CoreInstance getRawType()
+        {
+            return this.rawType;
+        }
+
+        boolean shouldSkip()
+        {
+            return false;
+        }
+
+        abstract boolean isToOne();
+    }
+
+    private static class ToOnePropertyInfo extends PropertyInfo
+    {
+        private ToOnePropertyInfo(CoreInstance rawType)
+        {
+            super(rawType);
+        }
+
+        @Override
+        public boolean isToOne()
+        {
+            return true;
+        }
+    }
+
+    private static class ToOneSkipPropertyInfo extends ToOnePropertyInfo
+    {
+        private ToOneSkipPropertyInfo(CoreInstance rawType)
+        {
+            super(rawType);
+        }
+
+        @Override
+        public boolean shouldSkip()
+        {
+            return true;
+        }
+    }
+
+    private static class ToManyPropertyInfo extends PropertyInfo
+    {
+        private ToManyPropertyInfo(CoreInstance rawType)
+        {
+            super(rawType);
+        }
+
+        @Override
+        public boolean isToOne()
+        {
+            return false;
+        }
+    }
+
+    private static class ToManySkipPropertyInfo extends ToManyPropertyInfo
+    {
+        private ToManySkipPropertyInfo(CoreInstance rawType)
+        {
+            super(rawType);
+        }
+
+        @Override
+        boolean shouldSkip()
+        {
+            return true;
+        }
+    }
+
+    private static class PropertyIndex
+    {
+        private final String property;
+        private final MapIterable<String, CoreInstance> index;
+
+        private PropertyIndex(String property, MapIterable<String, CoreInstance> index)
+        {
+            this.property = property;
+            this.index = index;
+        }
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ReferenceIdProviderV1.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ReferenceIdProviderV1.java
@@ -1,0 +1,168 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference.v1;
+
+import org.eclipse.collections.api.map.ConcurrentMutableMap;
+import org.eclipse.collections.api.map.MapIterable;
+import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdProvider;
+import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdProvisionException;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ReferenceIdProviderV1 implements ReferenceIdProvider
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceIdProviderV1.class);
+
+    private final ContainingElementIndex containingElementIndex;
+    private final ReferenceIdGenerator idGenerator;
+    private final ConcurrentMutableMap<CoreInstance, MapIterable<CoreInstance, String>> idCache = ConcurrentHashMap.newMap();
+
+    ReferenceIdProviderV1(ContainingElementIndex containingElementIndex, ReferenceIdGenerator idGenerator)
+    {
+        this.containingElementIndex = containingElementIndex;
+        this.idGenerator = idGenerator;
+    }
+
+    ReferenceIdProviderV1(ProcessorSupport processorSupport)
+    {
+        this(ContainingElementIndex.builder(processorSupport).withAllElements().build(), new ReferenceIdGenerator(processorSupport));
+    }
+
+    @Override
+    public int version()
+    {
+        return 1;
+    }
+
+    @Override
+    public boolean hasReferenceId(CoreInstance instance)
+    {
+        if (instance == null)
+        {
+            return false;
+        }
+
+        CoreInstance owner = findOwner(instance);
+        return (owner != null) && hasReferenceId(instance, owner);
+    }
+
+    @Override
+    public String getReferenceId(CoreInstance reference)
+    {
+        long start = System.nanoTime();
+        try
+        {
+            String id = getReferenceId_internal(reference);
+            long end = System.nanoTime();
+            LOGGER.debug("Got reference id {} in {}s", id, (end - start) / 1_000_000_000.0);
+            return id;
+        }
+        catch (Throwable t)
+        {
+            long end = System.nanoTime();
+            LOGGER.error("Failed to get reference id for {} in {}s", reference, (end - start) / 1_000_000_000.0);
+            throw t;
+        }
+    }
+
+    private String getReferenceId_internal(CoreInstance reference)
+    {
+        if (reference == null)
+        {
+            throw new ReferenceIdProvisionException("Cannot provide reference id for null");
+        }
+
+        CoreInstance owner = findOwner(reference);
+        if (owner == null)
+        {
+            StringBuilder builder = new StringBuilder("Cannot provide reference id for ");
+            appendReferenceDescription(builder, reference).append(": cannot find containing element");
+            throw new ReferenceIdProvisionException(builder.toString());
+        }
+
+        String id = getReferenceId(reference, owner);
+        if (id == null)
+        {
+            throw new ReferenceIdProvisionException(appendReferenceDescription(new StringBuilder("Cannot provide reference id for "), reference, owner).toString());
+        }
+        return id;
+    }
+
+    private CoreInstance findOwner(CoreInstance reference)
+    {
+        try
+        {
+            return this.containingElementIndex.findContainingElement(reference);
+        }
+        catch (Exception e)
+        {
+            throw new ReferenceIdProvisionException(appendReferenceDescription(new StringBuilder("Error providing reference id for "), reference).toString(), e);
+        }
+    }
+
+    private boolean hasReferenceId(CoreInstance reference, CoreInstance owner)
+    {
+        return getReferenceIds(reference, owner).containsKey(reference);
+    }
+
+    private String getReferenceId(CoreInstance reference, CoreInstance owner)
+    {
+        return getReferenceIds(reference, owner).get(reference);
+    }
+
+    private MapIterable<CoreInstance, String> getReferenceIds(CoreInstance reference, CoreInstance owner)
+    {
+        try
+        {
+            return this.idCache.getIfAbsentPutWithKey(owner, this.idGenerator::generateIdsForElement);
+        }
+        catch (Exception e)
+        {
+            throw new ReferenceIdProvisionException(appendReferenceDescription(new StringBuilder("Error providing reference id for "), reference, owner).toString(), e);
+        }
+    }
+
+    private StringBuilder appendReferenceDescription(StringBuilder builder, CoreInstance reference)
+    {
+        if (reference == null)
+        {
+            return builder.append("null");
+        }
+
+        builder.append("instance ").append(reference);
+        SourceInformation sourceInfo = reference.getSourceInformation();
+        if (sourceInfo == null)
+        {
+            builder.append(" with no source information");
+        }
+        else
+        {
+            sourceInfo.appendMessage(builder.append(" at "));
+        }
+        return builder;
+    }
+
+    private StringBuilder appendReferenceDescription(StringBuilder builder, CoreInstance reference, CoreInstance owner)
+    {
+        appendReferenceDescription(builder, reference);
+        PackageableElement.writeUserPathForPackageableElement(builder.append(" contained in "), owner);
+        return builder;
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ReferenceIdResolverV1.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ReferenceIdResolverV1.java
@@ -1,0 +1,78 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference.v1;
+
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.graph.GraphPath;
+import org.finos.legend.pure.m3.serialization.compiler.reference.InvalidReferenceIdException;
+import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdResolver;
+import org.finos.legend.pure.m3.serialization.compiler.reference.UnresolvableReferenceIdException;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ReferenceIdResolverV1 implements ReferenceIdResolver
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceIdResolverV1.class);
+
+    private final ProcessorSupport processorSupport;
+
+    ReferenceIdResolverV1(ProcessorSupport processorSupport)
+    {
+        this.processorSupport = processorSupport;
+    }
+
+    @Override
+    public int version()
+    {
+        return 1;
+    }
+
+    @Override
+    public CoreInstance resolveReference(String referenceId)
+    {
+        long start = System.nanoTime();
+        if (referenceId == null)
+        {
+            throw new InvalidReferenceIdException(null);
+        }
+
+        GraphPath graphPath;
+        try
+        {
+            graphPath = GraphPath.parse(referenceId);
+        }
+        catch (Exception e)
+        {
+            long end = System.nanoTime();
+            LOGGER.error("Error resolving {} in {}s", referenceId, (end - start) / 1_000_000_000.0, e);
+            throw new InvalidReferenceIdException(referenceId, e);
+        }
+
+        try
+        {
+            CoreInstance result = graphPath.resolve(this.processorSupport);
+            long end = System.nanoTime();
+            LOGGER.debug("Resolved {} in {}s", referenceId, (end - start) / 1_000_000_000.0);
+            return result;
+        }
+        catch (Exception e)
+        {
+            long end = System.nanoTime();
+            LOGGER.error("Error resolving {} in {}s", referenceId, (end - start) / 1_000_000_000.0, e);
+            throw new UnresolvableReferenceIdException(referenceId, e);
+        }
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/META-INF/services/org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdExtension
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/META-INF/services/org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdExtension
@@ -1,0 +1,1 @@
+org.finos.legend.pure.m3.serialization.compiler.reference.v1.ReferenceIdExtensionV1

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/reference/AbstractReferenceIdExtensionTest.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/reference/AbstractReferenceIdExtensionTest.java
@@ -1,0 +1,108 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.utility.Iterate;
+import org.finos.legend.pure.m3.coreinstance.helper.AnyStubHelper;
+import org.finos.legend.pure.m3.navigation.M3PropertyPaths;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation._package._Package;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+import org.finos.legend.pure.m4.tools.GraphNodeIterable;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ServiceLoader;
+
+public abstract class AbstractReferenceIdExtensionTest extends AbstractReferenceTest
+{
+    protected static ReferenceIdExtension extension;
+
+    @Test
+    public void testLoadAsService()
+    {
+        int version = extension.version();
+        MutableList<ReferenceIdExtension> extensionsAtVersion = Iterate.select(ServiceLoader.load(ReferenceIdExtension.class), ext -> version == ext.version(), Lists.mutable.empty());
+        Assert.assertEquals(Lists.fixedSize.with(extension.getClass()), extensionsAtVersion.collect(Object::getClass));
+    }
+
+    @Test
+    public void testReferenceIds()
+    {
+        int version = extension.version();
+        ReferenceIds referenceIds = ReferenceIds.builder(processorSupport).withExtension(extension).build();
+        Assert.assertTrue(referenceIds.isVersionAvailable(version));
+        Assert.assertSame(extension, referenceIds.getExtension(version));
+    }
+
+    @Test
+    public void testProviderAndResolverVersions()
+    {
+        Assert.assertEquals(extension.version(), extension.newProvider(processorSupport).version());
+        Assert.assertEquals(extension.version(), extension.newResolver(processorSupport).version());
+    }
+
+    @Test
+    public void testAllInstances()
+    {
+        ReferenceIdProvider provider = extension.newProvider(processorSupport);
+        ReferenceIdResolver resolver = extension.newResolver(processorSupport);
+        GraphNodeIterable.builder()
+                .withStartingNodes(repository.getTopLevels())
+                .withKeyFilter((node, key) -> !M3PropertyPaths.BACK_REFERENCE_PROPERTY_PATHS.contains(node.getRealKeyByName(key)))
+                .build()
+                .forEach(instance ->
+                {
+                    if (provider.hasReferenceId(instance))
+                    {
+                        String id = provider.getReferenceId(instance);
+                        CoreInstance resolved = resolver.resolveReference(id);
+                        Assert.assertSame(id, instance, resolved);
+                    }
+                    else if (shouldHaveReferenceId(instance))
+                    {
+                        StringBuilder builder = new StringBuilder();
+                        if (PackageableElement.isPackageableElement(instance, processorSupport))
+                        {
+                            PackageableElement.writeUserPathForPackageableElement(builder, instance);
+                        }
+                        else
+                        {
+                            builder.append(instance);
+                        }
+                        PackageableElement.writeUserPathForPackageableElement(builder.append(" (instance of "), instance.getClassifier());
+                        SourceInformation sourceInfo = instance.getSourceInformation();
+                        if (sourceInfo != null)
+                        {
+                            sourceInfo.appendMessage(builder.append(", at "));
+                        }
+                        builder.append(") should have a reference id but does not");
+                        Assert.fail(builder.toString());
+                    }
+                    else
+                    {
+                        Assert.assertThrows(ReferenceIdProvisionException.class, () -> provider.getReferenceId(instance));
+                    }
+                });
+    }
+
+    private boolean shouldHaveReferenceId(CoreInstance instance)
+    {
+        return (instance.getSourceInformation() == null) ? _Package.isPackage(instance, processorSupport) : !AnyStubHelper.isStub(instance);
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/reference/AbstractReferenceTest.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/reference/AbstractReferenceTest.java
@@ -1,0 +1,360 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference;
+
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PropertyOwner;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Any;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.SimpleFunctionExpression;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
+import org.finos.legend.pure.m3.tools.ListHelper;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+public class AbstractReferenceTest extends AbstractPureTestWithCoreCompiled
+{
+    @BeforeClass
+    public static void setUpRuntime()
+    {
+        setUpRuntime(getFunctionExecution(), new CompositeCodeStorage(new ClassLoaderCodeStorage(getCodeRepositories())), getExtra());
+    }
+
+    protected static RichIterable<? extends CodeRepository> getCodeRepositories()
+    {
+        return Lists.mutable.<CodeRepository>withAll(AbstractPureTestWithCoreCompiled.getCodeRepositories())
+                .with(GenericCodeRepository.build("ref_test", "test(::.*)?", "platform"));
+    }
+
+    public static Pair<String, String> getExtra()
+    {
+        return Tuples.pair(
+                "/ref_test/test.pure",
+                "import test::model::*;\n" +
+                        "\n" +
+                        "Class test::model::SimpleClass\n" +
+                        "{\n" +
+                        "  name : String[1];\n" +
+                        "  id : Integer[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::model::Left\n" +
+                        "{\n" +
+                        "  name : String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::model::Right\n" +
+                        "{\n" +
+                        "  id : Integer[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Association test::model::LeftRight\n" +
+                        "{\n" +
+                        "  toLeft : Left[*];\n" +
+                        "  toLeft(name:String[1])\n" +
+                        "  {\n" +
+                        "    $this.toLeft->filter(l | $l.name == $name)\n" +
+                        "  } : Left[*];\n" +
+                        "  toRight : Right[*];" +
+                        "  toRight(id:Integer[1])\n" +
+                        "  {\n" +
+                        "    $this.toRight->filter(r | $r.id == $id)\n" +
+                        "  } : Right[*];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Profile test::model::SimpleProfile\n" +
+                        "{\n" +
+                        "  stereotypes : [st1, st2];\n" +
+                        "  tags : [t1, t2, t3];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Enum test::model::SimpleEnumeration\n" +
+                        "{\n" +
+                        "  VAL1, VAL2\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::model::BothSides extends Left, Right\n" +
+                        "{\n" +
+                        "  leftCount : Integer[1];\n" +
+                        "  rightCount : Integer[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class <<doc.deprecated>> {doc.doc = 'Deprecated class with annotations'} test::model::ClassWithAnnotations\n" +
+                        "{\n" +
+                        "  <<doc.deprecated>> deprecated : String[0..1];\n" +
+                        "  <<doc.deprecated>> {doc.doc = 'Deprecated: don\\'t use this'} alsoDeprecated : String[0..1];\n" +
+                        "  {doc.doc = 'Time must be specified', doc.todo = 'Change this to DateTime'} date : Date[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::model::ClassWithTypeAndMultParams<T,V|m,n>\n" +
+                        "{\n" +
+                        "  propT : T[m];\n" +
+                        "  propV : V[n];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::model::ClassWithQualifiedProperties\n" +
+                        "{\n" +
+                        "  names : String[*];\n" +
+                        "  title : String[0..1];\n" +
+                        "  firstName()\n" +
+                        "  {\n" +
+                        "    if($this.names->isEmpty(), |'', |$this.names->at(0))\n" +
+                        "  }:String[1];\n" +
+                        "  fullName()\n" +
+                        "  {\n" +
+                        "    $this.fullName(false)\n" +
+                        "  }:String[1];\n" +
+                        "  fullName(withTitle:Boolean[1])\n" +
+                        "  {\n" +
+                        "    let titleString = if($withTitle && !$this.title->isEmpty(), |$this.title->toOne() + ' ', |'');\n" +
+                        "    $this.names->joinStrings($titleString, ' ', '');\n" +
+                        "  }:String[1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class <<temporal.businesstemporal>> test::model::ClassWithMilestoning1\n" +
+                        "{\n" +
+                        "   toClass2:ClassWithMilestoning2[1];\n" +
+                        "   toClass3:ClassWithMilestoning3[*];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class <<temporal.processingtemporal>> test::model::ClassWithMilestoning2\n" +
+                        "{\n" +
+                        "   toClass1:ClassWithMilestoning1[1];\n" +
+                        "   toClass3:ClassWithMilestoning3[*];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class <<temporal.bitemporal>> test::model::ClassWithMilestoning3\n" +
+                        "{\n" +
+                        "   toClass1:ClassWithMilestoning1[0..1];\n" +
+                        "   toClass2:ClassWithMilestoning2[0..1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Association test::model::AssociationWithMilestoning1\n" +
+                        "{\n" +
+                        "   toClass1A:ClassWithMilestoning1[*];\n" +
+                        "   toClass2A:ClassWithMilestoning2[*];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Association test::model::AssociationWithMilestoning2\n" +
+                        "{\n" +
+                        "   toClass1B:ClassWithMilestoning1[*];\n" +
+                        "   toClass3B:ClassWithMilestoning3[*];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Association test::model::AssociationWithMilestoning3\n" +
+                        "{\n" +
+                        "   toClass2C:ClassWithMilestoning2[*];\n" +
+                        "   toClass3C:ClassWithMilestoning3[*];\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test::model::testFunc<T|m>(col:T[m], func:Function<{T[1]->String[1]}>[0..1]):String[m]\n" +
+                        "{\n" +
+                        "  let toStringFunc = if($func->isEmpty(), |{x:T[1] | $x->toString()}, |$func->toOne());\n" +
+                        "  $col->map(x | $toStringFunc->eval($x));\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test::model::testFunc2():String[1]\n" +
+                        "{\n" +
+                        "  let pkg = test::model;\n" +
+                        "  let unit = Mass~Pound;\n" +
+                        "  $pkg->elementToPath() + '::' + $unit.measure.name->toOne() + '~' + $unit.name->toOne();\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test::model::testFunc3():Any[*]\n" +
+                        "{\n" +
+                        "  [test::model, 'a', 1, true, |test::model.children, %2024-11-04]\n" +
+                        "}\n" +
+                        "\n" +
+                        "function test::model::testFunc4(input:ClassWithMilestoning1[1]):ClassWithMilestoning3[*]\n" +
+                        "{\n" +
+                        "  $input.toClass3(%latest, %latest)\n" +
+                        "}\n" +
+                        "\n" +
+                        "Measure test::model::Currency\n" +
+                        "{\n" +
+                        "  USD;\n" +
+                        "  GBP;\n" +
+                        "  EUR;\n" +
+                        "}\n" +
+                        "\n" +
+                        "Measure test::model::Mass\n" +
+                        "{\n" +
+                        "  *Gram: x -> $x;\n" +
+                        "  Kilogram: x -> $x*1000;\n" +
+                        "  Pound: x -> $x*453.59;\n" +
+                        "}\n"
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static <T extends CoreInstance> T getCoreInstance(String path)
+    {
+        CoreInstance instance = runtime.getCoreInstance(path);
+        Assert.assertNotNull(path, instance);
+        return (T) instance;
+    }
+
+    protected static Property<?, ?> findProperty(PropertyOwner owner, String name)
+    {
+        RichIterable<? extends Property<?, ?>> properties = (owner instanceof Class) ? ((Class<?>) owner)._properties() : ((Association) owner)._properties();
+        Property<?, ?> property = properties.detect(p -> name.equals(p._name()));
+        if (property == null)
+        {
+            StringBuilder builder = new StringBuilder("Could not find property '").append(name).append("' for ");
+            PackageableElement.writeUserPathForPackageableElement(builder, owner);
+            if (properties.isEmpty())
+            {
+                builder.append("; no available properties");
+            }
+            else
+            {
+                properties.collect(Property::_name, Lists.mutable.empty()).sortThis().appendString(builder, "; available properties: '", "', '", "'");
+            }
+            Assert.fail(builder.toString());
+        }
+        return property;
+    }
+
+    protected static QualifiedProperty<?> findQualifiedProperty(PropertyOwner owner, String id)
+    {
+        RichIterable<? extends QualifiedProperty<?>> qualifiedProperties = (owner instanceof Class) ? ((Class<?>) owner)._qualifiedProperties() : ((Association) owner)._qualifiedProperties();
+        QualifiedProperty<?> qualifiedProperty = qualifiedProperties.detect(qp -> id.equals(qp._id()));
+        if (qualifiedProperty == null)
+        {
+            StringBuilder builder = new StringBuilder("Could not find qualified property '").append(id).append("' for ");
+            PackageableElement.writeUserPathForPackageableElement(builder, owner);
+            if (qualifiedProperties.isEmpty())
+            {
+                builder.append("; no available qualified properties");
+            }
+            else
+            {
+                qualifiedProperties.collect(QualifiedProperty::_id, Lists.mutable.empty()).sortThis().appendString(builder, "; available qualified properties: '", "', '", "'");
+            }
+            Assert.fail(builder.toString());
+        }
+        return qualifiedProperty;
+    }
+
+    protected static VariableExpression funcTypeParam(CoreInstance functionType, String paramName)
+    {
+        return funcTypeParam((FunctionType) functionType, paramName);
+    }
+
+    protected static VariableExpression funcTypeParam(FunctionType functionType, String paramName)
+    {
+        VariableExpression param = functionType._parameters().detect(p -> paramName.equals(p._name()));
+        if (param == null)
+        {
+            StringBuilder builder = new StringBuilder("Could not find parameter '").append(paramName).append("' in FunctionType: ");
+            org.finos.legend.pure.m3.navigation.function.FunctionType.print(builder, functionType, true, processorSupport);
+            SourceInformation sourceInfo = functionType.getSourceInformation();
+            if (sourceInfo != null)
+            {
+                sourceInfo.appendMessage(builder.append(" at "));
+            }
+            Assert.fail(builder.toString());
+        }
+        return param;
+    }
+
+    protected static GenericType funcTypeRetType(CoreInstance functionType)
+    {
+        return funcTypeRetType((FunctionType) functionType);
+    }
+
+    protected static GenericType funcTypeRetType(FunctionType functionType)
+    {
+        GenericType retType = functionType._returnType();
+        if (retType == null)
+        {
+            StringBuilder builder = new StringBuilder("Could not find return type in FunctionType: ");
+            org.finos.legend.pure.m3.navigation.function.FunctionType.print(builder, functionType, true, processorSupport);
+            SourceInformation sourceInfo = functionType.getSourceInformation();
+            if (sourceInfo != null)
+            {
+                sourceInfo.appendMessage(builder.append(" at "));
+            }
+            Assert.fail(builder.toString());
+        }
+        return retType;
+    }
+
+    protected static GenericType typeArgument(GenericType genericType, int index)
+    {
+        return at(genericType._typeArguments(), index);
+    }
+
+    protected static ValueSpecification exprSeq(CoreInstance func, int index)
+    {
+        return exprSeq((FunctionDefinition<?>) func, index);
+    }
+
+    protected static ValueSpecification exprSeq(FunctionDefinition<?> func, int index)
+    {
+        return at(func._expressionSequence(), index);
+    }
+
+    protected static ValueSpecification paramValue(CoreInstance funcExpr, int index)
+    {
+        return paramValue((SimpleFunctionExpression) funcExpr, index);
+    }
+
+    protected static ValueSpecification paramValue(SimpleFunctionExpression funcExpr, int index)
+    {
+        return at(funcExpr._parametersValues(), index);
+    }
+
+    protected static <T extends Any> T instanceValueValue(CoreInstance instanceValue, int index)
+    {
+        return instanceValueValue((InstanceValue) instanceValue, index);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static <T extends Any> T instanceValueValue(InstanceValue instanceValue, int index)
+    {
+        return (T) at(instanceValue._valuesCoreInstance(), index);
+    }
+
+    protected static <T> ListIterable<T> toList(Iterable<T> iterable)
+    {
+        return ListHelper.wrapListIterable(iterable);
+    }
+
+    protected static <T> T at(RichIterable<? extends T> iterable, int index)
+    {
+        return toList(iterable).get(index);
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/TestContainingElementIndex.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/TestContainingElementIndex.java
@@ -1,0 +1,376 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference.v1;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.pure.m3.coreinstance.Package;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation._package._Package;
+import org.finos.legend.pure.m3.navigation.function.FunctionType;
+import org.finos.legend.pure.m3.navigation.generictype.GenericType;
+import org.finos.legend.pure.m3.navigation.importstub.ImportStub;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
+import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
+import org.finos.legend.pure.m3.serialization.compiler.reference.AbstractReferenceTest;
+import org.finos.legend.pure.m3.tools.PackageableElementIterable;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+import org.finos.legend.pure.m4.tools.GraphNodeIterable;
+import org.finos.legend.pure.m4.tools.GraphWalkFilterResult;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestContainingElementIndex extends AbstractReferenceTest
+{
+    private static ContainingElementIndex index;
+
+    @BeforeClass
+    public static void setUpIndex()
+    {
+        index = ContainingElementIndex.builder(processorSupport).withAllElements().build();
+    }
+
+    @Test
+    public void testVirtualPackage()
+    {
+        Package testModel = getCoreInstance("test::model");
+        assertContainingInstance(testModel, testModel);
+    }
+
+    @Test
+    public void testConcretePackage()
+    {
+        Package root = getCoreInstance("Root");
+        assertContainingInstance(root, root);
+    }
+
+    @Test
+    public void testSimpleClass()
+    {
+        testInstance("test::model::SimpleClass");
+    }
+
+    @Test
+    public void testLeftClass()
+    {
+        Class<?> leftClass = testInstance("test::model::Left");
+        assertContainingInstance(getCoreInstance("test::model::LeftRight"), leftClass._propertiesFromAssociations().getOnly());
+    }
+
+    @Test
+    public void testRightClass()
+    {
+        Class<?> rightClass = testInstance("test::model::Right");
+        assertContainingInstance(getCoreInstance("test::model::LeftRight"), rightClass._propertiesFromAssociations().getOnly());
+    }
+
+    @Test
+    public void testLeftRightAssociation()
+    {
+        Association leftRight = testInstance("test::model::LeftRight");
+        assertContainingInstance(leftRight, leftRight._properties().getFirst());
+        assertContainingInstance(leftRight, leftRight._properties().getLast());
+    }
+
+    @Test
+    public void testSimpleProfile()
+    {
+        testInstance("test::model::SimpleProfile");
+    }
+
+    @Test
+    public void testSimpleEnumeration()
+    {
+        testInstance("test::model::SimpleEnumeration");
+    }
+
+    @Test
+    public void testBothSidesClass()
+    {
+        testInstance("test::model::BothSides");
+    }
+
+    @Test
+    public void testClassWithAnnotations()
+    {
+        testInstance("test::model::ClassWithAnnotations");
+    }
+
+    @Test
+    public void testClassWithTypeAndMultParams()
+    {
+        testInstance("test::model::ClassWithTypeAndMultParams");
+    }
+
+    @Test
+    public void testClassWithQualifiedProperties()
+    {
+        testInstance("test::model::ClassWithQualifiedProperties");
+    }
+
+    @Test
+    public void testClassWithMilestoning1()
+    {
+        testInstance("test::model::ClassWithMilestoning1");
+    }
+
+    @Test
+    public void testClassWithMilestoning2()
+    {
+        testInstance("test::model::ClassWithMilestoning2");
+    }
+
+    @Test
+    public void testClassWithMilestoning3()
+    {
+        testInstance("test::model::ClassWithMilestoning2");
+    }
+
+    @Test
+    public void testAssociationWithMilestoning1()
+    {
+        testInstance("test::model::AssociationWithMilestoning1");
+    }
+
+    @Test
+    public void testAssociationWithMilestoning2()
+    {
+        testInstance("test::model::AssociationWithMilestoning2");
+    }
+
+    @Test
+    public void testAssociationWithMilestoning3()
+    {
+        testInstance("test::model::AssociationWithMilestoning3");
+    }
+
+    @Test
+    public void testTestFunc()
+    {
+        testInstance("test::model::testFunc_T_m__Function_$0_1$__String_m_");
+    }
+
+    @Test
+    public void testTopLevelsAndPackaged()
+    {
+        PackageableElementIterable.fromProcessorSupport(processorSupport).forEach(this::testInstance);
+    }
+
+    @Test
+    public void testAllInstances()
+    {
+        MutableList<Pair<CoreInstance, CoreInstance>> shouldBeNull = Lists.mutable.empty();
+        MutableList<CoreInstance> shouldBeNonNull = Lists.mutable.empty();
+        GraphNodeIterable.fromModelRepository(repository).forEach(instance ->
+        {
+            CoreInstance containing = index.findContainingElement(instance);
+            SourceInformation sourceInfo = instance.getSourceInformation();
+            if ((sourceInfo != null) || _Package.isPackage(instance, processorSupport))
+            {
+                if (containing == null)
+                {
+                    shouldBeNonNull.add(instance);
+                }
+            }
+            else if (containing != null)
+            {
+                shouldBeNull.add(Tuples.pair(instance, containing));
+            }
+        });
+        if (shouldBeNull.notEmpty() || shouldBeNonNull.notEmpty())
+        {
+            StringBuilder builder = new StringBuilder();
+            if (shouldBeNull.notEmpty())
+            {
+                builder.append("There were ").append(shouldBeNull.size()).append(" instances that should not have a containing element but did:");
+                shouldBeNull.forEach(pair ->
+                {
+                    appendInstanceDescriptionForFailureMessage(builder.append("\n\tinstance: "), pair.getOne());
+                    appendInstanceDescriptionForFailureMessage(builder.append("\n\t\tfound containing element: "), pair.getTwo());
+                });
+            }
+            if (shouldBeNonNull.notEmpty())
+            {
+                MutableMap<String, MutableList<CoreInstance>> bySource = Maps.mutable.empty();
+                shouldBeNonNull.forEach(i -> bySource.getIfAbsentPut(i.getSourceInformation().getSourceId(), Lists.mutable::empty).add(i));
+                builder.append("There were ").append(shouldBeNonNull.size()).append(" instances in ").append(bySource.size()).append(" sources that should have a containing element but did not:");
+                bySource.keyValuesView().toSortedListBy(Pair::getOne).forEach(bySourcePair ->
+                {
+                    MutableList<CoreInstance> instances = bySourcePair.getTwo();
+                    builder.append("\n\t").append(bySourcePair.getOne()).append(" (").append(instances.size()).append(')');
+                    if (instances.size() <= 10)
+                    {
+                        instances.sortThisBy(CoreInstance::getSourceInformation)
+                                .forEach(i ->
+                                {
+                                    appendInstanceForFailureMessage(builder.append("\n\t\t"), i);
+                                    appendClassifierForFailureMessage(builder.append(" ("), i);
+                                    i.getSourceInformation().appendIntervalMessage(builder.append(", ")).append(')');
+                                });
+                    }
+                    else
+                    {
+                        MutableMap<CoreInstance, MutableList<CoreInstance>> byClassifier = Maps.mutable.empty();
+                        instances.forEach(i -> byClassifier.getIfAbsentPut(i.getClassifier(), Lists.mutable::empty).add(i));
+                        byClassifier.keyValuesView()
+                                .collect(p -> Tuples.pair(PackageableElement.getUserPathForPackageableElement(p.getOne()), p.getTwo()), Lists.mutable.ofInitialCapacity(byClassifier.size()))
+                                .sortThisBy(Pair::getOne)
+                                .forEach(byClassifierPair ->
+                                {
+                                    MutableList<CoreInstance> classifierInstances = byClassifierPair.getTwo();
+                                    builder.append("\n\t\tclassifier: ").append(byClassifierPair.getOne()).append(" (").append(classifierInstances.size()).append(')');
+                                    classifierInstances.sortThisBy(CoreInstance::getSourceInformation)
+                                            .forEach(i ->
+                                            {
+                                                appendInstanceForFailureMessage(builder.append("\n\t\t\t"), i);
+                                                i.getSourceInformation().appendIntervalMessage(builder.append(" (")).append(')');
+                                            });
+                                });
+                    }
+                });
+            }
+            Assert.fail(builder.toString());
+        }
+    }
+
+    private <T extends CoreInstance> T testInstance(String path)
+    {
+        T instance = getCoreInstance(path);
+        testInstance(instance);
+        return instance;
+    }
+
+    private void testInstance(CoreInstance instance)
+    {
+        SourceInformation sourceInfo = instance.getSourceInformation();
+        GraphNodeIterable.builder()
+                .withStartingNode(instance)
+                .withNodeFilter(node ->
+                {
+                    SourceInformation nodeSourceInfo = node.getSourceInformation();
+                    if (nodeSourceInfo == null)
+                    {
+                        return GraphWalkFilterResult.get(false, !_Package.isPackage(node, processorSupport));
+                    }
+                    if (sourceInfo.subsumes(nodeSourceInfo))
+                    {
+                        return GraphWalkFilterResult.ACCEPT_AND_CONTINUE;
+                    }
+                    return GraphWalkFilterResult.REJECT_AND_STOP;
+                })
+                .build()
+                .forEach(node -> assertContainingInstance(instance, node));
+    }
+
+    private void assertContainingInstance(CoreInstance expected, CoreInstance instance)
+    {
+        CoreInstance actual = index.findContainingElement(instance);
+        if (expected != actual)
+        {
+            Assert.assertSame(getFailureMessage(instance, expected, actual), expected, actual);
+        }
+    }
+
+    private String getFailureMessage(CoreInstance instance, CoreInstance expected, CoreInstance actual)
+    {
+        StringBuilder builder = new StringBuilder("input instance: ");
+        appendInstanceDescriptionForFailureMessage(builder, instance);
+        appendInstanceDescriptionForFailureMessage(builder.append(", expected: "), expected);
+        appendInstanceDescriptionForFailureMessage(builder.append(", actual: "), actual);
+        return builder.toString();
+    }
+
+    private StringBuilder appendInstanceDescriptionForFailureMessage(StringBuilder builder, CoreInstance instance)
+    {
+        appendInstanceForFailureMessage(builder, instance);
+        if (instance != null)
+        {
+            appendClassifierForFailureMessage(builder.append(" ("), instance);
+
+            SourceInformation sourceInfo = instance.getSourceInformation();
+            if (sourceInfo != null)
+            {
+                sourceInfo.appendMessage(builder.append(", "));
+            }
+            builder.append(')');
+        }
+        return builder;
+    }
+
+    private StringBuilder appendInstanceForFailureMessage(StringBuilder builder, CoreInstance instance)
+    {
+        if (instance instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement)
+        {
+            return PackageableElement.writeUserPathForPackageableElement(builder, instance);
+        }
+        if (instance instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType)
+        {
+            return GenericType.print(builder, instance, true, processorSupport);
+        }
+        if (instance instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity)
+        {
+            return Multiplicity.print(builder, instance, true);
+        }
+        if (instance instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType)
+        {
+            return FunctionType.print(builder, instance, true, processorSupport);
+        }
+        if (instance instanceof Unit)
+        {
+            return Measure.printUnit(builder, instance, true);
+        }
+        if (instance instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel._import.ImportStub)
+        {
+            return ImportStub.writeImportStubInfo(builder, instance);
+        }
+        if (instance instanceof VariableExpression)
+        {
+            VariableExpression var = (VariableExpression) instance;
+            builder.append('$').append(var._name()).append(':');
+            GenericType.print(builder, var._genericType(), true, processorSupport);
+            Multiplicity.print(builder, var._multiplicity(), true);
+            return builder;
+        }
+        if (instance instanceof ValueSpecification)
+        {
+            ValueSpecification valueSpec = (ValueSpecification) instance;
+            builder.append('<').append(instance).append(">:");
+            GenericType.print(builder, valueSpec._genericType(), true, processorSupport);
+            Multiplicity.print(builder, valueSpec._multiplicity(), true);
+            return builder;
+        }
+        return builder.append(instance);
+    }
+
+    private StringBuilder appendClassifierForFailureMessage(StringBuilder builder, CoreInstance instance)
+    {
+        CoreInstance classifier = instance.getClassifier();
+        return (classifier == null) ?
+               builder.append("<null classifier>") :
+               PackageableElement.writeUserPathForPackageableElement(builder, classifier);
+    }
+
+}

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/TestReferenceIdExtensionV1.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/TestReferenceIdExtensionV1.java
@@ -1,0 +1,27 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference.v1;
+
+import org.finos.legend.pure.m3.serialization.compiler.reference.AbstractReferenceIdExtensionTest;
+import org.junit.BeforeClass;
+
+public class TestReferenceIdExtensionV1 extends AbstractReferenceIdExtensionTest
+{
+    @BeforeClass
+    public static void setUpExtension()
+    {
+        extension = new ReferenceIdExtensionV1();
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/TestReferenceIdGenerator.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/TestReferenceIdGenerator.java
@@ -1,0 +1,5363 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.reference.v1;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MapIterable;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.Counter;
+import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.pure.m3.coreinstance.Package;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.NativeFunction;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.Property;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.property.QualifiedProperty;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.SimpleFunctionExpression;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation._package._Package;
+import org.finos.legend.pure.m3.serialization.compiler.reference.AbstractReferenceTest;
+import org.finos.legend.pure.m3.tools.PackageableElementIterable;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestReferenceIdGenerator extends AbstractReferenceTest
+{
+    private static ReferenceIdGenerator idGenerator;
+
+    @BeforeClass
+    public static void setUpIdGenerator()
+    {
+        idGenerator = new ReferenceIdGenerator(processorSupport);
+    }
+
+    @Test
+    public void testTopLevelAndPackaged()
+    {
+        PackageableElementIterable.fromProcessorSupport(processorSupport).forEach(this::assertIds);
+    }
+
+    @Test
+    public void testVirtualPackages()
+    {
+        String testPath = "test";
+        org.finos.legend.pure.m3.coreinstance.Package testPackage = getCoreInstance(testPath);
+        Assert.assertNull(testPackage.getSourceInformation());
+        assertIds(testPath, Maps.immutable.with(testPath, testPackage));
+
+        String testModelPath = "test::model";
+        Package testModelPackage = getCoreInstance(testModelPath);
+        Assert.assertNull(testModelPackage.getSourceInformation());
+        assertIds(testModelPath, Maps.immutable.with(testModelPath, testModelPackage));
+    }
+
+    @Test
+    public void testSimpleClass()
+    {
+        String path = "test::model::SimpleClass";
+        Class<?> simpleClass = getCoreInstance(path);
+        Property<?, ?> name = findProperty(simpleClass, "name");
+        Property<?, ?> id = findProperty(simpleClass, "id");
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, simpleClass)
+                .withKeyValue(path + ".classifierGenericType", simpleClass._classifierGenericType())
+                .withKeyValue(path + ".generalizations[0]", at(simpleClass._generalizations(), 0))
+                .withKeyValue(path + ".generalizations[0].general", at(simpleClass._generalizations(), 0)._general())
+                .withKeyValue(path + ".properties['name']", name)
+                .withKeyValue(path + ".properties['name'].classifierGenericType", name._classifierGenericType())
+                .withKeyValue(path + ".properties['name'].classifierGenericType.typeArguments[0]", typeArgument(name._classifierGenericType(), 0))
+                .withKeyValue(path + ".properties['name'].classifierGenericType.typeArguments[1]", typeArgument(name._classifierGenericType(), 1))
+                .withKeyValue(path + ".properties['name'].genericType", name._genericType())
+                .withKeyValue(path + ".properties['id']", id)
+                .withKeyValue(path + ".properties['id'].classifierGenericType", id._classifierGenericType())
+                .withKeyValue(path + ".properties['id'].classifierGenericType.typeArguments[0]", typeArgument(id._classifierGenericType(), 0))
+                .withKeyValue(path + ".properties['id'].classifierGenericType.typeArguments[1]", typeArgument(id._classifierGenericType(), 1))
+                .withKeyValue(path + ".properties['id'].genericType", id._genericType());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testEnumeration()
+    {
+        String path = "test::model::SimpleEnumeration";
+        Enumeration<? extends Enum> testEnumeration = getCoreInstance(path);
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, testEnumeration)
+                .withKeyValue(path + ".classifierGenericType", testEnumeration._classifierGenericType())
+                .withKeyValue(path + ".classifierGenericType.typeArguments[0]", typeArgument(testEnumeration._classifierGenericType(), 0))
+                .withKeyValue(path + ".generalizations[0]", at(testEnumeration._generalizations(), 0))
+                .withKeyValue(path + ".generalizations[0].general", at(testEnumeration._generalizations(), 0)._general())
+                .withKeyValue(path + ".values['VAL1']", at(testEnumeration._values(), 0))
+                .withKeyValue(path + ".values['VAL2']", at(testEnumeration._values(), 1));
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testAssociation()
+    {
+        String path = "test::model::LeftRight";
+        Association leftRight = getCoreInstance(path);
+
+        MutableMap<String, Object> expectedLR = Maps.mutable.<String, Object>with(path, leftRight)
+                .withKeyValue(path + ".classifierGenericType", leftRight._classifierGenericType());
+
+        Property<?, ?> toLeft = findProperty(leftRight, "toLeft");
+        expectedLR.put(path + ".properties['toLeft']", toLeft);
+        expectedLR.put(path + ".properties['toLeft'].classifierGenericType", toLeft._classifierGenericType());
+        expectedLR.put(path + ".properties['toLeft'].classifierGenericType.typeArguments[0]", typeArgument(toLeft._classifierGenericType(), 0));
+        expectedLR.put(path + ".properties['toLeft'].classifierGenericType.typeArguments[1]", typeArgument(toLeft._classifierGenericType(), 1));
+        expectedLR.put(path + ".properties['toLeft'].genericType", toLeft._genericType());
+
+        Property<?, ?> toRight = findProperty(leftRight, "toRight");
+        expectedLR.put(path + ".properties['toRight']", toRight);
+        expectedLR.put(path + ".properties['toRight'].classifierGenericType", toRight._classifierGenericType());
+        expectedLR.put(path + ".properties['toRight'].classifierGenericType.typeArguments[0]", typeArgument(toRight._classifierGenericType(), 0));
+        expectedLR.put(path + ".properties['toRight'].classifierGenericType.typeArguments[1]", typeArgument(toRight._classifierGenericType(), 1));
+        expectedLR.put(path + ".properties['toRight'].genericType", toRight._genericType());
+
+        QualifiedProperty<?> toLeftByName = findQualifiedProperty(leftRight, "toLeft(String[1])");
+        expectedLR.put(path + ".qualifiedProperties[id='toLeft(String[1])']", toLeftByName);
+        expectedLR.put(path + ".qualifiedProperties[id='toLeft(String[1])'].classifierGenericType", toLeftByName._classifierGenericType());
+        expectedLR.put(path + ".qualifiedProperties[id='toLeft(String[1])'].classifierGenericType.typeArguments[0]", typeArgument(toLeftByName._classifierGenericType(), 0));
+        expectedLR.put(path + ".qualifiedProperties[id='toLeft(String[1])'].classifierGenericType.typeArguments[0].rawType", typeArgument(toLeftByName._classifierGenericType(), 0)._rawType());
+//        expectedLR.put(
+//                path + ".qualifiedProperties[id='toLeft(String[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this']",
+//                findFuncTypeParam(typeArgument(toLeftByName._classifierGenericType(), 0)._rawType(), "this"));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toLeftByName._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].classifierGenericType.typeArguments[0].rawType.parameters['name']",
+                funcTypeParam(typeArgument(toLeftByName._classifierGenericType(), 0)._rawType(), "name"));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].classifierGenericType.typeArguments[0].rawType.parameters['name'].genericType",
+                funcTypeParam(typeArgument(toLeftByName._classifierGenericType(), 0)._rawType(), "name")._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toLeftByName._classifierGenericType(), 0)._rawType()));
+        expectedLR.put(path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0]", exprSeq(toLeftByName, 0));
+        expectedLR.put(path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].genericType", exprSeq(toLeftByName, 0)._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toLeftByName, 0), 0));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toLeftByName, 0), 0)._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toLeftByName, 0), 0))._parametersValues().getOnly());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toLeftByName, 0), 0))._parametersValues().getOnly()._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toLeftByName, 0), 0))._propertyName());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toLeftByName, 0), 1));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toLeftByName, 0), 1)._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(exprSeq(toLeftByName, 0), 1)._genericType(), 0));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(exprSeq(toLeftByName, 0), 1)._genericType(), 0)._rawType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['l']",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toLeftByName, 0), 1)._genericType(), 0)._rawType(), "l"));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['l'].genericType",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toLeftByName, 0), 1)._genericType(), 0)._rawType(), "l")._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(exprSeq(toLeftByName, 0), 1)._genericType(), 0)._rawType()));
+        LambdaFunction<?> nameFilterLambda = instanceValueValue(paramValue(exprSeq(toLeftByName, 0), 1), 0);
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                nameFilterLambda);
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                nameFilterLambda._classifierGenericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(nameFilterLambda._classifierGenericType(), 0));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(nameFilterLambda._classifierGenericType(), 0)._rawType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['l']",
+                funcTypeParam(typeArgument(nameFilterLambda._classifierGenericType(), 0)._rawType(), "l"));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['l'].genericType",
+                funcTypeParam(typeArgument(nameFilterLambda._classifierGenericType(), 0)._rawType(), "l")._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(nameFilterLambda._classifierGenericType(), 0)._rawType()));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                nameFilterLambda._expressionSequence().getOnly());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                nameFilterLambda._expressionSequence().getOnly()._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(nameFilterLambda, 0), 0));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(nameFilterLambda, 0), 0)._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                ((SimpleFunctionExpression) paramValue(exprSeq(nameFilterLambda, 0), 0))._parametersValues().getOnly());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) paramValue(exprSeq(nameFilterLambda, 0), 0))._parametersValues().getOnly()._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(nameFilterLambda, 0), 0))._propertyName());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(nameFilterLambda, 0), 1));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toLeft(String[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(nameFilterLambda, 0), 1)._genericType());
+        expectedLR.put(path + ".qualifiedProperties[id='toLeft(String[1])'].genericType", toLeftByName._genericType());
+
+        QualifiedProperty<?> toRightById = findQualifiedProperty(leftRight, "toRight(Integer[1])");
+        expectedLR.put(path + ".qualifiedProperties[id='toRight(Integer[1])']", toRightById);
+        expectedLR.put(path + ".qualifiedProperties[id='toRight(Integer[1])'].classifierGenericType", toRightById._classifierGenericType());
+        expectedLR.put(path + ".qualifiedProperties[id='toRight(Integer[1])'].classifierGenericType.typeArguments[0]", typeArgument(toRightById._classifierGenericType(), 0));
+        expectedLR.put(path + ".qualifiedProperties[id='toRight(Integer[1])'].classifierGenericType.typeArguments[0].rawType", typeArgument(toRightById._classifierGenericType(), 0)._rawType());
+//        expectedLR.put(
+//                path + ".qualifiedProperties[id='toRight(Integer[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this']",
+//                findFuncTypeParam(typeArgument(toRightById._classifierGenericType(), 0)._rawType(), "this"));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toRightById._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].classifierGenericType.typeArguments[0].rawType.parameters['id']",
+                funcTypeParam(typeArgument(toRightById._classifierGenericType(), 0)._rawType(), "id"));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].classifierGenericType.typeArguments[0].rawType.parameters['id'].genericType",
+                funcTypeParam(typeArgument(toRightById._classifierGenericType(), 0)._rawType(), "id")._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toRightById._classifierGenericType(), 0)._rawType()));
+        expectedLR.put(path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0]", exprSeq(toRightById, 0));
+        expectedLR.put(path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].genericType", exprSeq(toRightById, 0)._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toRightById, 0), 0));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toRightById, 0), 0)._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toRightById, 0), 0))._parametersValues().getOnly());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toRightById, 0), 0))._parametersValues().getOnly()._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toRightById, 0), 0))._propertyName());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toRightById, 0), 1));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toRightById, 0), 1)._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(exprSeq(toRightById, 0), 1)._genericType(), 0));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(exprSeq(toRightById, 0), 1)._genericType(), 0)._rawType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['r']",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toRightById, 0), 1)._genericType(), 0)._rawType(), "r"));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['r'].genericType",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toRightById, 0), 1)._genericType(), 0)._rawType(), "r")._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(exprSeq(toRightById, 0), 1)._genericType(), 0)._rawType()));
+        LambdaFunction<?> idFilterLambda = (LambdaFunction<?>) ((InstanceValue) paramValue(exprSeq(toRightById, 0), 1))._values().getOnly();
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                idFilterLambda);
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                idFilterLambda._classifierGenericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(idFilterLambda._classifierGenericType(), 0));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(idFilterLambda._classifierGenericType(), 0)._rawType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['r']",
+                funcTypeParam(typeArgument(idFilterLambda._classifierGenericType(), 0)._rawType(), "r"));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['r'].genericType",
+                funcTypeParam(typeArgument(idFilterLambda._classifierGenericType(), 0)._rawType(), "r")._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(idFilterLambda._classifierGenericType(), 0)._rawType()));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(idFilterLambda, 0));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(idFilterLambda, 0)._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(idFilterLambda, 0), 0));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(idFilterLambda, 0), 0)._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                ((SimpleFunctionExpression) paramValue(exprSeq(idFilterLambda, 0), 0))._parametersValues().getOnly());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) paramValue(exprSeq(idFilterLambda, 0), 0))._parametersValues().getOnly()._genericType());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(idFilterLambda, 0), 0))._propertyName());
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(idFilterLambda, 0), 1));
+        expectedLR.put(
+                path + ".qualifiedProperties[id='toRight(Integer[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(idFilterLambda, 0), 1)._genericType());
+        expectedLR.put(path + ".qualifiedProperties[id='toRight(Integer[1])'].genericType", toRightById._genericType());
+
+        assertIds(path, expectedLR);
+
+        String leftPath = "test::model::Left";
+        Class<?> left = getCoreInstance(leftPath);
+        Property<?, ?> leftName = findProperty(left, "name");
+        MutableMap<String, CoreInstance> expectedL = Maps.mutable.<String, CoreInstance>with(leftPath, left)
+                .withKeyValue(leftPath + ".classifierGenericType", left._classifierGenericType())
+                .withKeyValue(leftPath + ".generalizations[0]", left._generalizations().getOnly())
+                .withKeyValue(leftPath + ".generalizations[0].general", left._generalizations().getOnly()._general())
+                .withKeyValue(leftPath + ".properties['name']", leftName)
+                .withKeyValue(leftPath + ".properties['name'].classifierGenericType", leftName._classifierGenericType())
+                .withKeyValue(leftPath + ".properties['name'].classifierGenericType.typeArguments[0]", typeArgument(leftName._classifierGenericType(), 0))
+                .withKeyValue(leftPath + ".properties['name'].classifierGenericType.typeArguments[1]", typeArgument(leftName._classifierGenericType(), 1))
+                .withKeyValue(leftPath + ".properties['name'].genericType", leftName._genericType());
+        assertIds(leftPath, expectedL);
+
+        String rightPath = "test::model::Right";
+        Class<?> right = getCoreInstance(rightPath);
+        Property<?, ?> rightId = findProperty(right, "id");
+        MutableMap<String, CoreInstance> expectedR = Maps.mutable.<String, CoreInstance>with(rightPath, right)
+                .withKeyValue(rightPath + ".classifierGenericType", right._classifierGenericType())
+                .withKeyValue(rightPath + ".generalizations[0]", right._generalizations().getOnly())
+                .withKeyValue(rightPath + ".generalizations[0].general", right._generalizations().getOnly()._general())
+                .withKeyValue(rightPath + ".properties['id']", rightId)
+                .withKeyValue(rightPath + ".properties['id'].classifierGenericType", rightId._classifierGenericType())
+                .withKeyValue(rightPath + ".properties['id'].classifierGenericType.typeArguments[0]", typeArgument(rightId._classifierGenericType(), 0))
+                .withKeyValue(rightPath + ".properties['id'].classifierGenericType.typeArguments[1]", typeArgument(rightId._classifierGenericType(), 1))
+                .withKeyValue(rightPath + ".properties['id'].genericType", rightId._genericType());
+        assertIds(rightPath, expectedR);
+    }
+
+    @Test
+    public void testSimpleProfile()
+    {
+        String path = "test::model::SimpleProfile";
+        Profile testProfile = getCoreInstance(path);
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, testProfile)
+                .withKeyValue(path + ".classifierGenericType", testProfile._classifierGenericType())
+                .withKeyValue(path + ".p_stereotypes[value='st1']", at(testProfile._p_stereotypes(), 0))
+                .withKeyValue(path + ".p_stereotypes[value='st2']", at(testProfile._p_stereotypes(), 1))
+                .withKeyValue(path + ".p_tags[value='t1']", at(testProfile._p_tags(), 0))
+                .withKeyValue(path + ".p_tags[value='t2']", at(testProfile._p_tags(), 1))
+                .withKeyValue(path + ".p_tags[value='t3']", at(testProfile._p_tags(), 2));
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testClassWithGeneralizations()
+    {
+        String path = "test::model::BothSides";
+        Class<?> bothSides = getCoreInstance(path);
+        Property<?, ?> leftCount = findProperty(bothSides, "leftCount");
+        Property<?, ?> rightCount = findProperty(bothSides, "rightCount");
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, bothSides)
+                .withKeyValue(path + ".classifierGenericType", bothSides._classifierGenericType())
+                .withKeyValue(path + ".generalizations[0]", at(bothSides._generalizations(), 0))
+                .withKeyValue(path + ".generalizations[0].general", at(bothSides._generalizations(), 0)._general())
+                .withKeyValue(path + ".generalizations[1]", at(bothSides._generalizations(), 1))
+                .withKeyValue(path + ".generalizations[1].general", at(bothSides._generalizations(), 1)._general())
+                .withKeyValue(path + ".properties['leftCount']", leftCount)
+                .withKeyValue(path + ".properties['leftCount'].classifierGenericType", leftCount._classifierGenericType())
+                .withKeyValue(path + ".properties['leftCount'].classifierGenericType.typeArguments[0]", typeArgument(leftCount._classifierGenericType(), 0))
+                .withKeyValue(path + ".properties['leftCount'].classifierGenericType.typeArguments[1]", typeArgument(leftCount._classifierGenericType(), 1))
+                .withKeyValue(path + ".properties['leftCount'].genericType", leftCount._genericType())
+                .withKeyValue(path + ".properties['rightCount']", rightCount)
+                .withKeyValue(path + ".properties['rightCount'].classifierGenericType", rightCount._classifierGenericType())
+                .withKeyValue(path + ".properties['rightCount'].classifierGenericType.typeArguments[0]", typeArgument(rightCount._classifierGenericType(), 0))
+                .withKeyValue(path + ".properties['rightCount'].classifierGenericType.typeArguments[1]", typeArgument(rightCount._classifierGenericType(), 1))
+                .withKeyValue(path + ".properties['rightCount'].genericType", rightCount._genericType());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testClassWithAnnotations()
+    {
+        String path = "test::model::ClassWithAnnotations";
+        Class<?> classWithAnnotations = getCoreInstance(path);
+        Property<?, ?> deprecated = findProperty(classWithAnnotations, "deprecated");
+        Property<?, ?> alsoDeprecated = findProperty(classWithAnnotations, "alsoDeprecated");
+        Property<?, ?> date = findProperty(classWithAnnotations, "date");
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, classWithAnnotations)
+                .withKeyValue(path + ".classifierGenericType", classWithAnnotations._classifierGenericType())
+                .withKeyValue(path + ".generalizations[0]", at(classWithAnnotations._generalizations(), 0))
+                .withKeyValue(path + ".generalizations[0].general", at(classWithAnnotations._generalizations(), 0)._general())
+                .withKeyValue(path + ".taggedValues[0]", at(classWithAnnotations._taggedValues(), 0))
+                .withKeyValue(path + ".properties['deprecated']", deprecated)
+                .withKeyValue(path + ".properties['deprecated'].classifierGenericType", deprecated._classifierGenericType())
+                .withKeyValue(path + ".properties['deprecated'].classifierGenericType.typeArguments[0]", typeArgument(deprecated._classifierGenericType(), 0))
+                .withKeyValue(path + ".properties['deprecated'].classifierGenericType.typeArguments[1]", typeArgument(deprecated._classifierGenericType(), 1))
+                .withKeyValue(path + ".properties['deprecated'].genericType", deprecated._genericType())
+                .withKeyValue(path + ".properties['alsoDeprecated']", alsoDeprecated)
+                .withKeyValue(path + ".properties['alsoDeprecated'].classifierGenericType", alsoDeprecated._classifierGenericType())
+                .withKeyValue(path + ".properties['alsoDeprecated'].classifierGenericType.typeArguments[0]", typeArgument(alsoDeprecated._classifierGenericType(), 0))
+                .withKeyValue(path + ".properties['alsoDeprecated'].classifierGenericType.typeArguments[1]", typeArgument(alsoDeprecated._classifierGenericType(), 1))
+                .withKeyValue(path + ".properties['alsoDeprecated'].genericType", alsoDeprecated._genericType())
+                .withKeyValue(path + ".properties['alsoDeprecated'].taggedValues[0]", alsoDeprecated._taggedValues().getOnly())
+                .withKeyValue(path + ".properties['date']", date)
+                .withKeyValue(path + ".properties['date'].classifierGenericType", date._classifierGenericType())
+                .withKeyValue(path + ".properties['date'].classifierGenericType.typeArguments[0]", typeArgument(date._classifierGenericType(), 0))
+                .withKeyValue(path + ".properties['date'].classifierGenericType.typeArguments[1]", typeArgument(date._classifierGenericType(), 1))
+                .withKeyValue(path + ".properties['date'].genericType", date._genericType())
+                .withKeyValue(path + ".properties['date'].taggedValues[0]", at(date._taggedValues(), 0))
+                .withKeyValue(path + ".properties['date'].taggedValues[1]", at(date._taggedValues(), 1));
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testClassWithTypeAndMultiplicityParameters()
+    {
+        String path = "test::model::ClassWithTypeAndMultParams";
+        Class<?> classWithTypeMultParams = getCoreInstance(path);
+        ListIterable<? extends Property<?, ?>> properties = toList(classWithTypeMultParams._properties());
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, classWithTypeMultParams)
+                .withKeyValue(path + ".classifierGenericType", classWithTypeMultParams._classifierGenericType())
+                .withKeyValue(path + ".generalizations[0]", at(classWithTypeMultParams._generalizations(), 0))
+                .withKeyValue(path + ".generalizations[0].general", at(classWithTypeMultParams._generalizations(), 0)._general())
+//                .withKeyValue(path + ".multiplicityParameters[0]", at(classWithTypeMultParams._multiplicityParameters(), 0))
+//                .withKeyValue(path + ".multiplicityParameters[1]", at(classWithTypeMultParams._multiplicityParameters(), 1))
+//                .withKeyValue(path + ".typeParameters[0]", at(classWithTypeMultParams._typeParameters(), 0))
+//                .withKeyValue(path + ".typeParameters[1]", at(classWithTypeMultParams._typeParameters(), 1))
+                .withKeyValue(path + ".properties['propT']", properties.get(0))
+                .withKeyValue(path + ".properties['propT'].classifierGenericType", properties.get(0)._classifierGenericType())
+                .withKeyValue(path + ".properties['propT'].classifierGenericType.typeArguments[0]", typeArgument(properties.get(0)._classifierGenericType(), 0))
+                .withKeyValue(path + ".properties['propT'].classifierGenericType.typeArguments[1]", typeArgument(properties.get(0)._classifierGenericType(), 1))
+                .withKeyValue(path + ".properties['propT'].genericType", properties.get(0)._genericType())
+                .withKeyValue(path + ".properties['propT'].multiplicity", properties.get(0)._multiplicity())
+                .withKeyValue(path + ".properties['propV']", properties.get(1))
+                .withKeyValue(path + ".properties['propV'].classifierGenericType", properties.get(1)._classifierGenericType())
+                .withKeyValue(path + ".properties['propV'].classifierGenericType.typeArguments[0]", typeArgument(properties.get(1)._classifierGenericType(), 0))
+                .withKeyValue(path + ".properties['propV'].classifierGenericType.typeArguments[1]", typeArgument(properties.get(1)._classifierGenericType(), 1))
+                .withKeyValue(path + ".properties['propV'].genericType", properties.get(1)._genericType())
+                .withKeyValue(path + ".properties['propV'].multiplicity", properties.get(1)._multiplicity());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testClassWithQualifiedProperties()
+    {
+        String path = "test::model::ClassWithQualifiedProperties";
+        Class<?> classWithQualifiedProps = getCoreInstance(path);
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, classWithQualifiedProps)
+                .withKeyValue(path + ".classifierGenericType", classWithQualifiedProps._classifierGenericType())
+                .withKeyValue(path + ".generalizations[0]", classWithQualifiedProps._generalizations().getOnly())
+                .withKeyValue(path + ".generalizations[0].general", classWithQualifiedProps._generalizations().getOnly()._general());
+
+        Property<?, ?> names = classWithQualifiedProps._properties().getFirst();
+        expected.put(path + ".properties['names']", names);
+        expected.put(path + ".properties['names'].classifierGenericType", names._classifierGenericType());
+        expected.put(path + ".properties['names'].classifierGenericType.typeArguments[0]", typeArgument(names._classifierGenericType(), 0));
+        expected.put(path + ".properties['names'].classifierGenericType.typeArguments[1]", typeArgument(names._classifierGenericType(), 1));
+        expected.put(path + ".properties['names'].genericType", names._genericType());
+
+        Property<?, ?> title = classWithQualifiedProps._properties().getLast();
+        expected.put(path + ".properties['title']", title);
+        expected.put(path + ".properties['title'].classifierGenericType", title._classifierGenericType());
+        expected.put(path + ".properties['title'].classifierGenericType.typeArguments[0]", typeArgument(title._classifierGenericType(), 0));
+        expected.put(path + ".properties['title'].classifierGenericType.typeArguments[1]", typeArgument(title._classifierGenericType(), 1));
+        expected.put(path + ".properties['title'].genericType", title._genericType());
+
+
+        ListIterable<? extends QualifiedProperty<?>> qualifiedProperties = toList(classWithQualifiedProps._qualifiedProperties());
+
+        QualifiedProperty<?> firstName = qualifiedProperties.get(0);
+        SimpleFunctionExpression firstNameIfExp = (SimpleFunctionExpression) firstName._expressionSequence().getOnly();
+        ListIterable<? extends ValueSpecification> firstNameIfParams = toList(firstNameIfExp._parametersValues());
+        SimpleFunctionExpression firstNameIfCond = (SimpleFunctionExpression) firstNameIfParams.get(0);
+        InstanceValue firstNameIfTrue = (InstanceValue) firstNameIfParams.get(1);
+        LambdaFunction<?> firstNameIfTrueLambda = (LambdaFunction<?>) firstNameIfTrue._values().getOnly();
+        InstanceValue firstNameIfFalse = (InstanceValue) firstNameIfParams.get(2);
+        LambdaFunction<?> firstNameIfFalseLambda = (LambdaFunction<?>) firstNameIfFalse._values().getOnly();
+        expected.put(path + ".qualifiedProperties[id='firstName()']", firstName);
+        expected.put(path + ".qualifiedProperties[id='firstName()'].classifierGenericType", firstName._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].classifierGenericType.typeArguments[0]", typeArgument(firstName._classifierGenericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='firstName()'].classifierGenericType.typeArguments[0].rawType", typeArgument(firstName._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='firstName()'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(firstName._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='firstName()'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(firstName._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0]", firstName._expressionSequence().getOnly());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].genericType", firstName._expressionSequence().getOnly()._genericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[0]", firstNameIfParams.get(0));
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[0].genericType", firstNameIfParams.get(0)._genericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[0].parametersValues[0]", firstNameIfCond._parametersValues().getOnly());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType", firstNameIfCond._parametersValues().getOnly()._genericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]", ((SimpleFunctionExpression) firstNameIfCond._parametersValues().getOnly())._parametersValues().getOnly());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType", ((SimpleFunctionExpression) firstNameIfCond._parametersValues().getOnly())._parametersValues().getOnly()._genericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName", ((SimpleFunctionExpression) firstNameIfCond._parametersValues().getOnly())._propertyName());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[1]", firstNameIfParams.get(1));
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[1].genericType", firstNameIfParams.get(1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]", firstNameIfParams.get(1)._genericType()._typeArguments().getOnly());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType", firstNameIfParams.get(1)._genericType()._typeArguments().getOnly()._rawType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType", funcTypeRetType(firstNameIfParams.get(1)._genericType()._typeArguments().getOnly()._rawType()));
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[1].values[0]", firstNameIfTrueLambda);
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType", firstNameIfTrueLambda._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]", typeArgument(firstNameIfTrueLambda._classifierGenericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType", typeArgument(firstNameIfTrueLambda._classifierGenericType(), 0)._rawType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType", funcTypeRetType(typeArgument(firstNameIfTrueLambda._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]", firstNameIfTrueLambda._expressionSequence().getOnly());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType", firstNameIfTrueLambda._expressionSequence().getOnly()._genericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2]", firstNameIfFalse);
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].genericType", firstNameIfFalse._genericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].genericType.typeArguments[0]", typeArgument(firstNameIfFalse._genericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].genericType.typeArguments[0].rawType", typeArgument(firstNameIfFalse._genericType(), 0)._rawType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].genericType.typeArguments[0].rawType.returnType", funcTypeRetType(typeArgument(firstNameIfFalse._genericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0]", firstNameIfFalseLambda);
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].classifierGenericType", firstNameIfFalseLambda._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].classifierGenericType.typeArguments[0]", typeArgument(firstNameIfFalseLambda._classifierGenericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].classifierGenericType.typeArguments[0].rawType", typeArgument(firstNameIfFalseLambda._classifierGenericType(), 0)._rawType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].classifierGenericType.typeArguments[0].rawType.returnType", funcTypeRetType(typeArgument(firstNameIfFalseLambda._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].expressionSequence[0]", firstNameIfFalseLambda._expressionSequence().getOnly());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].expressionSequence[0].genericType", firstNameIfFalseLambda._expressionSequence().getOnly()._genericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].expressionSequence[0].parametersValues[0]", ((SimpleFunctionExpression) firstNameIfFalseLambda._expressionSequence().getOnly())._parametersValues().getFirst());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].expressionSequence[0].parametersValues[0].genericType", ((SimpleFunctionExpression) firstNameIfFalseLambda._expressionSequence().getOnly())._parametersValues().getFirst()._genericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]", ((SimpleFunctionExpression) ((SimpleFunctionExpression) firstNameIfFalseLambda._expressionSequence().getOnly())._parametersValues().getFirst())._parametersValues().getOnly());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType", ((SimpleFunctionExpression) ((SimpleFunctionExpression) firstNameIfFalseLambda._expressionSequence().getOnly())._parametersValues().getFirst())._parametersValues().getOnly()._genericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].expressionSequence[0].parametersValues[0].propertyName", ((SimpleFunctionExpression) ((SimpleFunctionExpression) firstNameIfFalseLambda._expressionSequence().getOnly())._parametersValues().getFirst())._propertyName());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].expressionSequence[0].parametersValues[1]", ((SimpleFunctionExpression) firstNameIfFalseLambda._expressionSequence().getOnly())._parametersValues().getLast());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].expressionSequence[0].parametersValues[2].values[0].expressionSequence[0].parametersValues[1].genericType", ((SimpleFunctionExpression) firstNameIfFalseLambda._expressionSequence().getOnly())._parametersValues().getLast()._genericType());
+        expected.put(path + ".qualifiedProperties[id='firstName()'].genericType", firstName._genericType());
+
+        QualifiedProperty<?> fullNameNoTitle = qualifiedProperties.get(1);
+        SimpleFunctionExpression fullNameExpression = (SimpleFunctionExpression) fullNameNoTitle._expressionSequence().getOnly();
+        expected.put(path + ".qualifiedProperties[id='fullName()']", fullNameNoTitle);
+        expected.put(path + ".qualifiedProperties[id='fullName()'].classifierGenericType", fullNameNoTitle._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='fullName()'].classifierGenericType.typeArguments[0]", typeArgument(fullNameNoTitle._classifierGenericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='fullName()'].classifierGenericType.typeArguments[0].rawType", typeArgument(fullNameNoTitle._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName()'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(fullNameNoTitle._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName()'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(fullNameNoTitle._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='fullName()'].expressionSequence[0]", fullNameNoTitle._expressionSequence().getOnly());
+        expected.put(path + ".qualifiedProperties[id='fullName()'].expressionSequence[0].genericType", fullNameNoTitle._expressionSequence().getOnly()._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName()'].expressionSequence[0].parametersValues[0]", fullNameExpression._parametersValues().getFirst());
+        expected.put(path + ".qualifiedProperties[id='fullName()'].expressionSequence[0].parametersValues[0].genericType", fullNameExpression._parametersValues().getFirst()._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName()'].expressionSequence[0].parametersValues[1]", fullNameExpression._parametersValues().getLast());
+        expected.put(path + ".qualifiedProperties[id='fullName()'].expressionSequence[0].parametersValues[1].genericType", fullNameExpression._parametersValues().getLast()._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName()'].expressionSequence[0].qualifiedPropertyName", fullNameExpression._qualifiedPropertyName());
+        expected.put(path + ".qualifiedProperties[id='fullName()'].genericType", fullNameNoTitle._genericType());
+
+        QualifiedProperty<?> fullNameWithTitle = qualifiedProperties.get(2);
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])']", fullNameWithTitle);
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].classifierGenericType", fullNameWithTitle._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].classifierGenericType.typeArguments[0]", typeArgument(fullNameWithTitle._classifierGenericType(), 0));
+
+        FunctionType fullNameWithTitleFunctionType = (FunctionType) typeArgument(fullNameWithTitle._classifierGenericType(), 0)._rawType();
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].classifierGenericType.typeArguments[0].rawType", fullNameWithTitleFunctionType);
+//        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this']", findFuncTypeParam(fullNameWithTitleFunctionType, "this"));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType", funcTypeParam(fullNameWithTitleFunctionType, "this")._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].classifierGenericType.typeArguments[0].rawType.parameters['withTitle']", funcTypeParam(fullNameWithTitleFunctionType, "withTitle"));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].classifierGenericType.typeArguments[0].rawType.parameters['withTitle'].genericType", funcTypeParam(fullNameWithTitleFunctionType, "withTitle")._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].classifierGenericType.typeArguments[0].rawType.returnType", funcTypeRetType(fullNameWithTitleFunctionType));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].genericType", fullNameWithTitle._genericType());
+
+        SimpleFunctionExpression fullNameWithTitleLetExp = (SimpleFunctionExpression) fullNameWithTitle._expressionSequence().getFirst();
+        InstanceValue fullNameWithTitleLetVarExp = (InstanceValue) fullNameWithTitleLetExp._parametersValues().getFirst();
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0]", fullNameWithTitleLetExp);
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].genericType", fullNameWithTitleLetExp._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[0]", fullNameWithTitleLetVarExp);
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[0].genericType", fullNameWithTitleLetVarExp._genericType());
+
+        SimpleFunctionExpression fullNameWithTitleLetValExp = (SimpleFunctionExpression) fullNameWithTitleLetExp._parametersValues().getLast();
+        ListIterable<? extends ValueSpecification> fullNameWithTitleLetValIfParams = toList(fullNameWithTitleLetValExp._parametersValues());
+        SimpleFunctionExpression fullNameWithTitleLetValIfCond = (SimpleFunctionExpression) fullNameWithTitleLetValIfParams.get(0);
+        InstanceValue fullNameWithTitleLetValIfTrue = (InstanceValue) fullNameWithTitleLetValIfParams.get(1);
+        LambdaFunction<?> fullNameWithTitleLetValIfTrueLambda = (LambdaFunction<?>) fullNameWithTitleLetValIfTrue._values().getOnly();
+        InstanceValue fullNameWithTitleLetValIfFalse = (InstanceValue) fullNameWithTitleLetValIfParams.get(2);
+        LambdaFunction<?> fullNameWithTitleLetValIfFalseLambda = (LambdaFunction<?>) fullNameWithTitleLetValIfFalse._values().getOnly();
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1]", fullNameWithTitleLetValExp);
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].genericType", fullNameWithTitleLetValExp._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0]", fullNameWithTitleLetValIfCond);
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0].genericType", fullNameWithTitleLetValIfCond._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0]", fullNameWithTitleLetValIfCond._parametersValues().getFirst());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType", fullNameWithTitleLetValIfCond._parametersValues().getFirst()._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[1]", fullNameWithTitleLetValIfCond._parametersValues().getLast());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[1].genericType", fullNameWithTitleLetValIfCond._parametersValues().getLast()._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[1].parametersValues[0]",
+                ((SimpleFunctionExpression) fullNameWithTitleLetValIfCond._parametersValues().getLast())._parametersValues().getOnly());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[1].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) fullNameWithTitleLetValIfCond._parametersValues().getLast())._parametersValues().getOnly()._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[1].parametersValues[0].parametersValues[0]",
+                ((SimpleFunctionExpression) ((SimpleFunctionExpression) fullNameWithTitleLetValIfCond._parametersValues().getLast())._parametersValues().getOnly())._parametersValues().getOnly());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) ((SimpleFunctionExpression) fullNameWithTitleLetValIfCond._parametersValues().getLast())._parametersValues().getOnly())._parametersValues().getOnly()._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[1].parametersValues[0].parametersValues[0].parametersValues[0]",
+                ((SimpleFunctionExpression) ((SimpleFunctionExpression) ((SimpleFunctionExpression) fullNameWithTitleLetValIfCond._parametersValues().getLast())._parametersValues().getOnly())._parametersValues().getOnly())._parametersValues().getOnly());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[1].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) ((SimpleFunctionExpression) ((SimpleFunctionExpression) fullNameWithTitleLetValIfCond._parametersValues().getLast())._parametersValues().getOnly())._parametersValues().getOnly())._parametersValues().getOnly()._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[1].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) ((SimpleFunctionExpression) ((SimpleFunctionExpression) fullNameWithTitleLetValIfCond._parametersValues().getLast())._parametersValues().getOnly())._parametersValues().getOnly())._propertyName());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1]", fullNameWithTitleLetValIfTrue);
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].genericType", fullNameWithTitleLetValIfTrue._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].genericType.typeArguments[0]", typeArgument(fullNameWithTitleLetValIfTrue._genericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].genericType.typeArguments[0].rawType", typeArgument(fullNameWithTitleLetValIfTrue._genericType(), 0)._rawType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].genericType.typeArguments[0].rawType.returnType", funcTypeRetType(typeArgument(fullNameWithTitleLetValIfTrue._genericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0]", fullNameWithTitleLetValIfTrueLambda);
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType", fullNameWithTitleLetValIfTrueLambda._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0]", typeArgument(fullNameWithTitleLetValIfTrueLambda._classifierGenericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType", typeArgument(fullNameWithTitleLetValIfTrueLambda._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(fullNameWithTitleLetValIfTrueLambda._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0]", fullNameWithTitleLetValIfTrueLambda._expressionSequence().getOnly());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].genericType", fullNameWithTitleLetValIfTrueLambda._expressionSequence().getOnly()._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) fullNameWithTitleLetValIfTrueLambda._expressionSequence().getOnly())._parametersValues().getOnly()._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].values[0]",
+                (SimpleFunctionExpression) ((InstanceValue) ((SimpleFunctionExpression) fullNameWithTitleLetValIfTrueLambda._expressionSequence().getOnly())._parametersValues().getOnly())._values().getFirst());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].values[0].genericType",
+                ((SimpleFunctionExpression) ((InstanceValue) ((SimpleFunctionExpression) fullNameWithTitleLetValIfTrueLambda._expressionSequence().getOnly())._parametersValues().getOnly())._values().getFirst())._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].values[0].parametersValues[0]",
+                ((SimpleFunctionExpression) ((InstanceValue) ((SimpleFunctionExpression) fullNameWithTitleLetValIfTrueLambda._expressionSequence().getOnly())._parametersValues().getOnly())._values().getFirst())._parametersValues().getOnly());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].values[0].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) ((InstanceValue) ((SimpleFunctionExpression) fullNameWithTitleLetValIfTrueLambda._expressionSequence().getOnly())._parametersValues().getOnly())._values().getFirst())._parametersValues().getOnly()._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].values[0].parametersValues[0].parametersValues[0]",
+                ((SimpleFunctionExpression) ((SimpleFunctionExpression) ((InstanceValue) ((SimpleFunctionExpression) fullNameWithTitleLetValIfTrueLambda._expressionSequence().getOnly())._parametersValues().getOnly())._values().getFirst())._parametersValues().getOnly())._parametersValues().getOnly());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].values[0].parametersValues[0].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) ((SimpleFunctionExpression) ((InstanceValue) ((SimpleFunctionExpression) fullNameWithTitleLetValIfTrueLambda._expressionSequence().getOnly())._parametersValues().getOnly())._values().getFirst())._parametersValues().getOnly())._parametersValues().getOnly()._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].values[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) ((SimpleFunctionExpression) ((InstanceValue) ((SimpleFunctionExpression) fullNameWithTitleLetValIfTrueLambda._expressionSequence().getOnly())._parametersValues().getOnly())._values().getFirst())._parametersValues().getOnly())._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].values[1]",
+                (InstanceValue) ((InstanceValue) ((SimpleFunctionExpression) fullNameWithTitleLetValIfTrueLambda._expressionSequence().getOnly())._parametersValues().getOnly())._values().getLast());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].values[1].genericType",
+                ((InstanceValue) ((InstanceValue) ((SimpleFunctionExpression) fullNameWithTitleLetValIfTrueLambda._expressionSequence().getOnly())._parametersValues().getOnly())._values().getLast())._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[2]", fullNameWithTitleLetValIfFalse);
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[2].genericType", fullNameWithTitleLetValIfFalse._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[2].genericType.typeArguments[0]", typeArgument(fullNameWithTitleLetValIfFalse._genericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[2].genericType.typeArguments[0].rawType", typeArgument(fullNameWithTitleLetValIfFalse._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[2].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(fullNameWithTitleLetValIfFalse._genericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[2].values[0]", fullNameWithTitleLetValIfFalseLambda);
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType", fullNameWithTitleLetValIfFalseLambda._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType.typeArguments[0]", typeArgument(fullNameWithTitleLetValIfFalseLambda._classifierGenericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType.typeArguments[0].rawType", typeArgument(fullNameWithTitleLetValIfFalseLambda._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(fullNameWithTitleLetValIfFalseLambda._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0]", fullNameWithTitleLetValIfFalseLambda._expressionSequence().getOnly());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].genericType", fullNameWithTitleLetValIfFalseLambda._expressionSequence().getOnly()._genericType());
+
+        SimpleFunctionExpression fullNameWithTitleJoinStrExp = (SimpleFunctionExpression) exprSeq(fullNameWithTitle, 1);
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1]", fullNameWithTitleJoinStrExp);
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1].genericType", fullNameWithTitleJoinStrExp._genericType());
+        ListIterable<? extends ValueSpecification> fullNameWithTitleJoinStrExpParams = toList(fullNameWithTitleJoinStrExp._parametersValues());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1].parametersValues[0]", fullNameWithTitleJoinStrExpParams.get(0));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1].parametersValues[0].genericType", fullNameWithTitleJoinStrExpParams.get(0)._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1].parametersValues[0].parametersValues[0]", ((SimpleFunctionExpression) fullNameWithTitleJoinStrExpParams.get(0))._parametersValues().getOnly());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1].parametersValues[0].parametersValues[0].genericType", ((SimpleFunctionExpression) fullNameWithTitleJoinStrExpParams.get(0))._parametersValues().getOnly()._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1].parametersValues[0].propertyName", ((SimpleFunctionExpression) fullNameWithTitleJoinStrExpParams.get(0))._propertyName());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1].parametersValues[1]", fullNameWithTitleJoinStrExpParams.get(1));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1].parametersValues[1].genericType", fullNameWithTitleJoinStrExpParams.get(1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1].parametersValues[2]", fullNameWithTitleJoinStrExpParams.get(2));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1].parametersValues[2].genericType", fullNameWithTitleJoinStrExpParams.get(2)._genericType());
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1].parametersValues[3]", fullNameWithTitleJoinStrExpParams.get(3));
+        expected.put(path + ".qualifiedProperties[id='fullName(Boolean[1])'].expressionSequence[1].parametersValues[3].genericType", fullNameWithTitleJoinStrExpParams.get(3)._genericType());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testClassWithMilestoning1()
+    {
+        String path = "test::model::ClassWithMilestoning1";
+        Class<?> classWithMilestoning1 = getCoreInstance(path);
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, classWithMilestoning1)
+                .withKeyValue(path + ".classifierGenericType", classWithMilestoning1._classifierGenericType())
+                .withKeyValue(path + ".generalizations[0]", classWithMilestoning1._generalizations().getOnly())
+                .withKeyValue(path + ".generalizations[0].general", classWithMilestoning1._generalizations().getOnly()._general());
+
+        ListIterable<? extends Property<?, ?>> originalMilestonedProperties = toList(classWithMilestoning1._originalMilestonedProperties());
+        Property<?, ?> toClass2Original = originalMilestonedProperties.get(0);
+        expected.put(path + ".originalMilestonedProperties['toClass2']", toClass2Original);
+        expected.put(path + ".originalMilestonedProperties['toClass2'].classifierGenericType", toClass2Original._classifierGenericType());
+        expected.put(path + ".originalMilestonedProperties['toClass2'].classifierGenericType.typeArguments[0]", typeArgument(toClass2Original._classifierGenericType(), 0));
+        expected.put(path + ".originalMilestonedProperties['toClass2'].classifierGenericType.typeArguments[1]", typeArgument(toClass2Original._classifierGenericType(), 1));
+        expected.put(path + ".originalMilestonedProperties['toClass2'].genericType", toClass2Original._genericType());
+
+        Property<?, ?> toClass3Original = originalMilestonedProperties.get(1);
+        expected.put(path + ".originalMilestonedProperties['toClass3']", toClass3Original);
+        expected.put(path + ".originalMilestonedProperties['toClass3'].classifierGenericType", toClass3Original._classifierGenericType());
+        expected.put(path + ".originalMilestonedProperties['toClass3'].classifierGenericType.typeArguments[0]", typeArgument(toClass3Original._classifierGenericType(), 0));
+        expected.put(path + ".originalMilestonedProperties['toClass3'].classifierGenericType.typeArguments[1]", typeArgument(toClass3Original._classifierGenericType(), 1));
+        expected.put(path + ".originalMilestonedProperties['toClass3'].genericType", toClass3Original._genericType());
+
+        Property<?, ?> businessDate = findProperty(classWithMilestoning1, "businessDate");
+        expected.put(path + ".properties['businessDate']", businessDate);
+        expected.put(path + ".properties['businessDate'].classifierGenericType", businessDate._classifierGenericType());
+        expected.put(path + ".properties['businessDate'].classifierGenericType.typeArguments[0]", typeArgument(businessDate._classifierGenericType(), 0));
+        expected.put(path + ".properties['businessDate'].classifierGenericType.typeArguments[1]", typeArgument(businessDate._classifierGenericType(), 1));
+        expected.put(path + ".properties['businessDate'].genericType", businessDate._genericType());
+
+        Property<?, ?> milestoning = findProperty(classWithMilestoning1, "milestoning");
+        expected.put(path + ".properties['milestoning']", milestoning);
+        expected.put(path + ".properties['milestoning'].classifierGenericType", milestoning._classifierGenericType());
+        expected.put(path + ".properties['milestoning'].classifierGenericType.typeArguments[0]", typeArgument(milestoning._classifierGenericType(), 0));
+        expected.put(path + ".properties['milestoning'].classifierGenericType.typeArguments[1]", typeArgument(milestoning._classifierGenericType(), 1));
+        expected.put(path + ".properties['milestoning'].genericType", milestoning._genericType());
+
+        Property<?, ?> toClass2AllVersions = findProperty(classWithMilestoning1, "toClass2AllVersions");
+        expected.put(path + ".properties['toClass2AllVersions']", toClass2AllVersions);
+        expected.put(path + ".properties['toClass2AllVersions'].classifierGenericType", toClass2AllVersions._classifierGenericType());
+        expected.put(path + ".properties['toClass2AllVersions'].classifierGenericType.typeArguments[0]", typeArgument(toClass2AllVersions._classifierGenericType(), 0));
+        expected.put(path + ".properties['toClass2AllVersions'].classifierGenericType.typeArguments[1]", typeArgument(toClass2AllVersions._classifierGenericType(), 1));
+        expected.put(path + ".properties['toClass2AllVersions'].genericType", toClass2AllVersions._genericType());
+
+        Property<?, ?> toClass3AllVersions = findProperty(classWithMilestoning1, "toClass3AllVersions");
+        expected.put(path + ".properties['toClass3AllVersions']", toClass3AllVersions);
+        expected.put(path + ".properties['toClass3AllVersions'].classifierGenericType", toClass3AllVersions._classifierGenericType());
+        expected.put(path + ".properties['toClass3AllVersions'].classifierGenericType.typeArguments[0]", typeArgument(toClass3AllVersions._classifierGenericType(), 0));
+        expected.put(path + ".properties['toClass3AllVersions'].classifierGenericType.typeArguments[1]", typeArgument(toClass3AllVersions._classifierGenericType(), 1));
+        expected.put(path + ".properties['toClass3AllVersions'].genericType", toClass3AllVersions._genericType());
+
+        ListIterable<? extends QualifiedProperty<?>> qualifiedProperties = toList(classWithMilestoning1._qualifiedProperties());
+        QualifiedProperty<?> toClass2 = qualifiedProperties.get(0);
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])']", toClass2);
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType", toClass2._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType.typeArguments[0]", typeArgument(toClass2._classifierGenericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType.typeArguments[0].rawType", typeArgument(toClass2._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass2._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td']",
+                funcTypeParam(typeArgument(toClass2._classifierGenericType(), 0)._rawType(), "td"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td'].genericType",
+                funcTypeParam(typeArgument(toClass2._classifierGenericType(), 0)._rawType(), "td")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass2._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0]", exprSeq(toClass2, 0));
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].genericType", exprSeq(toClass2, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass2, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass2, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass2, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass2, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(toClass2, 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(toClass2, 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(toClass2, 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2, 0), 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])'].genericType", toClass2._genericType());
+
+        QualifiedProperty<?> toClass2AllVersionsInRange = qualifiedProperties.get(1);
+        expected.put(path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])']", toClass2AllVersionsInRange);
+        expected.put(path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType", toClass2AllVersionsInRange._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start']",
+                funcTypeParam(typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType(), "start"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start'].genericType",
+                funcTypeParam(typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType(), "start")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end']",
+                funcTypeParam(typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType(), "end"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end'].genericType",
+                funcTypeParam(typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType(), "end")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0]",
+                exprSeq(toClass2AllVersionsInRange, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass2AllVersionsInRange, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].genericType", toClass2AllVersionsInRange._genericType());
+
+        QualifiedProperty<?> toClass3_date_date = qualifiedProperties.get(2);
+        expected.put(path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])']", toClass3_date_date);
+        expected.put(path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType", toClass3_date_date._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass3_date_date._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['bd']",
+                funcTypeParam(typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType(), "bd"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['bd'].genericType",
+                funcTypeParam(typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType(), "bd")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['pd']",
+                funcTypeParam(typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType(), "pd"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['pd'].genericType",
+                funcTypeParam(typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType(), "pd")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0]",
+                exprSeq(toClass3_date_date, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass3_date_date, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass3_date_date, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass3_date_date, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass3_date_date, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass3_date_date, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass3_date_date, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass3_date_date, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass3_date_date, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(exprSeq(toClass3_date_date, 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(exprSeq(toClass3_date_date, 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3_date_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3_date_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(exprSeq(toClass3_date_date, 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].genericType", toClass3_date_date._genericType());
+
+        QualifiedProperty<?> toClass3_date = qualifiedProperties.get(3);
+        expected.put(path + ".qualifiedProperties[id='toClass3(Date[1])']", toClass3_date);
+        expected.put(path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType", toClass3_date._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass3_date._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass3_date._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass3_date._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td']",
+                funcTypeParam(typeArgument(toClass3_date._classifierGenericType(), 0)._rawType(), "td"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td'].genericType",
+                funcTypeParam(typeArgument(toClass3_date._classifierGenericType(), 0)._rawType(), "td")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass3_date._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0]",
+                exprSeq(toClass3_date, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass3_date, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass3_date, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass3_date, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass3_date, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass3_date, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass3_date, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass3_date, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass3_date, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(exprSeq(toClass3_date, 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(exprSeq(toClass3_date, 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(exprSeq(toClass3_date, 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 1))._propertyName());
+        expected.put(path + ".qualifiedProperties[id='toClass3(Date[1])'].genericType", toClass3_date._genericType());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testClassWithMilestoning2()
+    {
+        String path = "test::model::ClassWithMilestoning2";
+        Class<?> classWithMilestoning2 = getCoreInstance(path);
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, classWithMilestoning2)
+                .withKeyValue(path + ".classifierGenericType", classWithMilestoning2._classifierGenericType())
+                .withKeyValue(path + ".generalizations[0]", classWithMilestoning2._generalizations().getOnly())
+                .withKeyValue(path + ".generalizations[0].general", classWithMilestoning2._generalizations().getOnly()._general());
+
+        ListIterable<? extends Property<?, ?>> originalMilestonedProperties = toList(classWithMilestoning2._originalMilestonedProperties());
+        Property<?, ?> toClass1Original = originalMilestonedProperties.get(0);
+        expected.put(path + ".originalMilestonedProperties['toClass1']", toClass1Original);
+        expected.put(path + ".originalMilestonedProperties['toClass1'].classifierGenericType", toClass1Original._classifierGenericType());
+        expected.put(path + ".originalMilestonedProperties['toClass1'].classifierGenericType.typeArguments[0]", typeArgument(toClass1Original._classifierGenericType(), 0));
+        expected.put(path + ".originalMilestonedProperties['toClass1'].classifierGenericType.typeArguments[1]", typeArgument(toClass1Original._classifierGenericType(), 1));
+        expected.put(path + ".originalMilestonedProperties['toClass1'].genericType", toClass1Original._genericType());
+
+        Property<?, ?> toClass3Original = originalMilestonedProperties.get(1);
+        expected.put(path + ".originalMilestonedProperties['toClass3']", toClass3Original);
+        expected.put(path + ".originalMilestonedProperties['toClass3'].classifierGenericType", toClass3Original._classifierGenericType());
+        expected.put(path + ".originalMilestonedProperties['toClass3'].classifierGenericType.typeArguments[0]", typeArgument(toClass3Original._classifierGenericType(), 0));
+        expected.put(path + ".originalMilestonedProperties['toClass3'].classifierGenericType.typeArguments[1]", typeArgument(toClass3Original._classifierGenericType(), 1));
+        expected.put(path + ".originalMilestonedProperties['toClass3'].genericType", toClass3Original._genericType());
+
+        ListIterable<? extends Property<?, ?>> properties = toList(classWithMilestoning2._properties());
+        Property<?, ?> processingDate = properties.get(0);
+        expected.put(path + ".properties['processingDate']", processingDate);
+        expected.put(path + ".properties['processingDate'].classifierGenericType", processingDate._classifierGenericType());
+        expected.put(path + ".properties['processingDate'].classifierGenericType.typeArguments[0]", typeArgument(processingDate._classifierGenericType(), 0));
+        expected.put(path + ".properties['processingDate'].classifierGenericType.typeArguments[1]", typeArgument(processingDate._classifierGenericType(), 1));
+        expected.put(path + ".properties['processingDate'].genericType", processingDate._genericType());
+
+        Property<?, ?> milestoning = properties.get(1);
+        expected.put(path + ".properties['milestoning']", milestoning);
+        expected.put(path + ".properties['milestoning'].classifierGenericType", milestoning._classifierGenericType());
+        expected.put(path + ".properties['milestoning'].classifierGenericType.typeArguments[0]", typeArgument(milestoning._classifierGenericType(), 0));
+        expected.put(path + ".properties['milestoning'].classifierGenericType.typeArguments[1]", typeArgument(milestoning._classifierGenericType(), 1));
+        expected.put(path + ".properties['milestoning'].genericType", milestoning._genericType());
+
+        Property<?, ?> toClass1AllVersions = properties.get(2);
+        expected.put(path + ".properties['toClass1AllVersions']", toClass1AllVersions);
+        expected.put(path + ".properties['toClass1AllVersions'].classifierGenericType", toClass1AllVersions._classifierGenericType());
+        expected.put(path + ".properties['toClass1AllVersions'].classifierGenericType.typeArguments[0]", typeArgument(toClass1AllVersions._classifierGenericType(), 0));
+        expected.put(path + ".properties['toClass1AllVersions'].classifierGenericType.typeArguments[1]", typeArgument(toClass1AllVersions._classifierGenericType(), 1));
+        expected.put(path + ".properties['toClass1AllVersions'].genericType", toClass1AllVersions._genericType());
+
+        Property<?, ?> toClass3AllVersions = properties.get(3);
+        expected.put(path + ".properties['toClass3AllVersions']", toClass3AllVersions);
+        expected.put(path + ".properties['toClass3AllVersions'].classifierGenericType", toClass3AllVersions._classifierGenericType());
+        expected.put(path + ".properties['toClass3AllVersions'].classifierGenericType.typeArguments[0]", typeArgument(toClass3AllVersions._classifierGenericType(), 0));
+        expected.put(path + ".properties['toClass3AllVersions'].classifierGenericType.typeArguments[1]", typeArgument(toClass3AllVersions._classifierGenericType(), 1));
+        expected.put(path + ".properties['toClass3AllVersions'].genericType", toClass3AllVersions._genericType());
+
+        ListIterable<? extends QualifiedProperty<?>> qualifiedProperties = toList(classWithMilestoning2._qualifiedProperties());
+        QualifiedProperty<?> toClass1 = qualifiedProperties.get(0);
+        expected.put(path + ".qualifiedProperties[id='toClass1(Date[1])']", toClass1);
+        expected.put(path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType", toClass1._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass1._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass1._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass1._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td']",
+                funcTypeParam(typeArgument(toClass1._classifierGenericType(), 0)._rawType(), "td"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td'].genericType",
+                funcTypeParam(typeArgument(toClass1._classifierGenericType(), 0)._rawType(), "td")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass1._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0]",
+                exprSeq(toClass1, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass1, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass1, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass1, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass1, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass1, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(toClass1, 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(toClass1, 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(toClass1, 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1, 0), 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass1(Date[1])'].genericType", toClass1._genericType());
+
+        QualifiedProperty<?> toClass1AllVersionsInRange = qualifiedProperties.get(1);
+        expected.put(path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])']", toClass1AllVersionsInRange);
+        expected.put(path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType", toClass1AllVersionsInRange._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start']",
+                funcTypeParam(typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType(), "start"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start'].genericType",
+                funcTypeParam(typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType(), "start")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end']",
+                funcTypeParam(typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType(), "end"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end'].genericType",
+                funcTypeParam(typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType(), "end")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0]",
+                exprSeq(toClass1AllVersionsInRange, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass1AllVersionsInRange, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].genericType", toClass1AllVersionsInRange._genericType());
+
+        QualifiedProperty<?> toClass3_date_date = qualifiedProperties.get(2);
+        expected.put(path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])']", toClass3_date_date);
+        expected.put(path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType", toClass3_date_date._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass3_date_date._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['bd']",
+                funcTypeParam(typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType(), "bd"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['bd'].genericType",
+                funcTypeParam(typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType(), "bd")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['pd']",
+                funcTypeParam(typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType(), "pd"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['pd'].genericType",
+                funcTypeParam(typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType(), "pd")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass3_date_date._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0]",
+                exprSeq(toClass3_date_date, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass3_date_date, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass3_date_date, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass3_date_date, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass3_date_date, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass3_date_date, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass3_date_date, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass3_date_date, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass3_date_date, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(exprSeq(toClass3_date_date, 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(exprSeq(toClass3_date_date, 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3_date_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3_date_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(exprSeq(toClass3_date_date, 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date_date, 0), 1), 0), 0), 1), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass3(Date[1],Date[1])'].genericType", toClass3_date_date._genericType());
+
+        QualifiedProperty<?> toClass3_date = qualifiedProperties.get(3);
+        expected.put(path + ".qualifiedProperties[id='toClass3(Date[1])']", toClass3_date);
+        expected.put(path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType", toClass3_date._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass3_date._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass3_date._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass3_date._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td']",
+                funcTypeParam(typeArgument(toClass3_date._classifierGenericType(), 0)._rawType(), "td"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td'].genericType",
+                funcTypeParam(typeArgument(toClass3_date._classifierGenericType(), 0)._rawType(), "td")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass3_date._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0]",
+                exprSeq(toClass3_date, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass3_date, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass3_date, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass3_date, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass3_date, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass3_date, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass3_date, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass3_date, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass3_date, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(exprSeq(toClass3_date, 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(exprSeq(toClass3_date, 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(exprSeq(toClass3_date, 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 0), 1))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3_date, 0), 1), 0), 0), 1), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass3(Date[1])'].genericType", toClass3_date._genericType());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testClassWithMilestoning3()
+    {
+        String path = "test::model::ClassWithMilestoning3";
+        Class<?> classWithMilestoning3 = getCoreInstance(path);
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, classWithMilestoning3)
+                .withKeyValue(path + ".classifierGenericType", classWithMilestoning3._classifierGenericType())
+                .withKeyValue(path + ".generalizations[0]", classWithMilestoning3._generalizations().getOnly())
+                .withKeyValue(path + ".generalizations[0].general", classWithMilestoning3._generalizations().getOnly()._general());
+
+        ListIterable<? extends Property<?, ?>> originalMilestonedProperties = toList(classWithMilestoning3._originalMilestonedProperties());
+        Property<?, ?> toClass1Original = originalMilestonedProperties.get(0);
+        expected.put(path + ".originalMilestonedProperties['toClass1']", toClass1Original);
+        expected.put(path + ".originalMilestonedProperties['toClass1'].classifierGenericType", toClass1Original._classifierGenericType());
+        expected.put(path + ".originalMilestonedProperties['toClass1'].classifierGenericType.typeArguments[0]", typeArgument(toClass1Original._classifierGenericType(), 0));
+        expected.put(path + ".originalMilestonedProperties['toClass1'].classifierGenericType.typeArguments[1]", typeArgument(toClass1Original._classifierGenericType(), 1));
+        expected.put(path + ".originalMilestonedProperties['toClass1'].genericType", toClass1Original._genericType());
+
+        Property<?, ?> toClass2Original = originalMilestonedProperties.get(1);
+        expected.put(path + ".originalMilestonedProperties['toClass2']", toClass2Original);
+        expected.put(path + ".originalMilestonedProperties['toClass2'].classifierGenericType", toClass2Original._classifierGenericType());
+        expected.put(path + ".originalMilestonedProperties['toClass2'].classifierGenericType.typeArguments[0]", typeArgument(toClass2Original._classifierGenericType(), 0));
+        expected.put(path + ".originalMilestonedProperties['toClass2'].classifierGenericType.typeArguments[1]", typeArgument(toClass2Original._classifierGenericType(), 1));
+        expected.put(path + ".originalMilestonedProperties['toClass2'].genericType", toClass2Original._genericType());
+
+        ListIterable<? extends Property<?, ?>> properties = toList(classWithMilestoning3._properties());
+        Property<?, ?> processingDate = properties.get(0);
+        expected.put(path + ".properties['processingDate']", processingDate);
+        expected.put(path + ".properties['processingDate'].classifierGenericType", processingDate._classifierGenericType());
+        expected.put(path + ".properties['processingDate'].classifierGenericType.typeArguments[0]", typeArgument(processingDate._classifierGenericType(), 0));
+        expected.put(path + ".properties['processingDate'].classifierGenericType.typeArguments[1]", typeArgument(processingDate._classifierGenericType(), 1));
+        expected.put(path + ".properties['processingDate'].genericType", processingDate._genericType());
+
+        Property<?, ?> businessDate = properties.get(1);
+        expected.put(path + ".properties['businessDate']", businessDate);
+        expected.put(path + ".properties['businessDate'].classifierGenericType", businessDate._classifierGenericType());
+        expected.put(path + ".properties['businessDate'].classifierGenericType.typeArguments[0]", typeArgument(businessDate._classifierGenericType(), 0));
+        expected.put(path + ".properties['businessDate'].classifierGenericType.typeArguments[1]", typeArgument(businessDate._classifierGenericType(), 1));
+        expected.put(path + ".properties['businessDate'].genericType", businessDate._genericType());
+
+        Property<?, ?> milestoning = properties.get(2);
+        expected.put(path + ".properties['milestoning']", milestoning);
+        expected.put(path + ".properties['milestoning'].classifierGenericType", milestoning._classifierGenericType());
+        expected.put(path + ".properties['milestoning'].classifierGenericType.typeArguments[0]", typeArgument(milestoning._classifierGenericType(), 0));
+        expected.put(path + ".properties['milestoning'].classifierGenericType.typeArguments[1]", typeArgument(milestoning._classifierGenericType(), 1));
+        expected.put(path + ".properties['milestoning'].genericType", milestoning._genericType());
+
+        Property<?, ?> toClass1AllVersions = properties.get(3);
+        expected.put(path + ".properties['toClass1AllVersions']", toClass1AllVersions);
+        expected.put(path + ".properties['toClass1AllVersions'].classifierGenericType", toClass1AllVersions._classifierGenericType());
+        expected.put(path + ".properties['toClass1AllVersions'].classifierGenericType.typeArguments[0]", typeArgument(toClass1AllVersions._classifierGenericType(), 0));
+        expected.put(path + ".properties['toClass1AllVersions'].classifierGenericType.typeArguments[1]", typeArgument(toClass1AllVersions._classifierGenericType(), 1));
+        expected.put(path + ".properties['toClass1AllVersions'].genericType", toClass1AllVersions._genericType());
+
+        Property<?, ?> toClass2AllVersions = properties.get(4);
+        expected.put(path + ".properties['toClass2AllVersions']", toClass2AllVersions);
+        expected.put(path + ".properties['toClass2AllVersions'].classifierGenericType", toClass2AllVersions._classifierGenericType());
+        expected.put(path + ".properties['toClass2AllVersions'].classifierGenericType.typeArguments[0]", typeArgument(toClass2AllVersions._classifierGenericType(), 0));
+        expected.put(path + ".properties['toClass2AllVersions'].classifierGenericType.typeArguments[1]", typeArgument(toClass2AllVersions._classifierGenericType(), 1));
+        expected.put(path + ".properties['toClass2AllVersions'].genericType", toClass2AllVersions._genericType());
+
+        ListIterable<? extends QualifiedProperty<?>> qualifiedProperties = toList(classWithMilestoning3._qualifiedProperties());
+        QualifiedProperty<?> toClass1_noDate = qualifiedProperties.get(0);
+        expected.put(path + ".qualifiedProperties[id='toClass1()']", toClass1_noDate);
+        expected.put(path + ".qualifiedProperties[id='toClass1()'].classifierGenericType", toClass1_noDate._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass1_noDate._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass1_noDate._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass1_noDate._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass1_noDate._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0]",
+                exprSeq(toClass1_noDate, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].genericType",
+                exprSeq(toClass1_noDate, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass1_noDate, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass1_noDate, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_noDate, 0), 0), 1), 0), 0), 1))._propertyName());
+        expected.put(path + ".qualifiedProperties[id='toClass1()'].genericType", toClass1_noDate._genericType());
+
+        QualifiedProperty<?> toClass1_date = qualifiedProperties.get(1);
+        expected.put(path + ".qualifiedProperties[id='toClass1(Date[1])']", toClass1_date);
+        expected.put(path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType", toClass1_date._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass1_date._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass1_date._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass1_date._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td']",
+                funcTypeParam(typeArgument(toClass1_date._classifierGenericType(), 0)._rawType(), "td"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td'].genericType",
+                funcTypeParam(typeArgument(toClass1_date._classifierGenericType(), 0)._rawType(), "td")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass1_date._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0]",
+                exprSeq(toClass1_date, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass1_date, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass1_date, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass1_date, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1_date, 0), 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass1(Date[1])'].genericType", toClass1_date._genericType());
+
+        QualifiedProperty<?> toClass1AllVersionsInRange = qualifiedProperties.get(2);
+        expected.put(path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])']", toClass1AllVersionsInRange);
+        expected.put(path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType", toClass1AllVersionsInRange._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start']",
+                funcTypeParam(typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType(), "start"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start'].genericType",
+                funcTypeParam(typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType(), "start")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end']",
+                funcTypeParam(typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType(), "end"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end'].genericType",
+                funcTypeParam(typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType(), "end")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass1AllVersionsInRange._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0]",
+                exprSeq(toClass1AllVersionsInRange, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass1AllVersionsInRange, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass1AllVersionsInRange, 0), 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass1AllVersionsInRange(Date[1],Date[1])'].genericType", toClass1AllVersionsInRange._genericType());
+
+        QualifiedProperty<?> toClass2_noDate = qualifiedProperties.get(3);
+        expected.put(path + ".qualifiedProperties[id='toClass2()']", toClass2_noDate);
+        expected.put(path + ".qualifiedProperties[id='toClass2()'].classifierGenericType", toClass2_noDate._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass2_noDate._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass2_noDate._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass2_noDate._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass2_noDate._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0]",
+                exprSeq(toClass2_noDate, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].genericType",
+                exprSeq(toClass2_noDate, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass2_noDate, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass2_noDate, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2()'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_noDate, 0), 0), 1), 0), 0), 1))._propertyName());
+        expected.put(path + ".qualifiedProperties[id='toClass2()'].genericType", toClass2_noDate._genericType());
+
+        QualifiedProperty<?> toClass2_date = qualifiedProperties.get(4);
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])']", toClass2_date);
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType", toClass2_date._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType.typeArguments[0]", typeArgument(toClass2_date._classifierGenericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType.typeArguments[0].rawType", typeArgument(toClass2_date._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass2_date._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td']",
+                funcTypeParam(typeArgument(toClass2_date._classifierGenericType(), 0)._rawType(), "td"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td'].genericType",
+                funcTypeParam(typeArgument(toClass2_date._classifierGenericType(), 0)._rawType(), "td")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass2_date._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0]", exprSeq(toClass2_date, 0));
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].genericType", exprSeq(toClass2_date, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass2_date, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass2_date, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2_date, 0), 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass2(Date[1])'].genericType", toClass2_date._genericType());
+
+        QualifiedProperty<?> toClass2AllVersionsInRange = qualifiedProperties.get(5);
+        expected.put(path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])']", toClass2AllVersionsInRange);
+        expected.put(path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType", toClass2AllVersionsInRange._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start']",
+                funcTypeParam(typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType(), "start"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start'].genericType",
+                funcTypeParam(typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType(), "start")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end']",
+                funcTypeParam(typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType(), "end"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end'].genericType",
+                funcTypeParam(typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType(), "end")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass2AllVersionsInRange._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0]",
+                exprSeq(toClass2AllVersionsInRange, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass2AllVersionsInRange, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(paramValue(exprSeq(toClass2AllVersionsInRange, 0), 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass2AllVersionsInRange(Date[1],Date[1])'].genericType", toClass2AllVersionsInRange._genericType());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testAssociationWithMilestoning1()
+    {
+        String path = "test::model::AssociationWithMilestoning1";
+        Association association = getCoreInstance(path);
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, association)
+                .withKeyValue(path + ".classifierGenericType", association._classifierGenericType());
+
+        ListIterable<? extends Property<?, ?>> originalMilestonedProperties = toList(association._originalMilestonedProperties());
+        Property<?, ?> toClass1AOriginal = originalMilestonedProperties.get(0);
+        expected.put(path + ".originalMilestonedProperties['toClass1A']", toClass1AOriginal);
+        expected.put(path + ".originalMilestonedProperties['toClass1A'].classifierGenericType", toClass1AOriginal._classifierGenericType());
+//        expected.put(path + ".originalMilestonedProperties['toClass1A'].classifierGenericType.typeArguments[0]", typeArgument(toClass1AOriginal._classifierGenericType(), 0));
+        expected.put(path + ".originalMilestonedProperties['toClass1A'].classifierGenericType.typeArguments[1]", typeArgument(toClass1AOriginal._classifierGenericType(), 1));
+        expected.put(path + ".originalMilestonedProperties['toClass1A'].genericType", toClass1AOriginal._genericType());
+
+        Property<?, ?> toClass2AOriginal = originalMilestonedProperties.get(1);
+        expected.put(path + ".originalMilestonedProperties['toClass2A']", toClass2AOriginal);
+        expected.put(path + ".originalMilestonedProperties['toClass2A'].classifierGenericType", toClass2AOriginal._classifierGenericType());
+//        expected.put(path + ".originalMilestonedProperties['toClass2A'].classifierGenericType.typeArguments[0]", typeArgument(toClass2AOriginal._classifierGenericType(), 0));
+        expected.put(path + ".originalMilestonedProperties['toClass2A'].classifierGenericType.typeArguments[1]", typeArgument(toClass2AOriginal._classifierGenericType(), 1));
+        expected.put(path + ".originalMilestonedProperties['toClass2A'].genericType", toClass2AOriginal._genericType());
+
+        ListIterable<? extends Property<?, ?>> properties = toList(association._properties());
+        Property<?, ?> toClass1AAllVersions = properties.get(0);
+        expected.put(path + ".properties['toClass1AAllVersions']", toClass1AAllVersions);
+        expected.put(path + ".properties['toClass1AAllVersions'].classifierGenericType", toClass1AAllVersions._classifierGenericType());
+        expected.put(path + ".properties['toClass1AAllVersions'].classifierGenericType.typeArguments[0]", typeArgument(toClass1AAllVersions._classifierGenericType(), 0));
+        expected.put(path + ".properties['toClass1AAllVersions'].classifierGenericType.typeArguments[1]", typeArgument(toClass1AAllVersions._classifierGenericType(), 1));
+        expected.put(path + ".properties['toClass1AAllVersions'].genericType", toClass1AAllVersions._genericType());
+
+        Property<?, ?> toClass2AAllVersions = properties.get(1);
+        expected.put(path + ".properties['toClass2AAllVersions']", toClass2AAllVersions);
+        expected.put(path + ".properties['toClass2AAllVersions'].classifierGenericType", toClass2AAllVersions._classifierGenericType());
+        expected.put(path + ".properties['toClass2AAllVersions'].classifierGenericType.typeArguments[0]", typeArgument(toClass2AAllVersions._classifierGenericType(), 0));
+        expected.put(path + ".properties['toClass2AAllVersions'].classifierGenericType.typeArguments[1]", typeArgument(toClass2AAllVersions._classifierGenericType(), 1));
+        expected.put(path + ".properties['toClass2AAllVersions'].genericType", toClass2AAllVersions._genericType());
+
+        ListIterable<? extends QualifiedProperty<?>> qualifiedProperties = toList(association._qualifiedProperties());
+        QualifiedProperty<?> toClass1A = qualifiedProperties.get(0);
+        expected.put(path + ".qualifiedProperties[id='toClass1A(Date[1])']", toClass1A);
+        expected.put(path + ".qualifiedProperties[id='toClass1A(Date[1])'].classifierGenericType", toClass1A._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='toClass1A(Date[1])'].classifierGenericType.typeArguments[0]", typeArgument(toClass1A._classifierGenericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='toClass1A(Date[1])'].classifierGenericType.typeArguments[0].rawType", typeArgument(toClass1A._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass1A._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td']",
+                funcTypeParam(typeArgument(toClass1A._classifierGenericType(), 0)._rawType(), "td"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td'].genericType",
+                funcTypeParam(typeArgument(toClass1A._classifierGenericType(), 0)._rawType(), "td")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass1A._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0]",
+                exprSeq(toClass1A, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass1A, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass1A, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass1A, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass1A, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass1A, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass1A, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass1A, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass1A, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                at(paramValue(exprSeq(toClass1A, 0), 1)._genericType()._typeArguments(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                at(paramValue(exprSeq(toClass1A, 0), 1)._genericType()._typeArguments(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(at(paramValue(exprSeq(toClass1A, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(at(paramValue(exprSeq(toClass1A, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(at(paramValue(exprSeq(toClass1A, 0), 1)._genericType()._typeArguments(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1A, 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass1A(Date[1])'].genericType", toClass1A._genericType());
+
+        QualifiedProperty<?> toClass1AAllVersionsInRange = qualifiedProperties.get(1);
+        expected.put(path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])']", toClass1AAllVersionsInRange);
+        expected.put(path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType", toClass1AAllVersionsInRange._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass1AAllVersionsInRange._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass1AAllVersionsInRange._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass1AAllVersionsInRange._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start']",
+                funcTypeParam(typeArgument(toClass1AAllVersionsInRange._classifierGenericType(), 0)._rawType(), "start"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start'].genericType",
+                funcTypeParam(typeArgument(toClass1AAllVersionsInRange._classifierGenericType(), 0)._rawType(), "start")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end']",
+                funcTypeParam(typeArgument(toClass1AAllVersionsInRange._classifierGenericType(), 0)._rawType(), "end"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end'].genericType",
+                funcTypeParam(typeArgument(toClass1AAllVersionsInRange._classifierGenericType(), 0)._rawType(), "end")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass1AAllVersionsInRange._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0]", exprSeq(toClass1AAllVersionsInRange, 0));
+        expected.put(path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].genericType", exprSeq(toClass1AAllVersionsInRange, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1)._genericType()._typeArguments().getOnly());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1)._genericType()._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1)._genericType()._typeArguments().getOnly()._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1)._genericType()._typeArguments().getOnly()._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1)._genericType()._typeArguments().getOnly()._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1AAllVersionsInRange, 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass1AAllVersionsInRange(Date[1],Date[1])'].genericType", toClass1AAllVersionsInRange._genericType());
+
+        QualifiedProperty<?> toClass2A = qualifiedProperties.get(2);
+        expected.put(path + ".qualifiedProperties[id='toClass2A(Date[1])']", toClass2A);
+        expected.put(path + ".qualifiedProperties[id='toClass2A(Date[1])'].classifierGenericType", toClass2A._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='toClass2A(Date[1])'].classifierGenericType.typeArguments[0]", typeArgument(toClass2A._classifierGenericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='toClass2A(Date[1])'].classifierGenericType.typeArguments[0].rawType", typeArgument(toClass2A._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass2A._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td']",
+                funcTypeParam(typeArgument(toClass2A._classifierGenericType(), 0)._rawType(), "td"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td'].genericType",
+                funcTypeParam(typeArgument(toClass2A._classifierGenericType(), 0)._rawType(), "td")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass2A._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0]", exprSeq(toClass2A, 0));
+        expected.put(path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].genericType", exprSeq(toClass2A, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass2A, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass2A, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass2A, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass2A, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass2A, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass2A, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass2A, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                at(paramValue(exprSeq(toClass2A, 0), 1)._genericType()._typeArguments(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                at(paramValue(exprSeq(toClass2A, 0), 1)._genericType()._typeArguments(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(at(paramValue(exprSeq(toClass2A, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(at(paramValue(exprSeq(toClass2A, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(at(paramValue(exprSeq(toClass2A, 0), 1)._genericType()._typeArguments(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2A(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2A, 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass2A(Date[1])'].genericType", toClass2A._genericType());
+
+        QualifiedProperty<?> toClass2AAllVersionsInRange = qualifiedProperties.get(3);
+        expected.put(path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])']", toClass2AAllVersionsInRange);
+        expected.put(path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType", toClass2AAllVersionsInRange._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass2AAllVersionsInRange._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass2AAllVersionsInRange._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass2AAllVersionsInRange._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start']",
+                funcTypeParam(typeArgument(toClass2AAllVersionsInRange._classifierGenericType(), 0)._rawType(), "start"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start'].genericType",
+                funcTypeParam(typeArgument(toClass2AAllVersionsInRange._classifierGenericType(), 0)._rawType(), "start")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end']",
+                funcTypeParam(typeArgument(toClass2AAllVersionsInRange._classifierGenericType(), 0)._rawType(), "end"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end'].genericType",
+                funcTypeParam(typeArgument(toClass2AAllVersionsInRange._classifierGenericType(), 0)._rawType(), "end")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass2AAllVersionsInRange._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0]",
+                exprSeq(toClass2AAllVersionsInRange, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass2AAllVersionsInRange, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                at(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1)._genericType()._typeArguments(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                at(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1)._genericType()._typeArguments(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(at(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(at(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(at(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1)._genericType()._typeArguments(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2AAllVersionsInRange, 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass2AAllVersionsInRange(Date[1],Date[1])'].genericType", toClass2AAllVersionsInRange._genericType());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testAssociationWithMilestoning2()
+    {
+        String path = "test::model::AssociationWithMilestoning2";
+        Association association = getCoreInstance(path);
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, association)
+                .withKeyValue(path + ".classifierGenericType", association._classifierGenericType());
+
+        ListIterable<? extends Property<?, ?>> originalMilestonedProperties = toList(association._originalMilestonedProperties());
+        Property<?, ?> toClass1BOriginal = originalMilestonedProperties.get(0);
+        expected.put(path + ".originalMilestonedProperties['toClass1B']", toClass1BOriginal);
+        expected.put(path + ".originalMilestonedProperties['toClass1B'].classifierGenericType", toClass1BOriginal._classifierGenericType());
+//        expected.put(path + ".originalMilestonedProperties['toClass1B'].classifierGenericType.typeArguments[0]", typeArgument(toClass1BOriginal._classifierGenericType(), 0));
+        expected.put(path + ".originalMilestonedProperties['toClass1B'].classifierGenericType.typeArguments[1]", typeArgument(toClass1BOriginal._classifierGenericType(), 1));
+        expected.put(path + ".originalMilestonedProperties['toClass1B'].genericType", toClass1BOriginal._genericType());
+
+        Property<?, ?> toClass3BOriginal = originalMilestonedProperties.get(1);
+        expected.put(path + ".originalMilestonedProperties['toClass3B']", toClass3BOriginal);
+        expected.put(path + ".originalMilestonedProperties['toClass3B'].classifierGenericType", toClass3BOriginal._classifierGenericType());
+//        expected.put(path + ".originalMilestonedProperties['toClass3B'].classifierGenericType.typeArguments[0]", typeArgument(toClass3BOriginal._classifierGenericType(), 0));
+        expected.put(path + ".originalMilestonedProperties['toClass3B'].classifierGenericType.typeArguments[1]", typeArgument(toClass3BOriginal._classifierGenericType(), 1));
+        expected.put(path + ".originalMilestonedProperties['toClass3B'].genericType", toClass3BOriginal._genericType());
+
+        ListIterable<? extends Property<?, ?>> properties = toList(association._properties());
+        Property<?, ?> toClass1BAllVersions = properties.get(0);
+        expected.put(path + ".properties['toClass1BAllVersions']", toClass1BAllVersions);
+        expected.put(path + ".properties['toClass1BAllVersions'].classifierGenericType", toClass1BAllVersions._classifierGenericType());
+        expected.put(path + ".properties['toClass1BAllVersions'].classifierGenericType.typeArguments[0]", typeArgument(toClass1BAllVersions._classifierGenericType(), 0));
+        expected.put(path + ".properties['toClass1BAllVersions'].classifierGenericType.typeArguments[1]", typeArgument(toClass1BAllVersions._classifierGenericType(), 1));
+        expected.put(path + ".properties['toClass1BAllVersions'].genericType", toClass1BAllVersions._genericType());
+
+        Property<?, ?> toClass3BAllVersions = properties.get(1);
+        expected.put(path + ".properties['toClass3BAllVersions']", toClass3BAllVersions);
+        expected.put(path + ".properties['toClass3BAllVersions'].classifierGenericType", toClass3BAllVersions._classifierGenericType());
+        expected.put(path + ".properties['toClass3BAllVersions'].classifierGenericType.typeArguments[0]", typeArgument(toClass3BAllVersions._classifierGenericType(), 0));
+        expected.put(path + ".properties['toClass3BAllVersions'].classifierGenericType.typeArguments[1]", typeArgument(toClass3BAllVersions._classifierGenericType(), 1));
+        expected.put(path + ".properties['toClass3BAllVersions'].genericType", toClass3BAllVersions._genericType());
+
+        ListIterable<? extends QualifiedProperty<?>> qualifiedProperties = toList(association._qualifiedProperties());
+        QualifiedProperty<?> toClass1B_noDate = qualifiedProperties.get(0);
+        expected.put(path + ".qualifiedProperties[id='toClass1B()']", toClass1B_noDate);
+        expected.put(path + ".qualifiedProperties[id='toClass1B()'].classifierGenericType", toClass1B_noDate._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='toClass1B()'].classifierGenericType.typeArguments[0]", typeArgument(toClass1B_noDate._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass1B_noDate._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass1B_noDate._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass1B_noDate._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0]",
+                exprSeq(toClass1B_noDate, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].genericType",
+                exprSeq(toClass1B_noDate, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass1B_noDate, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass1B_noDate, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass1B_noDate, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass1B_noDate, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass1B_noDate, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass1B_noDate, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass1B_noDate, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                at(paramValue(exprSeq(toClass1B_noDate, 0), 1)._genericType()._typeArguments(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                at(paramValue(exprSeq(toClass1B_noDate, 0), 1)._genericType()._typeArguments(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(at(paramValue(exprSeq(toClass1B_noDate, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(at(paramValue(exprSeq(toClass1B_noDate, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(at(paramValue(exprSeq(toClass1B_noDate, 0), 1)._genericType()._typeArguments(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_noDate, 0), 1), 0), 0), 1))._propertyName());
+        expected.put(path + ".qualifiedProperties[id='toClass1B()'].genericType", toClass1B_noDate._genericType());
+
+        QualifiedProperty<?> toClass1B_date = qualifiedProperties.get(1);
+        expected.put(path + ".qualifiedProperties[id='toClass1B(Date[1])']", toClass1B_date);
+        expected.put(path + ".qualifiedProperties[id='toClass1B(Date[1])'].classifierGenericType", toClass1B_date._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass1B_date._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass1B_date._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass1B_date._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td']",
+                funcTypeParam(typeArgument(toClass1B_date._classifierGenericType(), 0)._rawType(), "td"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td'].genericType",
+                funcTypeParam(typeArgument(toClass1B_date._classifierGenericType(), 0)._rawType(), "td")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass1B_date._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0]",
+                exprSeq(toClass1B_date, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass1B_date, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass1B_date, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass1B_date, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass1B_date, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass1B_date, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass1B_date, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass1B_date, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass1B_date, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                at(paramValue(exprSeq(toClass1B_date, 0), 1)._genericType()._typeArguments(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                at(paramValue(exprSeq(toClass1B_date, 0), 1)._genericType()._typeArguments(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(at(paramValue(exprSeq(toClass1B_date, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(at(paramValue(exprSeq(toClass1B_date, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(at(paramValue(exprSeq(toClass1B_date, 0), 1)._genericType()._typeArguments(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1B_date, 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass1B(Date[1])'].genericType", toClass1B_date._genericType());
+
+        QualifiedProperty<?> toClass1BAllVersionsInRange = qualifiedProperties.get(2);
+        expected.put(path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])']", toClass1BAllVersionsInRange);
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].classifierGenericType",
+                toClass1BAllVersionsInRange._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass1BAllVersionsInRange._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass1BAllVersionsInRange._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass1BAllVersionsInRange._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start']",
+                funcTypeParam(typeArgument(toClass1BAllVersionsInRange._classifierGenericType(), 0)._rawType(), "start"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start'].genericType",
+                funcTypeParam(typeArgument(toClass1BAllVersionsInRange._classifierGenericType(), 0)._rawType(), "start")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end']",
+                funcTypeParam(typeArgument(toClass1BAllVersionsInRange._classifierGenericType(), 0)._rawType(), "end"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end'].genericType",
+                funcTypeParam(typeArgument(toClass1BAllVersionsInRange._classifierGenericType(), 0)._rawType(), "end")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass1BAllVersionsInRange._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0]", exprSeq(toClass1BAllVersionsInRange, 0));
+        expected.put(path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].genericType", exprSeq(toClass1BAllVersionsInRange, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1)._genericType()._typeArguments().getOnly());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1)._genericType()._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1)._genericType()._typeArguments().getOnly()._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1)._genericType()._typeArguments().getOnly()._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1)._genericType()._typeArguments().getOnly()._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass1BAllVersionsInRange, 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass1BAllVersionsInRange(Date[1],Date[1])'].genericType", toClass1BAllVersionsInRange._genericType());
+
+        QualifiedProperty<?> toClass3B_date_date = qualifiedProperties.get(3);
+        expected.put(path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])']", toClass3B_date_date);
+        expected.put(path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].classifierGenericType", toClass3B_date_date._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass3B_date_date._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass3B_date_date._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass3B_date_date._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['bd']",
+                funcTypeParam(typeArgument(toClass3B_date_date._classifierGenericType(), 0)._rawType(), "bd"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['bd'].genericType",
+                funcTypeParam(typeArgument(toClass3B_date_date._classifierGenericType(), 0)._rawType(), "bd")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['pd']",
+                funcTypeParam(typeArgument(toClass3B_date_date._classifierGenericType(), 0)._rawType(), "pd"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['pd'].genericType",
+                funcTypeParam(typeArgument(toClass3B_date_date._classifierGenericType(), 0)._rawType(), "pd")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass3B_date_date._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0]",
+                exprSeq(toClass3B_date_date, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass3B_date_date, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass3B_date_date, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass3B_date_date, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass3B_date_date, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass3B_date_date, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass3B_date_date, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass3B_date_date, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass3B_date_date, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(exprSeq(toClass3B_date_date, 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(exprSeq(toClass3B_date_date, 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3B_date_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3B_date_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(exprSeq(toClass3B_date_date, 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 1), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 1), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date_date, 0), 1), 0), 0), 1), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass3B(Date[1],Date[1])'].genericType", toClass3B_date_date._genericType());
+
+        QualifiedProperty<?> toClass3B_date = qualifiedProperties.get(4);
+        expected.put(path + ".qualifiedProperties[id='toClass3B(Date[1])']", toClass3B_date);
+        expected.put(path + ".qualifiedProperties[id='toClass3B(Date[1])'].classifierGenericType", toClass3B_date._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass3B_date._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass3B_date._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass3B_date._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td']",
+                funcTypeParam(typeArgument(toClass3B_date._classifierGenericType(), 0)._rawType(), "td"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td'].genericType",
+                funcTypeParam(typeArgument(toClass3B_date._classifierGenericType(), 0)._rawType(), "td")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass3B_date._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0]",
+                exprSeq(toClass3B_date, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass3B_date, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass3B_date, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass3B_date, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass3B_date, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass3B_date, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass3B_date, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass3B_date, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass3B_date, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(exprSeq(toClass3B_date, 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(exprSeq(toClass3B_date, 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3B_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3B_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(exprSeq(toClass3B_date, 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 1), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 1), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 1), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 1), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 1), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3B(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3B_date, 0), 1), 0), 0), 1), 1))._propertyName());
+        expected.put(path + ".qualifiedProperties[id='toClass3B(Date[1])'].genericType", toClass3B_date._genericType());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testAssociationWithMilestoning3()
+    {
+        String path = "test::model::AssociationWithMilestoning3";
+        Association association = getCoreInstance(path);
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, association)
+                .withKeyValue(path + ".classifierGenericType", association._classifierGenericType());
+
+        ListIterable<? extends Property<?, ?>> originalMilestonedProperties = toList(association._originalMilestonedProperties());
+        Property<?, ?> toClass2COriginal = originalMilestonedProperties.get(0);
+        expected.put(path + ".originalMilestonedProperties['toClass2C']", toClass2COriginal);
+        expected.put(path + ".originalMilestonedProperties['toClass2C'].classifierGenericType", toClass2COriginal._classifierGenericType());
+//        expected.put(path + ".originalMilestonedProperties['toClass2C'].classifierGenericType.typeArguments[0]", typeArgument(toClass2COriginal._classifierGenericType(), 0));
+        expected.put(path + ".originalMilestonedProperties['toClass2C'].classifierGenericType.typeArguments[1]", typeArgument(toClass2COriginal._classifierGenericType(), 1));
+        expected.put(path + ".originalMilestonedProperties['toClass2C'].genericType", toClass2COriginal._genericType());
+
+        Property<?, ?> toClass3COriginal = originalMilestonedProperties.get(1);
+        expected.put(path + ".originalMilestonedProperties['toClass3C']", toClass3COriginal);
+        expected.put(path + ".originalMilestonedProperties['toClass3C'].classifierGenericType", toClass3COriginal._classifierGenericType());
+//        expected.put(path + ".originalMilestonedProperties['toClass3C'].classifierGenericType.typeArguments[0]", typeArgument(toClass3COriginal._classifierGenericType(), 0));
+        expected.put(path + ".originalMilestonedProperties['toClass3C'].classifierGenericType.typeArguments[1]", typeArgument(toClass3COriginal._classifierGenericType(), 1));
+        expected.put(path + ".originalMilestonedProperties['toClass3C'].genericType", toClass3COriginal._genericType());
+
+        ListIterable<? extends Property<?, ?>> properties = toList(association._properties());
+        Property<?, ?> toClass2CAllVersions = properties.get(0);
+        expected.put(path + ".properties['toClass2CAllVersions']", toClass2CAllVersions);
+        expected.put(path + ".properties['toClass2CAllVersions'].classifierGenericType", toClass2CAllVersions._classifierGenericType());
+        expected.put(path + ".properties['toClass2CAllVersions'].classifierGenericType.typeArguments[0]", typeArgument(toClass2CAllVersions._classifierGenericType(), 0));
+        expected.put(path + ".properties['toClass2CAllVersions'].classifierGenericType.typeArguments[1]", typeArgument(toClass2CAllVersions._classifierGenericType(), 1));
+        expected.put(path + ".properties['toClass2CAllVersions'].genericType", toClass2CAllVersions._genericType());
+
+        Property<?, ?> toClass3CAllVersions = properties.get(1);
+        expected.put(path + ".properties['toClass3CAllVersions']", toClass3CAllVersions);
+        expected.put(path + ".properties['toClass3CAllVersions'].classifierGenericType", toClass3CAllVersions._classifierGenericType());
+        expected.put(path + ".properties['toClass3CAllVersions'].classifierGenericType.typeArguments[0]", typeArgument(toClass3CAllVersions._classifierGenericType(), 0));
+        expected.put(path + ".properties['toClass3CAllVersions'].classifierGenericType.typeArguments[1]", typeArgument(toClass3CAllVersions._classifierGenericType(), 1));
+        expected.put(path + ".properties['toClass3CAllVersions'].genericType", toClass3CAllVersions._genericType());
+
+        ListIterable<? extends QualifiedProperty<?>> qualifiedProperties = toList(association._qualifiedProperties());
+        QualifiedProperty<?> toClass2C_noDate = qualifiedProperties.get(0);
+        expected.put(path + ".qualifiedProperties[id='toClass2C()']", toClass2C_noDate);
+        expected.put(path + ".qualifiedProperties[id='toClass2C()'].classifierGenericType", toClass2C_noDate._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass2C_noDate._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass2C_noDate._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass2C_noDate._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass2C_noDate._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0]",
+                exprSeq(toClass2C_noDate, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].genericType",
+                exprSeq(toClass2C_noDate, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass2C_noDate, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass2C_noDate, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass2C_noDate, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass2C_noDate, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass2C_noDate, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass2C_noDate, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass2C_noDate, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(exprSeq(toClass2C_noDate, 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(exprSeq(toClass2C_noDate, 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass2C_noDate, 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass2C_noDate, 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(exprSeq(toClass2C_noDate, 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C()'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_noDate, 0), 1), 0), 0), 1))._propertyName());
+        expected.put(path + ".qualifiedProperties[id='toClass2C()'].genericType", toClass2C_noDate._genericType());
+
+        QualifiedProperty<?> toClass2C_date = qualifiedProperties.get(1);
+        expected.put(path + ".qualifiedProperties[id='toClass2C(Date[1])']", toClass2C_date);
+        expected.put(path + ".qualifiedProperties[id='toClass2C(Date[1])'].classifierGenericType", toClass2C_date._classifierGenericType());
+        expected.put(path + ".qualifiedProperties[id='toClass2C(Date[1])'].classifierGenericType.typeArguments[0]", typeArgument(toClass2C_date._classifierGenericType(), 0));
+        expected.put(path + ".qualifiedProperties[id='toClass2C(Date[1])'].classifierGenericType.typeArguments[0].rawType", typeArgument(toClass2C_date._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass2C_date._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td']",
+                funcTypeParam(typeArgument(toClass2C_date._classifierGenericType(), 0)._rawType(), "td"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td'].genericType",
+                funcTypeParam(typeArgument(toClass2C_date._classifierGenericType(), 0)._rawType(), "td")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass2C_date._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0]", exprSeq(toClass2C_date, 0));
+        expected.put(path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].genericType", exprSeq(toClass2C_date, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass2C_date, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass2C_date, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass2C_date, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass2C_date, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass2C_date, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass2C_date, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass2C_date, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                at(paramValue(exprSeq(toClass2C_date, 0), 1)._genericType()._typeArguments(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                at(paramValue(exprSeq(toClass2C_date, 0), 1)._genericType()._typeArguments(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(at(paramValue(exprSeq(toClass2C_date, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(at(paramValue(exprSeq(toClass2C_date, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(at(paramValue(exprSeq(toClass2C_date, 0), 1)._genericType()._typeArguments(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2C_date, 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass2C(Date[1])'].genericType", toClass2C_date._genericType());
+
+        QualifiedProperty<?> toClass2CAllVersionsInRange = qualifiedProperties.get(2);
+        expected.put(path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])']", toClass2CAllVersionsInRange);
+        expected.put(path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].classifierGenericType", toClass2CAllVersionsInRange._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass2CAllVersionsInRange._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass2CAllVersionsInRange._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass2CAllVersionsInRange._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start']",
+                funcTypeParam(typeArgument(toClass2CAllVersionsInRange._classifierGenericType(), 0)._rawType(), "start"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['start'].genericType",
+                funcTypeParam(typeArgument(toClass2CAllVersionsInRange._classifierGenericType(), 0)._rawType(), "start")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end']",
+                funcTypeParam(typeArgument(toClass2CAllVersionsInRange._classifierGenericType(), 0)._rawType(), "end"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['end'].genericType",
+                funcTypeParam(typeArgument(toClass2CAllVersionsInRange._classifierGenericType(), 0)._rawType(), "end")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass2CAllVersionsInRange._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0]",
+                exprSeq(toClass2CAllVersionsInRange, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass2CAllVersionsInRange, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                at(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1)._genericType()._typeArguments(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                at(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1)._genericType()._typeArguments(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(at(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(at(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1)._genericType()._typeArguments(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(at(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1)._genericType()._typeArguments(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass2CAllVersionsInRange, 0), 1), 0), 0), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass2CAllVersionsInRange(Date[1],Date[1])'].genericType", toClass2CAllVersionsInRange._genericType());
+
+        QualifiedProperty<?> toClass3C_date_date = qualifiedProperties.get(3);
+        expected.put(path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])']", toClass3C_date_date);
+        expected.put(path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].classifierGenericType", toClass3C_date_date._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass3C_date_date._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass3C_date_date._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass3C_date_date._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['bd']",
+                funcTypeParam(typeArgument(toClass3C_date_date._classifierGenericType(), 0)._rawType(), "bd"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['bd'].genericType",
+                funcTypeParam(typeArgument(toClass3C_date_date._classifierGenericType(), 0)._rawType(), "bd")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['pd']",
+                funcTypeParam(typeArgument(toClass3C_date_date._classifierGenericType(), 0)._rawType(), "pd"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['pd'].genericType",
+                funcTypeParam(typeArgument(toClass3C_date_date._classifierGenericType(), 0)._rawType(), "pd")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass3C_date_date._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0]",
+                exprSeq(toClass3C_date_date, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass3C_date_date, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass3C_date_date, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass3C_date_date, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass3C_date_date, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass3C_date_date, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass3C_date_date, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass3C_date_date, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass3C_date_date, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(exprSeq(toClass3C_date_date, 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(exprSeq(toClass3C_date_date, 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3C_date_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3C_date_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(exprSeq(toClass3C_date_date, 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 1), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 1), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date_date, 0), 1), 0), 0), 1), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass3C(Date[1],Date[1])'].genericType", toClass3C_date_date._genericType());
+
+        QualifiedProperty<?> toClass3C_date = qualifiedProperties.get(4);
+        expected.put(path + ".qualifiedProperties[id='toClass3C(Date[1])']", toClass3C_date);
+        expected.put(path + ".qualifiedProperties[id='toClass3C(Date[1])'].classifierGenericType", toClass3C_date._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].classifierGenericType.typeArguments[0]",
+                typeArgument(toClass3C_date._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(toClass3C_date._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['this'].genericType",
+                funcTypeParam(typeArgument(toClass3C_date._classifierGenericType(), 0)._rawType(), "this")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td']",
+                funcTypeParam(typeArgument(toClass3C_date._classifierGenericType(), 0)._rawType(), "td"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].classifierGenericType.typeArguments[0].rawType.parameters['td'].genericType",
+                funcTypeParam(typeArgument(toClass3C_date._classifierGenericType(), 0)._rawType(), "td")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(toClass3C_date._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0]",
+                exprSeq(toClass3C_date, 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].genericType",
+                exprSeq(toClass3C_date, 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(toClass3C_date, 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(toClass3C_date, 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(toClass3C_date, 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(toClass3C_date, 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(exprSeq(toClass3C_date, 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(toClass3C_date, 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(toClass3C_date, 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0]",
+                typeArgument(paramValue(exprSeq(toClass3C_date, 0), 1)._genericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType",
+                typeArgument(paramValue(exprSeq(toClass3C_date, 0), 1)._genericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3C_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(paramValue(exprSeq(toClass3C_date, 0), 1)._genericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(paramValue(exprSeq(toClass3C_date, 0), 1)._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0]",
+                instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType",
+                instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0)._classifierGenericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0]",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0)._classifierGenericType(), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType",
+                typeArgument(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0)._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone']",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone"));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['v_milestone'].genericType",
+                funcTypeParam(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0)._classifierGenericType(), 0)._rawType(), "v_milestone")._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0)._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0]",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].genericType",
+                exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 0), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 0), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 0), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].parametersValues[1].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 0), 1))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 1)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 1), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 1), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0]",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 1), 0), 0));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType",
+                paramValue(paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 1), 0), 0)._genericType());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[0].propertyName",
+                ((SimpleFunctionExpression) paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 1), 0))._propertyName());
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1]",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 1), 1));
+        expected.put(
+                path + ".qualifiedProperties[id='toClass3C(Date[1])'].expressionSequence[0].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].parametersValues[1].genericType",
+                paramValue(paramValue(exprSeq(instanceValueValue(paramValue(exprSeq(toClass3C_date, 0), 1), 0), 0), 1), 1)._genericType());
+        expected.put(path + ".qualifiedProperties[id='toClass3C(Date[1])'].genericType", toClass3C_date._genericType());
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testNativeFunction()
+    {
+        String path = "meta::pure::functions::lang::compare_T_1__T_1__Integer_1_";
+        NativeFunction<?> compare = getCoreInstance(path);
+
+        MutableMap<String, CoreInstance> expected = Maps.mutable.<String, CoreInstance>with(path, compare)
+                .withKeyValue(path + ".classifierGenericType", compare._classifierGenericType())
+                .withKeyValue(path + ".classifierGenericType.typeArguments[0]", typeArgument(compare._classifierGenericType(), 0))
+                .withKeyValue(path + ".classifierGenericType.typeArguments[0].rawType", typeArgument(compare._classifierGenericType(), 0)._rawType())
+                .withKeyValue(path + ".classifierGenericType.typeArguments[0].rawType.parameters['a']", funcTypeParam(typeArgument(compare._classifierGenericType(), 0)._rawType(), "a"))
+                .withKeyValue(path + ".classifierGenericType.typeArguments[0].rawType.parameters['a'].genericType", funcTypeParam(typeArgument(compare._classifierGenericType(), 0)._rawType(), "a")._genericType())
+                .withKeyValue(path + ".classifierGenericType.typeArguments[0].rawType.parameters['b']", funcTypeParam(typeArgument(compare._classifierGenericType(), 0)._rawType(), "b"))
+                .withKeyValue(path + ".classifierGenericType.typeArguments[0].rawType.parameters['b'].genericType", funcTypeParam(typeArgument(compare._classifierGenericType(), 0)._rawType(), "b")._genericType())
+                .withKeyValue(path + ".classifierGenericType.typeArguments[0].rawType.returnType", funcTypeRetType(typeArgument(compare._classifierGenericType(), 0)._rawType()))
+                .withKeyValue(path + ".taggedValues[0]", compare._taggedValues().getFirst())
+                .withKeyValue(path + ".taggedValues[1]", compare._taggedValues().getLast());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testFunction()
+    {
+        String path = "test::model::testFunc_T_m__Function_$0_1$__String_m_";
+        ConcreteFunctionDefinition<?> testFunction = getCoreInstance(path);
+        MutableMap<String, CoreInstance> expected = Maps.mutable.with(path, testFunction);
+
+        FunctionType functionType = (FunctionType) typeArgument(testFunction._classifierGenericType(), 0)._rawType();
+        expected.put(path + ".classifierGenericType", testFunction._classifierGenericType());
+        expected.put(path + ".classifierGenericType.typeArguments[0]", typeArgument(testFunction._classifierGenericType(), 0));
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType", functionType);
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.parameters['col']", funcTypeParam(functionType, "col"));
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.parameters['col'].genericType", funcTypeParam(functionType, "col")._genericType());
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.parameters['col'].multiplicity", funcTypeParam(functionType, "col")._multiplicity());
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.parameters['func']", funcTypeParam(functionType, "func"));
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.parameters['func'].genericType", funcTypeParam(functionType, "func")._genericType());
+//        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.parameters['func'].genericType.typeArguments[0]", funcTypeParam(functionType, "func")._genericType()._typeArguments().getOnly());
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.parameters['func'].genericType.typeArguments[0].rawType", funcTypeParam(functionType, "func")._genericType()._typeArguments().getOnly()._rawType());
+//        expected.put(
+//                path + ".classifierGenericType.typeArguments[0].rawType.parameters['func'].genericType.typeArguments[0].rawType.parameters['']",
+//                funcTypeParam(funcTypeParam(functionType, "func")._genericType()._typeArguments().getOnly()._rawType(), ""));
+        expected.put(
+                path + ".classifierGenericType.typeArguments[0].rawType.parameters['func'].genericType.typeArguments[0].rawType.parameters[''].genericType",
+                funcTypeParam(funcTypeParam(functionType, "func")._genericType()._typeArguments().getOnly()._rawType(), "")._genericType());
+        expected.put(
+                path + ".classifierGenericType.typeArguments[0].rawType.parameters['func'].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(funcTypeParam(functionType, "func")._genericType()._typeArguments().getOnly()._rawType()));
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.returnMultiplicity", functionType._returnMultiplicity());
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.returnType", funcTypeRetType(functionType));
+
+        SimpleFunctionExpression letExp = (SimpleFunctionExpression) testFunction._expressionSequence().getFirst();
+        expected.put(path + ".expressionSequence[0]", letExp);
+        expected.put(path + ".expressionSequence[0].genericType", letExp._genericType());
+        expected.put(path + ".expressionSequence[0].genericType.typeArguments[0]", typeArgument(letExp._genericType(), 0));
+        expected.put(path + ".expressionSequence[0].genericType.typeArguments[0].rawType", typeArgument(letExp._genericType(), 0)._rawType());
+        expected.put(path + ".expressionSequence[0].genericType.typeArguments[0].rawType.parameters['']", funcTypeParam(typeArgument(letExp._genericType(), 0)._rawType(), ""));
+        expected.put(path + ".expressionSequence[0].genericType.typeArguments[0].rawType.parameters[''].genericType", funcTypeParam(typeArgument(letExp._genericType(), 0)._rawType(), "")._genericType());
+        expected.put(path + ".expressionSequence[0].genericType.typeArguments[0].rawType.parameters[''].genericType.typeParameter", funcTypeParam(typeArgument(letExp._genericType(), 0)._rawType(), "")._genericType()._typeParameter());
+        expected.put(path + ".expressionSequence[0].genericType.typeArguments[0].rawType.returnType", funcTypeRetType(typeArgument(letExp._genericType(), 0)._rawType()));
+
+        InstanceValue letVar = (InstanceValue) letExp._parametersValues().getFirst();
+        expected.put(path + ".expressionSequence[0].parametersValues[0]", letVar);
+        expected.put(path + ".expressionSequence[0].parametersValues[0].genericType", letVar._genericType());
+
+        SimpleFunctionExpression letValIfExp = (SimpleFunctionExpression) letExp._parametersValues().getLast();
+        expected.put(path + ".expressionSequence[0].parametersValues[1]", letValIfExp);
+        expected.put(path + ".expressionSequence[0].parametersValues[1].genericType", letValIfExp._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].genericType.typeArguments[0]", typeArgument(letValIfExp._genericType(), 0));
+        expected.put(path + ".expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType", typeArgument(letValIfExp._genericType(), 0)._rawType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters['']", funcTypeParam(typeArgument(letValIfExp._genericType(), 0)._rawType(), ""));
+        expected.put(path + ".expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters[''].genericType", funcTypeParam(typeArgument(letValIfExp._genericType(), 0)._rawType(), "")._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.parameters[''].genericType.typeParameter", funcTypeParam(typeArgument(letValIfExp._genericType(), 0)._rawType(), "")._genericType()._typeParameter());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].genericType.typeArguments[0].rawType.returnType", funcTypeRetType(typeArgument(letValIfExp._genericType(), 0)._rawType()));
+
+        ListIterable<? extends ValueSpecification> letValIfParams = toList(letValIfExp._parametersValues());
+        SimpleFunctionExpression letValIfCond = (SimpleFunctionExpression) letValIfParams.get(0);
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[0]", letValIfCond);
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[0].genericType", letValIfCond._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0]", letValIfCond._parametersValues().getOnly());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType", letValIfCond._parametersValues().getOnly()._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType.typeArguments[0]", letValIfCond._parametersValues().getOnly()._genericType()._typeArguments().getOnly());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType.typeArguments[0].rawType", letValIfCond._parametersValues().getOnly()._genericType()._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType.typeArguments[0].rawType.parameters['']",
+                funcTypeParam(letValIfCond._parametersValues().getOnly()._genericType()._typeArguments().getOnly()._rawType(), ""));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType.typeArguments[0].rawType.parameters[''].genericType",
+                funcTypeParam(letValIfCond._parametersValues().getOnly()._genericType()._typeArguments().getOnly()._rawType(), "")._genericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType.typeArguments[0].rawType.parameters[''].genericType.typeParameter",
+                funcTypeParam(letValIfCond._parametersValues().getOnly()._genericType()._typeArguments().getOnly()._rawType(), "")._genericType()._typeParameter());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[0].parametersValues[0].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(letValIfCond._parametersValues().getOnly()._genericType()._typeArguments().getOnly()._rawType()));
+
+        InstanceValue letValIfTrue = (InstanceValue) letValIfParams.get(1);
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1]", letValIfTrue);
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1].genericType", letValIfTrue._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1].genericType.typeArguments[0]", typeArgument(letValIfTrue._genericType(), 0));
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1].genericType.typeArguments[0].rawType", typeArgument(letValIfTrue._genericType(), 0)._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(letValIfTrue._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].genericType.typeArguments[0].rawType.returnType.typeArguments[0]",
+                funcTypeRetType(typeArgument(letValIfTrue._genericType(), 0)._rawType())._typeArguments().getOnly());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].genericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType",
+                funcTypeRetType(typeArgument(letValIfTrue._genericType(), 0)._rawType())._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].genericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.parameters['x']",
+                funcTypeParam(funcTypeRetType(typeArgument(letValIfTrue._genericType(), 0)._rawType())._typeArguments().getOnly()._rawType(), "x"));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].genericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.parameters['x'].genericType",
+                funcTypeParam(funcTypeRetType(typeArgument(letValIfTrue._genericType(), 0)._rawType())._typeArguments().getOnly()._rawType(), "x")._genericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].genericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.parameters['x'].genericType.typeParameter",
+                funcTypeParam(funcTypeRetType(typeArgument(letValIfTrue._genericType(), 0)._rawType())._typeArguments().getOnly()._rawType(), "x")._genericType()._typeParameter());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].genericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(funcTypeRetType(typeArgument(letValIfTrue._genericType(), 0)._rawType())._typeArguments().getOnly()._rawType()));
+
+        LambdaFunction<?> letValIfTrueLambda = (LambdaFunction<?>) letValIfTrue._values().getOnly();
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0]", letValIfTrueLambda);
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType", letValIfTrueLambda._classifierGenericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0]", typeArgument(letValIfTrueLambda._classifierGenericType(), 0));
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType", typeArgument(letValIfTrueLambda._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(letValIfTrueLambda._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType.typeArguments[0]",
+                funcTypeRetType(typeArgument(letValIfTrueLambda._classifierGenericType(), 0)._rawType())._typeArguments().getOnly());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType",
+                funcTypeRetType(typeArgument(letValIfTrueLambda._classifierGenericType(), 0)._rawType())._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.parameters['x']",
+                funcTypeParam(funcTypeRetType(typeArgument(letValIfTrueLambda._classifierGenericType(), 0)._rawType())._typeArguments().getOnly()._rawType(), "x"));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.parameters['x'].genericType",
+                funcTypeParam(funcTypeRetType(typeArgument(letValIfTrueLambda._classifierGenericType(), 0)._rawType())._typeArguments().getOnly()._rawType(), "x")._genericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.parameters['x'].genericType.typeParameter",
+                funcTypeParam(funcTypeRetType(typeArgument(letValIfTrueLambda._classifierGenericType(), 0)._rawType())._typeArguments().getOnly()._rawType(), "x")._genericType()._typeParameter());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(funcTypeRetType(typeArgument(letValIfTrueLambda._classifierGenericType(), 0)._rawType())._typeArguments().getOnly()._rawType()));
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0]", letValIfTrueLambda._expressionSequence().getOnly());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].genericType", letValIfTrueLambda._expressionSequence().getOnly()._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].genericType.typeArguments[0]", letValIfTrueLambda._expressionSequence().getOnly()._genericType()._typeArguments().getOnly());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].genericType.typeArguments[0].rawType", letValIfTrueLambda._expressionSequence().getOnly()._genericType()._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].genericType.typeArguments[0].rawType.parameters['x']",
+                funcTypeParam(letValIfTrueLambda._expressionSequence().getOnly()._genericType()._typeArguments().getOnly()._rawType(), "x"));
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].genericType.typeArguments[0].rawType.parameters['x'].genericType",
+                funcTypeParam(letValIfTrueLambda._expressionSequence().getOnly()._genericType()._typeArguments().getOnly()._rawType(), "x")._genericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].genericType.typeArguments[0].rawType.parameters['x'].genericType.typeParameter",
+                funcTypeParam(letValIfTrueLambda._expressionSequence().getOnly()._genericType()._typeArguments().getOnly()._rawType(), "x")._genericType()._typeParameter());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(letValIfTrueLambda._expressionSequence().getOnly()._genericType()._typeArguments().getOnly()._rawType()));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].values[0]",
+                (LambdaFunction<?>) ((InstanceValue) letValIfTrueLambda._expressionSequence().getOnly())._values().getOnly());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].values[0].classifierGenericType",
+                ((LambdaFunction<?>) ((InstanceValue) letValIfTrueLambda._expressionSequence().getOnly())._values().getOnly())._classifierGenericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].values[0].classifierGenericType.typeArguments[0]",
+                ((LambdaFunction<?>) ((InstanceValue) letValIfTrueLambda._expressionSequence().getOnly())._values().getOnly())._classifierGenericType()._typeArguments().getOnly());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].values[0].classifierGenericType.typeArguments[0].rawType",
+                ((LambdaFunction<?>) ((InstanceValue) letValIfTrueLambda._expressionSequence().getOnly())._values().getOnly())._classifierGenericType()._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].values[0].classifierGenericType.typeArguments[0].rawType.parameters['x']",
+                funcTypeParam(((LambdaFunction<?>) ((InstanceValue) letValIfTrueLambda._expressionSequence().getOnly())._values().getOnly())._classifierGenericType()._typeArguments().getOnly()._rawType(), "x"));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].values[0].classifierGenericType.typeArguments[0].rawType.parameters['x'].genericType",
+                funcTypeParam(((LambdaFunction<?>) ((InstanceValue) letValIfTrueLambda._expressionSequence().getOnly())._values().getOnly())._classifierGenericType()._typeArguments().getOnly()._rawType(), "x")._genericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(((LambdaFunction<?>) ((InstanceValue) letValIfTrueLambda._expressionSequence().getOnly())._values().getOnly())._classifierGenericType()._typeArguments().getOnly()._rawType()));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].values[0].expressionSequence[0]",
+                ((LambdaFunction<?>) ((InstanceValue) letValIfTrueLambda._expressionSequence().getOnly())._values().getOnly())._expressionSequence().getOnly());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].values[0].expressionSequence[0].genericType",
+                ((LambdaFunction<?>) ((InstanceValue) letValIfTrueLambda._expressionSequence().getOnly())._values().getOnly())._expressionSequence().getOnly()._genericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].values[0].expressionSequence[0].parametersValues[0]",
+                ((SimpleFunctionExpression) ((LambdaFunction<?>) ((InstanceValue) letValIfTrueLambda._expressionSequence().getOnly())._values().getOnly())._expressionSequence().getOnly())._parametersValues().getOnly());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].values[0].expressionSequence[0].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) ((LambdaFunction<?>) ((InstanceValue) letValIfTrueLambda._expressionSequence().getOnly())._values().getOnly())._expressionSequence().getOnly())._parametersValues().getOnly()._genericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[1].values[0].expressionSequence[0].values[0].expressionSequence[0].parametersValues[0].genericType.typeParameter",
+                ((SimpleFunctionExpression) ((LambdaFunction<?>) ((InstanceValue) letValIfTrueLambda._expressionSequence().getOnly())._values().getOnly())._expressionSequence().getOnly())._parametersValues().getOnly()._genericType()._typeParameter());
+
+        InstanceValue letValIfFalse = (InstanceValue) letValIfParams.get(2);
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[2]", letValIfFalse);
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[2].genericType", letValIfFalse._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[2].genericType.typeArguments[0]", typeArgument(letValIfFalse._genericType(), 0));
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[2].genericType.typeArguments[0].rawType", typeArgument(letValIfFalse._genericType(), 0)._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(letValIfFalse._genericType(), 0)._rawType()));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].genericType.typeArguments[0].rawType.returnType.typeArguments[0]",
+                funcTypeRetType(typeArgument(letValIfFalse._genericType(), 0)._rawType())._typeArguments().getOnly());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].genericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType",
+                funcTypeRetType(typeArgument(letValIfFalse._genericType(), 0)._rawType())._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].genericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.parameters['']",
+                funcTypeParam(funcTypeRetType(typeArgument(letValIfFalse._genericType(), 0)._rawType())._typeArguments().getOnly()._rawType(), ""));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].genericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.parameters[''].genericType",
+                funcTypeParam(funcTypeRetType(typeArgument(letValIfFalse._genericType(), 0)._rawType())._typeArguments().getOnly()._rawType(), "")._genericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].genericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.parameters[''].genericType.typeParameter",
+                funcTypeParam(funcTypeRetType(typeArgument(letValIfFalse._genericType(), 0)._rawType())._typeArguments().getOnly()._rawType(), "")._genericType()._typeParameter());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].genericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(funcTypeRetType(typeArgument(letValIfFalse._genericType(), 0)._rawType())._typeArguments().getOnly()._rawType()));
+
+        LambdaFunction<?> letValIfFalseLambda = (LambdaFunction<?>) letValIfFalse._values().getOnly();
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0]", letValIfFalseLambda);
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType", letValIfFalseLambda._classifierGenericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType.typeArguments[0]", typeArgument(letValIfFalseLambda._classifierGenericType(), 0));
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType.typeArguments[0].rawType", typeArgument(letValIfFalseLambda._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(letValIfFalseLambda._classifierGenericType(), 0)._rawType()));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType.typeArguments[0].rawType.returnType.typeArguments[0]",
+                funcTypeRetType(typeArgument(letValIfFalseLambda._classifierGenericType(), 0)._rawType())._typeArguments().getOnly());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType",
+                funcTypeRetType(typeArgument(letValIfFalseLambda._classifierGenericType(), 0)._rawType())._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.parameters['']",
+                funcTypeParam(funcTypeRetType(typeArgument(letValIfFalseLambda._classifierGenericType(), 0)._rawType())._typeArguments().getOnly()._rawType(), ""));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.parameters[''].genericType",
+                funcTypeParam(funcTypeRetType(typeArgument(letValIfFalseLambda._classifierGenericType(), 0)._rawType())._typeArguments().getOnly()._rawType(), "")._genericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.parameters[''].genericType.typeParameter",
+                funcTypeParam(funcTypeRetType(typeArgument(letValIfFalseLambda._classifierGenericType(), 0)._rawType())._typeArguments().getOnly()._rawType(), "")._genericType()._typeParameter());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].classifierGenericType.typeArguments[0].rawType.returnType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(funcTypeRetType(typeArgument(letValIfFalseLambda._classifierGenericType(), 0)._rawType())._typeArguments().getOnly()._rawType()));
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0]", letValIfFalseLambda._expressionSequence().getOnly());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].genericType", letValIfFalseLambda._expressionSequence().getOnly()._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].genericType.typeArguments[0]", letValIfFalseLambda._expressionSequence().getOnly()._genericType()._typeArguments().getOnly());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].genericType.typeArguments[0].rawType",
+                letValIfFalseLambda._expressionSequence().getOnly()._genericType()._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].genericType.typeArguments[0].rawType.parameters['']",
+                funcTypeParam(letValIfFalseLambda._expressionSequence().getOnly()._genericType()._typeArguments().getOnly()._rawType(), ""));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].genericType.typeArguments[0].rawType.parameters[''].genericType",
+                funcTypeParam(letValIfFalseLambda._expressionSequence().getOnly()._genericType()._typeArguments().getOnly()._rawType(), "")._genericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].genericType.typeArguments[0].rawType.parameters[''].genericType.typeParameter",
+                funcTypeParam(letValIfFalseLambda._expressionSequence().getOnly()._genericType()._typeArguments().getOnly()._rawType(), "")._genericType()._typeParameter());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(letValIfFalseLambda._expressionSequence().getOnly()._genericType()._typeArguments().getOnly()._rawType()));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].parametersValues[0]",
+                ((SimpleFunctionExpression) letValIfFalseLambda._expressionSequence().getOnly())._parametersValues().getOnly());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) letValIfFalseLambda._expressionSequence().getOnly())._parametersValues().getOnly()._genericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].parametersValues[0].genericType.typeArguments[0]",
+                ((SimpleFunctionExpression) letValIfFalseLambda._expressionSequence().getOnly())._parametersValues().getOnly()._genericType()._typeArguments().getOnly());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].parametersValues[0].genericType.typeArguments[0].rawType",
+                ((SimpleFunctionExpression) letValIfFalseLambda._expressionSequence().getOnly())._parametersValues().getOnly()._genericType()._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].parametersValues[0].genericType.typeArguments[0].rawType.parameters['']",
+                funcTypeParam(((SimpleFunctionExpression) letValIfFalseLambda._expressionSequence().getOnly())._parametersValues().getOnly()._genericType()._typeArguments().getOnly()._rawType(), ""));
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].parametersValues[0].genericType.typeArguments[0].rawType.parameters[''].genericType",
+                funcTypeParam(((SimpleFunctionExpression) letValIfFalseLambda._expressionSequence().getOnly())._parametersValues().getOnly()._genericType()._typeArguments().getOnly()._rawType(), "")._genericType());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].parametersValues[0].genericType.typeArguments[0].rawType.parameters[''].genericType.typeParameter",
+                funcTypeParam(((SimpleFunctionExpression) letValIfFalseLambda._expressionSequence().getOnly())._parametersValues().getOnly()._genericType()._typeArguments().getOnly()._rawType(), "")._genericType()._typeParameter());
+        expected.put(
+                path + ".expressionSequence[0].parametersValues[1].parametersValues[2].values[0].expressionSequence[0].parametersValues[0].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(((SimpleFunctionExpression) letValIfFalseLambda._expressionSequence().getOnly())._parametersValues().getOnly()._genericType()._typeArguments().getOnly()._rawType()));
+
+        SimpleFunctionExpression mapExp = (SimpleFunctionExpression) testFunction._expressionSequence().getLast();
+        VariableExpression mapColParam = (VariableExpression) mapExp._parametersValues().getFirst();
+        InstanceValue mapFuncParam = (InstanceValue) mapExp._parametersValues().getLast();
+        LambdaFunction<?> mapFunc = (LambdaFunction<?>) mapFuncParam._values().getOnly();
+        expected.put(path + ".expressionSequence[1]", mapExp);
+        expected.put(path + ".expressionSequence[1].genericType", mapExp._genericType());
+        expected.put(path + ".expressionSequence[1].multiplicity", mapExp._multiplicity());
+        expected.put(path + ".expressionSequence[1].parametersValues[0]", mapColParam);
+        expected.put(path + ".expressionSequence[1].parametersValues[0].genericType", mapColParam._genericType());
+        expected.put(path + ".expressionSequence[1].parametersValues[0].genericType.typeParameter", mapColParam._genericType()._typeParameter());
+        expected.put(path + ".expressionSequence[1].parametersValues[0].multiplicity", mapColParam._multiplicity());
+        expected.put(path + ".expressionSequence[1].parametersValues[1]", mapFuncParam);
+        expected.put(path + ".expressionSequence[1].parametersValues[1].genericType", mapFuncParam._genericType());
+        expected.put(path + ".expressionSequence[1].parametersValues[1].genericType.typeArguments[0]", typeArgument(mapFuncParam._genericType(), 0));
+        expected.put(path + ".expressionSequence[1].parametersValues[1].genericType.typeArguments[0].rawType", typeArgument(mapFuncParam._genericType(), 0)._rawType());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].genericType.typeArguments[0].rawType.parameters['x']",
+                funcTypeParam(typeArgument(mapFuncParam._genericType(), 0)._rawType(), "x"));
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].genericType.typeArguments[0].rawType.parameters['x'].genericType",
+                funcTypeParam(typeArgument(mapFuncParam._genericType(), 0)._rawType(), "x")._genericType());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].genericType.typeArguments[0].rawType.parameters['x'].genericType.typeParameter",
+                funcTypeParam(typeArgument(mapFuncParam._genericType(), 0)._rawType(), "x")._genericType()._typeParameter());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(mapFuncParam._genericType(), 0)._rawType()));
+        expected.put(path + ".expressionSequence[1].parametersValues[1].values[0]", mapFunc);
+        expected.put(path + ".expressionSequence[1].parametersValues[1].values[0].classifierGenericType", mapFunc._classifierGenericType());
+        expected.put(path + ".expressionSequence[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0]", typeArgument(mapFunc._classifierGenericType(), 0));
+        expected.put(path + ".expressionSequence[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType", typeArgument(mapFunc._classifierGenericType(), 0)._rawType());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['x']",
+                funcTypeParam(typeArgument(mapFunc._classifierGenericType(), 0)._rawType(), "x"));
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['x'].genericType",
+                funcTypeParam(typeArgument(mapFunc._classifierGenericType(), 0)._rawType(), "x")._genericType());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.parameters['x'].genericType.typeParameter",
+                funcTypeParam(typeArgument(mapFunc._classifierGenericType(), 0)._rawType(), "x")._genericType()._typeParameter());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(typeArgument(mapFunc._classifierGenericType(), 0)._rawType()));
+        expected.put(path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0]", mapFunc._expressionSequence().getOnly());
+        expected.put(path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0].genericType", mapFunc._expressionSequence().getOnly()._genericType());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0]",
+                ((SimpleFunctionExpression) mapFunc._expressionSequence().getOnly())._parametersValues().getFirst());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType",
+                ((SimpleFunctionExpression) mapFunc._expressionSequence().getOnly())._parametersValues().getFirst()._genericType());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType.typeArguments[0]",
+                ((SimpleFunctionExpression) mapFunc._expressionSequence().getOnly())._parametersValues().getFirst()._genericType()._typeArguments().getOnly());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType.typeArguments[0].rawType",
+                ((SimpleFunctionExpression) mapFunc._expressionSequence().getOnly())._parametersValues().getFirst()._genericType()._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType.typeArguments[0].rawType.parameters['']",
+                funcTypeParam(((SimpleFunctionExpression) mapFunc._expressionSequence().getOnly())._parametersValues().getFirst()._genericType()._typeArguments().getOnly()._rawType(), ""));
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType.typeArguments[0].rawType.parameters[''].genericType",
+                funcTypeParam(((SimpleFunctionExpression) mapFunc._expressionSequence().getOnly())._parametersValues().getFirst()._genericType()._typeArguments().getOnly()._rawType(), "")._genericType());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType.typeArguments[0].rawType.parameters[''].genericType.typeParameter",
+                funcTypeParam(((SimpleFunctionExpression) mapFunc._expressionSequence().getOnly())._parametersValues().getFirst()._genericType()._typeArguments().getOnly()._rawType(), "")._genericType()._typeParameter());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[0].genericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(((SimpleFunctionExpression) mapFunc._expressionSequence().getOnly())._parametersValues().getFirst()._genericType()._typeArguments().getOnly()._rawType()));
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[1]",
+                ((SimpleFunctionExpression) mapFunc._expressionSequence().getOnly())._parametersValues().getLast());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType",
+                ((SimpleFunctionExpression) mapFunc._expressionSequence().getOnly())._parametersValues().getLast()._genericType());
+        expected.put(
+                path + ".expressionSequence[1].parametersValues[1].values[0].expressionSequence[0].parametersValues[1].genericType.typeParameter",
+                ((SimpleFunctionExpression) mapFunc._expressionSequence().getOnly())._parametersValues().getLast()._genericType()._typeParameter());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testFunction2()
+    {
+        String path = "test::model::testFunc2__String_1_";
+        ConcreteFunctionDefinition<?> testFunction = getCoreInstance(path);
+        MutableMap<String, Object> expected = Maps.mutable.with(path, testFunction);
+
+        FunctionType functionType = (FunctionType) typeArgument(testFunction._classifierGenericType(), 0)._rawType();
+        expected.put(path + ".classifierGenericType", testFunction._classifierGenericType());
+        expected.put(path + ".classifierGenericType.typeArguments[0]", typeArgument(testFunction._classifierGenericType(), 0));
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType", functionType);
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.returnType", funcTypeRetType(functionType));
+
+        ListIterable<? extends ValueSpecification> expressionSequence = toList(testFunction._expressionSequence());
+        SimpleFunctionExpression letPkg = (SimpleFunctionExpression) expressionSequence.get(0);
+        expected.put(path + ".expressionSequence[0]", letPkg);
+        expected.put(path + ".expressionSequence[0].genericType", letPkg._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[0]", letPkg._parametersValues().getFirst());
+        expected.put(path + ".expressionSequence[0].parametersValues[0].genericType", letPkg._parametersValues().getFirst()._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1]", letPkg._parametersValues().getLast());
+        expected.put(path + ".expressionSequence[0].parametersValues[1].genericType", letPkg._parametersValues().getLast()._genericType());
+
+        SimpleFunctionExpression letUnit = (SimpleFunctionExpression) expressionSequence.get(1);
+        expected.put(path + ".expressionSequence[1]", letUnit);
+        expected.put(path + ".expressionSequence[1].genericType", letUnit._genericType());
+        expected.put(path + ".expressionSequence[1].parametersValues[0]", letUnit._parametersValues().getFirst());
+        expected.put(path + ".expressionSequence[1].parametersValues[0].genericType", letUnit._parametersValues().getFirst()._genericType());
+        expected.put(path + ".expressionSequence[1].parametersValues[1]", letUnit._parametersValues().getLast());
+        expected.put(path + ".expressionSequence[1].parametersValues[1].genericType", letUnit._parametersValues().getLast()._genericType());
+
+        SimpleFunctionExpression joinStrs = (SimpleFunctionExpression) expressionSequence.get(2);
+        expected.put(path + ".expressionSequence[2]", joinStrs);
+        expected.put(path + ".expressionSequence[2].genericType", joinStrs._genericType());
+//        expected.put(path + ".expressionSequence[2].parametersValues[0]", joinStrs._parametersValues().getOnly());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].genericType", joinStrs._parametersValues().getOnly()._genericType());
+
+        ListIterable<?> stringValSpecs = toList(((InstanceValue) joinStrs._parametersValues().getOnly())._values());
+
+        SimpleFunctionExpression eltToPath = (SimpleFunctionExpression) stringValSpecs.get(0);
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[0]", eltToPath);
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[0].genericType", eltToPath._genericType());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[0].parametersValues[0]", eltToPath._parametersValues().getOnly());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[0].parametersValues[0].genericType", eltToPath._parametersValues().getOnly()._genericType());
+
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[1]", stringValSpecs.get(1));
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[1].genericType", ((ValueSpecification) stringValSpecs.get(1))._genericType());
+
+        SimpleFunctionExpression measureNameToOne = (SimpleFunctionExpression) stringValSpecs.get(2);
+        SimpleFunctionExpression measureName = (SimpleFunctionExpression) measureNameToOne._parametersValues().getOnly();
+        SimpleFunctionExpression unitMeasure = (SimpleFunctionExpression) measureName._parametersValues().getOnly();
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[2]", measureNameToOne);
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[2].genericType", measureNameToOne._genericType());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[2].parametersValues[0]", measureName);
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[2].parametersValues[0].genericType", measureName._genericType());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[2].parametersValues[0].parametersValues[0]", unitMeasure);
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[2].parametersValues[0].parametersValues[0].genericType", unitMeasure._genericType());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[2].parametersValues[0].parametersValues[0].propertyName", unitMeasure._propertyName());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[2].parametersValues[0].parametersValues[0].parametersValues[0]", unitMeasure._parametersValues().getOnly());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[2].parametersValues[0].parametersValues[0].parametersValues[0].genericType", unitMeasure._parametersValues().getOnly()._genericType());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[2].parametersValues[0].propertyName", measureName._propertyName());
+
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[3]", stringValSpecs.get(3));
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[3].genericType", ((ValueSpecification) stringValSpecs.get(3))._genericType());
+
+        SimpleFunctionExpression unitNameToOne = (SimpleFunctionExpression) stringValSpecs.get(4);
+        SimpleFunctionExpression unitName = (SimpleFunctionExpression) unitNameToOne._parametersValues().getOnly();
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[4]", unitNameToOne);
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[4].genericType", unitNameToOne._genericType());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[4].parametersValues[0]", unitName);
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[4].parametersValues[0].genericType", unitName._genericType());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[4].parametersValues[0].parametersValues[0]", unitName._parametersValues().getOnly());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[4].parametersValues[0].parametersValues[0].genericType", unitName._parametersValues().getOnly()._genericType());
+        expected.put(path + ".expressionSequence[2].parametersValues[0].values[4].parametersValues[0].propertyName", unitName._propertyName());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testFunction3()
+    {
+        String path = "test::model::testFunc3__Any_MANY_";
+        ConcreteFunctionDefinition<?> testFunction = getCoreInstance(path);
+        MutableMap<String, Object> expected = Maps.mutable.with(path, testFunction);
+
+        Assert.assertNull(getCoreInstance("test::model").getSourceInformation());
+
+        FunctionType functionType = (FunctionType) typeArgument(testFunction._classifierGenericType(), 0)._rawType();
+        expected.put(path + ".classifierGenericType", testFunction._classifierGenericType());
+        expected.put(path + ".classifierGenericType.typeArguments[0]", typeArgument(testFunction._classifierGenericType(), 0));
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType", functionType);
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.returnType", funcTypeRetType(functionType));
+
+        InstanceValue listExpr = (InstanceValue) testFunction._expressionSequence().getOnly();
+        expected.put(path + ".expressionSequence[0]", listExpr);
+        expected.put(path + ".expressionSequence[0].genericType", listExpr._genericType());
+
+        ListIterable<?> listValues = toList(listExpr._values());
+
+        InstanceValue pkgWrapper = (InstanceValue) listValues.get(0);
+        expected.put(path + ".expressionSequence[0].values[0]", pkgWrapper);
+        expected.put(path + ".expressionSequence[0].values[0].genericType", pkgWrapper._genericType());
+
+        LambdaFunction<?> lambdaFunc = (LambdaFunction<?>) listValues.get(4);
+        expected.put(path + ".expressionSequence[0].values[4]", lambdaFunc);
+        expected.put(path + ".expressionSequence[0].values[4].classifierGenericType", lambdaFunc._classifierGenericType());
+        expected.put(path + ".expressionSequence[0].values[4].classifierGenericType.typeArguments[0]", typeArgument(lambdaFunc._classifierGenericType(), 0));
+
+        FunctionType lambdaFuncType = (FunctionType) typeArgument(lambdaFunc._classifierGenericType(), 0)._rawType();
+        expected.put(path + ".expressionSequence[0].values[4].classifierGenericType.typeArguments[0].rawType", lambdaFuncType);
+        expected.put(path + ".expressionSequence[0].values[4].classifierGenericType.typeArguments[0].rawType.returnType", funcTypeRetType(lambdaFuncType));
+
+        SimpleFunctionExpression childrenExpr = (SimpleFunctionExpression) lambdaFunc._expressionSequence().getOnly();
+        expected.put(path + ".expressionSequence[0].values[4].expressionSequence[0]", childrenExpr);
+        expected.put(path + ".expressionSequence[0].values[4].expressionSequence[0].genericType", childrenExpr._genericType());
+        expected.put(path + ".expressionSequence[0].values[4].expressionSequence[0].parametersValues[0]", childrenExpr._parametersValues().getOnly());
+        expected.put(path + ".expressionSequence[0].values[4].expressionSequence[0].parametersValues[0].genericType", childrenExpr._parametersValues().getOnly()._genericType());
+        expected.put(path + ".expressionSequence[0].values[4].expressionSequence[0].propertyName", childrenExpr._propertyName());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testFunction4()
+    {
+        String path = "test::model::testFunc4_ClassWithMilestoning1_1__ClassWithMilestoning3_MANY_";
+        ConcreteFunctionDefinition<?> testFunction = getCoreInstance(path);
+        MutableMap<String, Object> expected = Maps.mutable.with(path, testFunction);
+
+        Assert.assertNull(getCoreInstance("test::model").getSourceInformation());
+
+        FunctionType functionType = (FunctionType) typeArgument(testFunction._classifierGenericType(), 0)._rawType();
+        expected.put(path + ".classifierGenericType", testFunction._classifierGenericType());
+        expected.put(path + ".classifierGenericType.typeArguments[0]", typeArgument(testFunction._classifierGenericType(), 0));
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType", functionType);
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.parameters['input']", funcTypeParam(typeArgument(testFunction._classifierGenericType(), 0)._rawType(), "input"));
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.parameters['input'].genericType", funcTypeParam(typeArgument(testFunction._classifierGenericType(), 0)._rawType(), "input")._genericType());
+        expected.put(path + ".classifierGenericType.typeArguments[0].rawType.returnType", funcTypeRetType(functionType));
+
+        SimpleFunctionExpression expr = (SimpleFunctionExpression) testFunction._expressionSequence().getOnly();
+        expected.put(path + ".expressionSequence[0]", expr);
+        expected.put(path + ".expressionSequence[0].genericType", expr._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[0]", paramValue(expr, 0));
+        expected.put(path + ".expressionSequence[0].parametersValues[0].genericType", paramValue(expr, 0)._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[1]", paramValue(expr, 1));
+        expected.put(path + ".expressionSequence[0].parametersValues[1].genericType", paramValue(expr, 1)._genericType());
+        expected.put(path + ".expressionSequence[0].parametersValues[2]", paramValue(expr, 2));
+        expected.put(path + ".expressionSequence[0].parametersValues[2].genericType", paramValue(expr, 2)._genericType());
+        expected.put(path + ".expressionSequence[0].qualifiedPropertyName", expr._qualifiedPropertyName());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testMeasureWithNonconvertibleUnits()
+    {
+        String path = "test::model::Currency";
+        Measure currency = getCoreInstance(path);
+        MutableMap<String, CoreInstance> expected = Maps.mutable.with(path, currency);
+
+        expected.put(path + ".classifierGenericType", currency._classifierGenericType());
+        expected.put(path + ".generalizations[0]", currency._generalizations().getOnly());
+        expected.put(path + ".generalizations[0].general", currency._generalizations().getOnly()._general());
+
+        expected.put(path + ".canonicalUnit", currency._canonicalUnit());
+        expected.put(path + ".canonicalUnit.classifierGenericType", currency._canonicalUnit()._classifierGenericType());
+        expected.put(path + ".canonicalUnit.generalizations[0]", currency._canonicalUnit()._generalizations().getOnly());
+        expected.put(path + ".canonicalUnit.generalizations[0].general", currency._canonicalUnit()._generalizations().getOnly()._general());
+
+        ListIterable<? extends Unit> units = toList(currency._nonCanonicalUnits());
+        expected.put(path + ".nonCanonicalUnits['GBP']", units.get(0));
+        expected.put(path + ".nonCanonicalUnits['GBP'].classifierGenericType", units.get(0)._classifierGenericType());
+        expected.put(path + ".nonCanonicalUnits['GBP'].generalizations[0]", units.get(0)._generalizations().getOnly());
+        expected.put(path + ".nonCanonicalUnits['GBP'].generalizations[0].general", units.get(0)._generalizations().getOnly()._general());
+
+        expected.put(path + ".nonCanonicalUnits['EUR']", units.get(1));
+        expected.put(path + ".nonCanonicalUnits['EUR'].classifierGenericType", units.get(1)._classifierGenericType());
+        expected.put(path + ".nonCanonicalUnits['EUR'].generalizations[0]", units.get(1)._generalizations().getOnly());
+        expected.put(path + ".nonCanonicalUnits['EUR'].generalizations[0].general", units.get(1)._generalizations().getOnly()._general());
+
+        assertIds(path, expected);
+    }
+
+    @Test
+    public void testMeasureWithConveritbleUnits()
+    {
+        String path = "test::model::Mass";
+        Measure mass = getCoreInstance(path);
+        MutableMap<String, Object> expected = Maps.mutable.with(path, mass);
+
+        expected.put(path + ".classifierGenericType", mass._classifierGenericType());
+        expected.put(path + ".generalizations[0]", mass._generalizations().getOnly());
+        expected.put(path + ".generalizations[0].general", mass._generalizations().getOnly()._general());
+
+        expected.put(path + ".canonicalUnit", mass._canonicalUnit());
+        expected.put(path + ".canonicalUnit.classifierGenericType", mass._canonicalUnit()._classifierGenericType());
+        expected.put(path + ".canonicalUnit.conversionFunction", mass._canonicalUnit()._conversionFunction());
+        expected.put(path + ".canonicalUnit.conversionFunction.classifierGenericType", mass._canonicalUnit()._conversionFunction()._classifierGenericType());
+        expected.put(path + ".canonicalUnit.conversionFunction.classifierGenericType.typeArguments[0]", mass._canonicalUnit()._conversionFunction()._classifierGenericType()._typeArguments().getOnly());
+        expected.put(path + ".canonicalUnit.conversionFunction.classifierGenericType.typeArguments[0].rawType", mass._canonicalUnit()._conversionFunction()._classifierGenericType()._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".canonicalUnit.conversionFunction.classifierGenericType.typeArguments[0].rawType.parameters['x']",
+                funcTypeParam(mass._canonicalUnit()._conversionFunction()._classifierGenericType()._typeArguments().getOnly()._rawType(), "x"));
+        expected.put(
+                path + ".canonicalUnit.conversionFunction.classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(mass._canonicalUnit()._conversionFunction()._classifierGenericType()._typeArguments().getOnly()._rawType()));
+        expected.put(path + ".canonicalUnit.conversionFunction.expressionSequence[0]", mass._canonicalUnit()._conversionFunction()._expressionSequence().getOnly());
+        expected.put(path + ".canonicalUnit.conversionFunction.expressionSequence[0].genericType", mass._canonicalUnit()._conversionFunction()._expressionSequence().getOnly()._genericType());
+        expected.put(path + ".canonicalUnit.generalizations[0]", mass._canonicalUnit()._generalizations().getOnly());
+        expected.put(path + ".canonicalUnit.generalizations[0].general", mass._canonicalUnit()._generalizations().getOnly()._general());
+
+        ListIterable<? extends Unit> units = toList(mass._nonCanonicalUnits());
+        expected.put(path + ".nonCanonicalUnits['Kilogram']", units.get(0));
+        expected.put(path + ".nonCanonicalUnits['Kilogram'].classifierGenericType", units.get(0)._classifierGenericType());
+        expected.put(path + ".nonCanonicalUnits['Kilogram'].conversionFunction", units.get(0)._conversionFunction());
+        expected.put(path + ".nonCanonicalUnits['Kilogram'].conversionFunction.classifierGenericType", units.get(0)._conversionFunction()._classifierGenericType());
+        expected.put(path + ".nonCanonicalUnits['Kilogram'].conversionFunction.classifierGenericType.typeArguments[0]", units.get(0)._conversionFunction()._classifierGenericType()._typeArguments().getOnly());
+        expected.put(path + ".nonCanonicalUnits['Kilogram'].conversionFunction.classifierGenericType.typeArguments[0].rawType", units.get(0)._conversionFunction()._classifierGenericType()._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".nonCanonicalUnits['Kilogram'].conversionFunction.classifierGenericType.typeArguments[0].rawType.parameters['x']",
+                funcTypeParam(units.get(0)._conversionFunction()._classifierGenericType()._typeArguments().getOnly()._rawType(), "x"));
+        expected.put(
+                path + ".nonCanonicalUnits['Kilogram'].conversionFunction.classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(units.get(0)._conversionFunction()._classifierGenericType()._typeArguments().getOnly()._rawType()));
+        expected.put(path + ".nonCanonicalUnits['Kilogram'].conversionFunction.expressionSequence[0]", units.get(0)._conversionFunction()._expressionSequence().getOnly());
+        expected.put(path + ".nonCanonicalUnits['Kilogram'].conversionFunction.expressionSequence[0].genericType", units.get(0)._conversionFunction()._expressionSequence().getOnly()._genericType());
+        expected.put(
+                path + ".nonCanonicalUnits['Kilogram'].conversionFunction.expressionSequence[0].parametersValues[0].values[0]",
+                ((InstanceValue) ((SimpleFunctionExpression) (units.get(0)._conversionFunction()._expressionSequence().getOnly()))._parametersValues().getOnly())._values().getFirst());
+        expected.put(
+                path + ".nonCanonicalUnits['Kilogram'].conversionFunction.expressionSequence[0].parametersValues[0].values[0].genericType",
+                ((VariableExpression) ((InstanceValue) ((SimpleFunctionExpression) (units.get(0)._conversionFunction()._expressionSequence().getOnly()))._parametersValues().getOnly())._values().getFirst())._genericType());
+        expected.put(
+                path + ".nonCanonicalUnits['Kilogram'].conversionFunction.expressionSequence[0].parametersValues[0].values[1]",
+                ((InstanceValue) ((SimpleFunctionExpression) (units.get(0)._conversionFunction()._expressionSequence().getOnly()))._parametersValues().getOnly())._values().getLast());
+        expected.put(
+                path + ".nonCanonicalUnits['Kilogram'].conversionFunction.expressionSequence[0].parametersValues[0].values[1].genericType",
+                ((InstanceValue) ((InstanceValue) ((SimpleFunctionExpression) (units.get(0)._conversionFunction()._expressionSequence().getOnly()))._parametersValues().getOnly())._values().getLast())._genericType());
+        expected.put(path + ".nonCanonicalUnits['Kilogram'].generalizations[0]", units.get(0)._generalizations().getOnly());
+        expected.put(path + ".nonCanonicalUnits['Kilogram'].generalizations[0].general", units.get(0)._generalizations().getOnly()._general());
+
+        expected.put(path + ".nonCanonicalUnits['Pound']", units.get(1));
+        expected.put(path + ".nonCanonicalUnits['Pound'].classifierGenericType", units.get(1)._classifierGenericType());
+        expected.put(path + ".nonCanonicalUnits['Pound'].conversionFunction", units.get(1)._conversionFunction());
+        expected.put(path + ".nonCanonicalUnits['Pound'].conversionFunction.classifierGenericType", units.get(1)._conversionFunction()._classifierGenericType());
+        expected.put(path + ".nonCanonicalUnits['Pound'].conversionFunction.classifierGenericType.typeArguments[0]", units.get(1)._conversionFunction()._classifierGenericType()._typeArguments().getOnly());
+        expected.put(path + ".nonCanonicalUnits['Pound'].conversionFunction.classifierGenericType.typeArguments[0].rawType", units.get(1)._conversionFunction()._classifierGenericType()._typeArguments().getOnly()._rawType());
+        expected.put(
+                path + ".nonCanonicalUnits['Pound'].conversionFunction.classifierGenericType.typeArguments[0].rawType.parameters['x']",
+                funcTypeParam(units.get(1)._conversionFunction()._classifierGenericType()._typeArguments().getOnly()._rawType(), "x"));
+        expected.put(
+                path + ".nonCanonicalUnits['Pound'].conversionFunction.classifierGenericType.typeArguments[0].rawType.returnType",
+                funcTypeRetType(units.get(1)._conversionFunction()._classifierGenericType()._typeArguments().getOnly()._rawType()));
+        expected.put(path + ".nonCanonicalUnits['Pound'].conversionFunction.expressionSequence[0]", units.get(1)._conversionFunction()._expressionSequence().getOnly());
+        expected.put(path + ".nonCanonicalUnits['Pound'].conversionFunction.expressionSequence[0].genericType", units.get(1)._conversionFunction()._expressionSequence().getOnly()._genericType());
+        expected.put(
+                path + ".nonCanonicalUnits['Pound'].conversionFunction.expressionSequence[0].parametersValues[0].values[0]",
+                ((InstanceValue) ((SimpleFunctionExpression) (units.get(1)._conversionFunction()._expressionSequence().getOnly()))._parametersValues().getOnly())._values().getFirst());
+        expected.put(
+                path + ".nonCanonicalUnits['Pound'].conversionFunction.expressionSequence[0].parametersValues[0].values[0].genericType",
+                ((VariableExpression) ((InstanceValue) ((SimpleFunctionExpression) (units.get(1)._conversionFunction()._expressionSequence().getOnly()))._parametersValues().getOnly())._values().getFirst())._genericType());
+        expected.put(
+                path + ".nonCanonicalUnits['Pound'].conversionFunction.expressionSequence[0].parametersValues[0].values[1]",
+                ((InstanceValue) ((SimpleFunctionExpression) (units.get(1)._conversionFunction()._expressionSequence().getOnly()))._parametersValues().getOnly())._values().getLast());
+        expected.put(
+                path + ".nonCanonicalUnits['Pound'].conversionFunction.expressionSequence[0].parametersValues[0].values[1].genericType",
+                ((InstanceValue) ((InstanceValue) ((SimpleFunctionExpression) (units.get(1)._conversionFunction()._expressionSequence().getOnly()))._parametersValues().getOnly())._values().getLast())._genericType());
+        expected.put(path + ".nonCanonicalUnits['Pound'].generalizations[0]", units.get(1)._generalizations().getOnly());
+        expected.put(path + ".nonCanonicalUnits['Pound'].generalizations[0].general", units.get(1)._generalizations().getOnly()._general());
+
+        assertIds(path, expected);
+    }
+
+    private void assertIds(CoreInstance element)
+    {
+        String path = PackageableElement.getUserPathForPackageableElement(element);
+        if (_Package.isPackage(element, processorSupport))
+        {
+            // For packages, we have specific expectations
+            assertIds(path, Maps.immutable.with(path, element));
+        }
+        else
+        {
+            // For everything else, we check that the element itself has the expected id
+            MapIterable<CoreInstance, String> idsByInstance = idGenerator.generateIdsForElement(element);
+            Assert.assertEquals(path, idsByInstance.get(element));
+            Assert.assertSame(element, reverseIdMap(idsByInstance, path).get(path));
+        }
+    }
+
+    private void assertIds(String path, MapIterable<String, ?> expected)
+    {
+        validateExpectedIds(path, expected);
+        MapIterable<CoreInstance, String> idsByInstance = idGenerator.generateIdsForElement(path);
+        MutableMap<String, CoreInstance> instancesById = reverseIdMap(idsByInstance, path);
+        if (!expected.equals(instancesById))
+        {
+            MutableList<Pair<String, ?>> expectedMismatches = Lists.mutable.empty();
+            Counter expectedMissing = new Counter();
+            Counter mismatches = new Counter();
+            Counter unexpected = new Counter();
+            expected.forEachKeyValue((id, instance) ->
+            {
+                CoreInstance actualInstance = instancesById.get(id);
+                if (!instance.equals(actualInstance))
+                {
+                    expectedMismatches.add(Tuples.pair(id, instance));
+                    ((actualInstance == null) ? expectedMissing : mismatches).increment();
+                }
+            });
+            MutableList<Pair<String, ?>> actualMismatches = Lists.mutable.empty();
+            instancesById.forEachKeyValue((id, instance) ->
+            {
+                Object expectedInstance = expected.get(id);
+                if (!instance.equals(expectedInstance))
+                {
+                    actualMismatches.add(Tuples.pair(id, instance));
+                    if (expectedInstance == null)
+                    {
+                        unexpected.increment();
+                    }
+                }
+            });
+            Assert.assertEquals(
+                    "Ids for " + path + " not as expected (" + expectedMissing.getCount() + " expected missing, " + mismatches.getCount() + " mismatches, " + unexpected.getCount() + " unexpected found)",
+                    expectedMismatches.sortThis().makeString(System.lineSeparator()),
+                    actualMismatches.sortThis().makeString(System.lineSeparator()));
+        }
+    }
+
+    private void validateExpectedIds(String path, MapIterable<String, ?> expected)
+    {
+        MutableList<String> nullInstances = Lists.mutable.empty();
+        expected.forEachKeyValue((id, instance) ->
+        {
+            if (instance == null)
+            {
+                nullInstances.add(id);
+            }
+        });
+        if (nullInstances.notEmpty())
+        {
+            StringBuilder builder = new StringBuilder("Null instances for ").append(nullInstances.size()).append(" expected ids for \"").append(path).append("\":");
+            nullInstances.sortThis().appendString(builder, "\n\t", "\n\t", "");
+            Assert.fail(builder.toString());
+        }
+    }
+
+    private MutableMap<String, CoreInstance> reverseIdMap(MapIterable<CoreInstance, String> idsByInstance, String path)
+    {
+        MutableMap<String, CoreInstance> instancesById = Maps.mutable.ofInitialCapacity(idsByInstance.size());
+        MutableSet<String> duplicateIds = Sets.mutable.empty();
+        idsByInstance.forEachKeyValue((instance, id) ->
+        {
+            if (instancesById.put(id, instance) != null)
+            {
+                duplicateIds.add(id);
+            }
+        });
+        if (duplicateIds.notEmpty())
+        {
+            Assert.fail(duplicateIds.toSortedList().makeString("Duplicate ids for " + path + ": \"", "\", \"", "\""));
+        }
+        return instancesById;
+    }
+}

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/test/java/org/finos/legend/pure/m2/dsl/mapping/serialization/compiler/reference/v1/TestReferenceIdExtensionV1Mapping.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/test/java/org/finos/legend/pure/m2/dsl/mapping/serialization/compiler/reference/v1/TestReferenceIdExtensionV1Mapping.java
@@ -1,0 +1,182 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m2.dsl.mapping.serialization.compiler.reference.v1;
+
+import org.finos.legend.pure.m3.coreinstance.meta.external.store.model.PureInstanceSetImplementation;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.MappingClass;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
+import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdProvider;
+import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdResolver;
+import org.finos.legend.pure.m3.serialization.compiler.reference.v1.TestReferenceIdExtensionV1;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestReferenceIdExtensionV1Mapping extends TestReferenceIdExtensionV1
+{
+    @BeforeClass
+    public static void extraSource()
+    {
+        compileTestSource(
+                "/ref_test/mapping/test_mapping.pure",
+                "import test::model::*;\n" +
+                        "\n" +
+                        "Class test::model::SourceSimpleClass\n" +
+                        "{\n" +
+                        "  names : String[*];\n" +
+                        "  id : Integer[1];\n" +
+                        "  titles : String[*];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::model::SourceLeft\n" +
+                        "{\n" +
+                        "  names : String[*];\n" +
+                        "  id : Integer[1];\n" +
+                        "  titles : String[*];\n" +
+                        "  family : String[0..1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "Class test::model::SourceRight\n" +
+                        "{\n" +
+                        "  id : Integer[0..1];\n" +
+                        "}\n" +
+                        "\n" +
+                        "###Mapping\n" +
+                        "\n" +
+                        "import test::model::*;\n" +
+                        "\n" +
+                        "Mapping test::mapping::TestMapping\n" +
+                        "(\n" +
+                        "   SimpleClass : Pure\n" +
+                        "   {\n" +
+                        "      ~src SourceSimpleClass\n" +
+                        "      name : $src.names->joinStrings(' '),\n" +
+                        "      id : $src.id,\n" +
+                        "      +title : String[0..1] : $src.titles->first()\n" +
+                        "   }\n" +
+                        "\n" +
+                        "   Left : Pure\n" +
+                        "   {\n" +
+                        "      ~src SourceLeft\n" +
+                        "      name : $src.names->joinStrings(' '),\n" +
+                        "      +titles : String[*] : $src.titles,\n" +
+                        "      +family : String[0..1] : $src.family\n" +
+                        "   }\n" +
+                        "\n" +
+                        "   Right : Pure\n" +
+                        "   {\n" +
+                        "      ~src SourceRight\n" +
+                        "      id : if($src.id->isEmpty(), |0, |$src.id->toOne())\n" +
+                        "   }\n" +
+                        "\n" +
+                        "   SimpleEnumeration: EnumerationMapping simpleEnum\n" +
+                        "   {\n" +
+                        "      VAL1: 1,\n" +
+                        "      VAL2: 2\n" +
+                        "   }\n" +
+                        "\n" +
+                        "   AggregationKind: EnumerationMapping aggKind\n" +
+                        "   {\n" +
+                        "      None: 'none',\n" +
+                        "      Shared: 'shared',\n" +
+                        "      Composite: ['composite', 'comp']\n" +
+                        "   }\n" +
+                        ")\n"
+        );
+    }
+
+    @Test
+    public void testMapping()
+    {
+        String path = "test::mapping::TestMapping";
+        Mapping mapping = getCoreInstance(path);
+
+        ReferenceIdProvider provider = extension.newProvider(processorSupport);
+        ReferenceIdResolver resolver = extension.newResolver(processorSupport);
+
+        Assert.assertEquals(path, provider.getReferenceId(mapping));
+        Assert.assertSame(path, mapping, resolver.resolveReference(path));
+
+        mapping._classMappings().forEach(classMapping ->
+        {
+            String classMappingId = provider.getReferenceId(classMapping);
+            Assert.assertEquals(path + ".classMappings[id='" + classMapping._id() + "']", classMappingId);
+            Assert.assertSame(classMappingId, classMapping, resolver.resolveReference(classMappingId));
+
+            PureInstanceSetImplementation pureClassMapping = (PureInstanceSetImplementation) classMapping;
+
+            LambdaFunction<?> filter = pureClassMapping._filter();
+            if (filter != null)
+            {
+                String filterId = provider.getReferenceId(filter);
+                Assert.assertEquals(path + ".filter", filterId);
+                Assert.assertSame(filterId, filter, resolver.resolveReference(filterId));
+            }
+
+            int[] counter = {0};
+            pureClassMapping._propertyMappings().forEach(propertyMapping ->
+            {
+                String propertyMappingId = provider.getReferenceId(propertyMapping);
+                Assert.assertEquals(path + ".classMappings[id='" + classMapping._id() + "'].propertyMappings[" + counter[0]++ + "]", propertyMappingId);
+                Assert.assertSame(propertyMappingId, propertyMapping, resolver.resolveReference(propertyMappingId));
+            });
+
+            MappingClass<?> mappingClass = pureClassMapping._mappingClass();
+            if (mappingClass != null)
+            {
+                String mappingClassId = provider.getReferenceId(mappingClass);
+                Assert.assertEquals(path + ".classMappings[id='" + classMapping._id() + "'].mappingClass", mappingClassId);
+                Assert.assertSame(mappingClassId, mappingClass, resolver.resolveReference(mappingClassId));
+                mappingClass._properties().forEach(property ->
+                {
+                    String propertyId = provider.getReferenceId(property);
+                    Assert.assertEquals(path + ".classMappings[id='" + classMapping._id() + "'].mappingClass.properties['" + property._name() + "']", propertyId);
+                    Assert.assertSame(propertyId, property, resolver.resolveReference(propertyId));
+                });
+            }
+        });
+
+        mapping._associationMappings().forEach(assocMapping ->
+        {
+            String assocMappingId = provider.getReferenceId(assocMapping);
+            Assert.assertEquals(path + ".associationMappings[id='" + assocMapping._id() + "']", assocMappingId);
+            Assert.assertSame(assocMappingId, assocMapping, resolver.resolveReference(assocMappingId));
+
+            int[] counter = {0};
+            assocMapping._propertyMappings().forEach(propertyMapping ->
+            {
+                String propertyMappingId = provider.getReferenceId(propertyMapping);
+                Assert.assertEquals(path + ".associationMappings[id='" + assocMapping._id() + "'].propertyMappings[" + counter[0]++ + "]", propertyMappingId);
+                Assert.assertSame(propertyMappingId, propertyMapping, resolver.resolveReference(propertyMappingId));
+            });
+        });
+
+        mapping._enumerationMappings().forEach(enumMapping ->
+        {
+            String enumMappingId = provider.getReferenceId(enumMapping);
+            Assert.assertEquals(path + ".enumerationMappings['" + enumMapping._name() + "']", enumMappingId);
+            Assert.assertSame(enumMappingId, enumMapping, resolver.resolveReference(enumMappingId));
+
+            int[] counter = {0};
+            enumMapping._enumValueMappings().forEach(enumValueMapping ->
+            {
+                String enumValueMappingId = provider.getReferenceId(enumValueMapping);
+                Assert.assertEquals(path + ".enumerationMappings['" + enumMapping._name() + "'].enumValueMappings[" + counter[0]++ + "]", enumValueMappingId);
+                Assert.assertSame(enumValueMappingId, enumValueMapping, resolver.resolveReference(enumValueMappingId));
+            });
+        });
+    }
+}

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/test/java/org/finos/legend/pure/m2/relational/serialization/compiler/reference/v1/TestReferenceIdExtensionV1Relational.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/test/java/org/finos/legend/pure/m2/relational/serialization/compiler/reference/v1/TestReferenceIdExtensionV1Relational.java
@@ -1,0 +1,333 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m2.relational.serialization.compiler.reference.v1;
+
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.set.MutableSet;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
+import org.finos.legend.pure.m3.coreinstance.meta.relational.mapping.FilterMapping;
+import org.finos.legend.pure.m3.coreinstance.meta.relational.mapping.GroupByMapping;
+import org.finos.legend.pure.m3.coreinstance.meta.relational.mapping.RelationalInstanceSetImplementation;
+import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Column;
+import org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Database;
+import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdProvider;
+import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdResolver;
+import org.finos.legend.pure.m3.serialization.compiler.reference.v1.TestReferenceIdExtensionV1;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestReferenceIdExtensionV1Relational extends TestReferenceIdExtensionV1
+{
+    @BeforeClass
+    public static void extraSources()
+    {
+        compileTestSource(
+                "/ref_test/relational/test_relational.pure",
+                "###Relational\n" +
+                        "\n" +
+                        "Database test::relational::TestDB\n" +
+                        "(\n" +
+                        "   Table SIMPLE\n" +
+                        "   (\n" +
+                        "      id INT PRIMARY KEY,\n" +
+                        "      name VARCHAR(256)\n" +
+                        "   )\n" +
+                        "\n" +
+                        "   View POS_SIMPLE\n" +
+                        "   (\n" +
+                        "      ~filter simple_pos_id\n" +
+                        "      name: SIMPLE.name,\n" +
+                        "      id: SIMPLE.id\n" +
+                        "   )\n" +
+                        "\n" +
+                        "   View SIMPLE_BY_NAME\n" +
+                        "   (\n" +
+                        "      ~groupBy (SIMPLE.name)\n" +
+                        "      name: SIMPLE.name\n" +
+                        "   )\n" +
+                        "\n" +
+                        "   Schema left_right\n" +
+                        "   (\n" +
+                        "      Table LEFT\n" +
+                        "      (\n" +
+                        "         name VARCHAR(256) PRIMARY KEY\n" +
+                        "      )\n" +
+                        "\n" +
+                        "      Table RIGHT\n" +
+                        "      (\n" +
+                        "         id INT PRIMARY KEY\n" +
+                        "      )\n" +
+                        "\n" +
+                        "      Table LR\n" +
+                        "      (\n" +
+                        "         left_name VARCHAR(256) PRIMARY KEY,\n" +
+                        "         right_id INT PRIMARY KEY\n" +
+                        "      )\n" +
+                        "   )\n" +
+                        "\n" +
+                        "   Schema milestoned\n" +
+                        "   (\n" +
+                        "      Table MS1\n" +
+                        "      (\n" +
+                        "         milestoning(\n" +
+                        "            business(BUS_FROM=from_z, BUS_THRU=thru_z)\n" +
+                        "         )\n" +
+                        "         id INT,\n" +
+                        "         in_z DATE,\n" +
+                        "         out_z DATE,\n" +
+                        "         from_z DATE,\n" +
+                        "         thru_z DATE\n" +
+                        "      )\n" +
+                        "\n" +
+                        "      Table MS2\n" +
+                        "      (\n" +
+                        "         milestoning(\n" +
+                        "            processing(PROCESSING_IN=in_z, PROCESSING_OUT=out_z)\n" +
+                        "         )\n" +
+                        "         id INT,\n" +
+                        "         in_z DATE,\n" +
+                        "         out_z DATE,\n" +
+                        "         from_z DATE,\n" +
+                        "         thru_z DATE\n" +
+                        "      )\n" +
+                        "\n" +
+                        "      Table MS3\n" +
+                        "      (\n" +
+                        "         milestoning(\n" +
+                        "            processing(PROCESSING_IN=in_z, PROCESSING_OUT=out_z),\n" +
+                        "            business(BUS_FROM=from_z, BUS_THRU=thru_z)\n" +
+                        "         )\n" +
+                        "         id INT,\n" +
+                        "         in_z DATE,\n" +
+                        "         out_z DATE,\n" +
+                        "         from_z DATE,\n" +
+                        "         thru_z DATE\n" +
+                        "      )\n" +
+                        "   )\n" +
+                        "\n" +
+                        "   Join left_lr\n" +
+                        "   (\n" +
+                        "      left_right.LEFT.name = left_right.LR.left_name\n" +
+                        "   )\n" +
+                        "\n" +
+                        "   Join right_lr\n" +
+                        "   (\n" +
+                        "      left_right.RIGHT.id = left_right.LR.right_id\n" +
+                        "   )\n" +
+                        "\n" +
+                        "   Filter simple_pos_id\n" +
+                        "   (\n" +
+                        "      SIMPLE.id > 0\n" +
+                        "   )\n" +
+                        ")\n"
+        );
+        compileTestSource(
+                "/ref_test/relational/test_relational_mapping.pure",
+                "###Mapping\n" +
+                        "\n" +
+                        "import test::model::*;\n" +
+                        "import test::relational::*;\n" +
+                        "\n" +
+                        "Mapping test::relational::TestMapping\n" +
+                        "(\n" +
+                        "   SimpleClass: Relational\n" +
+                        "   {\n" +
+                        "      name: [TestDB]SIMPLE.name,\n" +
+                        "      id: [TestDB]SIMPLE.id\n" +
+                        "   }\n" +
+                        "\n" +
+                        "   Left[left]: Relational\n" +
+                        "   {\n" +
+                        "      name: [TestDB]left_right.LEFT.name\n" +
+                        "   }\n" +
+                        "\n" +
+                        "   Right[right]: Relational\n" +
+                        "   {\n" +
+                        "      id: [TestDB]left_right.RIGHT.id\n" +
+                        "   }\n" +
+                        "\n" +
+                        "   LeftRight: Relational\n" +
+                        "   {\n" +
+                        "      AssociationMapping\n" +
+                        "      (\n" +
+                        "         toLeft[right, left]: [TestDB]@right_lr > [TestDB]@left_lr,\n" +
+                        "         toRight[left, right]: [TestDB]@left_lr > [TestDB]@right_lr\n" +
+                        "      )\n" +
+                        "   }\n" +
+                        ")\n"
+        );
+    }
+
+    @Test
+    public void testDatabase()
+    {
+        String path = "test::relational::TestDB";
+        Database testDB = getCoreInstance(path);
+        ReferenceIdProvider provider = extension.newProvider(processorSupport);
+        ReferenceIdResolver resolver = extension.newResolver(processorSupport);
+
+        Assert.assertEquals(path, provider.getReferenceId(testDB));
+        Assert.assertSame(path, testDB, resolver.resolveReference(path));
+
+        testDB._schemas().forEach(schema ->
+        {
+            String schemaId = provider.getReferenceId(schema);
+            Assert.assertEquals(path + ".schemas['" + schema._name() + "']", schemaId);
+            Assert.assertSame(schemaId, schema, resolver.resolveReference(schemaId));
+
+            schema._tables().forEach(table ->
+            {
+                String tableId = provider.getReferenceId(table);
+                Assert.assertEquals(path + ".schemas['" + schema._name() + "'].tables['" + table._name() + "']", tableId);
+                Assert.assertSame(tableId, table, resolver.resolveReference(tableId));
+
+                MutableSet<Column> primaryKeyColumns = Sets.mutable.withAll(table._primaryKey());
+                primaryKeyColumns.forEach(column ->
+                {
+                    String columnId = provider.getReferenceId(column);
+                    Assert.assertEquals(path + ".schemas['" + schema._name() + "'].tables['" + table._name() + "'].primaryKey['" + column._name() + "']", columnId);
+                    Assert.assertSame(columnId, column, resolver.resolveReference(columnId));
+                });
+
+                int[] counter = {0};
+                table._columns().forEach(column ->
+                {
+                    int index = counter[0]++;
+                    if (!primaryKeyColumns.contains(column))
+                    {
+                        String columnId = provider.getReferenceId(column);
+                        Assert.assertEquals(path + ".schemas['" + schema._name() + "'].tables['" + table._name() + "'].columns[" + index + "]", columnId);
+                        Assert.assertSame(columnId, column, resolver.resolveReference(columnId));
+                    }
+                });
+            });
+
+            schema._views().forEach(view ->
+            {
+                String viewId = provider.getReferenceId(view);
+                Assert.assertEquals(path + ".schemas['" + schema._name() + "'].views['" + view._name() + "']", viewId);
+                Assert.assertSame(viewId, view, resolver.resolveReference(viewId));
+
+                FilterMapping filter = view._filter();
+                if (filter != null)
+                {
+                    String filterId = provider.getReferenceId(filter);
+                    Assert.assertEquals(path + ".schemas['" + schema._name() + "'].views['" + view._name() + "'].filter", filterId);
+                    Assert.assertSame(filterId, filter, resolver.resolveReference(filterId));
+                }
+
+                GroupByMapping groupBy = view._groupBy();
+                if (groupBy != null)
+                {
+                    String groupById = provider.getReferenceId(groupBy);
+                    Assert.assertEquals(path + ".schemas['" + schema._name() + "'].views['" + view._name() + "'].groupBy", groupById);
+                    Assert.assertSame(groupById, groupBy, resolver.resolveReference(groupById));
+                }
+
+                MutableSet<Column> primaryKeyColumns = Sets.mutable.withAll(view._primaryKey());
+                primaryKeyColumns.forEach(column ->
+                {
+                    String columnId = provider.getReferenceId(column);
+                    Assert.assertEquals(path + ".schemas['" + schema._name() + "'].views['" + view._name() + "'].primaryKey['" + column._name() + "']", columnId);
+                    Assert.assertSame(columnId, column, resolver.resolveReference(columnId));
+                });
+
+                int[] counter = {0};
+                view._columns().forEach(column ->
+                {
+                    int index = counter[0]++;
+                    if (!primaryKeyColumns.contains(column))
+                    {
+                        String columnId = provider.getReferenceId(column);
+                        Assert.assertEquals(path + ".schemas['" + schema._name() + "'].views['" + view._name() + "'].columns[" + index + "]", columnId);
+                        Assert.assertSame(columnId, column, resolver.resolveReference(columnId));
+                    }
+                });
+            });
+        });
+
+        testDB._joins().forEach(join ->
+        {
+            String joinId = provider.getReferenceId(join);
+            Assert.assertEquals(path + ".joins['" + join._name() + "']", joinId);
+            Assert.assertSame(joinId, join, resolver.resolveReference(joinId));
+        });
+
+        testDB._filters().forEach(filter ->
+        {
+            String filterId = provider.getReferenceId(filter);
+            Assert.assertEquals(path + ".filters['" + filter._name() + "']", filterId);
+            Assert.assertSame(filterId, filter, resolver.resolveReference(filterId));
+        });
+    }
+
+    @Test
+    public void testRelationalMapping()
+    {
+        String path = "test::relational::TestMapping";
+        Mapping mapping = getCoreInstance(path);
+
+        ReferenceIdProvider provider = extension.newProvider(processorSupport);
+        ReferenceIdResolver resolver = extension.newResolver(processorSupport);
+
+        Assert.assertEquals(path, provider.getReferenceId(mapping));
+        Assert.assertSame(path, mapping, resolver.resolveReference(path));
+
+        mapping._classMappings().forEach(classMapping ->
+        {
+            String classMappingId = provider.getReferenceId(classMapping);
+            Assert.assertEquals(path + ".classMappings[id='" + classMapping._id() + "']", classMappingId);
+            Assert.assertSame(classMappingId, classMapping, resolver.resolveReference(classMappingId));
+
+            int[] counter = {0};
+            ((RelationalInstanceSetImplementation) classMapping)._propertyMappings().forEach(propertyMapping ->
+            {
+                String propertyMappingId = provider.getReferenceId(propertyMapping);
+                Assert.assertEquals(path + ".classMappings[id='" + classMapping._id() + "'].propertyMappings[" + counter[0]++ + "]", propertyMappingId);
+                Assert.assertSame(propertyMappingId, propertyMapping, resolver.resolveReference(propertyMappingId));
+            });
+        });
+
+        mapping._associationMappings().forEach(assocMapping ->
+        {
+            String assocMappingId = provider.getReferenceId(assocMapping);
+            Assert.assertEquals(path + ".associationMappings[id='" + assocMapping._id() + "']", assocMappingId);
+            Assert.assertSame(assocMappingId, assocMapping, resolver.resolveReference(assocMappingId));
+
+            int[] counter = {0};
+            assocMapping._propertyMappings().forEach(propertyMapping ->
+            {
+                String propertyMappingId = provider.getReferenceId(propertyMapping);
+                Assert.assertEquals(path + ".associationMappings[id='" + assocMapping._id() + "'].propertyMappings[" + counter[0]++ + "]", propertyMappingId);
+                Assert.assertSame(propertyMappingId, propertyMapping, resolver.resolveReference(propertyMappingId));
+            });
+        });
+
+        mapping._enumerationMappings().forEach(enumMapping ->
+        {
+            String enumMappingId = provider.getReferenceId(enumMapping);
+            Assert.assertEquals(path + ".enumerationMappings['" + enumMapping._name() + "']", enumMappingId);
+            Assert.assertSame(enumMappingId, enumMapping, resolver.resolveReference(enumMappingId));
+            int[] counter = {0};
+            enumMapping._enumValueMappings().forEach(enumValueMapping ->
+            {
+                String enumValueMappingId = provider.getReferenceId(enumValueMapping);
+                Assert.assertEquals(path + ".enumerationMappings['" + enumMapping._name() + "'].enumValueMappings[" + counter[0]++ + "]", enumValueMappingId);
+                Assert.assertSame(enumValueMappingId, enumValueMapping, resolver.resolveReference(enumValueMappingId));
+            });
+        });
+    }
+}


### PR DESCRIPTION
Add reference ids framework, including reference ids version 1. This provides unique and stable reference ids for all instances in the graph that have source information, excepting stubs and back references. The reference ids make use of graph paths and do not rely on any transient data, such as synthetic ids.