### PR TITLE
Use new reference ids in generated Java code

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/valuespecification/ValueSpecification.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/valuespecification/ValueSpecification.java
@@ -15,9 +15,13 @@
 package org.finos.legend.pure.m3.navigation.valuespecification;
 
 import org.eclipse.collections.api.list.ListIterable;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Any;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
 import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m4.coreinstance.AbstractCoreInstanceWrapper;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
 public class ValueSpecification
@@ -41,6 +45,19 @@ public class ValueSpecification
     {
         CoreInstance rawType = Instance.getValueForMetaPropertyToOneResolved(valueSpecification, M3Properties.genericType, M3Properties.rawType, processorSupport);
         return (rawType != null) && processorSupport.type_subTypeOf(rawType, type);
+    }
+
+    public static boolean isInstanceValue(CoreInstance instance, ProcessorSupport processorSupport)
+    {
+        if (instance == null)
+        {
+            return false;
+        }
+        if (instance instanceof InstanceValue)
+        {
+            return true;
+        }
+        return (!(instance instanceof Any) || (instance instanceof AbstractCoreInstanceWrapper)) && processorSupport.instance_instanceOf(instance, M3Paths.InstanceValue);
     }
 
     /**

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/delta/CodeBlockDeltaCompiler.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/delta/CodeBlockDeltaCompiler.java
@@ -76,7 +76,7 @@ public final class CodeBlockDeltaCompiler
             //First compile and validate that the code is actually correct
             incrementalCompiler.compileInCurrentTransaction(source);
             CoreInstance instance = source.getNewInstances().getFirst();
-            String functionName = PackageableElement.getSystemPathForPackageableElement(instance);
+            String functionName = PackageableElement.getUserPathForPackageableElement(instance);
             return new IntermediateCompilationResult(source, functionName);
         }
         catch (PureCompilationException | PureParserException e)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/delta/MetadataEagerCompilerEventHandler.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/delta/MetadataEagerCompilerEventHandler.java
@@ -22,6 +22,7 @@ import org.finos.legend.pure.m3.serialization.runtime.Message;
 import org.finos.legend.pure.m3.serialization.runtime.Source;
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataBuilder;
 import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataEager;
 import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataEventObserver;
 
@@ -78,7 +79,7 @@ public class MetadataEagerCompilerEventHandler implements CompilerEventHandlerMe
     @Override
     public void buildMetadata(RichIterable<CoreInstance> newInstances)
     {
-        this.metadataEager = new MetadataEager(new M3ProcessorSupport(this.repository));
+        this.metadataEager = MetadataBuilder.indexNew(this.metadataEager, newInstances, new M3ProcessorSupport(this.repository));
     }
 
     @Override
@@ -100,7 +101,7 @@ public class MetadataEagerCompilerEventHandler implements CompilerEventHandlerMe
             this.message.setMessage("Instantiating Graph");
         }
 
-        this.metadataEager = new MetadataEager(new M3ProcessorSupport(this.repository));
+        this.metadataEager = MetadataBuilder.indexAll(this.repository.getTopLevels(), this.processorSupport);
 
         if (this.message != null)
         {
@@ -111,7 +112,7 @@ public class MetadataEagerCompilerEventHandler implements CompilerEventHandlerMe
     @Override
     public void invalidate(RichIterable<? extends CoreInstance> consolidatedCoreInstances)
     {
-        this.metadataEager.clear();
+        this.metadataEager.invalidateCoreInstances(consolidatedCoreInstances);
     }
 
     @Override

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/delta/MetadataEagerCompilerEventHandler.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/delta/MetadataEagerCompilerEventHandler.java
@@ -22,8 +22,6 @@ import org.finos.legend.pure.m3.serialization.runtime.Message;
 import org.finos.legend.pure.m3.serialization.runtime.Source;
 import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.IdBuilder;
-import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataBuilder;
 import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataEager;
 import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataEventObserver;
 
@@ -80,7 +78,7 @@ public class MetadataEagerCompilerEventHandler implements CompilerEventHandlerMe
     @Override
     public void buildMetadata(RichIterable<CoreInstance> newInstances)
     {
-        this.metadataEager = MetadataBuilder.indexNew(this.metadataEager, newInstances, IdBuilder.newIdBuilder(this.processorSupport), new M3ProcessorSupport(this.repository));
+        this.metadataEager = new MetadataEager(new M3ProcessorSupport(this.repository));
     }
 
     @Override
@@ -102,7 +100,7 @@ public class MetadataEagerCompilerEventHandler implements CompilerEventHandlerMe
             this.message.setMessage("Instantiating Graph");
         }
 
-        this.metadataEager = MetadataBuilder.indexAll(this.repository.getTopLevels(), IdBuilder.newIdBuilder(this.processorSupport), this.processorSupport);
+        this.metadataEager = new MetadataEager(new M3ProcessorSupport(this.repository));
 
         if (this.message != null)
         {
@@ -113,7 +111,7 @@ public class MetadataEagerCompilerEventHandler implements CompilerEventHandlerMe
     @Override
     public void invalidate(RichIterable<? extends CoreInstance> consolidatedCoreInstances)
     {
-        this.metadataEager = new MetadataEager();
+        this.metadataEager.clear();
     }
 
     @Override
@@ -121,7 +119,7 @@ public class MetadataEagerCompilerEventHandler implements CompilerEventHandlerMe
     {
         this.coreIndexed = false;
         this.otherIndexed = false;
-        this.metadataEager = new MetadataEager();
+        this.metadataEager = new MetadataEager(new M3ProcessorSupport(this.repository));
     }
 
     @Override

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledExecutionSupport.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledExecutionSupport.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.pure.runtime.java.compiled.execution;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.set.MutableSet;
@@ -157,9 +158,16 @@ public class CompiledExecutionSupport implements ExecutionSupport
         return this.options;
     }
 
+    @SuppressWarnings("rawtypes")
     public MapIterable getMetadata(String classifier)
     {
         return getMetadata().getMetadata(classifier);
+    }
+
+    @SuppressWarnings("rawtypes")
+    public RichIterable getClassifierInstances(String classifier)
+    {
+        return getMetadata().getClassifierInstances(classifier);
     }
 
     public CoreInstance getMetadata(String classifier, String id)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledProcessorSupport.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledProcessorSupport.java
@@ -277,7 +277,7 @@ public class CompiledProcessorSupport implements ProcessorSupport
             // An element in Root - probably a package
             try
             {
-                CoreInstance element = this.metadataAccessor.getPackage(M3Paths.Root + "::" + path);
+                CoreInstance element = this.metadataAccessor.getPackage(path);
                 if (element != null)
                 {
                     return element;
@@ -300,7 +300,7 @@ public class CompiledProcessorSupport implements ProcessorSupport
         // Perhaps the element is a class?
         try
         {
-            CoreInstance element = this.metadataAccessor.getClass(M3Paths.Root + "::" + path);
+            CoreInstance element = this.metadataAccessor.getClass(path);
             if (element != null)
             {
                 return element;
@@ -315,7 +315,7 @@ public class CompiledProcessorSupport implements ProcessorSupport
         Package pkg;
         try
         {
-            pkg = this.metadataAccessor.getPackage(M3Paths.Root + "::" + path.substring(0, lastColon - 1));
+            pkg = this.metadataAccessor.getPackage(path.substring(0, lastColon - 1));
         }
         catch (Exception ignore)
         {

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledProcessorSupport.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledProcessorSupport.java
@@ -23,6 +23,7 @@ import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.set.SetIterable;
+import org.eclipse.collections.impl.utility.LazyIterate;
 import org.finos.legend.pure.m3.compiler.Context;
 import org.finos.legend.pure.m3.coreinstance.BaseCoreInstance;
 import org.finos.legend.pure.m3.coreinstance.Package;
@@ -404,8 +405,8 @@ public class CompiledProcessorSupport implements ProcessorSupport
     public SetIterable<CoreInstance> function_getFunctionsForName(String functionName)
     {
         //TODO Iterate over ConcreteFunctionDefinition and FunctionDefinition along with NativeFunction.
-        return this.metadata.getMetadata(MetadataJavaPaths.NativeFunction).valuesView().asLazy()
-                .concatenate(this.metadata.getMetadata(MetadataJavaPaths.ConcreteFunctionDefinition).valuesView())
+        return LazyIterate.adapt(this.metadata.getClassifierInstances(MetadataJavaPaths.NativeFunction))
+                .concatenate(this.metadata.getClassifierInstances(MetadataJavaPaths.ConcreteFunctionDefinition))
                 .select(f -> (f instanceof FunctionAccessor) && functionName.equals(((FunctionAccessor<?>) f)._functionName()), Sets.mutable.empty());
     }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/GenericTypeSerializationInCode.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/GenericTypeSerializationInCode.java
@@ -19,6 +19,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.Relati
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.PrimitiveType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
@@ -26,7 +27,6 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecificat
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.relation._Column;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.Pure;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.valuespecification.ValueSpecificationProcessor;
 
 public class GenericTypeSerializationInCode
@@ -55,34 +55,34 @@ public class GenericTypeSerializationInCode
     {
         if (type instanceof Class)
         {
-            return "((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + Pure.elementToPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) type, "::") + "\")";
+            return "((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + processorContext.getIdBuilder().buildId(type) + "\")";
         }
-        else if (type instanceof PrimitiveType)
+        if (type instanceof PrimitiveType)
         {
-            return "((CompiledExecutionSupport)es).getMetadataAccessor().getPrimitiveType(\"" + Pure.elementToPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) type, "::") + "\")";
+            return "((CompiledExecutionSupport)es).getMetadataAccessor().getPrimitiveType(\"" + processorContext.getIdBuilder().buildId(type) + "\")";
         }
-        else if (type instanceof RelationType)
+        if (type instanceof RelationType)
         {
             return "org.finos.legend.pure.m3.navigation.relation._RelationType.build(Lists.mutable.<org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.Column<?,?>>with(" + ((RelationType<?>) type)._columns().collect(c -> generateColumnBuilder(c, processorContext)).makeString(", ") + "), null, ((CompiledExecutionSupport)es).getProcessorSupport())";
         }
-        else if (type instanceof FunctionType)
+        if (type instanceof FunctionType)
         {
             return "new Root_meta_pure_metamodel_type_FunctionType_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + M3Paths.FunctionType + "\"))" +
                     "._parameters(Lists.mutable.with(" + ((FunctionType) type)._parameters().collect(v -> generateVariableBuilder(v, processorContext)).makeString(", ") + "))" +
                     "._returnType(" + generateGenericTypeBuilder(((FunctionType) type)._returnType(), processorContext) + ")" +
                     "._returnMultiplicity(" + generateMultiplicityBuilder(((FunctionType) type)._returnMultiplicity()) + ")";
         }
-        else if (type instanceof Unit)
+        if (type instanceof Unit)
         {
-            return "((CompiledExecutionSupport)es).getMetadataAccessor().getUnit(\"" + Pure.elementToPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) type, "::") + "\")";
+            return "((CompiledExecutionSupport)es).getMetadataAccessor().getUnit(\"" + processorContext.getIdBuilder().buildId(type) + "\")";
         }
-        else if (type instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure)
+        if (type instanceof Measure)
         {
-            return "((CompiledExecutionSupport)es).getMetadataAccessor().getMeasure(\"" + Pure.elementToPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) type, "::") + "\")";
+            return "((CompiledExecutionSupport)es).getMetadataAccessor().getMeasure(\"" + processorContext.getIdBuilder().buildId(type) + "\")";
         }
-        else if (type instanceof Enumeration)
+        if (type instanceof Enumeration)
         {
-            return "((CompiledExecutionSupport)es).getMetadataAccessor().getEnumeration(\"" + Pure.elementToPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) type, "::") + "\")";
+            return "((CompiledExecutionSupport)es).getMetadataAccessor().getEnumeration(\"" + processorContext.getIdBuilder().buildId(type) + "\")";
         }
         throw new RuntimeException("Unsupported type: " + type.getClass());
     }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/GenericTypeSerializationInCode.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/GenericTypeSerializationInCode.java
@@ -25,9 +25,8 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
 import org.finos.legend.pure.m3.navigation.M3Paths;
-import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
-import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m3.navigation.relation._Column;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.Pure;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.valuespecification.ValueSpecificationProcessor;
 
 public class GenericTypeSerializationInCode
@@ -36,9 +35,9 @@ public class GenericTypeSerializationInCode
 
     public static String generateGenericTypeBuilder(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType genericType, ProcessorContext processorContext)
     {
-        return "new Root_meta_pure_metamodel_type_generics_GenericType_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"Root::" + M3Paths.GenericType + "\"))" +
+        return "new Root_meta_pure_metamodel_type_generics_GenericType_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + M3Paths.GenericType + "\"))" +
                 (genericType._rawType() == null ? "" : "._rawType(" + generateTypeBuilder(genericType._rawType(), processorContext) + ")") +
-                (genericType._typeParameter() == null ? "" : "._typeParameter(new Root_meta_pure_metamodel_type_generics_TypeParameter_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"Root::" + M3Paths.TypeParameter + "\"))._name(\"" + genericType._typeParameter()._name() + "\"))") +
+                (genericType._typeParameter() == null ? "" : "._typeParameter(new Root_meta_pure_metamodel_type_generics_TypeParameter_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + M3Paths.TypeParameter + "\"))._name(\"" + genericType._typeParameter()._name() + "\"))") +
                 (genericType._typeArguments().isEmpty() ? "" : "._typeArguments(Lists.mutable.with(" + genericType._typeArguments().collect(x -> generateGenericTypeBuilder(x, processorContext)).makeString(", ") + "))") +
                 (genericType._multiplicityArguments().isEmpty() ? "" : "._multiplicityArguments(Lists.mutable.with(" + genericType._multiplicityArguments().collect(GenericTypeSerializationInCode::generateMultiplicityBuilder).makeString(", ") + "))") +
                 (genericType._typeVariableValues().isEmpty() ? "" : "._typeVariableValues(Lists.mutable.with(" + genericType._typeVariableValues().collect(vs -> generateValueSpecification(vs, processorContext)).makeString(", ") + "))");
@@ -46,7 +45,7 @@ public class GenericTypeSerializationInCode
 
     private static String generateValueSpecification(ValueSpecification vs, ProcessorContext processorContext)
     {
-        return "new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"Root::" + M3Paths.InstanceValue + "\"))" +
+        return "new Root_meta_pure_metamodel_valuespecification_InstanceValue_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + M3Paths.InstanceValue + "\"))" +
                 "._genericType(" + generateGenericTypeBuilder(vs._genericType(), processorContext) + ")" +
                 "._multiplicity(" + generateMultiplicityBuilder(vs._multiplicity()) + ")" +
                 "._values(Lists.mutable.with(" + ValueSpecificationProcessor.processValueSpecification(vs, processorContext) + "))";
@@ -56,11 +55,11 @@ public class GenericTypeSerializationInCode
     {
         if (type instanceof Class)
         {
-            return "((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + PackageableElement.getSystemPathForPackageableElement(type) + "\")";
+            return "((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + Pure.elementToPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) type, "::") + "\")";
         }
         else if (type instanceof PrimitiveType)
         {
-            return "((CompiledExecutionSupport)es).getMetadataAccessor().getPrimitiveType(\"" + PackageableElement.getSystemPathForPackageableElement(type) + "\")";
+            return "((CompiledExecutionSupport)es).getMetadataAccessor().getPrimitiveType(\"" + Pure.elementToPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) type, "::") + "\")";
         }
         else if (type instanceof RelationType)
         {
@@ -68,29 +67,29 @@ public class GenericTypeSerializationInCode
         }
         else if (type instanceof FunctionType)
         {
-            return "new Root_meta_pure_metamodel_type_FunctionType_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"Root::" + M3Paths.FunctionType + "\"))" +
+            return "new Root_meta_pure_metamodel_type_FunctionType_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + M3Paths.FunctionType + "\"))" +
                     "._parameters(Lists.mutable.with(" + ((FunctionType) type)._parameters().collect(v -> generateVariableBuilder(v, processorContext)).makeString(", ") + "))" +
                     "._returnType(" + generateGenericTypeBuilder(((FunctionType) type)._returnType(), processorContext) + ")" +
                     "._returnMultiplicity(" + generateMultiplicityBuilder(((FunctionType) type)._returnMultiplicity()) + ")";
         }
         else if (type instanceof Unit)
         {
-            return "((CompiledExecutionSupport)es).getMetadataAccessor().getUnit(\"" + Measure.getSystemPathForUnit(type) + "\")";
+            return "((CompiledExecutionSupport)es).getMetadataAccessor().getUnit(\"" + Pure.elementToPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) type, "::") + "\")";
         }
         else if (type instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure)
         {
-            return "((CompiledExecutionSupport)es).getMetadataAccessor().getMeasure(\"" + PackageableElement.getSystemPathForPackageableElement(type) + "\")";
+            return "((CompiledExecutionSupport)es).getMetadataAccessor().getMeasure(\"" + Pure.elementToPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) type, "::") + "\")";
         }
         else if (type instanceof Enumeration)
         {
-            return "((CompiledExecutionSupport)es).getMetadataAccessor().getEnumeration(\"" + PackageableElement.getSystemPathForPackageableElement(type) + "\")";
+            return "((CompiledExecutionSupport)es).getMetadataAccessor().getEnumeration(\"" + Pure.elementToPath((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement) type, "::") + "\")";
         }
         throw new RuntimeException("Unsupported type: " + type.getClass());
     }
 
     private static Object generateVariableBuilder(VariableExpression v, ProcessorContext processorContext)
     {
-        return "new Root_meta_pure_metamodel_valuespecification_VariableExpression_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"Root::" + M3Paths.VariableExpression + "\"))" +
+        return "new Root_meta_pure_metamodel_valuespecification_VariableExpression_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + M3Paths.VariableExpression + "\"))" +
                 "._name(\"" + v._name() + "\")" +
                 "._genericType(" + generateGenericTypeBuilder(v._genericType(), processorContext) + ")" +
                 "._multiplicity(" + generateMultiplicityBuilder(v._multiplicity()) + ")";
@@ -103,11 +102,11 @@ public class GenericTypeSerializationInCode
 
     public static String generateMultiplicityBuilder(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.multiplicity.Multiplicity multiplicity)
     {
-        return "new Root_meta_pure_metamodel_multiplicity_Multiplicity_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"Root::" + M3Paths.Multiplicity + "\"))" +
+        return "new Root_meta_pure_metamodel_multiplicity_Multiplicity_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + M3Paths.Multiplicity + "\"))" +
                 (multiplicity._multiplicityParameter() != null ?
                         "._multiplicityParameter(\"" + multiplicity._multiplicityParameter() + "\")" :
-                        "._lowerBound(new Root_meta_pure_metamodel_multiplicity_MultiplicityValue_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"Root::" + M3Paths.MultiplicityValue + "\"))._value(" + multiplicity._lowerBound()._value() + "L))" +
-                                "._upperBound(new Root_meta_pure_metamodel_multiplicity_MultiplicityValue_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"Root::" + M3Paths.MultiplicityValue + "\"))" +
+                        "._lowerBound(new Root_meta_pure_metamodel_multiplicity_MultiplicityValue_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + M3Paths.MultiplicityValue + "\"))._value(" + multiplicity._lowerBound()._value() + "L))" +
+                                "._upperBound(new Root_meta_pure_metamodel_multiplicity_MultiplicityValue_Impl(\"\", null, ((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + M3Paths.MultiplicityValue + "\"))" +
                                 (multiplicity._upperBound()._value() == null ? "" : "._value(" + multiplicity._upperBound()._value() + "L)") + ")");
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
@@ -159,7 +159,7 @@ public final class JavaSourceCodeGenerator
     {
         this.name = name;
         this.processorSupport = processorSupport;
-        this.idBuilder = (idBuilder == null) ? IdBuilder.newIdBuilder(this.processorSupport) : idBuilder;
+        this.idBuilder = (idBuilder == null) ? IdBuilder.newIdBuilder(this.processorSupport, false) : idBuilder;
         this.codeStorage = codeStorage;
         this.writeFilesToDisk = writeFilesToDisk;
         this.directoryToWriteFilesTo = directoryToWriteFilesTo;

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/ProcessorContext.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/ProcessorContext.java
@@ -70,7 +70,7 @@ public class ProcessorContext
         this.extraFunctionGenerator = compiledExtensions.collect(CompiledExtension::getExtraFunctionGeneration).select(Objects::nonNull);
         this.includePureStackTrace = includePureStackTrace;
         this.generator = M3CoreInstanceGenerator.generator(null, null, null);
-        this.idBuilder = (idBuilder == null) ? IdBuilder.newIdBuilder(this.support) : idBuilder;
+        this.idBuilder = (idBuilder == null) ? IdBuilder.newIdBuilder(this.support, false) : idBuilder;
     }
 
     @Deprecated

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/IdBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/IdBuilder.java
@@ -14,361 +14,77 @@
 
 package org.finos.legend.pure.runtime.java.compiled.generation.processors;
 
-import org.eclipse.collections.api.factory.Maps;
-import org.eclipse.collections.api.map.ConcurrentMutableMap;
-import org.eclipse.collections.api.map.ImmutableMap;
-import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
-import org.eclipse.collections.impl.utility.ArrayIterate;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association;
-import org.finos.legend.pure.m3.navigation.M3Paths;
-import org.finos.legend.pure.m3.navigation.M3Properties;
-import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
-import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
-import org.finos.legend.pure.m3.navigation.measure.Measure;
-import org.finos.legend.pure.m3.navigation.type.Type;
+import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdProvider;
+import org.finos.legend.pure.m3.serialization.compiler.reference.v1.ReferenceIdExtensionV1;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.CodeStorageTools;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.RepositoryCodeStorage;
 import org.finos.legend.pure.m3.serialization.runtime.Source;
-import org.finos.legend.pure.m4.ModelRepository;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
-import org.finos.legend.pure.runtime.java.compiled.extension.CompiledExtensionLoader;
 
-import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 
 public class IdBuilder
 {
-    private final String defaultIdPrefix;
     private final ProcessorSupport processorSupport;
-    private final ImmutableMap<CoreInstance, Function<? super CoreInstance, String>> idBuilders;
-    private final ConcurrentMutableMap<CoreInstance, Function<? super CoreInstance, String>> cache;
+    private final String defaultIdPrefix;
+    private final boolean allowNonReferenceIds;
+    private volatile ReferenceIdProvider idProvider;
 
-    private IdBuilder(String defaultIdPrefix, ProcessorSupport processorSupport, ImmutableMap<CoreInstance, Function<? super CoreInstance, String>> idBuilders)
+    private IdBuilder(ProcessorSupport processorSupport, String defaultIdPrefix, boolean allowNonReferenceIds)
     {
-        this.defaultIdPrefix = defaultIdPrefix;
         this.processorSupport = processorSupport;
-        this.idBuilders = idBuilders;
-        this.cache = ConcurrentHashMap.newMap(this.idBuilders.size());
-        this.idBuilders.forEachKeyValue(this.cache::put);
+        this.defaultIdPrefix = defaultIdPrefix;
+        this.allowNonReferenceIds = allowNonReferenceIds;
     }
 
     public String buildId(CoreInstance instance)
     {
-        Function<? super CoreInstance, String> function = findBuilderFunction(this.processorSupport.getClassifier(instance));
-        return (function == null) ? buildDefaultId(instance) : applyBuilderFunction(function, instance);
-    }
-
-    public Function<CoreInstance, String> getIdBuilderForClassifier(CoreInstance classifier)
-    {
-        Function<? super CoreInstance, String> function = findBuilderFunction(classifier);
-        return (function == null) ? this::buildDefaultId : i -> applyBuilderFunction(function, i);
-    }
-
-    private Function<? super CoreInstance, String> findBuilderFunction(CoreInstance classifier)
-    {
-        return this.cache.getIfAbsentPutWithKey(classifier, this::computeBuilderFunction);
-    }
-
-    private Function<? super CoreInstance, String> computeBuilderFunction(CoreInstance classifier)
-    {
-        for (CoreInstance genl : Type.getGeneralizationResolutionOrder(classifier, this.processorSupport))
+        ReferenceIdProvider provider = getIdProvider();
+        if (!this.allowNonReferenceIds || provider.hasReferenceId(instance))
         {
-            Function<? super CoreInstance, String> function = this.idBuilders.get(genl);
-            if (function != null)
-            {
-                return function;
-            }
+            return provider.getReferenceId(instance);
         }
-        return null;
-    }
 
-    private String applyBuilderFunction(Function<? super CoreInstance, String> function, CoreInstance instance)
-    {
-        String id = function.apply(instance);
-        return (id == null) ? buildDefaultId(instance) : id;
-    }
-
-    private String buildDefaultId(CoreInstance instance)
-    {
         int syntheticId = instance.getSyntheticId();
         return (this.defaultIdPrefix == null) ? Integer.toString(syntheticId) : (this.defaultIdPrefix + syntheticId);
     }
 
-    // QualifiedProperty
-
-    private static String buildIdForQualifiedProperty(CoreInstance property)
+    private ReferenceIdProvider getIdProvider()
     {
-        return PackageableElement.writeUserPathForPackageableElement(new StringBuilder(), property.getValueForMetaPropertyToOne(M3Properties.owner))
-                .append('.').append(property.getName())
-                .toString();
-    }
-
-    // Property
-
-    private static String buildIdForProperty(CoreInstance property)
-    {
-        CoreInstance owner = property.getValueForMetaPropertyToOne(M3Properties.owner);
-        String propertyProperty;
-        int index = owner.getValueForMetaPropertyToMany(M3Properties.properties).indexOf(property);
-        if (index == -1)
+        ReferenceIdProvider local = this.idProvider;
+        if (local == null)
         {
-            index = owner.getValueForMetaPropertyToMany(M3Properties.originalMilestonedProperties).indexOf(property);
-            if (index == -1)
+            synchronized (this)
             {
-                StringBuilder builder = new StringBuilder("Error generating id for property '").append(property.getName()).append("' owned by ");
-                PackageableElement.writeUserPathForPackageableElement(builder, owner);
-                builder.append(": could not find it in either '").append(M3Properties.properties).append("' or '").append(M3Properties.originalMilestonedProperties).append("'");
-                throw new IllegalStateException(builder.toString());
-            }
-            propertyProperty = M3Properties.originalMilestonedProperties;
-        }
-        else
-        {
-            propertyProperty = M3Properties.properties;
-        }
-
-        StringBuilder builder = PackageableElement.writeUserPathForPackageableElement(new StringBuilder(), owner);
-        builder.append('.').append(propertyProperty);
-        builder.append('.').append(property.getName());
-        if (owner instanceof Association)
-        {
-            // associations can have multiple properties with the same name
-            builder.append('_').append(index);
-        }
-        return builder.toString();
-    }
-
-    // LambdaFunction
-
-    private static String buildIdForLambdaFunction(CoreInstance lambda)
-    {
-        String name = lambda.getName();
-        return ModelRepository.isAnonymousInstanceName(name) ? null : name;
-    }
-
-    // Annotation
-
-    private static String buildIdForAnnotation(CoreInstance annotation)
-    {
-        return PackageableElement.writeUserPathForPackageableElement(new StringBuilder(), annotation.getValueForMetaPropertyToOne(M3Properties.profile))
-                .append('.').append(annotation.getName())
-                .toString();
-    }
-
-    // Unit
-
-    private static String buildIdForUnit(CoreInstance unit)
-    {
-        return Measure.getSystemPathForUnit(unit);
-    }
-
-    // PackageableElement
-
-    private static String buildIdForPackageableElement(CoreInstance instance)
-    {
-        String id = PackageableElement.getSystemPathForPackageableElement(instance);
-        if (ModelRepository.isAnonymousInstanceName(id) && (id.indexOf(':') == -1))
-        {
-            // don't return anonymous ids
-            return null;
-        }
-        return id;
-    }
-
-    // Builder
-
-    /**
-     * Function to build ids for instances of the given classifier.
-     */
-    public interface IdBuilderFunction extends Function<CoreInstance, String>
-    {
-        String getClassifierPath();
-    }
-
-    public static class Builder
-    {
-        private final MutableMap<CoreInstance, Function<? super CoreInstance, String>> idBuilders = Maps.mutable.empty();
-        private final ProcessorSupport processorSupport;
-        private String defaultIdPrefix;
-
-        public Builder(ProcessorSupport processorSupport)
-        {
-            this.processorSupport = Objects.requireNonNull(processorSupport, "processorSupport may not be null");
-            addStandardIdBuilders();
-        }
-
-        /**
-         * Set the optional default id prefix. If non-null, the default id function will use this as the prefix for
-         * all ids it generates.
-         *
-         * @param prefix default id prefix
-         */
-        public void setDefaultIdPrefix(String prefix)
-        {
-            this.defaultIdPrefix = prefix;
-        }
-
-        /**
-         * Set the optional default id prefix. If non-null, the default id function will use this as the prefix for
-         * all ids it generates.
-         *
-         * @param prefix default id prefix
-         */
-        public Builder withDefaultIdPrefix(String prefix)
-        {
-            setDefaultIdPrefix(prefix);
-            return this;
-        }
-
-        /**
-         * Add a function to build ids for the given classifier. An exception will be thrown if there is already a
-         * function registered for the classifier.
-         *
-         * @param classifierPath full path of the classifer
-         * @param function       id builder function
-         */
-        public void addIdBuilder(String classifierPath, Function<? super CoreInstance, String> function)
-        {
-            CoreInstance type = this.processorSupport.package_getByUserPath(Objects.requireNonNull(classifierPath, "classifier path may not be null"));
-            Function<? super CoreInstance, String> old = this.idBuilders.put(type, Objects.requireNonNull(function, "function may not be null"));
-            if (old != null)
-            {
-                throw new RuntimeException("An id builder function is already registered for classifier: " + classifierPath);
+                if ((local = this.idProvider) == null)
+                {
+                    return this.idProvider = new ReferenceIdExtensionV1().newProvider(this.processorSupport);
+                }
             }
         }
-
-        /**
-         * Add a function to build ids for the given classifier. An exception will be thrown if there is already a
-         * function registered for the classifier.
-         *
-         * @param classifierPath full path of the classifer
-         * @param function       id builder function
-         */
-        public Builder withIdBuilder(String classifierPath, Function<? super CoreInstance, String> function)
-        {
-            addIdBuilder(classifierPath, function);
-            return this;
-        }
-
-        /**
-         * Add functions to build ids for the corresponding classifiers. An exception will be thrown if there is already
-         * a function registered for any of the given classifiers. In case of an exception, some of the functions may
-         * be registered.
-         *
-         * @param idBuilderFunctions id builder functions by classifier path
-         */
-        public Builder withIdBuilders(Map<String, ? extends Function<? super CoreInstance, String>> idBuilderFunctions)
-        {
-            idBuilderFunctions.forEach(this::addIdBuilder);
-            return this;
-        }
-
-        /**
-         * Add an id builder function. An exception will be thrown if there is already a function registered for the
-         * classifier.
-         *
-         * @param idBuilderFunction id builder function
-         */
-        public void addIdBuilder(IdBuilderFunction idBuilderFunction)
-        {
-            addIdBuilder(idBuilderFunction.getClassifierPath(), idBuilderFunction);
-        }
-
-        /**
-         * Add an id builder function. An exception will be thrown if there is already a function registered for the
-         * classifier.
-         *
-         * @param idBuilderFunction id builder function
-         */
-        public Builder withIdBuilder(IdBuilderFunction idBuilderFunction)
-        {
-            addIdBuilder(idBuilderFunction.getClassifierPath(), idBuilderFunction);
-            return this;
-        }
-
-        /**
-         * Add functions to build ids for the corresponding classifiers. An exception will be thrown if there is already
-         * a function registered for any of the given classifiers. In case of an exception, some of the functions may
-         * be registered.
-         *
-         * @param idBuilderFunctions id builder functions by classifier path
-         */
-        public Builder withIdBuilders(IdBuilderFunction... idBuilderFunctions)
-        {
-            ArrayIterate.forEach(idBuilderFunctions, this::addIdBuilder);
-            return this;
-        }
-
-        /**
-         * Add functions to build ids for the corresponding classifiers. An exception will be thrown if there is already
-         * a function registered for any of the given classifiers. In case of an exception, some of the functions may
-         * be registered.
-         *
-         * @param idBuilderFunctions id builder functions by classifier path
-         */
-        public Builder withIdBuilders(Iterable<? extends IdBuilderFunction> idBuilderFunctions)
-        {
-            idBuilderFunctions.forEach(this::addIdBuilder);
-            return this;
-        }
-
-        /**
-         * Build the {@linkplain IdBuilder}.
-         *
-         * @return {@linkplain IdBuilder}
-         */
-        public IdBuilder build()
-        {
-            return new IdBuilder(this.defaultIdPrefix, this.processorSupport, this.idBuilders.toImmutable());
-        }
-
-        private void addStandardIdBuilders()
-        {
-            PrimitiveUtilities.getPrimitiveTypes(this.processorSupport).forEach(t -> this.idBuilders.put(t, CoreInstance::getName));
-            addIdBuilder(M3Paths.Annotation, IdBuilder::buildIdForAnnotation);
-            addIdBuilder(M3Paths.Enum, CoreInstance::getName);
-            addIdBuilder(M3Paths.LambdaFunction, IdBuilder::buildIdForLambdaFunction);
-            addIdBuilder(M3Paths.PackageableElement, IdBuilder::buildIdForPackageableElement);
-            addIdBuilder(M3Paths.Property, IdBuilder::buildIdForProperty);
-            addIdBuilder(M3Paths.QualifiedProperty, IdBuilder::buildIdForQualifiedProperty);
-            addIdBuilder(M3Paths.Unit, IdBuilder::buildIdForUnit);
-            CompiledExtensionLoader.extensions().flatCollect(x -> x.getExtraIdBuilders(this.processorSupport)).forEach(x -> addIdBuilder(x.getOne(), x.getTwo()));
-        }
-    }
-
-    public static Builder builder(ProcessorSupport processorSupport)
-    {
-        return new Builder(processorSupport);
+        return local;
     }
 
     public static IdBuilder newIdBuilder(String defaultIdPrefix, ProcessorSupport processorSupport)
     {
-        return builder(processorSupport).withDefaultIdPrefix(defaultIdPrefix).build();
+        return newIdBuilder(processorSupport, defaultIdPrefix, true);
     }
 
