### PR TITLE
Add preprocessFunction to Runtime

### DIFF
--- a/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-pure/src/main/resources/platform_dsl_store/grammar/runtime.pure
+++ b/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-pure/src/main/resources/platform_dsl_store/grammar/runtime.pure
@@ -16,6 +16,7 @@ import meta::core::runtime::*;
 
 Class meta::core::runtime::Runtime
 {
+   preprocessFunction : Function<{FunctionDefinition<Any>[1], Runtime[1] -> FunctionDefinition<Any>[1]}>[0..1];
    connectionStores : ConnectionStore[*];
    connectionByElement(a:Any[1]){$this.connectionStores->filter(c|$c.element == $a).connection->toOne()}:Connection[1];
 }


### PR DESCRIPTION
Add preprocessFunction to Runtime to be able to rewrite a function expression before preval and routing if needed