### PR TITLE
Fix SafeAppendable.append(CharSequence, int, int)

### DIFF
--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/tools/SafeAppendable.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/tools/SafeAppendable.java
@@ -137,7 +137,7 @@ public interface SafeAppendable extends Appendable
             @Override
             public SafeAppendable append(CharSequence csq, int start, int end)
             {
-                builder.append(csq);
+                builder.append(csq, start, end);
                 return this;
             }
 
@@ -213,7 +213,7 @@ public interface SafeAppendable extends Appendable
             @Override
             public SafeAppendable append(CharSequence csq, int start, int end)
             {
-                buffer.append(csq);
+                buffer.append(csq, start, end);
                 return this;
             }
 


### PR DESCRIPTION
Fix SafeAppendable.append(CharSequence, int, int) for the implementing classes for StringBuilder and StringBuffer, which were not propertly propagating start and end parameters.