-    public static IdBuilder newIdBuilder(String defaultIdPrefix, ProcessorSupport processorSupport, IdBuilderFunction... idBuilderFunctions)
+    public static IdBuilder newIdBuilder(ProcessorSupport processorSupport, boolean allowNonReferenceIds)
     {
-        return builder(processorSupport).withDefaultIdPrefix(defaultIdPrefix).withIdBuilders(idBuilderFunctions).build();
+        return newIdBuilder(processorSupport, null, allowNonReferenceIds);
     }
 
     public static IdBuilder newIdBuilder(ProcessorSupport processorSupport)
     {
-        return builder(processorSupport).build();
+        return newIdBuilder(processorSupport, null, true);
     }
 
-    public static IdBuilder newIdBuilder(ProcessorSupport processorSupport, IdBuilderFunction... idBuilderFunctions)
+    private static IdBuilder newIdBuilder(ProcessorSupport processorSupport, String defaultIdPrefix, boolean allowNonReferenceIds)
     {
-        return builder(processorSupport).withIdBuilders(idBuilderFunctions).build();
-    }
-
-    @Deprecated
-    public static String buildId(CoreInstance coreInstance, ProcessorSupport processorSupport)
-    {
-        return builder(processorSupport).build().buildId(coreInstance);
+        return new IdBuilder(Objects.requireNonNull(processorSupport), defaultIdPrefix, allowNonReferenceIds);
     }
 
     public static String sourceToId(SourceInformation sourceInformation)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/grammar/lang/all/GetAll.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/grammar/lang/all/GetAll.java
