### PR TITLE
Fix bug when setting type of ColSpec in compiled mode

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/M3Paths.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/M3Paths.java
@@ -39,6 +39,8 @@ public class M3Paths
     public static final String ClassConstraintValueSpecificationContext = "meta::pure::metamodel::valuespecification::ClassConstraintValueSpecificationContext";
     public static final String ClassProjection = "meta::pure::metamodel::type::ClassProjection";
     public static final String Column = "meta::pure::metamodel::relation::Column";
+    public static final String ColSpec = "meta::pure::metamodel::relation::ColSpec";
+    public static final String ColSpecArray = "meta::pure::metamodel::relation::ColSpecArray";
     public static final String ConcreteFunctionDefinition = "meta::pure::metamodel::function::ConcreteFunctionDefinition";
     public static final String Constraint = "meta::pure::metamodel::constraint::Constraint";
     public static final String ConstraintsOverride = "meta::pure::metamodel::type::ConstraintsOverride";

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/CoreHelper.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/CoreHelper.java
@@ -1154,7 +1154,7 @@ public class CoreHelper
     {
         ProcessorSupport processorSupport = ((CompiledExecutionSupport) es).getProcessorSupport();
         MutableList<Column<?,?>> columns = Lists.mutable.withAll(instance._columns());
-        columns.withAll(Lists.mutable.withAll(((RelationType<?>)colSpecArray._classifierGenericType()._rawType())._columns()));
+        columns.withAll(Lists.mutable.withAll(((RelationType<?>)colSpecArray._classifierGenericType()._typeArguments().getFirst()._rawType())._columns()));
         MutableList<? extends CoreInstance> newColumns = columns.collect(c -> _Column.getColumnInstance(c._name(), c._nameWildCard(), _Column.getColumnType(c), _Column.getColumnMultiplicity(c), c.getSourceInformation(), processorSupport)).toList();
         return _RelationType.build(newColumns, null, processorSupport);
     }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/valuespecification/FunctionExpressionProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/valuespecification/FunctionExpressionProcessor.java
