### PR TITLE
Updates slf4j version to 1.7.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <jersey.version>2.25.1</jersey.version>
         <json-simple.version>1.1.1</json-simple.version>
         <junit.version>4.13.1</junit.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <tomcat-dbcp.version>10.0.4</tomcat-dbcp.version>
 
         <!-- Plugin -->


### PR DESCRIPTION
#### What type of PR is this?
- Improvement


#### What does this PR do / why is it needed ?

We are replacing log4j-1.2.17 with reload4j-1.2.19 (This is done remove vulnerabilities). slf4j 1.7.36 version supports reload4j to keep in sync with other legend repo updating version over here as well.