@@ -51,7 +51,7 @@ public class GetAll extends AbstractNative
 
         String type = TypeProcessor.typeToJavaObjectSingle(Instance.getValueForMetaPropertyToOneResolved(functionExpression, M3Properties.genericType, processorSupport), true, processorSupport);
 
-        return "((RichIterable<" + type + ">)Lists.mutable.ofAll(((CompiledExecutionSupport)es).getMetadata(\"" + name + "\").valuesView()))";
+        return "((RichIterable<" + type + ">)Lists.mutable.ofAll(((CompiledExecutionSupport)es).getClassifierInstances(\"" + name + "\")))";
     }
 
     @Override
@@ -63,7 +63,7 @@ public class GetAll extends AbstractNative
                 "            public Object value(Object o, final ExecutionSupport es)\n" +
                 "            {\n" +
                 "                String name = org.finos.legend.pure.runtime.java.compiled.generation.processors.type.MetadataJavaPaths.buildMetadataKeyFromType((org.finos.legend.pure.m4.coreinstance.CoreInstance)o);\n" +
-                "                return ((RichIterable)Lists.mutable.ofAll(((CompiledExecutionSupport)es).getMetadata(name).valuesView()));\n" +
+                "                return Lists.mutable.ofAll(((CompiledExecutionSupport)es).getClassifierInstances(name));\n" +
                 "            }\n" +
                 "        }";
     }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/grammar/lang/creation/InstantiationHelpers.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/natives/grammar/lang/creation/InstantiationHelpers.java
