### PR TITLE
Generalize package path resolution for graph paths and reference ids

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdExtension.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/ReferenceIdExtension.java
@@ -15,6 +15,9 @@
 package org.finos.legend.pure.m3.serialization.compiler.reference;
 
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+import java.util.function.Function;
 
 public interface ReferenceIdExtension
 {
@@ -22,5 +25,5 @@ public interface ReferenceIdExtension
 
     ReferenceIdProvider newProvider(ProcessorSupport processorSupport);
 
-    ReferenceIdResolver newResolver(ProcessorSupport processorSupport);
+    ReferenceIdResolver newResolver(Function<? super String, ? extends CoreInstance> packagePathResolver);
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ContainingElementIndex.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ContainingElementIndex.java
@@ -198,7 +198,7 @@ class ContainingElementIndex
         void addAllElements()
         {
             addElement(this.processorSupport.repository_getTopLevel(M3Paths.Package));
-            PrimitiveUtilities.forEachPrimitiveType(processorSupport, this::addElement);
+            PrimitiveUtilities.forEachPrimitiveType(this.processorSupport, this::addElement);
             Deque<CoreInstance> packages = new ArrayDeque<>();
             packages.add(this.processorSupport.repository_getTopLevel(M3Paths.Root));
             while (!packages.isEmpty())

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ReferenceIdExtensionV1.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ReferenceIdExtensionV1.java
@@ -18,6 +18,9 @@ import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdExtension;
 import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdProvider;
 import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdResolver;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+import java.util.function.Function;
 
 public class ReferenceIdExtensionV1 implements ReferenceIdExtension
 {
@@ -34,8 +37,8 @@ public class ReferenceIdExtensionV1 implements ReferenceIdExtension
     }
 
     @Override
-    public ReferenceIdResolver newResolver(ProcessorSupport processorSupport)
+    public ReferenceIdResolver newResolver(Function<? super String, ? extends CoreInstance> packagePathResolver)
     {
-        return new ReferenceIdResolverV1(processorSupport);
+        return new ReferenceIdResolverV1(packagePathResolver);
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ReferenceIdResolverV1.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/reference/v1/ReferenceIdResolverV1.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.pure.m3.serialization.compiler.reference.v1;
 
-import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation.graph.GraphPath;
 import org.finos.legend.pure.m3.serialization.compiler.reference.InvalidReferenceIdException;
 import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdResolver;
@@ -23,15 +22,17 @@ import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.function.Function;
+
 class ReferenceIdResolverV1 implements ReferenceIdResolver
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceIdResolverV1.class);
 
-    private final ProcessorSupport processorSupport;
+    private final Function<? super String, ? extends CoreInstance> packagePathResolver;
 
-    ReferenceIdResolverV1(ProcessorSupport processorSupport)
+    ReferenceIdResolverV1(Function<? super String, ? extends CoreInstance> packagePathResolver)
     {
-        this.processorSupport = processorSupport;
+        this.packagePathResolver = packagePathResolver;
     }
 
     @Override
@@ -63,7 +64,7 @@ class ReferenceIdResolverV1 implements ReferenceIdResolver
 
         try
         {
-            CoreInstance result = graphPath.resolve(this.processorSupport);
+            CoreInstance result = graphPath.resolve(this.packagePathResolver);
             long end = System.nanoTime();
             LOGGER.debug("Resolved {} in {}s", referenceId, (end - start) / 1_000_000_000.0);
             return result;

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/navigation/graph/TestGraphPath.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/navigation/graph/TestGraphPath.java
@@ -19,6 +19,7 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation._package._Package;
 import org.finos.legend.pure.m3.navigation.graph.GraphPath.EdgeConsumer;
 import org.finos.legend.pure.m3.navigation.graph.GraphPath.EdgeVisitor;
 import org.finos.legend.pure.m3.navigation.graph.GraphPath.ToManyPropertyAtIndexEdge;
@@ -35,6 +36,8 @@ import org.finos.legend.pure.m4.serialization.grammar.StringEscape;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.function.Function;
 
 public class TestGraphPath extends AbstractPureTestWithCoreCompiled
 {
@@ -315,172 +318,195 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
     @Test
     public void testResolve()
     {
+        testResolve(processorSupport::package_getByUserPath);
+        testResolve(path -> _Package.getByUserPath(path, repository::getTopLevel));
+    }
+    
+    private void testResolve(Function<? super String, ? extends CoreInstance> packagePathResolver)
+    {
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassA"),
-                GraphPath.buildPath("test::domain::ClassA").resolve(processorSupport));
+                GraphPath.buildPath("test::domain::ClassA").resolve(packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassA").getValueForMetaPropertyToOne("classifierGenericType"),
-                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType").resolve(processorSupport));
+                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType").resolve(packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance(M3Paths.Class),
-                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType", "rawType").resolve(processorSupport));
+                GraphPath.buildPath("test::domain::ClassA", "classifierGenericType", "rawType").resolve(packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance(M3Paths.String),
-                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueAtIndex("properties", 0).addToOneProperties("genericType", "rawType").build().resolve(processorSupport));
+                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueAtIndex("properties", 0).addToOneProperties("genericType", "rawType").build().resolve(packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassA").getValueInValueForMetaPropertyToMany("properties", "prop2").getValueForMetaPropertyToOne("genericType").getValueForMetaPropertyToOne("rawType"),
-                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolve(processorSupport));
+                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolve(packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassB"),
-                ImportStub.withImportStubByPass(GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType").build().resolve(processorSupport), processorSupport));
+                ImportStub.withImportStubByPass(GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType").build().resolve(packagePathResolver), processorSupport));
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassB"),
-                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType", "resolvedNode").build().resolve(processorSupport));
+                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType", "resolvedNode").build().resolve(packagePathResolver));
 
         Assert.assertSame(
                 runtime.getCoreInstance("::"),
-                GraphPath.buildPath("::").resolve(processorSupport));
+                GraphPath.buildPath("::").resolve(packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("Root"),
-                GraphPath.buildPath("Root").resolve(processorSupport));
+                GraphPath.buildPath("Root").resolve(packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("test"),
-                GraphPath.builder("::").addToManyPropertyValueWithName("children", "test").build().resolve(processorSupport));
+                GraphPath.builder("::").addToManyPropertyValueWithName("children", "test").build().resolve(packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain"),
-                GraphPath.builder("::").addToManyPropertyValueWithName("children", "test").addToManyPropertyValueWithName("children", "domain").build().resolve(processorSupport));
+                GraphPath.builder("::").addToManyPropertyValueWithName("children", "test").addToManyPropertyValueWithName("children", "domain").build().resolve(packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassA"),
-                GraphPath.builder("::").addToManyPropertyValueWithName("children", "test").addToManyPropertyValueWithName("children", "domain").addToManyPropertyValueWithName("children", "ClassA").build().resolve(processorSupport));
+                GraphPath.builder("::").addToManyPropertyValueWithName("children", "test").addToManyPropertyValueWithName("children", "domain").addToManyPropertyValueWithName("children", "ClassA").build().resolve(packagePathResolver));
 
         Assert.assertSame(
                 runtime.getCoreInstance("Integer"),
-                GraphPath.buildPath("Integer").resolve(processorSupport));
+                GraphPath.buildPath("Integer").resolve(packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("Number"),
-                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolve(processorSupport));
+                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolve(packagePathResolver));
 
         Assert.assertEquals(
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength").resolve(processorSupport));
+                GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength").resolve(packagePathResolver));
         Assert.assertEquals(
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Cubitum"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").build().resolve(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").build().resolve(packagePathResolver));
         Assert.assertEquals(
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperty("measure").build().resolve(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperty("measure").build().resolve(packagePathResolver));
         Assert.assertEquals(
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueForMetaPropertyToOne("canonicalUnit"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit").build().resolve(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit").build().resolve(packagePathResolver));
         Assert.assertEquals(
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build().resolve(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build().resolve(packagePathResolver));
         Assert.assertEquals(
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Actus"),
-                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().resolve(processorSupport));
+                GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build().resolve(packagePathResolver));
     }
 
     @Test
     public void testResolveUpTo()
     {
+        testResolveUpTo(processorSupport::package_getByUserPath);
+        testResolveUpTo(path -> _Package.getByUserPath(path, repository::getTopLevel));
+    }
+
+    private void testResolveUpTo(Function<? super String, ? extends CoreInstance> packagePathResolver)
+    {
         Assert.assertSame(
                 runtime.getCoreInstance(M3Paths.String),
-                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueAtIndex("properties", 0).addToOneProperties("genericType", "rawType").build().resolve(processorSupport));
+                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueAtIndex("properties", 0).addToOneProperties("genericType", "rawType").build().resolveUpTo(3, packagePathResolver));
 
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassA"),
-                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(0, processorSupport));
+                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(0, packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassA"),
-                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(-3, processorSupport));
+                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(-3, packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassA").getValueInValueForMetaPropertyToMany("properties", "prop2"),
-                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(1, processorSupport));
+                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(1, packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassA").getValueInValueForMetaPropertyToMany("properties", "prop2"),
-                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(-2, processorSupport));
+                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(-2, packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassA").getValueInValueForMetaPropertyToMany("properties", "prop2").getValueForMetaPropertyToOne("genericType"),
-                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(2, processorSupport));
+                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(2, packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassA").getValueInValueForMetaPropertyToMany("properties", "prop2").getValueForMetaPropertyToOne("genericType"),
-                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(-1, processorSupport));
+                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(-1, packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("test::domain::ClassA").getValueInValueForMetaPropertyToMany("properties", "prop2").getValueForMetaPropertyToOne("genericType").getValueForMetaPropertyToOne("rawType"),
-                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(3, processorSupport));
+                GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(3, packagePathResolver));
         Assert.assertEquals(
                 "Index: 4; size: 3",
                 Assert.assertThrows(
                         IndexOutOfBoundsException.class,
-                        () -> GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(4, processorSupport)).getMessage());
+                        () -> GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(4, packagePathResolver)).getMessage());
         Assert.assertEquals(
                 "Index: -4; size: 3",
                 Assert.assertThrows(
                         IndexOutOfBoundsException.class,
-                        () -> GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(-4, processorSupport)).getMessage());
+                        () -> GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build().resolveUpTo(-4, packagePathResolver)).getMessage());
 
 
         Assert.assertSame(
                 runtime.getCoreInstance("Integer"),
-                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(0, processorSupport));
+                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(0, packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("Integer"),
-                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(-3, processorSupport));
+                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(-3, packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("Integer").getValueForMetaPropertyToOne("generalizations"),
-                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(1, processorSupport));
+                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(1, packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("Integer").getValueForMetaPropertyToOne("generalizations"),
-                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(-2, processorSupport));
+                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(-2, packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("Integer").getValueForMetaPropertyToOne("generalizations").getValueForMetaPropertyToOne("general"),
-                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(2, processorSupport));
+                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(2, packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("Integer").getValueForMetaPropertyToOne("generalizations").getValueForMetaPropertyToOne("general"),
-                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(-1, processorSupport));
+                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(-1, packagePathResolver));
         Assert.assertSame(
                 runtime.getCoreInstance("Number"),
-                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(3, processorSupport));
+                GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(3, packagePathResolver));
         Assert.assertEquals(
                 "Index: 4; size: 3",
                 Assert.assertThrows(
                         IndexOutOfBoundsException.class,
-                        () -> GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(4, processorSupport)).getMessage());
+                        () -> GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(4, packagePathResolver)).getMessage());
         Assert.assertEquals(
                 "Index: -4; size: 3",
                 Assert.assertThrows(
                         IndexOutOfBoundsException.class,
-                        () -> GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(-4, processorSupport)).getMessage());
+                        () -> GraphPath.buildPath("Integer", "generalizations", "general", "rawType").resolveUpTo(-4, packagePathResolver)).getMessage());
     }
 
     @Test
     public void testResolveFully()
     {
+
+    }
+
+    private void testResolveFully(Function<? super String, ? extends CoreInstance> packagePathResolver)
+    {
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.buildPath("test::domain::ClassA"),
                 runtime.getCoreInstance("test::domain::ClassA"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.buildPath("test::domain::ClassA", "classifierGenericType"),
                 runtime.getCoreInstance("test::domain::ClassA"),
                 runtime.getCoreInstance("test::domain::ClassA").getValueForMetaPropertyToOne("classifierGenericType"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.buildPath("test::domain::ClassA", "classifierGenericType", "rawType"),
                 runtime.getCoreInstance("test::domain::ClassA"),
                 runtime.getCoreInstance("test::domain::ClassA").getValueForMetaPropertyToOne("classifierGenericType"),
                 runtime.getCoreInstance(M3Paths.Class));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.builder("test::domain::ClassA").addToManyPropertyValueAtIndex("properties", 0).addToOneProperties("genericType", "rawType").build(),
                 runtime.getCoreInstance("test::domain::ClassA"),
                 runtime.getCoreInstance("test::domain::ClassA").getValueForMetaPropertyToMany("properties").get(0),
                 runtime.getCoreInstance("test::domain::ClassA").getValueForMetaPropertyToMany("properties").get(0).getValueForMetaPropertyToOne("genericType"),
                 runtime.getCoreInstance(M3Paths.String));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithName("properties", "prop2").addToOneProperties("genericType", "rawType").build(),
                 runtime.getCoreInstance("test::domain::ClassA"),
                 runtime.getCoreInstance("test::domain::ClassA").getValueInValueForMetaPropertyToMany("properties", "prop2"),
                 runtime.getCoreInstance("test::domain::ClassA").getValueInValueForMetaPropertyToMany("properties", "prop2").getValueForMetaPropertyToOne("genericType"),
                 runtime.getCoreInstance("test::domain::ClassA").getValueInValueForMetaPropertyToMany("properties", "prop2").getValueForMetaPropertyToOne("genericType").getValueForMetaPropertyToOne("rawType"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.builder("test::domain::ClassA").addToManyPropertyValueWithKey("properties", "name", "prop2").addToOneProperties("genericType", "rawType", "resolvedNode").build(),
                 runtime.getCoreInstance("test::domain::ClassA"),
                 runtime.getCoreInstance("test::domain::ClassA").getValueInValueForMetaPropertyToMany("properties", "prop2"),
@@ -489,21 +515,26 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 runtime.getCoreInstance("test::domain::ClassB"));
 
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.buildPath("::"),
                 runtime.getCoreInstance("::"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.buildPath("Root"),
                 runtime.getCoreInstance("Root"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.builder("::").addToManyPropertyValueWithName("children", "test").build(),
                 runtime.getCoreInstance("::"),
                 runtime.getCoreInstance("test"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.builder("::").addToManyPropertyValueWithName("children", "test").addToManyPropertyValueWithName("children", "domain").build(),
                 runtime.getCoreInstance("::"),
                 runtime.getCoreInstance("test"),
                 runtime.getCoreInstance("test::domain"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.builder("::").addToManyPropertyValueWithName("children", "test").addToManyPropertyValueWithName("children", "domain").addToManyPropertyValueWithName("children", "ClassA").build(),
                 runtime.getCoreInstance("::"),
                 runtime.getCoreInstance("test"),
@@ -511,9 +542,11 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 runtime.getCoreInstance("test::domain::ClassA"));
 
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.buildPath("Integer"),
                 runtime.getCoreInstance("Integer"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.buildPath("Integer", "generalizations", "general", "rawType"),
                 runtime.getCoreInstance("Integer"),
                 runtime.getCoreInstance("Integer").getValueForMetaPropertyToOne("generalizations"),
@@ -521,24 +554,29 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 runtime.getCoreInstance("Number"));
 
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.buildPath("meta::pure::functions::meta::tests::model::RomanLength"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Cubitum"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperty("measure").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Cubitum"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Cubitum"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueForMetaPropertyToOne("canonicalUnit"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Cubitum"),
@@ -546,6 +584,7 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueForMetaPropertyToOne("canonicalUnit"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"));
         assertResolveFully(
+                packagePathResolver,
                 GraphPath.builder("meta::pure::functions::meta::tests::model::RomanLength").addToManyPropertyValueWithName("nonCanonicalUnits", "Cubitum").addToOneProperties("measure", "canonicalUnit", "measure").addToManyPropertyValueWithName("nonCanonicalUnits", "Actus").build(),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength"),
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Cubitum"),
@@ -555,9 +594,9 @@ public class TestGraphPath extends AbstractPureTestWithCoreCompiled
                 runtime.getCoreInstance("meta::pure::functions::meta::tests::model::RomanLength").getValueInValueForMetaPropertyToMany("nonCanonicalUnits", "Actus"));
     }
 
-    private void assertResolveFully(GraphPath path, CoreInstance... nodes)
+    private void assertResolveFully(Function<? super String, ? extends CoreInstance> packagePathResolver, GraphPath path, CoreInstance... nodes)
     {
-        Assert.assertEquals(new ResolvedGraphPath(path, Lists.immutable.with(nodes)), path.resolveFully(processorSupport));
+        Assert.assertEquals(new ResolvedGraphPath(path, Lists.immutable.with(nodes)), path.resolveFully(packagePathResolver));
     }
 
     @Test

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/reference/AbstractReferenceIdExtensionTest.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/reference/AbstractReferenceIdExtensionTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractReferenceIdExtensionTest extends AbstractReference
     public void setUpProviderResolver()
     {
         this.provider = extension.newProvider(processorSupport);
-        this.resolver = extension.newResolver(processorSupport);
+        this.resolver = extension.newResolver(processorSupport::package_getByUserPath);
     }
 
     @Test
@@ -70,7 +70,7 @@ public abstract class AbstractReferenceIdExtensionTest extends AbstractReference
     public void testProviderAndResolverVersions()
     {
         Assert.assertEquals(extension.version(), extension.newProvider(processorSupport).version());
-        Assert.assertEquals(extension.version(), extension.newResolver(processorSupport).version());
+        Assert.assertEquals(extension.version(), extension.newResolver(processorSupport::package_getByUserPath).version());
     }
 
     @Test


### PR DESCRIPTION
Generalize package path resolution for graph path and reference id resolution. Specifically, allow a general package path resolver to be passed in instead of a ProcessorSupport.