### PR TITLE
Enhancement: Skip pct test to avoid running these twice

### DIFF
--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/testHelper/PureTestBuilderCompiled.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/testHelper/PureTestBuilderCompiled.java
@@ -70,20 +70,13 @@ public class PureTestBuilderCompiled extends TestSuite
 
     public static TestSuite buildSuite(String... all)
     {
-        return buildSuite(false, Maps.mutable.empty(), "meta::pure::test::pct::testAdapterForInMemoryExecution_Function_1__X_o_", all);
-    }
-
-    private static TestSuite buildSuite(boolean limitToPCT, MutableMap<String, String> exclusions, String executor, String... all)
-    {
         CompiledExecutionSupport executionSupport = getClassLoaderExecutionSupport();
-        PureTestBuilder.F2<CoreInstance, MutableList<Object>, Object> p = (a, b) -> executeFn(a, executor, exclusions, executionSupport, b);
+        PureTestBuilder.F2<CoreInstance, MutableList<Object>, Object> p = (a, b) -> executeFn(a, null, Maps.fixedSize.empty(), executionSupport, b);
         TestSuite suite = new TestSuite();
         ArrayIterate.forEach(all, (path) ->
                 {
                     TestCollection col = TestCollection.collectTests(path, executionSupport.getProcessorSupport(),
-                            limitToPCT ?
-                                    node -> isPCTTest(node, executionSupport.getProcessorSupport()) :
-                                    ci -> PureTestBuilder.satisfiesConditionsModular(ci, executionSupport.getProcessorSupport())
+                                    ci ->  !isPCTTest(ci, executionSupport.getProcessorSupport()) && PureTestBuilder.satisfiesConditionsModular(ci, executionSupport.getProcessorSupport())
                     );
                     suite.addTest(PureTestBuilder.buildSuite(col, p, executionSupport));
                 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/testHelper/PureTestBuilderInterpreted.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/testHelper/PureTestBuilderInterpreted.java
@@ -57,12 +57,12 @@ public class PureTestBuilderInterpreted
     {
         FunctionExecutionInterpreted functionExecution = getFunctionExecutionInterpreted();
 
-        PureTestBuilder.F2<CoreInstance, MutableList<Object>, Object> testExecutor = getTestExecutor(functionExecution, Maps.mutable.empty(), "meta::pure::test::pct::testAdapterForInMemoryExecution_Function_1__X_o_");
+        PureTestBuilder.F2<CoreInstance, MutableList<Object>, Object> testExecutor = getTestExecutor(functionExecution, Maps.mutable.empty(), null);
 
         TestSuite suite = new TestSuite();
         ArrayIterate.forEach(all, (path) ->
                 {
-                    TestCollection col = TestCollection.collectTests(path, functionExecution.getProcessorSupport(), ci -> PureTestBuilder.satisfiesConditionsInterpreted(ci, functionExecution.getProcessorSupport()));
+                    TestCollection col = TestCollection.collectTests(path, functionExecution.getProcessorSupport(), ci -> !isPCTTest(ci, functionExecution.getProcessorSupport()) && PureTestBuilder.satisfiesConditionsInterpreted(ci, functionExecution.getProcessorSupport()));
                     suite.addTest(PureTestBuilder.buildSuite(col, testExecutor, new ExecutionSupport()));
                 }
         );


### PR DESCRIPTION
The current tool to build test collection picks PCT test cases, while there are suites to execute PCT test cases already.  These leads to executing CPT test twice on each build cycle.