### PR TITLE
Fix execution exception callstacks for assertError

### DIFF
--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/FunctionExpressionExecutor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/FunctionExpressionExecutor.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.pure.runtime.java.interpreted;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
@@ -24,6 +25,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.Functi
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionCoreInstanceWrapper;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.FunctionExpression;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.FunctionExpressionCoreInstanceWrapper;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
@@ -33,6 +35,7 @@ import org.finos.legend.pure.m3.navigation.function.FunctionType;
 import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
 import org.finos.legend.pure.m3.navigation.property.Property;
+import org.finos.legend.pure.m3.tools.ListHelper;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.interpreted.natives.InstantiationContext;
 import org.finos.legend.pure.runtime.java.interpreted.profiler.Profiler;
@@ -52,43 +55,47 @@ class FunctionExpressionExecutor implements Executor
     {
         profiler.startExecutingFunctionExpression(instance, functionExpressionCallStack.isEmpty() ? null : functionExpressionCallStack.peek());
         functionExpressionCallStack.push(instance);
-        FunctionExpression functionExpression = FunctionExpressionCoreInstanceWrapper.toFunctionExpression(instance);
-        ListIterable<CoreInstance> params = (ListIterable<CoreInstance>) (Object) functionExpression._parametersValues();
-        Function function = FunctionCoreInstanceWrapper.toFunction(functionExpression._func());
-
-        MutableMap<String, CoreInstance> localResolvedTypeParameters = Maps.mutable.empty();
-        MutableMap<String, CoreInstance> localResolvedMultiplicityParameters = Maps.mutable.empty();
-        this.resolveLocalTypeAndMultiplicityParams(functionExpression, functionExpressionCallStack, processorSupport, params, function, localResolvedTypeParameters, localResolvedMultiplicityParameters);
-        boolean deferExecution = Instance.instanceOf(function, M3Paths.NativeFunction, processorSupport) && functionExecutionInterpreted.getNativeFunction(function.getName()) != null && functionExecutionInterpreted.getNativeFunction(function.getName()).deferParameterExecution();
-
-        MutableList<CoreInstance> parameters;
-        if (deferExecution || params.isEmpty())
+        try
         {
-            parameters = params.toList();
-        }
-        else
-        {
-            parameters = params.collect(p ->
+            FunctionExpression functionExpression = FunctionExpressionCoreInstanceWrapper.toFunctionExpression(instance);
+            ListIterable<? extends ValueSpecification> params = ListHelper.wrapListIterable(functionExpression._parametersValues());
+            Function<?> function = FunctionCoreInstanceWrapper.toFunction(functionExpression._func());
+
+            MutableMap<String, CoreInstance> localResolvedTypeParameters = Maps.mutable.empty();
+            MutableMap<String, CoreInstance> localResolvedMultiplicityParameters = Maps.mutable.empty();
+            this.resolveLocalTypeAndMultiplicityParams(functionExpression, functionExpressionCallStack, processorSupport, params, function, localResolvedTypeParameters, localResolvedMultiplicityParameters);
+            boolean deferExecution = Instance.instanceOf(function, M3Paths.NativeFunction, processorSupport) && functionExecutionInterpreted.getNativeFunction(function.getName()) != null && functionExecutionInterpreted.getNativeFunction(function.getName()).deferParameterExecution();
+
+            MutableList<CoreInstance> parameters = (deferExecution || params.isEmpty()) ?
+                                                   Lists.mutable.withAll(params) :
+                                                   params.collect(p ->
+                                                   {
+                                                       Executor executor = FunctionExecutionInterpreted.findValueSpecificationExecutor(p, functionExpressionCallStack, processorSupport, functionExecutionInterpreted);
+                                                       return executor.execute(p, resolvedTypeParameters, resolvedMultiplicityParameters, functionExpressionCallStack, variableContext, profiler, instantiationContext, executionSupport, functionExecutionInterpreted, processorSupport);
+                                                   }, Lists.mutable.ofInitialCapacity(params.size()));
+
+            if (Instance.instanceOf(function, M3Paths.QualifiedProperty, processorSupport))
             {
-                Executor executor = FunctionExecutionInterpreted.findValueSpecificationExecutor(p, functionExpressionCallStack, processorSupport, functionExecutionInterpreted);
-                return executor.execute(p, resolvedTypeParameters, resolvedMultiplicityParameters, functionExpressionCallStack, variableContext, profiler, instantiationContext, executionSupport, functionExecutionInterpreted, processorSupport);
-            }).toList();
-        }
+                parameters.addAll(1, parameters.get(0).getValueForMetaPropertyToOne(M3Properties.genericType).getValueForMetaPropertyToMany(M3Properties.typeVariableValues).toList());
+            }
 
