### PR TITLE
Move to default waitUntil config for central-maven-publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,6 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Move to default waitUntil config for central-maven-publishing