@@ -162,7 +162,7 @@ public class InstantiationHelpers
     {
         if (Instance.instanceOf(multiplicity, M3Paths.PackageableMultiplicity, processorSupport))
         {
-            return "(" + FullJavaPaths.PackageableMultiplicity + ")((CompiledExecutionSupport)es).getMetadata(\"" + MetadataJavaPaths.PackageableMultiplicity + "\",\"" + PackageableElement.getSystemPathForPackageableElement(multiplicity) + "\")";
+            return "(" + FullJavaPaths.PackageableMultiplicity + ")((CompiledExecutionSupport)es).getMetadata(\"" + MetadataJavaPaths.PackageableMultiplicity + "\",\"" + PackageableElement.getUserPathForPackageableElement(multiplicity) + "\")";
         }
 
         CoreInstance lowerBound = Instance.getValueForMetaPropertyToOneResolved(multiplicity, M3Properties.lowerBound, processorSupport);

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/CompiledSupport.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/CompiledSupport.java
@@ -2087,7 +2087,8 @@ public class CompiledSupport
     public static Type getType(Any val, MetadataAccessor metadata)
     {
         String fullSystemPath = val.getFullSystemPath();
-        return val instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum ? metadata.getEnumeration(fullSystemPath) : metadata.getClass(fullSystemPath);
+        String metadataId = fullSystemPath.startsWith("Root::") ? fullSystemPath.substring(6) : fullSystemPath;
+        return val instanceof org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enum ? metadata.getEnumeration(metadataId) : metadata.getClass(metadataId);
     }
 
     private static MutableList<String> getUserObjectPathForPackageableElement(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement packageableElement, boolean includeRoot)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/AbstractLazyReflectiveCoreInstance.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/AbstractLazyReflectiveCoreInstance.java
@@ -92,7 +92,9 @@ public abstract class AbstractLazyReflectiveCoreInstance extends PersistentRefle
         CoreInstance result = this.classifier;
         if (result == null)
         {
-            this.classifier = result = this.metadataLazy.getMetadata((this instanceof Enum) ? M3Paths.Enumeration : M3Paths.Class, getFullSystemPath());
+            String classifierSystemPath = getFullSystemPath();
+            String classifierId = classifierSystemPath.startsWith("Root::") ? classifierSystemPath.substring(6) : classifierSystemPath;
+            this.classifier = result = this.metadataLazy.getMetadata((this instanceof Enum) ? M3Paths.Enumeration : M3Paths.Class, classifierId);
         }
         return result;
     }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/AbstractQuantityCoreInstance.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/AbstractQuantityCoreInstance.java
@@ -83,11 +83,10 @@ public abstract class AbstractQuantityCoreInstance extends ReflectiveCoreInstanc
         Unit result = this.unit;
         if (result == null)
         {
-            String path = getUnitPath();
-            this.unit = result = this.executionSupport.getMetadataAccessor().getUnit("Root::" + path);
+            this.unit = result = this.executionSupport.getMetadataAccessor().getUnit(getUnitId());
             if (result == null)
             {
-                throw new IllegalStateException("Cannot find unit: " + path);
+                throw new IllegalStateException("Cannot find unit: " + getUnitPath());
             }
         }
         return result;
@@ -274,7 +273,7 @@ public abstract class AbstractQuantityCoreInstance extends ReflectiveCoreInstanc
     @Override
     public Multiplicity _multiplicity()
     {
-        return (Multiplicity) this.executionSupport.getMetadata().getMetadata(M3Paths.Multiplicity, "Root::" + M3Paths.PureOne);
+        return (Multiplicity) this.executionSupport.getMetadata(M3Paths.Multiplicity, M3Paths.PureOne);
     }
 
     @Override
@@ -361,6 +360,8 @@ public abstract class AbstractQuantityCoreInstance extends ReflectiveCoreInstanc
         throw new UnsupportedOperationException();
     }
 
+    protected abstract String getUnitId();
+
     protected abstract QuantityCoreInstance unwrap();
 
     private Object getValuePossiblyWrapped()
@@ -375,7 +376,7 @@ public abstract class AbstractQuantityCoreInstance extends ReflectiveCoreInstanc
 
     private Type getClassifierType()
     {
-        return this.executionSupport.getMetadataAccessor().getClass("Root::" + M3Paths.InstanceValue);
+        return this.executionSupport.getMetadataAccessor().getClass(M3Paths.InstanceValue);
     }
 
     private GenericType wrapGenericType(Type rawType)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassImplProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassImplProcessor.java
@@ -141,7 +141,7 @@ public class ClassImplProcessor
                 buildGetValueForMetaPropertyToOne(classGenericType, processorSupport) +
                 buildGetValueForMetaPropertyToMany(classGenericType, processorSupport) +
 
-                buildSimpleProperties(classGenericType, (property, name, unresolvedReturnType, returnType, returnMultiplicity, returnTypeJava, classOwnerFullId, ownerClassName, ownerTypeParams, processorContext1) ->
+                buildSimpleProperties(classGenericType, (property, name, unresolvedReturnType, returnType, returnMultiplicity, returnTypeJava, classOwnerId, ownerClassName, ownerTypeParams, processorContext1) ->
                 {
                     CoreInstance propertyOwner = Instance.getValueForMetaPropertyToOneResolved(property, M3Properties.owner, processorSupport);
 
@@ -154,7 +154,7 @@ public class ClassImplProcessor
                                 "    public " + returnTypeJava + " _" + name + ";\n" :
                                 "    public RichIterable _" + name + " = Lists.mutable.empty();\n";
                     }
-                    propertyString += buildProperty(property, ownerClassName + (ownerTypeParams.isEmpty() ? "" : "<" + ownerTypeParams + ">"), "this", classOwnerFullId, name, returnType, unresolvedReturnType, returnMultiplicity, processorContext1.getSupport(), includeGettor, processorContext1);
+                    propertyString += buildProperty(property, ownerClassName + (ownerTypeParams.isEmpty() ? "" : "<" + ownerTypeParams + ">"), "this", classOwnerId, name, returnType, unresolvedReturnType, returnMultiplicity, processorContext1.getSupport(), includeGettor, processorContext1);
                     return propertyString;
                 }, processorContext, processorSupport) +
                 buildQualifiedProperties(classGenericType, processorContext, processorSupport) +
@@ -508,8 +508,8 @@ public class ClassImplProcessor
             boolean makePrimitiveIfPossible = GenericType.isGenericTypeConcrete(unresolvedReturnType) && Multiplicity.isToOne(returnMultiplicity, true);
             String returnTypeJava = TypeProcessor.pureTypeToJava(returnType, true, makePrimitiveIfPossible, processorSupport);
             CoreInstance classOwner = Instance.getValueForMetaPropertyToOneResolved(property.getValueForMetaPropertyToOne(M3Properties.classifierGenericType).getValueForMetaPropertyToMany(M3Properties.typeArguments).get(0), M3Properties.rawType, processorSupport);
-            String classOwnerFullId = PackageableElement.getSystemPathForPackageableElement(classOwner);
-            return propertyImpl.build(property, name, unresolvedReturnType, returnType, returnMultiplicity, returnTypeJava, classOwnerFullId, ownerClassName, ownerTypeParams, processorContext);
+            String classOwnerId = processorContext.getIdBuilder().buildId(classOwner);
+            return propertyImpl.build(property, name, unresolvedReturnType, returnType, returnMultiplicity, returnTypeJava, classOwnerId, ownerClassName, ownerTypeParams, processorContext);
         }).makeString("", "\n", "\n");
     }
 
@@ -847,7 +847,7 @@ public class ClassImplProcessor
                 "\n";
     }
 
-    public static String buildProperty(CoreInstance property, String className, String owner, String classOwnerFullId, String name, CoreInstance returnType, CoreInstance unresolvedReturnType, CoreInstance multiplicity, ProcessorSupport processorSupport, boolean includeGettor, ProcessorContext processorContext)
+    public static String buildProperty(CoreInstance property, String className, String owner, String classOwnerId, String name, CoreInstance returnType, CoreInstance unresolvedReturnType, CoreInstance multiplicity, ProcessorSupport processorSupport, boolean includeGettor, ProcessorContext processorContext)
     {
         CoreInstance associationClass = processorSupport.package_getByUserPath(M3Paths.Association);
         CoreInstance propertyOwner = Instance.getValueForMetaPropertyToOneResolved(property, M3Properties.owner, processorSupport);
@@ -879,7 +879,7 @@ public class ClassImplProcessor
             return buildPropertyStandardWriteToOneBuilders(property, returnType, name, owner, className, typeObject, defaultValue, reversePropertyName, typePrimitive, false, processorContext) +
                     (includeGettor ? buildPropertyStandardWriteSeverReverseToOne(name, owner, typePrimitive, isPrimitive, false) +
                             buildPropertyToOneGetterCoreInstance(property, returnType, name, processorContext) +
-                            buildPropertyToOneGetter(owner, classOwnerFullId, name, isOverrider, isClassifierGenericType, isDataType, typePrimitive) : "");
+                            buildPropertyToOneGetter(owner, classOwnerId, name, isOverrider, isClassifierGenericType, isDataType, typePrimitive) : "");
         }
         else
         {
@@ -888,26 +888,26 @@ public class ClassImplProcessor
             // it just won't be called.
             return buildPropertyStandardWriteToManyBuilders(property, returnType, name, owner, className, typeObject, reversePropertyName, typePrimitive, rawType, false, processorSupport, processorContext) +
                     (includeGettor ? buildPropertyStandardSeverReverseToMany(name, owner, typePrimitive, isPrimitive, false) +
-                            buildPropertyToManyGetter(owner, classOwnerFullId, name, isOverrider, isClassifierGenericType, isDataType, typePrimitive) : "") +
+                            buildPropertyToManyGetter(owner, classOwnerId, name, isOverrider, isClassifierGenericType, isDataType, typePrimitive) : "") +
                     buildPropertyToManyGetterCoreInstance(property, returnType, name, processorContext);
         }
     }
 