-        if (Instance.instanceOf(function, M3Paths.QualifiedProperty, processorSupport))
+            resolvedTypeParameters.push(this.resolveTypeParamsFromParent(resolvedTypeParameters, resolvedMultiplicityParameters, localResolvedTypeParameters, functionExpressionCallStack, processorSupport));
+            resolvedMultiplicityParameters.push(this.resolveMultiplicityParametersFromParent(resolvedMultiplicityParameters, localResolvedMultiplicityParameters, functionExpressionCallStack));
+            CoreInstance result = functionExecutionInterpreted.executeFunction(true, function, parameters, resolvedTypeParameters, resolvedMultiplicityParameters, variableContext, functionExpressionCallStack, profiler, instantiationContext, executionSupport);
+
+            resolvedTypeParameters.pop();
+            resolvedMultiplicityParameters.pop();
+            profiler.finishedExecutingFunctionExpression(instance);
+            return result;
+        }
+        finally
         {
-            parameters.addAll(1, parameters.get(0).getValueForMetaPropertyToOne(M3Properties.genericType).getValueForMetaPropertyToMany(M3Properties.typeVariableValues).toList());
+            // These cases shouldn't happen, but it's better to make sure ...
+            if (functionExpressionCallStack.notEmpty() && (functionExpressionCallStack.peek() == instance))
+            {
+                functionExpressionCallStack.pop();
+            }
         }
-
-        resolvedTypeParameters.push(this.resolveTypeParamsFromParent(resolvedTypeParameters, resolvedMultiplicityParameters, localResolvedTypeParameters, functionExpressionCallStack, processorSupport));
-        resolvedMultiplicityParameters.push(this.resolveMultiplicityParametersFromParent(resolvedMultiplicityParameters, localResolvedMultiplicityParameters, functionExpressionCallStack));
-        CoreInstance result = functionExecutionInterpreted.executeFunction(true, function, parameters, resolvedTypeParameters, resolvedMultiplicityParameters, variableContext, functionExpressionCallStack, profiler, instantiationContext, executionSupport);
-
-        resolvedTypeParameters.pop();
-        resolvedMultiplicityParameters.pop();
-        functionExpressionCallStack.pop();
-        profiler.finishedExecutingFunctionExpression(instance);
-        return result;
     }
 
     private void resolveLocalTypeAndMultiplicityParams(FunctionExpression functionExpression, MutableStack<CoreInstance> functionExpressionCallStack, ProcessorSupport processorSupport, ListIterable<? extends CoreInstance> params, Function<?> function, MutableMap<String, CoreInstance> localResolvedTypeParameters, MutableMap<String, CoreInstance> localResolvedMultiplicityParameters)
