### PR TITLE
Remove potential conflictual names in precise primitives

### DIFF
--- a/legend-pure-core/legend-pure-m3-precisePrimitives/src/main/resources/platform_precise_primitives/precisePrimitives.pure
+++ b/legend-pure-core/legend-pure-m3-precisePrimitives/src/main/resources/platform_precise_primitives/precisePrimitives.pure
@@ -48,7 +48,8 @@ Primitive meta::pure::precisePrimitives::Varchar(x:Integer[1]) extends String
 
 Primitive meta::pure::precisePrimitives::Time extends StrictTime
 
-Primitive meta::pure::precisePrimitives::Date extends StrictDate
+// Use StrictDate
+//Primitive meta::pure::precisePrimitives::Date extends StrictDate
 
 Primitive meta::pure::precisePrimitives::Timestamp extends DateTime
 
@@ -56,7 +57,7 @@ Primitive meta::pure::precisePrimitives::Float4 extends Float
 
 Primitive meta::pure::precisePrimitives::Double extends Float
 
-Primitive meta::pure::precisePrimitives::Decimal(x:Integer[1], y:Integer[1]) extends Decimal
+Primitive meta::pure::precisePrimitives::Numeric(x:Integer[1], y:Integer[1]) extends Decimal
 [
   $this->floor()->toString()->length() <= $x && ($this->fractionDigits()->toString()->length()-2 <= $y)
 ]

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/main/java/org/finos/legend/pure/m2/relational/serialization/grammar/v1/RelationalParser.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/src/main/java/org/finos/legend/pure/m2/relational/serialization/grammar/v1/RelationalParser.java
@@ -360,7 +360,7 @@ public class RelationalParser implements IRelationalParser
             case "DECIMAL":
             {
                 GenericType genType = (GenericType) processorSupport.newAnonymousCoreInstance(null, M3Paths.GenericType);
-                genType._rawType((Type) _Package.getByUserPath("meta::pure::precisePrimitives::Decimal", processorSupport));
+                genType._rawType((Type) _Package.getByUserPath("meta::pure::precisePrimitives::Numeric", processorSupport));
                 genType._typeVariableValues(
                         Lists.mutable.with(
                                 (ValueSpecification)ValueSpecificationBootstrap.newIntegerLiteral(repository, Long.parseLong(type.getValueForMetaPropertyToOne("precision").getName()), processorSupport),
@@ -371,7 +371,8 @@ public class RelationalParser implements IRelationalParser
             }
             case "DATE":
             {
-                return (GenericType) processorSupport.type_wrapGenericType(_Package.getByUserPath("meta::pure::precisePrimitives::Date", processorSupport));
+                result = M3Paths.StrictDate;
+                break;
             }
             case "TIMESTAMP":
             {


### PR DESCRIPTION
Remove potential conflictual names in precise primitives