@@ -61,7 +61,11 @@ public class FunctionExpressionProcessor
             if (function instanceof PackageableElement && Sets.immutable.with("meta::pure::functions::relation::colSpec_String_1__T_1__ColSpec_1_", "meta::pure::functions::relation::colSpecArray_String_MANY__T_1__ColSpecArray_1_").contains(Pure.elementToPath((PackageableElement) function, "::")))
             {
                 FunctionExpression funcExpression = (FunctionExpression) functionExpression;
-                maySetClassifierGenericType = "._classifierGenericType(" + GenericTypeSerializationInCode.generateGenericTypeBuilder(funcExpression._parametersValues().getLast()._genericType(), processorContext) + ")";
+                String rawType = "meta::pure::functions::relation::colSpecArray_String_MANY__T_1__ColSpecArray_1_".equals(Pure.elementToPath((PackageableElement) function, "::")) ? M3Paths.ColSpecArray : M3Paths.ColSpec;
+                org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType colSpecGenericType = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType) support.newAnonymousCoreInstance(funcExpression._parametersValues().getFirst().getSourceInformation(), M3Paths.GenericType);
+                colSpecGenericType._rawType((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type) processorContext.getSupport().package_getByUserPath(rawType));
+                colSpecGenericType._typeArguments(Lists.mutable.with(funcExpression._parametersValues().getLast()._genericType()));
+                maySetClassifierGenericType = "._classifierGenericType(" + GenericTypeSerializationInCode.generateGenericTypeBuilder(colSpecGenericType, processorContext) + ")";
             }
 
             CoreInstance functionType = support.function_getFunctionType(function);

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/valuespecification/FunctionExpressionProcessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/valuespecification/FunctionExpressionProcessor.java
@@ -58,10 +58,11 @@ public class FunctionExpressionProcessor
         if (support.instance_instanceOf(function, M3Paths.FunctionDefinition) && !Property.isQualifiedProperty(function, support))
         {
             String maySetClassifierGenericType = "";
-            if (function instanceof PackageableElement && Sets.immutable.with("meta::pure::functions::relation::colSpec_String_1__T_1__ColSpec_1_", "meta::pure::functions::relation::colSpecArray_String_MANY__T_1__ColSpecArray_1_").contains(Pure.elementToPath((PackageableElement) function, "::")))
+            String functionName = (function instanceof PackageableElement) ? Pure.elementToPath((PackageableElement) function, "::") : "";
+            if (function instanceof PackageableElement && Sets.immutable.with("meta::pure::functions::relation::colSpec_String_1__T_1__ColSpec_1_", "meta::pure::functions::relation::colSpecArray_String_MANY__T_1__ColSpecArray_1_").contains(functionName))
             {
                 FunctionExpression funcExpression = (FunctionExpression) functionExpression;
-                String rawType = "meta::pure::functions::relation::colSpecArray_String_MANY__T_1__ColSpecArray_1_".equals(Pure.elementToPath((PackageableElement) function, "::")) ? M3Paths.ColSpecArray : M3Paths.ColSpec;
+                String rawType = "meta::pure::functions::relation::colSpecArray_String_MANY__T_1__ColSpecArray_1_".equals(functionName) ? M3Paths.ColSpecArray : M3Paths.ColSpec;
                 org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType colSpecGenericType = (org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType) support.newAnonymousCoreInstance(funcExpression._parametersValues().getFirst().getSourceInformation(), M3Paths.GenericType);
                 colSpecGenericType._rawType((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type) processorContext.getSupport().package_getByUserPath(rawType));
                 colSpecGenericType._typeArguments(Lists.mutable.with(funcExpression._parametersValues().getLast()._genericType()));

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/relation/TestColSpecType.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/function/base/relation/TestColSpecType.java
@@ -1,0 +1,84 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.base.relation;
+
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
+import org.finos.legend.pure.runtime.java.compiled.execution.FunctionExecutionCompiledBuilder;
+import org.finos.legend.pure.runtime.java.compiled.factory.JavaModelFactoryRegistryLoader;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestColSpecType extends AbstractPureTestWithCoreCompiled
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        setUpRuntime(new FunctionExecutionCompiledBuilder().build(), JavaModelFactoryRegistryLoader.loader());
+    }
+
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete("testSource.pure");
+        runtime.compile();
+    }
+
+    @Test
+    public void testGenericTypeSetCorrectlyOnColSpec()
+    {
+        compileTestSource("testSource.pure",
+                "function go():Any[*]\n" +
+                        "{\n" +
+                        "   let type = getRelation()->testColSpecType(~id);\n" +
+                        "   assertEquals('ColSpec', $type.rawType.name);\n" +
+                        "   assertEquals('id', $type.typeArguments->at(0).rawType->toOne()->cast(@meta::pure::metamodel::relation::RelationType<Any>).columns->toOne().name);\n" +
+                        "}\n" +
+                        "function getRelation():meta::pure::metamodel::relation::Relation<(id:Number[1], code:Number[1])>[0..1]\n" +
+                        "{\n" +
+                        "   [];\n" +
+                        "}" +
+                        "function testColSpecType<T,Z>(rel: meta::pure::metamodel::relation::Relation<T>[0..1], col:meta::pure::metamodel::relation::ColSpec<Z⊆T>[1]) : GenericType[1]\n" +
+                        "{\n" +
+                        "   $col->genericType();\n" +
+                        "}\n" +
+                        "\n"
+        );
+        execute("go():Any[*]");
+    }
+
+    @Test
+    public void testGenericTypeSetCorrectlyOnColSpecArray()
+    {
+        compileTestSource("testSource.pure",
+                "function go():Any[*]\n" +
+                        "{\n" +
+                        "   let type = getRelation()->testColSpecType(~[id,code]);\n" +
+                        "   assertEquals('ColSpecArray', $type.rawType.name);\n" +
+                        "   assertEquals(['id', 'code'], $type.typeArguments->at(0).rawType->toOne()->cast(@meta::pure::metamodel::relation::RelationType<Any>).columns.name);\n" +
+                        "}\n" +
+                        "function getRelation():meta::pure::metamodel::relation::Relation<(id:Number[1], code:Number[1])>[0..1]\n" +
+                        "{\n" +
+                        "   [];\n" +
+                        "}" +
+                        "function testColSpecType<T,Z>(rel: meta::pure::metamodel::relation::Relation<T>[0..1], col:meta::pure::metamodel::relation::ColSpecArray<Z⊆T>[1]) : GenericType[1]\n" +
+                        "{\n" +
+                        "   $col->genericType();\n" +
+                        "}\n" +
+                        "\n"
+        );
+        execute("go():Any[*]");
+    }
+}


### PR DESCRIPTION
In compiled mode the type of ColSpec was being set incorrectly as RelationType instead of setting the type as ColSpec with a type parameter that is of type RelationType