-    private static String buildPropertyToManyGetter(String owner, String classOwnerFullId, String name, boolean isOverrider, boolean isClassifierGenericType, boolean isDataType, String typeObject)
+    private static String buildPropertyToManyGetter(String owner, String classOwnerId, String name, boolean isOverrider, boolean isClassifierGenericType, boolean isDataType, String typeObject)
     {
         return "    public RichIterable<? extends " + typeObject + "> _" + name + "()\n" +
                 "    {\n" +
                 "        return " + (isDataType || isOverrider || isClassifierGenericType ? owner + "._" + name + ";\n" :
-                owner + "._elementOverride() == null || !GetterOverrideExecutor.class.isInstance(" + owner + "._elementOverride()) ? " + owner + "._" + name + " : (RichIterable<? extends " + typeObject + ">)((GetterOverrideExecutor)" + owner + "._elementOverride()).executeToMany(" + owner + ", \"" + classOwnerFullId + "\", \"" + name + "\");\n") +
+                owner + "._elementOverride() == null || !GetterOverrideExecutor.class.isInstance(" + owner + "._elementOverride()) ? " + owner + "._" + name + " : (RichIterable<? extends " + typeObject + ">)((GetterOverrideExecutor)" + owner + "._elementOverride()).executeToMany(" + owner + ", \"" + classOwnerId + "\", \"" + name + "\");\n") +
                 "    }\n";
     }
 
-    private static String buildPropertyToOneGetter(String owner, String classOwnerFullId, String name, boolean isOverrider, boolean isClassifierGenericType, boolean isDataType, String typeObject)
+    private static String buildPropertyToOneGetter(String owner, String classOwnerId, String name, boolean isOverrider, boolean isClassifierGenericType, boolean isDataType, String typeObject)
     {
         return "    public " + typeObject + " _" + name + "()\n" +
                 "    {\n" +
                 "        return " + (isDataType || isOverrider || isClassifierGenericType ? owner + "._" + name + ";\n" :
-                owner + "._elementOverride() == null || !GetterOverrideExecutor.class.isInstance(" + owner + "._elementOverride()) ? " + owner + "._" + name + " : (" + typeObject + ")((GetterOverrideExecutor)" + owner + "._elementOverride()).executeToOne(" + owner + ", \"" + classOwnerFullId + "\", \"" + name + "\");\n") +
+                owner + "._elementOverride() == null || !GetterOverrideExecutor.class.isInstance(" + owner + "._elementOverride()) ? " + owner + "._" + name + " : (" + typeObject + ")((GetterOverrideExecutor)" + owner + "._elementOverride()).executeToOne(" + owner + ", \"" + classOwnerId + "\", \"" + name + "\");\n") +
                 "    }\n";
     }
 
@@ -992,13 +992,13 @@ public class ClassImplProcessor
                 "        this.__getterOverrideToManyExec = f2;" +
                 "        return this;\n" +
                 "    }\n" +
-                "    public Object executeToOne(CoreInstance instance, String fullSystemClassName, String propertyName)\n" +
+                "    public Object executeToOne(CoreInstance instance, String classId, String propertyName)\n" +
                 "    {\n" +
-                "        return this.__getterOverrideToOneExec.value(instance, Pure.getProperty(fullSystemClassName, propertyName,((CompiledExecutionSupport)__getterOverrideToOneExec.getExecutionSupport()).getMetadataAccessor()), __getterOverrideToOneExec.getExecutionSupport());\n" +
+                "        return this.__getterOverrideToOneExec.value(instance, Pure.getProperty(classId, propertyName,((CompiledExecutionSupport)__getterOverrideToOneExec.getExecutionSupport()).getMetadataAccessor()), __getterOverrideToOneExec.getExecutionSupport());\n" +
                 "    }\n" +
-                "    public ListIterable executeToMany(CoreInstance instance, String fullSystemClassName, String propertyName)\n" +
+                "    public ListIterable executeToMany(CoreInstance instance, String classId, String propertyName)\n" +
                 "    {\n" +
-                "        return (ListIterable)this.__getterOverrideToManyExec.value(instance, Pure.getProperty(fullSystemClassName, propertyName,((CompiledExecutionSupport)__getterOverrideToOneExec.getExecutionSupport()).getMetadataAccessor()), __getterOverrideToManyExec.getExecutionSupport());\n" +
+                "        return (ListIterable)this.__getterOverrideToManyExec.value(instance, Pure.getProperty(classId, propertyName,((CompiledExecutionSupport)__getterOverrideToOneExec.getExecutionSupport()).getMetadataAccessor()), __getterOverrideToManyExec.getExecutionSupport());\n" +
                 "    }\n";
 
     }
@@ -1115,6 +1115,6 @@ public class ClassImplProcessor
 
     public interface FullPropertyImplementation
     {
-        String build(CoreInstance property, String name, CoreInstance unresolvedReturnType, CoreInstance returnType, CoreInstance returnMultiplicity, String returnTypeJava, String classOwnerFullId, String ownerClassName, String ownerTypeParams, ProcessorContext processorContext);
+        String build(CoreInstance property, String name, CoreInstance unresolvedReturnType, CoreInstance returnType, CoreInstance returnMultiplicity, String returnTypeJava, String classOwnerId, String ownerClassName, String ownerTypeParams, ProcessorContext processorContext);
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassLazyImplProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/_class/ClassLazyImplProcessor.java
@@ -90,11 +90,11 @@ public class ClassLazyImplProcessor
                 (instanceOfGetterOverride ? lazyGetterOverride(interfaceNamePlusTypeParams) : "") +
                 ClassImplProcessor.buildGetValueForMetaPropertyToOne(classGenericType, processorSupport) +
                 ClassImplProcessor.buildGetValueForMetaPropertyToMany(classGenericType, processorSupport) +
-                ClassImplProcessor.buildSimpleProperties(classGenericType, (property, name, unresolvedReturnType, returnType, returnMultiplicity, returnTypeJava, classOwnerFullId, ownerClassName, ownerTypeParams, processorContext1) -> "    public final AtomicBoolean _" + name + LAZY_INITIALIZED_SUFFIX + " = new AtomicBoolean(false);\n" +
+                ClassImplProcessor.buildSimpleProperties(classGenericType, (property, name, unresolvedReturnType, returnType, returnMultiplicity, returnTypeJava, classOwnerId, ownerClassName, ownerTypeParams, processorContext1) -> "    public final AtomicBoolean _" + name + LAZY_INITIALIZED_SUFFIX + " = new AtomicBoolean(false);\n" +
                         (Multiplicity.isToOne(returnMultiplicity, false) ?
                          "    public " + returnTypeJava + " _" + name + ";\n" :
                          "    public RichIterable _" + name + " = Lists.mutable.empty();\n") +
-                        buildLazyProperty(property, ownerClassName + (ownerTypeParams.isEmpty() ? "" : "<" + ownerTypeParams + ">"), "this", classOwnerFullId, name, returnType, unresolvedReturnType, returnMultiplicity, processorContext1.getSupport(), processorContext1), processorContext, processorSupport) +
+                        buildLazyProperty(property, ownerClassName + (ownerTypeParams.isEmpty() ? "" : "<" + ownerTypeParams + ">"), "this", name, returnType, unresolvedReturnType, returnMultiplicity, processorContext1.getSupport(), processorContext1), processorContext, processorSupport) +
                 ClassImplProcessor.buildQualifiedProperties(classGenericType, processorContext, processorSupport) +
                 buildLazyCopy(classGenericType, classInterfaceName, className, false, processorSupport) +
                 ClassImplProcessor.buildEquality(classGenericType, CLASS_LAZYIMPL_SUFFIX, true, false, true, processorContext, processorSupport) +
@@ -157,7 +157,7 @@ public class ClassLazyImplProcessor
 
     }
 
-    private static String buildLazyProperty(CoreInstance property, String className, String owner, String classOwnerFullId, String name, CoreInstance returnType, CoreInstance unresolvedReturnType, CoreInstance multiplicity, ProcessorSupport processorSupport, ProcessorContext processorContext)
+    private static String buildLazyProperty(CoreInstance property, String className, String owner, String name, CoreInstance returnType, CoreInstance unresolvedReturnType, CoreInstance multiplicity, ProcessorSupport processorSupport, ProcessorContext processorContext)
     {
         CoreInstance associationClass = processorSupport.package_getByUserPath(M3Paths.Association);
         CoreInstance propertyOwner = Instance.getValueForMetaPropertyToOneResolved(property, M3Properties.owner, processorSupport);

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/MeasureProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/type/measureUnit/MeasureProcessor.java
@@ -48,7 +48,7 @@ public class MeasureProcessor
         processorContext.addJavaSource(buildUnitInterface(packageName, measureInterfaceName, unitInterfaceName, Measure.getUserPathForUnit(unit)));
 
         String unitImplClassName = JavaPackageAndImportBuilder.buildImplClassNameFromType(unit, processorContext.getSupport());
-        processorContext.addJavaSource(buildUnitImplClass(packageName, unitInterfaceName, unitImplClassName));
+        processorContext.addJavaSource(buildUnitImplClass(packageName, unitInterfaceName, unitImplClassName, processorContext.getIdBuilder().buildId(unit)));
     }
 
     private static StringJavaSource buildMeasureInterface(String packageName, String interfaceName)
@@ -79,7 +79,7 @@ public class MeasureProcessor
         return StringJavaSource.newStringJavaSource(packageName, unitInterfaceName, code);
     }
 
-    private static StringJavaSource buildUnitImplClass(String packageName, String unitInterfaceName, String unitClassImplName)
+    private static StringJavaSource buildUnitImplClass(String packageName, String unitInterfaceName, String unitClassImplName, String unitId)
     {
         String code = "package " + packageName + ";\n" +
                 "\n" +
@@ -89,6 +89,8 @@ public class MeasureProcessor
                 "\n" +
                 "public class " + unitClassImplName + " extends " + AbstractQuantityCoreInstance.class.getSimpleName() + " implements " + unitInterfaceName + "\n" +
                 "{\n" +
+                "    private static final String UNIT_ID = \"" + StringEscapeUtils.escapeJava(unitId) + "\";\n" +
+                "\n" +
                 "    public " + unitClassImplName + "(Number value, " + CompiledExecutionSupport.class.getSimpleName() + " executionSupport)\n" +
                 "    {\n" +
                 "        super(value, UNIT_PATH, executionSupport);\n" +
@@ -119,6 +121,12 @@ public class MeasureProcessor
                 "    public " + unitInterfaceName + " copy()\n" +
                 "    {\n" +
                 "        return new " + unitClassImplName + "(this);\n" +
+                "    }\n" +
+                "\n" +
+                "    @Override\n" +
+                "    protected String getUnitId()\n" +
+                "    {\n" +
+                "        return UNIT_ID;\n" +
                 "    }\n" +
                 "\n" +
                 "    @Override\n" +

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/valuespecification/ValueSpecificationProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/valuespecification/ValueSpecificationProcessor.java
@@ -114,7 +114,7 @@ public class ValueSpecificationProcessor
                     else
                     {
                         CoreInstance _class = Instance.getValueForMetaPropertyToOneResolved(valueSpecification, M3Properties.genericType, M3Properties.typeArguments, M3Properties.rawType, processorSupport);
-                        return "((" + FullJavaPaths.Class + "<" + TypeProcessor.fullyQualifiedJavaInterfaceNameForType(_class, processorSupport) + ">)((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + PackageableElement.getSystemPathForPackageableElement(_class) + "\"))";
+                        return "((" + FullJavaPaths.Class + "<" + TypeProcessor.fullyQualifiedJavaInterfaceNameForType(_class, processorSupport) + ">)((CompiledExecutionSupport)es).getMetadataAccessor().getClass(\"" + PackageableElement.getUserPathForPackageableElement(_class) + "\"))";
                     }
                 }
                 else if (values.size() == 1)
