### PR TITLE
Improve compiled mode generation for pureEquals and pureHashCode

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/_class/_Class.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/_class/_Class.java
@@ -36,6 +36,8 @@ import org.finos.legend.pure.m3.navigation.type.Type;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.tools.SafeAppendable;
 
+import java.util.Collection;
+
 public class _Class
 {
     public static final String KEY_STEREOTYPE = "Key";
@@ -103,9 +105,14 @@ public class _Class
 
     public static ListIterable<CoreInstance> getEqualityKeyProperties(CoreInstance classifier, ProcessorSupport processorSupport)
     {
+        return collectEqualityKeyProperties(classifier, processorSupport, Lists.mutable.empty());
+    }
+
+    public static <T extends Collection<CoreInstance>> T collectEqualityKeyProperties(CoreInstance classifier, ProcessorSupport processorSupport, T target)
+    {
         CoreInstance profile = processorSupport.package_getByUserPath(M3Paths.equality);
         CoreInstance stereotype = Profile.findStereotype(profile, KEY_STEREOTYPE);
-        return processorSupport.class_getSimpleProperties(classifier).select(p -> hasStereotype(p, stereotype, processorSupport), Lists.mutable.empty());
+        return processorSupport.class_getSimpleProperties(classifier).select(p -> hasStereotype(p, stereotype, processorSupport), target);
     }
 
     private static boolean hasStereotype(CoreInstance property, CoreInstance stereotype, ProcessorSupport processorSupport)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/AbstractCompiledCoreInstance.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/AbstractCompiledCoreInstance.java
@@ -131,14 +131,4 @@ public abstract class AbstractCompiledCoreInstance extends AbstractCoreInstance 
         }
         return result;
     }
-
-    public ListIterable<String> getDefaultValueKeys()
-    {
-        return Lists.immutable.empty();
-    }
-
-    public RichIterable<?> getDefaultValue(String property, ExecutionSupport es)
-    {
-        return Lists.immutable.empty();
-    }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/JavaCompiledCoreInstance.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/coreinstance/JavaCompiledCoreInstance.java
@@ -14,6 +14,10 @@
 
 package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.coreinstance;
 
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ListIterable;
+import org.finos.legend.pure.m3.execution.ExecutionSupport;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
 /**
@@ -26,4 +30,14 @@ public interface JavaCompiledCoreInstance extends CoreInstance
     boolean pureEquals(Object obj);
 
     int pureHashCode();
+
+    default ListIterable<String> getDefaultValueKeys()
+    {
+        return Lists.immutable.empty();
+    }
+
+    default RichIterable<?> getDefaultValue(String property, ExecutionSupport es)
+    {
+        return Lists.immutable.empty();
+    }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/resources/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/core/CoreGen.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/resources/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/core/CoreGen.java
@@ -46,8 +46,8 @@ import org.finos.legend.pure.runtime.java.compiled.generation.processors.support
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.CompiledSupport;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.LambdaCompiledExtended;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.Pure;
-import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.coreinstance.AbstractCompiledCoreInstance;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.coreinstance.GetterOverrideExecutor;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.coreinstance.JavaCompiledCoreInstance;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.coreinstance.QuantityCoreInstance;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.PureFunction2;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.function.PureFunction2Wrapper;
@@ -209,7 +209,7 @@ public class CoreGen extends CoreHelper
             result.add(kv);
             keys.add(kv._key());
         }
-        AbstractCompiledCoreInstance coreInstance = (AbstractCompiledCoreInstance) instance;
+        JavaCompiledCoreInstance coreInstance = (JavaCompiledCoreInstance) instance;
         for (String key : coreInstance.getDefaultValueKeys())
         {
             if (!keys.contains(key))


### PR DESCRIPTION
Improve compiled mode generation for pureEquals and pureHashCode. In particular, sort the properties to ensure a deterministic order when there are multiple equality key properties.

Also, promote getDefaultValueKeys and getDefaultValue to JavaCompiledCoreInstance.