@@ -98,8 +105,8 @@ class FunctionExpressionExecutor implements Executor
         if (Property.isQualifiedProperty(function, processorSupport) || "copy_T_1__String_1__KeyExpression_MANY__T_1_".equals(function.getName()) || "new_Class_1__String_1__KeyExpression_MANY__T_1_".equals(function.getName()) || "new_Class_1__String_1__T_1_".equals(function.getName()))
         {
             CoreInstance genericType = Property.isQualifiedProperty(function, processorSupport) || "copy_T_1__String_1__KeyExpression_MANY__T_1_".equals(function.getName()) ?
-                    Instance.getValueForMetaPropertyToOneResolved(params.get(0), M3Properties.genericType, processorSupport) :
-                    Instance.getValueForMetaPropertyToOneResolved(params.get(0), M3Properties.genericType, M3Properties.typeArguments, processorSupport);
+                                       Instance.getValueForMetaPropertyToOneResolved(params.get(0), M3Properties.genericType, processorSupport) :
+                                       Instance.getValueForMetaPropertyToOneResolved(params.get(0), M3Properties.genericType, M3Properties.typeArguments, processorSupport);
             CoreInstance classifier = Instance.getValueForMetaPropertyToOneResolved(genericType, M3Properties.rawType, processorSupport);
             ListIterable<? extends CoreInstance> new_TypeParameters = Instance.getValueForMetaPropertyToManyResolved(classifier, M3Properties.typeParameters, processorSupport);
             ListIterable<? extends CoreInstance> new_MultiplicityParameters = Instance.getValueForMetaPropertyToManyResolved(classifier, M3Properties.multiplicityParameters, processorSupport);

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/DefaultConstraintHandler.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/DefaultConstraintHandler.java
@@ -15,7 +15,6 @@
 package org.finos.legend.pure.runtime.java.interpreted.natives;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.factory.Stacks;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.stack.MutableStack;
@@ -83,7 +82,7 @@ public class DefaultConstraintHandler
         CoreInstance owner = Instance.getValueForMetaPropertyToOneResolved(constraint, M3Properties.owner, functionExecution.getProcessorSupport());
         if (owner == null || "Global".equals(owner.getName()))
         {
-            CoreInstance result = functionExecution.executeValueSpecification(definition, new Stack<>(), new Stack<>(), Stacks.mutable.empty(), ctx, VoidProfiler.VOID_PROFILER, instantiationContext, executionSupport);
+            CoreInstance result = functionExecution.executeValueSpecification(definition, new Stack<>(), new Stack<>(), functionExpressionCallStack, ctx, VoidProfiler.VOID_PROFILER, instantiationContext, executionSupport);
             CoreInstance constraintClass = Instance.getValueForMetaPropertyToOneResolved(definition, M3Properties.usageContext, functionExecution.getProcessorSupport()).getValueForMetaPropertyToOne(M3Properties.type);
             CoreInstance messageFunction = Instance.getValueForMetaPropertyToOneResolved(constraint, M3Properties.messageFunction, functionExecution.getProcessorSupport());
             if (!PrimitiveUtilities.getBooleanValue(result.getValueForMetaPropertyToOne(M3Properties.values)))
@@ -92,7 +91,7 @@ public class DefaultConstraintHandler
                 if (messageFunction != null)
                 {
                     message.append(", Message: ");
-                    message.append(PrimitiveUtilities.getStringValue(functionExecution.executeValueSpecification(messageFunction.getValueForMetaPropertyToOne(M3Properties.expressionSequence), new Stack<>(), new Stack<>(), Stacks.mutable.empty(), ctx, VoidProfiler.VOID_PROFILER, instantiationContext, executionSupport).getValueForMetaPropertyToOne(M3Properties.values)));
+                    message.append(PrimitiveUtilities.getStringValue(functionExecution.executeValueSpecification(messageFunction.getValueForMetaPropertyToOne(M3Properties.expressionSequence), new Stack<>(), new Stack<>(), functionExpressionCallStack, ctx, VoidProfiler.VOID_PROFILER, instantiationContext, executionSupport).getValueForMetaPropertyToOne(M3Properties.values)));
                 }
                 throw new PureExecutionException(sourceInformation, message.toString(), functionExpressionCallStack);
             }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/runtime/api/TestFunctionExecutionStart.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/test/java/org/finos/legend/pure/runtime/java/interpreted/runtime/api/TestFunctionExecutionStart.java
@@ -107,14 +107,15 @@ public class TestFunctionExecutionStart extends AbstractPureTestWithCoreCompiled
     {
         compileTestSource("fromString.pure",
                 "###Pure\n" +
-                        "   function go():Boolean[1]\n" +
-                        "   {\n" +
-                        "       nest();\n" +
-                        "       true;\n" +
-                        "   }\n" +
-                        "function nest():Boolean[1]" +
-                        "{" +
-                        "   fail();" +
+                        "function go():Boolean[1]\n" +
+                        "{\n" +
+                        "    nest();\n" +
+                        "    true;\n" +
+                        "}\n" +
+                        "\n" +
+                        "function nest():Boolean[1]\n" +
+                        "{\n" +
+                        "   fail();\n" +
                         "}");
 
         PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> execute("go():Boolean[1]"));
@@ -123,10 +124,42 @@ public class TestFunctionExecutionStart extends AbstractPureTestWithCoreCompiled
                 "   1: resource:/platform/pure/essential/tests/assert.pure line:26 column:5\n" +
                         "\n" +
                         "   Full Stack:\n" +
-                        "       nest():Boolean[1]     <-     resource:fromString.pure line:4 column:8\n" +
-                        "       fail():Boolean[1]     <-     resource:fromString.pure line:7 column:31\n" +
+                        "       nest():Boolean[1]     <-     resource:fromString.pure line:4 column:5\n" +
+                        "       fail():Boolean[1]     <-     resource:fromString.pure line:10 column:4\n" +
                         "       assert(Boolean[1]):Boolean[1]     <-     resource:/platform/pure/essential/tests/fail.pure line:19 column:5\n" +
                         "       assert(Boolean[1], String[1]):Boolean[1]     <-     resource:/platform/pure/essential/tests/assert.pure line:31 column:5\n" +
-                        "       assert(Boolean[1], Function<{->String[1]}>[1]):Boolean[1]     <-     resource:/platform/pure/essential/tests/assert.pure line:26 column:5", trace);
+                        "       assert(Boolean[1], Function<{->String[1]}>[1]):Boolean[1]     <-     resource:/platform/pure/essential/tests/assert.pure line:26 column:5",
+                trace);
+    }
+
+    @Test
+    public void testCallStackInExecutionExceptionAfterAssertError()
+    {
+        compileTestSource("fromString.pure",
+                "###Pure\n" +
+                        "function go():Boolean[1]\n" +
+                        "{\n" +
+                        "    nest();\n" +
+                        "    true;\n" +
+                        "}\n" +
+                        "\n" +
+                        "function nest():Boolean[1]\n" +
+                        "{\n" +
+                        "   assertError(|fail('message'), 'message');\n" +
+                        "   fail();\n" +
+                        "}");
+
+        PureExecutionException e = Assert.assertThrows(PureExecutionException.class, () -> execute("go():Boolean[1]"));
+        String trace = e.printPureStackTrace(new StringBuilder(), "   ", functionExecution.getProcessorSupport()).toString();
+        Assert.assertEquals(
+                "   1: resource:/platform/pure/essential/tests/assert.pure line:26 column:5\n" +
+                        "\n" +
+                        "   Full Stack:\n" +
+                        "       nest():Boolean[1]     <-     resource:fromString.pure line:4 column:5\n" +
+                        "       fail():Boolean[1]     <-     resource:fromString.pure line:11 column:4\n" +
+                        "       assert(Boolean[1]):Boolean[1]     <-     resource:/platform/pure/essential/tests/fail.pure line:19 column:5\n" +
+                        "       assert(Boolean[1], String[1]):Boolean[1]     <-     resource:/platform/pure/essential/tests/assert.pure line:31 column:5\n" +
+                        "       assert(Boolean[1], Function<{->String[1]}>[1]):Boolean[1]     <-     resource:/platform/pure/essential/tests/assert.pure line:26 column:5",
+                trace);
     }
 }


### PR DESCRIPTION
Fix execution exception callstacks for assertError. Previously, not everything was being popped off the stack in the case of errors that were caught.