### PR TITLE
BugFix: Fix fold compile behavior to allow variable expressions on its parameters

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/iteration/fold.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/iteration/fold.pure
@@ -23,6 +23,18 @@ native function
     }
     meta::pure::functions::collection::fold<T,V|m>(value:T[*], func:Function<{T[1],V[m]->V[m]}>[1], accumulator:V[m]):V[m];
 
+function <<PCT.test>> meta::pure::functions::collection::tests::fold::testFoldFunctionAsParameter<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
+{
+    let fold = {x: Integer[1], y: Integer[1] | $x + $y};
+    let acc = 0;
+    assertEq(10, $f->eval(|[1, 2, 3, 4]->meta::pure::functions::collection::tests::fold::outerFold($fold, $acc)));
+}
+
+function <<access.private>> meta::pure::functions::collection::tests::fold::outerFold<V,T|m>(val: V[*], fold:Function<{V[1],T[m]->T[m]}>[1], acc: T[m]):T[m]
+{
+    $val->fold($fold, $acc);
+}
+
 function <<PCT.test>> meta::pure::functions::collection::tests::fold::testIntegerSum<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEq(10, $f->eval(|[1, 2, 3, 4]->fold({x, y | $x + $y}, 0)));

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/essentials/collection/iteration/Fold.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/essentials/collection/iteration/Fold.java
@@ -85,7 +85,7 @@ public class Fold extends AbstractNativeFunctionGeneric
         }
         else
         {
-            return "CompiledSupport.fold(" + list + "," + "new DefendedFunction2<" + functionParamTypeO2 + "," + sourceTypeO1 + "," + functionReturnTypeWithMul + ">(){public " + functionReturnTypeWithMul + " value(final " + functionParamTypeO2 + " _param2, final " + sourceTypeO1 + " _param1){  return ((PureFunction2<" + functionParamTypeO2 + "," + sourceTypeO1 + "," + functionReturnTypeWithMul + ">)PureCompiledLambda.getPureFunction(" + ValueSpecificationProcessor.processValueSpecification(topLevelElement, parametersValues.get(1), processorContext) + ", es)).value(_param2,_param1, es); }}" + "," + init + ")";
+            return "CompiledSupport.fold(" + list + "," + "new DefendedFunction2<" + functionParamTypeO2 + "," + sourceTypeO1 + "," + functionReturnTypeWithMul + ">(){public " + functionReturnTypeWithMul + " value(final " + functionParamTypeO2 + " _param2, final " + sourceTypeO1 + " _param1){  return (" + functionReturnTypeWithMul + ")CompiledSupport.toPureCollection(PureCompiledLambda.getPureFunction(" + ValueSpecificationProcessor.processValueSpecification(topLevelElement, parametersValues.get(1), processorContext) + ", es).execute(Lists.fixedSize.of(_param2,_param1), es)); }}" + "," + init + ")";
         }
     }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/essentials/collection/iteration/Fold.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/essentials/collection/iteration/Fold.java
@@ -17,10 +17,12 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.native
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
+import org.finos.legend.pure.m3.navigation.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.compiled.generation.ProcessorContext;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.FunctionProcessor;
@@ -48,28 +50,43 @@ public class Fold extends AbstractNativeFunctionGeneric
         ProcessorSupport processorSupport = processorContext.getSupport();
         ListIterable<? extends CoreInstance> parametersValues = Instance.getValueForMetaPropertyToManyResolved(functionExpression, M3Properties.parametersValues, processorSupport);
 
-        String list = ValueSpecificationProcessor.processValueSpecification(topLevelElement, parametersValues.get(0), processorContext);
+        String sourceTypeO1 = TypeProcessor.typeToJavaObjectSingle(Instance.getValueForMetaPropertyToOneResolved(parametersValues.get(0), M3Properties.genericType, processorSupport), true, processorSupport);
         CoreInstance valueMultiplicity = Instance.getValueForMetaPropertyToOneResolved(parametersValues.get(0), M3Properties.multiplicity, processorSupport);
+
+        String list = ValueSpecificationProcessor.processValueSpecification(topLevelElement, parametersValues.get(0), processorContext);
         //TODO Remove this hack
         if (Multiplicity.isToZeroOrOne(valueMultiplicity))
         {
-            list = "CompiledSupport.toPureCollection(" + list + ")";
+            list = "CompiledSupport.<" + sourceTypeO1 + ">toPureCollection(" + list + ")";
         }
+
+        boolean isLambdaFunction = Instance.instanceOf(parametersValues.get(1), M3Paths.InstanceValue, processorSupport) && ValueSpecification.instanceOf(parametersValues.get(1), M3Paths.LambdaFunction, processorSupport);
+
         CoreInstance functionType = Instance.getValueForMetaPropertyToOneResolved(parametersValues.get(1), M3Properties.genericType, M3Properties.typeArguments, M3Properties.rawType, processorSupport);
         ListIterable<? extends CoreInstance> functionParams = Instance.getValueForMetaPropertyToManyResolved(functionType, M3Properties.parameters, processorSupport);
