### PR TITLE
Support for nulls on primitives when parsing TDS

### DIFF
--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-grammar/src/main/java/org/finos/legend/pure/m2/inlinedsl/tds/TDSExtension.java
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-grammar/src/main/java/org/finos/legend/pure/m2/inlinedsl/tds/TDSExtension.java
@@ -19,6 +19,7 @@ import io.deephaven.csv.parsers.DataType;
 import io.deephaven.csv.reading.CsvReader;
 import io.deephaven.csv.sinks.SinkFactory;
 import io.deephaven.csv.util.CsvReaderException;
+import java.util.Arrays;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.tuple.Pair;
@@ -135,7 +136,7 @@ public class TDSExtension implements InlineDSL
         CsvReader.Result result;
         try
         {
-            result = CsvReader.read(CsvSpecs.csv(), new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)), makeMySinkFactory());
+            result = CsvReader.read(makePureCsvSpecs(), new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)), makePureSinkFactory());
         }
         catch (CsvReaderException e)
         {
@@ -236,17 +237,22 @@ public class TDSExtension implements InlineDSL
         }
     }
 
-    private static SinkFactory makeMySinkFactory()
+    public static CsvSpecs makePureCsvSpecs()
+    {
+        return CsvSpecs.builder().nullValueLiterals(Arrays.asList("", "null")).build();
+    }
+
+    public static SinkFactory makePureSinkFactory()
     {
         return SinkFactory.arrays(
                 null,
                 null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
+                2_147_483_647, //largest prime for 32 signed numbers
+                9_223_372_036_854_775_783L, //largest prime for 64 signed numbers
+                Float.NEGATIVE_INFINITY,
+                Double.NEGATIVE_INFINITY,
+                Byte.MIN_VALUE,
+                Character.MIN_VALUE,
                 null,
                 Long.MIN_VALUE,
                 Long.MIN_VALUE);

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-runtime-java-extension-interpreted-dsl-tds/src/test/java/org/finos/legend/pure/runtime/java/extension/tds/interpeted/TestFunctionTester.java
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-runtime-java-extension-interpreted-dsl-tds/src/test/java/org/finos/legend/pure/runtime/java/extension/tds/interpeted/TestFunctionTester.java
@@ -14,10 +14,15 @@
 
 package org.finos.legend.pure.runtime.java.extension.tds.interpeted;
 
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.TDS;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m3.tests.function.base.PureExpressionTest;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 
 public class TestFunctionTester extends PureExpressionTest
@@ -48,6 +53,18 @@ public class TestFunctionTester extends PureExpressionTest
                                         " meta::pure::metamodel::relation::stringToTDS('a\\n1');" +
                                         "}");
         this.execute("test():Any[*]");
-        runtime.delete("fromString.pure");
+    }
+
+    @org.junit.Test
+    public void testStringToTDSWithEmpty()
+    {
+        compileTestSource("fromString.pure",
+                "function test():Any[*]\n" +
+                        "{" +
+                        " meta::pure::metamodel::relation::stringToTDS('a,b,c\\n2,c,true\\n,,\\nnull,null,null\\n');" +
+                        "}");
+        CoreInstance tdsCoreInstance = this.execute("test():Any[*]");
+        TDS<?> tds = (TDS<?>) tdsCoreInstance.getValueForMetaPropertyToOne(M3Properties.values);
+        Assert.assertEquals("TDS<(a:Integer, b:String, c:Boolean)>", GenericType.print(tds._classifierGenericType(), processorSupport));
     }
 }


### PR DESCRIPTION
Allow primitive types to be null. For int/long, using largest primes as unlikely we would see these on our test cases, rather than using min int/long, as these can be used for testing boundary conditions. 