@@ -127,7 +127,7 @@ public class ValueSpecificationProcessor
                     }
                     CoreInstance type = processorSupport.getClassifier(cls);
                     String classifier = MetadataJavaPaths.buildMetadataKeyFromType(type);
-                    return "((" + TypeProcessor.fullyQualifiedJavaInterfaceNameForType(type, processorSupport) + "<" + TypeProcessor.fullyQualifiedJavaInterfaceNameForType(cls, processorSupport) + ">)((CompiledExecutionSupport)es).getMetadata(\"" + classifier + "\",\"" + PackageableElement.getSystemPathForPackageableElement(cls) + "\"))";
+                    return "((" + TypeProcessor.fullyQualifiedJavaInterfaceNameForType(type, processorSupport) + "<" + TypeProcessor.fullyQualifiedJavaInterfaceNameForType(cls, processorSupport) + ">)((CompiledExecutionSupport)es).getMetadata(\"" + classifier + "\",\"" + PackageableElement.getUserPathForPackageableElement(cls) + "\"))";
                 }
                 else
                 {
@@ -144,7 +144,7 @@ public class ValueSpecificationProcessor
                         String type = TypeProcessor.fullyQualifiedJavaInterfaceNameForType(cls, processorSupport);
                         types.add(type);
                         String classifier = TypeProcessor.fullyQualifiedJavaInterfaceNameForType(processorSupport.getClassifier(cls), processorSupport);
-                        return "((" + classifier + "<? extends " + type + ">)((CompiledExecutionSupport)es).getMetadata(\"" + MetadataJavaPaths.buildMetadataKeyFromType(processorSupport.getClassifier(cls)) + "\",\"" + PackageableElement.getSystemPathForPackageableElement(cls) + "\"))";
+                        return "((" + classifier + "<? extends " + type + ">)((CompiledExecutionSupport)es).getMetadata(\"" + MetadataJavaPaths.buildMetadataKeyFromType(processorSupport.getClassifier(cls)) + "\",\"" + PackageableElement.getUserPathForPackageableElement(cls) + "\"))";
                     }).makeString();
                     String typeString = (types.size() > 1) ? ("<" + TypeProcessor.typeToJavaObjectSingle(Instance.getValueForMetaPropertyToOneResolved(valueSpecification, M3Properties.genericType, processorSupport), true, processorSupport) + ">") : "";
                     return "Lists.mutable." + typeString + "with(" + listElements + ")";
@@ -162,7 +162,7 @@ public class ValueSpecificationProcessor
                         // Enumeration is wrapped in an InstanceValue
                         enumeration = Instance.getValueForMetaPropertyToOneResolved(enumeration, M3Properties.values, processorSupport);
                     }