-        String param = Instance.getValueForMetaPropertyToOneResolved(functionParams.get(0), M3Properties.name, processorSupport).getName();
-        String param2 = Instance.getValueForMetaPropertyToOneResolved(functionParams.get(1), M3Properties.name, processorSupport).getName();
-        String init = ValueSpecificationProcessor.processValueSpecification(topLevelElement, parametersValues.get(2), processorContext);
-        String sourceTypeO1 = TypeProcessor.typeToJavaObjectWithMul(functionParams.get(0).getValueForMetaPropertyToOne(M3Properties.genericType), functionParams.get(0).getValueForMetaPropertyToOne(M3Properties.multiplicity), processorSupport);
+
         String sourceTypeO2 = TypeProcessor.typeToJavaObjectWithMul(functionParams.get(1).getValueForMetaPropertyToOne(M3Properties.genericType), functionType.getValueForMetaPropertyToOne(M3Properties.returnMultiplicity), processorSupport);
+
         String functionReturnTypeWithMul = TypeProcessor.typeToJavaObjectWithMul(functionType.getValueForMetaPropertyToOne(M3Properties.returnType), functionType.getValueForMetaPropertyToOne(M3Properties.returnMultiplicity), processorSupport);
+
+        String init = ValueSpecificationProcessor.processValueSpecification(topLevelElement, parametersValues.get(2), processorContext);
         if (!Multiplicity.isToZeroOrOne(functionType.getValueForMetaPropertyToOne(M3Properties.returnMultiplicity)) && Multiplicity.isToZeroOrOne(parametersValues.get(2).getValueForMetaPropertyToOne(M3Properties.multiplicity)))
         {
             init = "CompiledSupport.<" + TypeProcessor.typeToJavaObjectSingle(functionType.getValueForMetaPropertyToOne(M3Properties.returnType), true, processorSupport) + ">toPureCollection(" + init + ")";
         }
         CoreInstance sourceTypeO2GenericType = functionParams.get(1).getValueForMetaPropertyToOne(M3Properties.genericType);
         String functionParamTypeO2 = GenericType.isGenericTypeConcrete(sourceTypeO2GenericType, processorSupport) && "Nil".equals(sourceTypeO2GenericType.getValueForMetaPropertyToOne(M3Properties.rawType).getName()) ? functionReturnTypeWithMul : sourceTypeO2;
-        return "CompiledSupport.fold(" + list + "," + "new DefendedFunction2<" + functionParamTypeO2 + "," + sourceTypeO1 + "," + functionReturnTypeWithMul + ">(){public " + functionReturnTypeWithMul + " value(final " + functionParamTypeO2 + " _" + param2 + ", final " + sourceTypeO1 + " _" + param + "){" + FunctionProcessor.processFunctionDefinitionContent(topLevelElement, Instance.getValueForMetaPropertyToOneResolved(parametersValues.get(1), M3Properties.values, processorSupport), true, processorContext, processorSupport) + "}}" + "," + init + ")";
+
+        if (isLambdaFunction)
+        {
+            String param = Instance.getValueForMetaPropertyToOneResolved(functionParams.get(0), M3Properties.name, processorSupport).getName();
+            String param2 = Instance.getValueForMetaPropertyToOneResolved(functionParams.get(1), M3Properties.name, processorSupport).getName();
+            return "CompiledSupport.fold(" + list + "," + "new DefendedFunction2<" + functionParamTypeO2 + "," + sourceTypeO1 + "," + functionReturnTypeWithMul + ">(){public " + functionReturnTypeWithMul + " value(final " + functionParamTypeO2 + " _" + param2 + ", final " + sourceTypeO1 + " _" + param + "){" + FunctionProcessor.processFunctionDefinitionContent(topLevelElement, Instance.getValueForMetaPropertyToOneResolved(parametersValues.get(1), M3Properties.values, processorSupport), true, processorContext, processorSupport) + "}}" + "," + init + ")";
+        }
+        else
+        {
+            return "CompiledSupport.fold(" + list + "," + "new DefendedFunction2<" + functionParamTypeO2 + "," + sourceTypeO1 + "," + functionReturnTypeWithMul + ">(){public " + functionReturnTypeWithMul + " value(final " + functionParamTypeO2 + " _param2, final " + sourceTypeO1 + " _param1){  return ((PureFunction2<" + functionParamTypeO2 + "," + sourceTypeO1 + "," + functionReturnTypeWithMul + ">)PureCompiledLambda.getPureFunction(" + ValueSpecificationProcessor.processValueSpecification(topLevelElement, parametersValues.get(1), processorContext) + ", es)).value(_param2,_param1, es); }}" + "," + init + ")";
+        }
     }
 
     @Override


### PR DESCRIPTION
Currently, the fold compile behavior expects its parameters to be VS Instance, and it leads to NPE when the parameters are VS VariableExpression.  This propose a change to generate proper java code when the parameter are variable expressions.