### PR TITLE
Fix to rolling back using new reference ids in generated Java code

### DIFF
--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/GenericTypeSerializationInCode.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/GenericTypeSerializationInCode.java
@@ -46,7 +46,7 @@ public class GenericTypeSerializationInCode
 
     private static String generateValueSpecification(ValueSpecification vs, ProcessorContext processorContext)
     {
-        return "new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + M3Paths.InstanceValue + "\"))" +
+        return "new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"Root::" + M3Paths.InstanceValue + "\"))" +
                 "._genericType(" + generateGenericTypeBuilder(vs._genericType(), processorContext) + ")" +
                 "._multiplicity(" + generateMultiplicityBuilder(vs._multiplicity()) + ")" +
                 "._values(Lists.mutable.with(" + ValueSpecificationProcessor.processValueSpecification(vs, processorContext) + "))";


### PR DESCRIPTION
Fix to rolling back using new reference ids in generated Java code. Add one missed change.