### PR TITLE
Extract KeyIndex from ReflectiveCoreInstance

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/coreinstance/KeyIndex.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/coreinstance/KeyIndex.java
@@ -1,0 +1,139 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.coreinstance;
+
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MapIterable;
+import org.eclipse.collections.api.map.MutableMap;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+
+public class KeyIndex
+{
+    private final MapIterable<String, ImmutableList<String>> realKeysByKey;
+
+    private KeyIndex(MapIterable<String, ImmutableList<String>> realKeysByKey)
+    {
+        this.realKeysByKey = realKeysByKey;
+    }
+
+    public RichIterable<String> getKeys()
+    {
+        return this.realKeysByKey.keysView();
+    }
+
+    public ListIterable<String> getRealKeyByName(String name)
+    {
+        ImmutableList<String> realKey = this.realKeysByKey.get(name);
+        if (realKey == null)
+        {
+            throw new RuntimeException("Unsupported key: " + name);
+        }
+        return realKey;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static Builder builder(int keyCount)
+    {
+        return new Builder(keyCount);
+    }
+
+    public static class Builder
+    {
+        private final MutableMap<String, ImmutableList<String>> realKeys;
+
+        private Builder(int keyCount)
+        {
+            this.realKeys = Maps.mutable.ofInitialCapacity(keyCount);
+        }
+
+        private Builder()
+        {
+            this.realKeys = Maps.mutable.empty();
+        }
+
+        public Builder withKey(String sourceType, String keyName)
+        {
+            addKey(sourceType, M3Properties.properties, keyName);
+            return this;
+        }
+
+        public Builder withKeyFromAssociation(String sourceType, String keyName)
+        {
+            addKey(sourceType, M3Properties.propertiesFromAssociations, keyName);
+            return this;
+        }
+
+        public Builder withKeys(String sourceType, String keyName, String... moreKeyNames)
+        {
+            addKeys(sourceType, M3Properties.properties, keyName, moreKeyNames);
+            return this;
+        }
+
+        public Builder withKeysFromAssociation(String sourceType, String keyName, String... moreKeyNames)
+        {
+            addKeys(sourceType, M3Properties.propertiesFromAssociations, keyName, moreKeyNames);
+            return this;
+        }
+
+        public KeyIndex build()
+        {
+            return new KeyIndex(this.realKeys.isEmpty() ? Maps.immutable.empty() : this.realKeys);
+        }
+
+        private void addKey(String sourceType, String propertiesProperty, String keyName)
+        {
+            MutableList<String> realKey = buildRealKey(sourceType, propertiesProperty, keyName);
+            this.realKeys.put(keyName, realKey.toImmutable());
+        }
+
+        private void addKeys(String sourceType, String propertiesProperty, String keyName, String... moreKeyNames)
+        {
+            MutableList<String> realKey = buildRealKey(sourceType, propertiesProperty, keyName);
+            this.realKeys.put(keyName, realKey.toImmutable());
+            int keyIndex = realKey.size() - 1;
+            for (String otherKeyName : moreKeyNames)
+            {
+                realKey.set(keyIndex, otherKeyName);
+                this.realKeys.put(otherKeyName, realKey.toImmutable());
+            }
+        }
+
+        private MutableList<String> buildRealKey(String sourceType, String propertyProperty, String keyName)
+        {
+            MutableList<String> list = Lists.mutable.empty();
+            PackageableElement.forEachSystemPathElement(sourceType, n ->
+            {
+                if (list.notEmpty())
+                {
+                    list.add(M3Properties.children);
+                }
+                list.add(n);
+            });
+            list.add(propertyProperty);
+            list.add(keyName);
+            return list;
+        }
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/coreinstance/TestKeyIndex.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/coreinstance/TestKeyIndex.java
@@ -1,4 +1,4 @@
-// Copyright 2024 Goldman Sachs
+// Copyright 2025 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package org.finos.legend.pure.runtime.java.compiled.runtime.generation.processors.support.coreinstance;
+package org.finos.legend.pure.m3.coreinstance;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.coreinstance.ReflectiveCoreInstance;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestReflectiveCoreInstance
+public class TestKeyIndex
 {
     @Test
     public void testEmptyKeyIndex()
     {
-        ReflectiveCoreInstance.KeyIndex empty = ReflectiveCoreInstance.keyIndexBuilder().build();
+        KeyIndex empty = KeyIndex.builder().build();
         Assert.assertEquals(Sets.immutable.empty(), empty.getKeys().toSet());
         RuntimeException e = Assert.assertThrows(RuntimeException.class, () -> empty.getRealKeyByName("fakeKey"));
         Assert.assertEquals("Unsupported key: fakeKey", e.getMessage());
@@ -34,7 +33,7 @@ public class TestReflectiveCoreInstance
     @Test
     public void testKeyIndex()
     {
-        ReflectiveCoreInstance.KeyIndex index = ReflectiveCoreInstance.keyIndexBuilder(18)
+        KeyIndex index = KeyIndex.builder(18)
                 .withKey("Root::meta::pure::metamodel::extension::ElementWithConstraints", "constraints")
                 .withKey("Root::meta::pure::metamodel::extension::ElementWithStereotypes", "stereotypes")
                 .withKey("Root::meta::pure::metamodel::extension::ElementWithTaggedValues", "taggedValues")

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/AbstractQuantityCoreInstance.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/AbstractQuantityCoreInstance.java
@@ -18,6 +18,7 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.set.MutableSet;
+import org.finos.legend.pure.m3.coreinstance.KeyIndex;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.ElementOverride;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
@@ -38,7 +39,7 @@ import java.util.Objects;
 
 public abstract class AbstractQuantityCoreInstance extends ReflectiveCoreInstance implements QuantityCoreInstance
 {
-    private static final KeyIndex KEY_INDEX = keyIndexBuilder(6)
+    private static final KeyIndex KEY_INDEX = KeyIndex.builder(6)
             .withKeys("Root::meta::pure::metamodel::valuespecification::ValueSpecification", "genericType", "multiplicity", "usageContext")
             .withKey("Root::meta::pure::metamodel::valuespecification::InstanceValue", "values")
             .withKeys("Root::meta::pure::metamodel::type::Any", "classifierGenericType", "elementOverride")

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/ReflectiveCoreInstance.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/ReflectiveCoreInstance.java
@@ -16,12 +16,8 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.suppor
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.factory.Maps;
-import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.map.MapIterable;
-import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.eclipse.collections.impl.utility.Iterate;
@@ -29,8 +25,6 @@ import org.finos.legend.pure.m3.coreinstance.helper.AnyHelper;
 import org.finos.legend.pure.m3.coreinstance.helper.AnyStubHelper;
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
 import org.finos.legend.pure.m3.navigation.M3Paths;
-import org.finos.legend.pure.m3.navigation.M3Properties;
-import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
@@ -696,119 +690,6 @@ public abstract class ReflectiveCoreInstance extends AbstractCompiledCoreInstanc
             {
                 throw new IllegalArgumentException("Type not supported to retrieve value from ReflectiveCoreInstance - " + valueType);
             }
-        }
-    }
-
-    public static KeyIndexBuilder keyIndexBuilder()
-    {
-        return new KeyIndexBuilder();
-    }
-
-    public static KeyIndexBuilder keyIndexBuilder(int keyCount)
-    {
-        return new KeyIndexBuilder(keyCount);
-    }
-
-    public static class KeyIndexBuilder
-    {
-        private final MutableMap<String, ImmutableList<String>> realKeys;
-
-        private KeyIndexBuilder(int keyCount)
-        {
-            this.realKeys = Maps.mutable.ofInitialCapacity(keyCount);
-        }
-
-        private KeyIndexBuilder()
-        {
-            this.realKeys = Maps.mutable.empty();
-        }
-
-        public KeyIndexBuilder withKey(String sourceType, String keyName)
-        {
-            addKey(sourceType, M3Properties.properties, keyName);
-            return this;
-        }
-
-        public KeyIndexBuilder withKeyFromAssociation(String sourceType, String keyName)
-        {
-            addKey(sourceType, M3Properties.propertiesFromAssociations, keyName);
-            return this;
-        }
-
-        public KeyIndexBuilder withKeys(String sourceType, String keyName, String... moreKeyNames)
-        {
-            addKeys(sourceType, M3Properties.properties, keyName, moreKeyNames);
-            return this;
-        }
-
-        public KeyIndexBuilder withKeysFromAssociation(String sourceType, String keyName, String... moreKeyNames)
-        {
-            addKeys(sourceType, M3Properties.propertiesFromAssociations, keyName, moreKeyNames);
-            return this;
-        }
-
-        public KeyIndex build()
-        {
-            return new KeyIndex(this.realKeys.isEmpty() ? Maps.immutable.empty() : this.realKeys);
-        }
-
-        private void addKey(String sourceType, String propertiesProperty, String keyName)
-        {
-            MutableList<String> realKey = buildRealKey(sourceType, propertiesProperty, keyName);
-            this.realKeys.put(keyName, realKey.toImmutable());
-        }
-
-        private void addKeys(String sourceType, String propertiesProperty, String keyName, String... moreKeyNames)
-        {
-            MutableList<String> realKey = buildRealKey(sourceType, propertiesProperty, keyName);
-            this.realKeys.put(keyName, realKey.toImmutable());
-            int keyIndex = realKey.size() - 1;
-            for (String otherKeyName : moreKeyNames)
-            {
-                realKey.set(keyIndex, otherKeyName);
-                this.realKeys.put(otherKeyName, realKey.toImmutable());
-            }
-        }
-
-        private MutableList<String> buildRealKey(String sourceType, String propertyProperty, String keyName)
-        {
-            MutableList<String> list = Lists.mutable.empty();
-            PackageableElement.forEachSystemPathElement(sourceType, n ->
-            {
-                if (list.notEmpty())
-                {
-                    list.add(M3Properties.children);
-                }
-                list.add(n);
-            });
-            list.add(propertyProperty);
-            list.add(keyName);
-            return list;
-        }
-    }
-
-    public static class KeyIndex
-    {
-        private final MapIterable<String, ImmutableList<String>> realKeysByKey;
-
-        private KeyIndex(MapIterable<String, ImmutableList<String>> realKeysByKey)
-        {
-            this.realKeysByKey = realKeysByKey;
-        }
-
-        public RichIterable<String> getKeys()
-        {
-            return this.realKeysByKey.keysView();
-        }
-
-        public ListIterable<String> getRealKeyByName(String name)
-        {
-            ImmutableList<String> realKey = this.realKeysByKey.get(name);
-            if (realKey == null)
-            {
-                throw new RuntimeException("Unsupported key: " + name);
-            }
-            return realKey;
         }
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassImplProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassImplProcessor.java
@@ -54,6 +54,7 @@ public class ClassImplProcessor
             "import org.eclipse.collections.api.list.ListIterable;\n" +
             "import org.eclipse.collections.api.list.MutableList;\n" +
             "import org.eclipse.collections.api.map.MutableMap;\n" +
+            "import org.finos.legend.pure.m3.coreinstance.KeyIndex;\n" +
             "import org.finos.legend.pure.m3.execution.ExecutionSupport;\n" +
             "import org.finos.legend.pure.m4.ModelRepository;\n" +
             "import org.finos.legend.pure.m4.coreinstance.CoreInstance;\n" +
@@ -151,7 +152,7 @@ public class ClassImplProcessor
 
                         propertyString += Multiplicity.isToOne(returnMultiplicity, false) ?
                                 "    public " + returnTypeJava + " _" + name + ";\n" :
-                                "    public RichIterable _" + name + " = Lists.mutable.with();\n";
+                                "    public RichIterable _" + name + " = Lists.mutable.empty();\n";
                     }
                     propertyString += buildProperty(property, ownerClassName + (ownerTypeParams.isEmpty() ? "" : "<" + ownerTypeParams + ">"), "this", classOwnerId, name, returnType, unresolvedReturnType, returnMultiplicity, processorContext1.getSupport(), includeGettor, processorContext1);
                     return propertyString;
@@ -301,7 +302,7 @@ public class ClassImplProcessor
         builder.append("    private static final String tempFullTypeId = \"").append(fullId).append("\";\n");
 
         MapIterable<String, CoreInstance> simplePropertiesByName = processorSupport.class_getSimplePropertiesByName(_class);
-        builder.append("    private static final KeyIndex KEY_INDEX = keyIndexBuilder(").append(simplePropertiesByName.size()).append(")\n");
+        builder.append("    private static final KeyIndex KEY_INDEX = KeyIndex.builder(").append(simplePropertiesByName.size()).append(")\n");
         MutableMap<CoreInstance, MutableMap<String, CoreInstance>> propertiesBySourceType = Maps.mutable.empty();
         simplePropertiesByName.forEachKeyValue((name, property) ->
         {
@@ -726,7 +727,7 @@ public class ClassImplProcessor
                                         "                {\n" +
                                         "                    v._sever_reverse_" + reversePropertyName + "(" + owner + ");\n" +
                                         "                }\n") +
-                        "                " + owner + "._" + name + " = Lists.mutable.with();\n" +
+                        "                " + owner + "._" + name + " = Lists.mutable.empty();\n" +
                         "            }\n" +
                         "            return this;\n" +
                         "        }\n" : "") +

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassLazyImplProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassLazyImplProcessor.java
@@ -32,35 +32,34 @@ import org.finos.legend.pure.runtime.java.compiled.generation.processors.type.Ty
 public class ClassLazyImplProcessor
 {
     private static final String IMPORTS = "import java.util.concurrent.atomic.AtomicBoolean;\n" +
+            "import org.eclipse.collections.api.RichIterable;\n" +
+            "import org.eclipse.collections.api.factory.Lists;\n" +
+            "import org.eclipse.collections.api.factory.Maps;\n" +
             "import org.eclipse.collections.api.list.ListIterable;\n" +
             "import org.eclipse.collections.api.list.MutableList;\n" +
-            "import org.eclipse.collections.api.RichIterable;\n" +
-            "import org.eclipse.collections.api.map.MutableMap;\n" +
-            "import org.eclipse.collections.impl.factory.Lists;\n" +
-            "import org.eclipse.collections.impl.factory.Maps;\n" +
-            "import org.eclipse.collections.impl.map.mutable.UnifiedMap;\n" +
             "import org.eclipse.collections.api.map.ImmutableMap;\n" +
+            "import org.eclipse.collections.api.map.MutableMap;\n" +
             "import org.eclipse.collections.impl.list.mutable.FastList;\n" +
-            "import org.finos.legend.pure.m4.coreinstance.CoreInstance;\n" +
-            "import org.finos.legend.pure.m4.coreinstance.factory.CoreInstanceFactory;\n" +
+            "import org.finos.legend.pure.m3.coreinstance.KeyIndex;\n" +
+            "import org.finos.legend.pure.m3.execution.ExecutionSupport;\n" +
             "import org.finos.legend.pure.m4.ModelRepository;\n" +
+            "import org.finos.legend.pure.m4.coreinstance.CoreInstance;\n" +
+            "import org.finos.legend.pure.m4.coreinstance.CoreInstance;\n" +
             "import org.finos.legend.pure.m4.coreinstance.SourceInformation;\n" +
+            "import org.finos.legend.pure.m4.coreinstance.factory.CoreInstanceFactory;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataLazy;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.execution.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.execution.sourceInformation.*;\n" +
+            "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.*;\n" +
             "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.coreinstance.*;\n" +
-            "import org.finos.legend.pure.runtime.java.compiled.serialization.model.*;\n" +
-            "import org.finos.legend.pure.m3.execution.ExecutionSupport;\n" +
-            "import org.finos.legend.pure.m4.coreinstance.CoreInstance;\n";
+            "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.*;\n" +
+            "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.defended.*;\n" +
+            "import org.finos.legend.pure.runtime.java.compiled.serialization.model.*;\n";
 
 
-    private static final String QUALIFIER_IMPORTS =
+    private static final String QUALIFIER_IMPORTS = "import org.eclipse.collections.api.block.function.Function0;\n" +
             "import org.eclipse.collections.api.block.function.Function2;\n" +
-                    "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.map.PureMap;\n" +
-                    "import org.eclipse.collections.api.block.function.Function0;\n";
+            "import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.map.PureMap;\n";
 
     private static final String LAZY_INITIALIZED_SUFFIX = "_initialized";
 
@@ -94,8 +93,8 @@ public class ClassLazyImplProcessor
                 ClassImplProcessor.buildGetValueForMetaPropertyToMany(classGenericType, processorSupport) +
                 ClassImplProcessor.buildSimpleProperties(classGenericType, (property, name, unresolvedReturnType, returnType, returnMultiplicity, returnTypeJava, classOwnerId, ownerClassName, ownerTypeParams, processorContext1) -> "    public final AtomicBoolean _" + name + LAZY_INITIALIZED_SUFFIX + " = new AtomicBoolean(false);\n" +
                         (Multiplicity.isToOne(returnMultiplicity, false) ?
-                                "    public " + returnTypeJava + " _" + name + ";\n" :
-                                "    public RichIterable _" + name + " = Lists.mutable.with();\n") +
+                         "    public " + returnTypeJava + " _" + name + ";\n" :
+                         "    public RichIterable _" + name + " = Lists.mutable.empty();\n") +
                         buildLazyProperty(property, ownerClassName + (ownerTypeParams.isEmpty() ? "" : "<" + ownerTypeParams + ">"), "this", name, returnType, unresolvedReturnType, returnMultiplicity, processorContext1.getSupport(), processorContext1), processorContext, processorSupport) +
                 ClassImplProcessor.buildQualifiedProperties(classGenericType, processorContext, processorSupport) +
                 buildLazyCopy(classGenericType, classInterfaceName, className, false, processorSupport) +


### PR DESCRIPTION
Extract KeyIndex from ReflectiveCoreInstance so it can be used more generally. In passing, clean up generated imports in ClassLazyImplProcessor.