-                    return "((" + type + ")((CompiledExecutionSupport)es).getMetadataAccessor().getEnumeration(\"" + PackageableElement.getSystemPathForPackageableElement(enumeration) + "\"))";
+                    return "((" + type + ")((CompiledExecutionSupport)es).getMetadataAccessor().getEnumeration(\"" + PackageableElement.getUserPathForPackageableElement(enumeration) + "\"))";
                 }
                 else
                 {
@@ -283,15 +283,15 @@ public class ValueSpecificationProcessor
         if (fullyConcreteSignature && notOpenVariables && !processorContext.isInLineAllLambda())
         {
             String sourceId = IdBuilder.sourceToId(function.getSourceInformation());
-            String functionId = processorContext.getIdBuilder().buildId(function);
+            String functionKey = function.getName();
 
             //Only need to create this if we are currently generating this file
             if (registerLambdasInProcessorContext && (topLevelElement == null || function.getSourceInformation().getSourceId().equals(topLevelElement.getSourceInformation().getSourceId())))
             {
                 String func = createLambdaBody(topLevelElement, function, processorContext, notOpenVariables, functionType, params);
-                processorContext.registerLambdaFunction(sourceId, functionId, func);
+                processorContext.registerLambdaFunction(sourceId, functionKey, func);
             }
-            pureFunctionString = sourceId + ".__functions.get(\"" + functionId + "\")";
+            pureFunctionString = sourceId + ".__functions.get(\"" + functionKey + "\")";
         }
         else
         {

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/Metadata.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/Metadata.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.pure.runtime.java.compiled.metadata;
 
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.map.MapIterable;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
@@ -28,6 +29,11 @@ public interface Metadata
     CoreInstance getMetadata(String classifier, String id);
 
     MapIterable<String, CoreInstance> getMetadata(String classifier);
+
+    default RichIterable<CoreInstance> getClassifierInstances(String classifier)
+    {
+        return getMetadata(classifier).valuesView();
+    }
 
     CoreInstance getEnum(String enumerationName, String enumName);
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataAccessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataAccessor.java
@@ -28,6 +28,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Measure;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Nil;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.PrimitiveType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Unit;
+import org.finos.legend.pure.m3.navigation.M3Paths;
 
 /**
  * Provides key meta data
@@ -61,12 +62,12 @@ public interface MetadataAccessor
     @SuppressWarnings("unchecked")
     default Class<Any> getTopType()
     {
-        return (Class<Any>) getClass("Root::meta::pure::metamodel::type::Any");
+        return (Class<Any>) getClass(M3Paths.Any);
     }
 
     @SuppressWarnings("unchecked")
     default Class<Nil> getBottomType()
     {
-        return (Class<Nil>) getClass("Root::meta::pure::metamodel::type::Nil");
+        return (Class<Nil>) getClass(M3Paths.Nil);
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataBuilder.java
@@ -21,7 +21,6 @@ import org.eclipse.collections.api.stack.MutableStack;
 import org.eclipse.collections.impl.factory.Maps;
 import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.factory.Stacks;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
@@ -83,15 +82,7 @@ public class MetadataBuilder
                         .flatCollect(key -> Instance.getValueForMetaPropertyToManyResolved(instance, key, processorSupport))
                         .reject(value -> state.isPrimitiveType(value.getClassifier()))
                         .forEach(state::addNode);
-
-                if (classifier instanceof Enumeration)
-                {
-                    metadataEager.add(state.getClassifierId(classifier), instance.getName(), instance);
-                }
-                else
-                {
-                    metadataEager.add(state.getClassifierId(classifier), id, instance);
-                }
+                metadataEager.add(state.getClassifierId(classifier), id, instance);
             }
         }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataBuilder.java
@@ -14,26 +14,15 @@
 
 package org.finos.legend.pure.runtime.java.compiled.metadata;
 
-import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.api.set.SetIterable;
-import org.eclipse.collections.api.stack.MutableStack;
-import org.eclipse.collections.impl.factory.Maps;
-import org.eclipse.collections.impl.factory.Sets;
-import org.eclipse.collections.impl.factory.Stacks;
-import org.finos.legend.pure.m3.navigation.Instance;
-import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.compileState.CompileState;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.IdBuilder;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.type.MetadataJavaPaths;
 
-/**
- * Creates the metadata index
- */
+@Deprecated
 public class MetadataBuilder
 {
+    @Deprecated
     public static final CompileState SERIALIZED = CompileState.COMPILE_EVENT_EXTRA_STATE_1;
 
     private MetadataBuilder()
@@ -43,167 +32,24 @@ public class MetadataBuilder
     @Deprecated
     public static MetadataEager indexAll(Iterable<? extends CoreInstance> startingNodes, ProcessorSupport processorSupport)
     {
-        return indexAll(startingNodes, IdBuilder.newIdBuilder(processorSupport), processorSupport);
+        return new MetadataEager(processorSupport);
     }
 
+    @Deprecated
     public static MetadataEager indexAll(Iterable<? extends CoreInstance> startingNodes, IdBuilder idBuilder, ProcessorSupport processorSupport)
     {
-        MetadataEager metadataEager = new MetadataEager();
-        PrivateSetSearchStateWithCompileStateMarking state = new PrivateSetSearchStateWithCompileStateMarking(Stacks.mutable.withAll(startingNodes), processorSupport);
-        indexNodes(state, metadataEager, idBuilder, processorSupport);
-        return metadataEager;
+        return new MetadataEager(processorSupport);
     }
 
     @Deprecated
     public static MetadataEager indexNew(MetadataEager metadataEager, Iterable<? extends CoreInstance> startingNodes, ProcessorSupport processorSupport)
     {
-        return indexNew(metadataEager, startingNodes, IdBuilder.newIdBuilder(processorSupport), processorSupport);
-    }
-
-    public static MetadataEager indexNew(MetadataEager metadataEager, Iterable<? extends CoreInstance> startingNodes, IdBuilder idBuilder, ProcessorSupport processorSupport)
-    {
-        CompiledStateSearchState state = new CompiledStateSearchState(Stacks.mutable.withAll(startingNodes), processorSupport);
-        return indexNodes(state, metadataEager, idBuilder, processorSupport);
-    }
-
-    private static MetadataEager indexNodes(SearchState state, MetadataEager metadataEager, IdBuilder idBuilder, ProcessorSupport processorSupport)
-    {
-        while (state.hasNodes())
-        {
-            CoreInstance instance = state.nextNode();
-            if (state.shouldVisit(instance))
-            {
-                state.noteVisited(instance);
-
-                String id = idBuilder.buildId(instance);
-                CoreInstance classifier = instance.getClassifier();
-
-                instance.getKeys().asLazy()
-                        .flatCollect(key -> Instance.getValueForMetaPropertyToManyResolved(instance, key, processorSupport))
-                        .reject(value -> state.isPrimitiveType(value.getClassifier()))
-                        .forEach(state::addNode);
-                metadataEager.add(state.getClassifierId(classifier), id, instance);
-            }
-        }
-
         return metadataEager;
     }
 
-    private static class ClassifierCaches
+    @Deprecated
+    public static MetadataEager indexNew(MetadataEager metadataEager, Iterable<? extends CoreInstance> startingNodes, IdBuilder idBuilder, ProcessorSupport processorSupport)
     {
-        private final SetIterable<CoreInstance> primitiveTypes;
-        private final MutableMap<CoreInstance, String> classifierIdCache = Maps.mutable.empty();
-
-        private ClassifierCaches(ProcessorSupport processorSupport)
-        {
-            this.primitiveTypes = PrimitiveUtilities.getPrimitiveTypes(processorSupport).toSet();
-        }
-
-        boolean isPrimitiveType(CoreInstance classifier)
-        {
-            return this.primitiveTypes.contains(classifier);
-        }
-
-        String getClassifierId(CoreInstance classifier)
-        {
-            return this.classifierIdCache.getIfAbsentPutWithKey(classifier, ClassifierCaches::newClassifierId);
-        }
-
-        private static String newClassifierId(CoreInstance classifier)
-        {
-            return MetadataJavaPaths.buildMetadataKeyFromType(classifier).intern();
-        }
-    }
-
-    private abstract static class SearchState extends ClassifierCaches
-    {
-        private final MutableStack<CoreInstance> stack;
-
-        private SearchState(MutableStack<CoreInstance> stack, ProcessorSupport processorSupport)
-        {
-            super(processorSupport);
-            this.stack = stack;
-        }
-
-        boolean hasNodes()
-        {
-            return this.stack.notEmpty();
-        }
-
-        CoreInstance nextNode()
-        {
-            return this.stack.pop();
-        }
-
-        void addNode(CoreInstance node)
-        {
-            this.stack.push(node);
-        }
-
-        boolean shouldVisit(CoreInstance node)
-        {
-            return !hasVisited(node) && !isPrimitiveType(node.getClassifier());
-        }
-
-        abstract boolean hasVisited(CoreInstance node);
-
-        abstract void noteVisited(CoreInstance node);
-    }
-
-    private static class CompiledStateSearchState extends SearchState
-    {
-        private CompiledStateSearchState(MutableStack<CoreInstance> stack, ProcessorSupport processorSupport)
-        {
-            super(stack, processorSupport);
-        }
-
-        @Override
-        boolean hasVisited(CoreInstance node)
-        {
-            return node.hasCompileState(SERIALIZED);
-        }
-
-        @Override
-        void noteVisited(CoreInstance node)
-        {
-            node.addCompileState(SERIALIZED);
-        }
-    }
-
-    private static class PrivateSetSearchState extends SearchState
-    {
-        private final MutableSet<CoreInstance> visited = Sets.mutable.with();
-
-        private PrivateSetSearchState(MutableStack<CoreInstance> stack, ProcessorSupport processorSupport)
-        {
-            super(stack, processorSupport);
-        }
-
-        @Override
-        boolean hasVisited(CoreInstance node)
-        {
-            return this.visited.contains(node);
-        }
-
-        @Override
-        void noteVisited(CoreInstance node)
-        {
-            this.visited.add(node);
-        }
-    }
-
-    private static class PrivateSetSearchStateWithCompileStateMarking extends PrivateSetSearchState
-    {
-        private PrivateSetSearchStateWithCompileStateMarking(MutableStack<CoreInstance> stack, ProcessorSupport processorSupport)
-        {
-            super(stack, processorSupport);
-        }
-
-        @Override
-        void noteVisited(CoreInstance node)
-        {
-            super.noteVisited(node);
-            node.addCompileState(SERIALIZED);
-        }
+        return metadataEager;
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataEager.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataEager.java
@@ -145,10 +145,7 @@ public final class MetadataEager implements Metadata
     @Deprecated
     public int getSize()
     {
-        return GraphNodeIterable.builder()
-                .withStartingNodes(GraphTools.getTopLevels(this.processorSupport))
-                .build()
-                .size();
+        return getCache().idCache.size();
     }
 
     private Cache getCache()

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataEager.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataEager.java
@@ -15,101 +15,100 @@
 package org.finos.legend.pure.runtime.java.compiled.metadata;
 
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.map.ConcurrentMutableMap;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
-import org.finos.legend.pure.m3.coreinstance.Package;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdResolver;
+import org.finos.legend.pure.m3.serialization.compiler.reference.v1.ReferenceIdExtensionV1;
+import org.finos.legend.pure.m3.tools.GraphTools;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.tools.GraphNodeIterable;
+import org.finos.legend.pure.m4.tools.GraphWalkFilterResult;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.IdBuilder;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.coreinstance.ReflectiveCoreInstance;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.type.MetadataJavaPaths;
-
-import java.util.Objects;
 
 public final class MetadataEager implements Metadata
 {
-    private final MetamodelByClassifier metamodelByClassifier = new MetamodelByClassifier();
+    private final ProcessorSupport processorSupport;
+    private final ReferenceIdResolver resolver;
+    private final ConcurrentMutableMap<String, CoreInstance> cache = ConcurrentHashMap.newMap();
+    private final ThreadLocal<ConcurrentMutableMap<String, CoreInstance>> transaction = new ThreadLocal<>();
 
-    private final ThreadLocal<MetamodelByClassifier> added = new ThreadLocal<>();
+    public MetadataEager(ProcessorSupport processorSupport)
+    {
+        this.processorSupport = processorSupport;
+        this.resolver = new ReferenceIdExtensionV1().newResolver(this.processorSupport::package_getByUserPath);
+    }
 
     @Override
     public void startTransaction()
     {
-        this.added.set(new MetamodelByClassifier());
+        this.transaction.set(ConcurrentHashMap.newMap());
     }
 
     @Override
     public void commitTransaction()
     {
-        MetamodelByClassifier trans = this.added.get();
-        if (trans != null)
+        ConcurrentMutableMap<String, CoreInstance> fromTransaction = this.transaction.get();
+        if (fromTransaction != null)
         {
-            this.added.remove();
-            this.metamodelByClassifier.commitChanges(trans);
+            this.transaction.remove();
+            this.cache.clear();
         }
     }
 
     @Override
     public void rollbackTransaction()
     {
-        this.added.remove();
+        this.transaction.remove();
     }
 
     public void clear()
     {
-        this.metamodelByClassifier.clear();
-        this.added.remove();
+        ConcurrentMutableMap<String, CoreInstance> transactionCache = this.transaction.get();
+        if (transactionCache == null)
+        {
+            this.cache.clear();
+        }
+        else
+        {
+            this.transaction.set(ConcurrentHashMap.newMap());
+        }
     }
 
+    public void reset()
+    {
+        this.transaction.remove();
+        this.cache.clear();
+    }
+
+    @Deprecated
     public void addChild(String packageClassifier, String packageId, String objectClassifier, String instanceId)
     {
-        if (this.isInTransaction())
-        {
-            if (this.added.get().getMetadata(packageClassifier, packageId) == null)
-            {
-                CoreInstance packageInstance = Objects.requireNonNull(this.metamodelByClassifier.getMetadata(packageClassifier, packageId));
-                CoreInstance copy = ((ReflectiveCoreInstance) packageInstance).copy();
-
-                this.added.get().add(packageClassifier, packageId, copy);
-            }
-        }
-
-        this.getMetamodel().addChild(packageClassifier, packageId, objectClassifier, instanceId);
+        // nothing to do
     }
 
     @Override
     public CoreInstance getEnum(String enumerationName, String enumName)
     {
-        return getMetadata(enumerationName, enumerationName + "." + M3Properties.values + "['" + enumName + "']");
+        return getFromCache(enumerationName + "." + M3Properties.values + "['" + enumName + "']");
     }
 
     @Deprecated
     public void invalidateCoreInstances(RichIterable<? extends CoreInstance> instances, ProcessorSupport processorSupport)
     {
-        IdBuilder idBuilder = IdBuilder.newIdBuilder(processorSupport);
-        for (CoreInstance coreInstance : instances)
-        {
-            String identifier = idBuilder.buildId(coreInstance);
-            String classifier = MetadataJavaPaths.buildMetadataKeyFromType(coreInstance.getClassifier()).intern();
-
-            CoreInstance pack = coreInstance.getValueForMetaPropertyToOne(M3Properties._package);
-            if (pack != null)
-            {
-                String packIdentifier = idBuilder.buildId(pack);
-                String packClassifier = MetadataJavaPaths.buildMetadataKeyFromType(pack.getClassifier()).intern();
-
-                this.getMetamodel().remove(classifier, identifier, packClassifier, packIdentifier);
-            }
-        }
+        clear();
     }
 
+    @Deprecated
     public void add(String classifier, String id, CoreInstance instance)
     {
-        this.getMetamodel().add(classifier, id, instance);
+        // nothing to do
     }
 
 
@@ -121,103 +120,68 @@ public final class MetadataEager implements Metadata
         {
             id = id.substring(6);
         }
-        CoreInstance coreInstance = this.metamodelByClassifier.getMetadata(classifier, id);
-        if (coreInstance == null && this.isInTransaction())
-        {
-            coreInstance = this.added.get().getMetadata(classifier, id);
-        }
 
-        if (coreInstance == null)
+        try
         {
-            throw new PureExecutionException("Element " + id + " of type " + classifier + " does not exist");
+            return getFromCache(id);
         }
-
-        return coreInstance;
+        catch (Exception e)
+        {
+            throw new PureExecutionException("Element " + id + " of type " + classifier + " does not exist", e);
+        }
     }
 
     @Override
     public MapIterable<String, CoreInstance> getMetadata(String classifier)
     {
-        MapIterable<String, CoreInstance> instances = this.metamodelByClassifier.getMetadata(classifier);
-        if (isInTransaction())
-        {
-            MapIterable<String, CoreInstance> addedInstances = this.added.get().getMetadata(classifier);
-            if (addedInstances.notEmpty())
-            {
-                MutableMap<String, CoreInstance> allInstances = Maps.mutable.ofInitialCapacity(instances.size());
-                instances.forEachKeyValue(allInstances::put);
-                addedInstances.forEachKeyValue(allInstances::put);
-                return allInstances;
-            }
-        }
+        IdBuilder idBuilder = IdBuilder.newIdBuilder(this.processorSupport, true);
+        MutableMap<String, CoreInstance> instances = Maps.mutable.empty();
+        getClassifierInstances(classifier).forEach(inst -> instances.put(idBuilder.buildId(inst), inst));
         return instances;
     }
 
+    @Override
+    public RichIterable<CoreInstance> getClassifierInstances(String classifier)
+    {
+        CoreInstance classifierInstance;
+        try
+        {
+            classifierInstance = getFromCache(classifier);
+        }
+        catch (Exception e)
+        {
+            // unknown classifier
+            return Lists.immutable.empty();
+        }
+
+        return GraphNodeIterable.builder()
+                .withStartingNodes(GraphTools.getTopLevels(this.processorSupport))
+                .withNodeFilter(node -> GraphWalkFilterResult.cont(classifierInstance == this.processorSupport.getClassifier(node)))
+                .build();
+    }
+
+    @Deprecated
     public int getSize()
     {
-        return this.getMetamodel().metadata.valuesView().size();
+        return GraphNodeIterable.builder()
+                .withStartingNodes(GraphTools.getTopLevels(this.processorSupport))
+                .build()
+                .size();
     }
 
-    private boolean isInTransaction()
+    private CoreInstance getFromCache(String id)
     {
-        return this.added.get() != null;
+        return getCache().getIfAbsentPutWithKey(id, this::resolveId);
     }
 
-
-    private MetamodelByClassifier getMetamodel()
+    private ConcurrentMutableMap<String, CoreInstance> getCache()
     {
-        return this.isInTransaction() ? this.added.get() : this.metamodelByClassifier;
+        ConcurrentMutableMap<String, CoreInstance> fromTransaction = this.transaction.get();
+        return (fromTransaction == null) ? this.cache : fromTransaction;
     }
 
-    private static class MetamodelByClassifier
+    private CoreInstance resolveId(String id)
     {
-        private final MutableMap<String, MutableMap<String, CoreInstance>> metadata = Maps.mutable.empty();
-
-        private void clear()
-        {
-            this.metadata.clear();
-        }
-
-        private void add(String classifier, String id, CoreInstance coreInstance)
-        {
-            this.metadata.getIfAbsentPut(classifier, Maps.mutable::empty).put(id, coreInstance);
-        }
-
-        private void commitChanges(MetamodelByClassifier toBeAdded)
-        {
-            toBeAdded.metadata.forEachKeyValue((classifier, instancesById) -> this.metadata.getIfAbsentPut(classifier, Maps.mutable::empty).putAll(instancesById));
-        }
-
-        private CoreInstance getMetadata(String classifier, String id)
-        {
-            MutableMap<String, CoreInstance> instancesForClassifier = this.metadata.get(classifier);
-            return instancesForClassifier == null ? null : instancesForClassifier.get(id);
-        }
-
-        private MapIterable<String, CoreInstance> getMetadata(String classifier)
-        {
-            return this.metadata.getIfAbsentValue(classifier, Maps.fixedSize.empty());
-        }
-
-        private void addChild(String packageClassifier, String packageId, String objectClassifier, String instanceId)
-        {
-            Package _package = (Package) Objects.requireNonNull(getMetadata(packageClassifier, packageId));
-            PackageableElement child = (PackageableElement) Objects.requireNonNull(getMetadata(objectClassifier, instanceId));
-            _package._childrenAdd(child);
-        }
-
-        private void remove(String classifier, String identifier, String packClassifier, String packIdentifier)
-        {
-            MutableMap<String, CoreInstance> classifierMetaData = this.metadata.get(classifier);
-            if (classifierMetaData != null)
-            {
-                CoreInstance o = classifierMetaData.remove(identifier);
-                if (o instanceof PackageableElement)
-                {
-                    Package _package = (Package) Objects.requireNonNull(this.getMetadata(packClassifier, packIdentifier));
-                    _package._childrenRemove((PackageableElement) o);
-                }
-            }
-        }
+        return this.resolver.resolveReference(id);
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataEager.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataEager.java
@@ -84,7 +84,7 @@ public final class MetadataEager implements Metadata
     @Override
     public CoreInstance getEnum(String enumerationName, String enumName)
     {
-        return getMetadata(enumerationName, enumName);
+        return getMetadata(enumerationName, enumerationName + "." + M3Properties.values + "['" + enumName + "']");
     }
 
     @Deprecated
@@ -116,6 +116,11 @@ public final class MetadataEager implements Metadata
     @Override
     public CoreInstance getMetadata(String classifier, String id)
     {
+        // for backward compatibility
+        if (id.startsWith("Root::"))
+        {
+            id = id.substring(6);
+        }
         CoreInstance coreInstance = this.metamodelByClassifier.getMetadata(classifier, id);
         if (coreInstance == null && this.isInTransaction())
         {

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
@@ -121,6 +121,12 @@ public class MetadataLazy implements Metadata
     }
 
     @Override
+    public RichIterable<CoreInstance> getClassifierInstances(String classifier)
+    {
+        return hasClassifier(classifier) ? loadAllClassifierInstances(classifier).valuesView() : Lists.immutable.empty();
+    }
+
+    @Override
     public CoreInstance getEnum(String enumerationName, String enumName)
     {
         if (!hasClassifier(enumerationName))

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
@@ -26,6 +26,7 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.Counter;
 import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
+import org.finos.legend.pure.m3.navigation.M3Properties;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.compiled.generation.JavaPackageAndImportBuilder;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.type.EnumProcessor;
@@ -101,7 +102,16 @@ public class MetadataLazy implements Metadata
     @Override
     public CoreInstance getMetadata(String classifier, String id)
     {
-        return hasClassifier(classifier) ? toJavaObject(classifier, id) : null;
+        if (!hasClassifier(classifier))
+        {
+            return null;
+        }
+        // for backward compatibility
+        if (id.startsWith("Root::"))
+        {
+            id = id.substring(6);
+        }
+        return toJavaObject(classifier, id);
     }
 
     @Override
@@ -118,13 +128,14 @@ public class MetadataLazy implements Metadata
             throw new RuntimeException("Cannot find enum '" + enumName + "' in enumeration '" + enumerationName + "': unknown enumeration");
         }
 
+        String enumId = enumerationName + "." + M3Properties.values + "['" + enumName + "']";
         ConcurrentMutableMap<String, CoreInstance> cache = getClassifierInstanceCache(enumerationName);
-        CoreInstance result = cache.get(enumName);
+        CoreInstance result = cache.get(enumId);
         if (result == null)
         {
             //might not have loaded yet, so request full load and try again:
             loadAllClassifierInstances(enumerationName);
-            result = cache.get(enumName);
+            result = cache.get(enumId);
             if (result == null)
             {
                 StringBuilder builder = new StringBuilder("Cannot find enum '").append(enumName).append("' in enumeration '").append(enumerationName).append("' unknown enum value");

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/serialization/GraphSerializer.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/serialization/GraphSerializer.java
@@ -222,7 +222,7 @@ public class GraphSerializer
             }
             if (Instance.instanceOf(value, M3Paths.Class, m3ProcessorSupport))
             {
-                return metamodel.getMetadata(MetadataJavaPaths.Class, PackageableElement.getSystemPathForPackageableElement(value));
+                return metamodel.getMetadata(MetadataJavaPaths.Class, PackageableElement.getUserPathForPackageableElement(value));
             }
         }
         return value;

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/CompiledMetadataStateVerifier.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/CompiledMetadataStateVerifier.java
@@ -14,40 +14,26 @@
 
 package org.finos.legend.pure.runtime.java.compiled.runtime;
 
-import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
-import org.finos.legend.pure.runtime.java.compiled.execution.CompiledProcessorSupport;
+import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiled;
-import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataEager;
 import org.junit.Assert;
 
 public class CompiledMetadataStateVerifier implements RuntimeVerifier.FunctionExecutionStateVerifier
 {
     private int classCacheSizeBefore;
-    private int metadataCount;
 
     @Override
     public void snapshotState(FunctionExecution functionExecution)
     {
-        FunctionExecutionCompiled functionExecutionCompiled = (FunctionExecutionCompiled)functionExecution;
-
-        MetadataEager metamodel = this.getMetamodel(functionExecutionCompiled);
+        FunctionExecutionCompiled functionExecutionCompiled = (FunctionExecutionCompiled) functionExecution;
         this.classCacheSizeBefore = functionExecutionCompiled.getClassCacheSize();
-        this.metadataCount = metamodel.getSize();
     }
 
     @Override
     public void assertStateSame(FunctionExecution functionExecution)
     {
-        FunctionExecutionCompiled functionExecutionCompiled = (FunctionExecutionCompiled)functionExecution;
-        MetadataEager metamodel = this.getMetamodel(functionExecutionCompiled);
+        FunctionExecutionCompiled functionExecutionCompiled = (FunctionExecutionCompiled) functionExecution;
         Assert.assertEquals(this.classCacheSizeBefore, functionExecutionCompiled.getClassCacheSize());
-        Assert.assertEquals(this.metadataCount, metamodel.getSize());
-    }
-
-    private MetadataEager getMetamodel(FunctionExecutionCompiled functionExecutionCompiled)
-    {
-        CompiledProcessorSupport compiledProcessorSupport = (CompiledProcessorSupport)functionExecutionCompiled.getProcessorSupport();
-        return (MetadataEager)compiledProcessorSupport.getMetadata();
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/TestIdBuilder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/TestIdBuilder.java
@@ -21,7 +21,6 @@ import org.eclipse.collections.api.map.primitive.MutableObjectIntMap;
 import org.eclipse.collections.api.map.primitive.ObjectIntMap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.factory.primitive.ObjectIntMaps;
-import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
@@ -94,31 +93,6 @@ public class TestIdBuilder
             });
             Assert.fail(builder.toString());
         }
-    }
-
-    @Test
-    public void testCustomIdBuilder()
-    {
-        IdBuilder standardIdBuilder = IdBuilder.builder(processorSupport).build();
-        IdBuilder customIdBuilder = IdBuilder.builder(processorSupport)
-                .withIdBuilder(M3Paths.Class, c -> PackageableElement.getSystemPathForPackageableElement(c, "/"))
-                .withIdBuilder(M3Paths.Package, c -> PackageableElement.getSystemPathForPackageableElement(c, "+"))
-                .build();
-
-        // Class (with custom builder)
-        CoreInstance classClass = runtime.getCoreInstance("meta::pure::metamodel::type::Class");
-        Assert.assertEquals("Root::meta::pure::metamodel::type::Class", standardIdBuilder.buildId(classClass));
-        Assert.assertEquals("Root/meta/pure/metamodel/type/Class", customIdBuilder.buildId(classClass));
-
-        // Package (with custom builder)
-        CoreInstance metaPurePackage = runtime.getCoreInstance("meta::pure");
-        Assert.assertEquals("Root::meta::pure", standardIdBuilder.buildId(metaPurePackage));
-        Assert.assertEquals("Root+meta+pure", customIdBuilder.buildId(metaPurePackage));
-
-        // Profile (no custom builder)
-        CoreInstance testProfile = runtime.getCoreInstance("meta::pure::profiles::test");
-        Assert.assertEquals("Root::meta::pure::profiles::test", standardIdBuilder.buildId(testProfile));
-        Assert.assertEquals("Root::meta::pure::profiles::test", customIdBuilder.buildId(testProfile));
     }
 
     private void testIdUniqueness(IdBuilder idBuilder)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/serialization/TestLazyImplClassifiers.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/serialization/TestLazyImplClassifiers.java
@@ -53,7 +53,7 @@ public class TestLazyImplClassifiers extends AbstractPureTestWithCoreCompiled
     public void testLazyMetaDataClassifierPrimitiveType()
     {
         CoreInstance expected = this.metadataLazy.getMetadata("meta::pure::metamodel::type::Class", "meta::pure::metamodel::type::PrimitiveType");
-        MutableList<String> invalidPrimitiveTypes = this.metadataLazy.getMetadata("meta::pure::metamodel::type::PrimitiveType")
+        MutableList<String> invalidPrimitiveTypes = this.metadataLazy.getClassifierInstances("meta::pure::metamodel::type::PrimitiveType")
                 .collectIf(ci -> ci.getClassifier() != expected, CoreInstance::getName, Lists.mutable.empty());
         Assert.assertEquals("primitive types with the wrong classifier", Lists.fixedSize.empty(), invalidPrimitiveTypes);
     }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/serialization/TestLazyImplClassifiers.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/serialization/TestLazyImplClassifiers.java
@@ -52,7 +52,7 @@ public class TestLazyImplClassifiers extends AbstractPureTestWithCoreCompiled
     @Test
     public void testLazyMetaDataClassifierPrimitiveType()
     {
-        CoreInstance expected = this.metadataLazy.getMetadata("meta::pure::metamodel::type::Class", "Root::meta::pure::metamodel::type::PrimitiveType");
+        CoreInstance expected = this.metadataLazy.getMetadata("meta::pure::metamodel::type::Class", "meta::pure::metamodel::type::PrimitiveType");
         MutableList<String> invalidPrimitiveTypes = this.metadataLazy.getMetadata("meta::pure::metamodel::type::PrimitiveType")
                 .collectIf(ci -> ci.getClassifier() != expected, CoreInstance::getName, Lists.mutable.empty());
         Assert.assertEquals("primitive types with the wrong classifier", Lists.fixedSize.empty(), invalidPrimitiveTypes);
@@ -61,8 +61,8 @@ public class TestLazyImplClassifiers extends AbstractPureTestWithCoreCompiled
     @Test
     public void testLazyMetaDataClassifierForClasses()
     {
-        CoreInstance expected = this.metadataLazy.getMetadata("meta::pure::metamodel::type::Class", "Root::meta::pure::metamodel::type::Class");
-        CoreInstance ci = this.metadataLazy.getMetadata("meta::pure::metamodel::type::Class", "Root::meta::pure::metamodel::function::property::Property");
+        CoreInstance expected = this.metadataLazy.getMetadata("meta::pure::metamodel::type::Class", "meta::pure::metamodel::type::Class");
+        CoreInstance ci = this.metadataLazy.getMetadata("meta::pure::metamodel::type::Class", "meta::pure::metamodel::function::property::Property");
         CoreInstance classifier = ci.getClassifier();
         Assert.assertEquals(expected, classifier);
     }
@@ -70,8 +70,8 @@ public class TestLazyImplClassifiers extends AbstractPureTestWithCoreCompiled
     @Test
     public void testLazyMetaDataClassifierForEnums()
     {
-        CoreInstance expected = this.metadataLazy.getMetadata("meta::pure::metamodel::type::Class", "Root::meta::pure::metamodel::type::Enumeration");
-        CoreInstance ci = this.metadataLazy.getMetadata("meta::pure::metamodel::type::Enumeration", "Root::meta::pure::metamodel::function::property::AggregationKind");
+        CoreInstance expected = this.metadataLazy.getMetadata("meta::pure::metamodel::type::Class", "meta::pure::metamodel::type::Enumeration");
+        CoreInstance ci = this.metadataLazy.getMetadata("meta::pure::metamodel::type::Enumeration", "meta::pure::metamodel::function::property::AggregationKind");
         CoreInstance classifier = ci.getClassifier();
         Assert.assertEquals(expected, classifier);
     }


### PR DESCRIPTION
Use new reference ids in generated Java code. Change MetadataEager to lazily index by id to mitigate the effects of larger ids.