### PR TITLE
Default sourceInformation in PureCompiledLambda constructor to that of the provided LambdaFunction

### DIFF
--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
@@ -528,8 +528,9 @@ public final class JavaSourceCodeGenerator
                 "    public PureCompiledLambda(LambdaFunction lambdaFunction, SharedPureFunction pureFunction)\n" +
                 "    {\n" +
                 "        this();\n" +
-                "        this.lambdaFunction = (LambdaFunction)lambdaFunction;\n" +
                 "        this.pureFunction = pureFunction;\n" +
+                "        this.lambdaFunction = (LambdaFunction)lambdaFunction;\n" +
+                "        if (this.lambdaFunction != null) { setSourceInformation(this.lambdaFunction.getSourceInformation());}\n" +
                 "    }" +
                 "\n" +
                 "    public SharedPureFunction pureFunction()" +


### PR DESCRIPTION
Required to resolve issue in legend-engine with code generated to evaluate constraints on DynamicNew code

The modified code is covered by the existing unit test that generated code compiles.  The functional change needs to be tested in legend-engine (with a new test being added there)


`
  java.lang.NullPointerException
    at org.finos.legend.pure.runtime.java.compiled.generation.processors.IdBuilder.sourceToId(IdBuilder.java:376)
    at org.finos.legend.pure.runtime.java.compiled.generation.processors.support.CompiledSupport.executeFunction(CompiledSupport.java:1878)
    at org.finos.legend.pure.runtime.java.compiled.generation.processors.support.Pure.handleValidation(Pure.java:715)
    at org.finos.legend.pure.generated.core_pure_constraints_tests_constraintsExtension.Root_meta_pure_constraints_functions_tests_testEvaluateConstraint__Boolean_1_(core_pure_constraints_tests_constraintsExtension.java:114)
`