### PR TITLE
Visibility check and inference fixes

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/valuespecification/FunctionExpressionProcessor.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/valuespecification/FunctionExpressionProcessor.java
@@ -388,7 +388,7 @@ public class FunctionExpressionProcessor extends Processor<FunctionExpression>
             }
             else
             {
-                ctx.register((GenericType) processorSupport.function_getFunctionType(foundFunction).getValueForMetaPropertyToMany("parameters").get(1).getValueForMetaPropertyToOne("genericType"), (GenericType) processorSupport.type_wrapGenericType(_RelationType.build(found.collect(foundC -> _Column.getColumnInstance(foundC._name(), false, _Column.getColumnType(foundC), _Column.getColumnMultiplicity(foundC), functionExpression.getSourceInformation(), processorSupport)), null, processorSupport)), ctx, observer);
+                ctx.register((GenericType) processorSupport.function_getFunctionType(foundFunction).getValueForMetaPropertyToMany("parameters").get(1).getValueForMetaPropertyToOne("genericType"), (GenericType) processorSupport.type_wrapGenericType(_RelationType.build(found.collect(foundC -> _Column.getColumnInstance(foundC._name(), false, _Column.getColumnType(foundC), _Column.getColumnMultiplicity(foundC), functionExpression.getSourceInformation(), processorSupport)), functionExpression.getSourceInformation(), processorSupport)), ctx, observer);
                 columnTypeInferenceSuccess = true;
             }
         }
@@ -445,7 +445,7 @@ public class FunctionExpressionProcessor extends Processor<FunctionExpression>
             }
             else
             {
-                ctx.register((GenericType) processorSupport.function_getFunctionType(foundFunction).getValueForMetaPropertyToMany("parameters").get(1).getValueForMetaPropertyToOne("genericType"), (GenericType) processorSupport.type_wrapGenericType(_RelationType.build(found.collect(foundC -> _Column.getColumnInstance(foundC._name(), false, _Column.getColumnType(foundC), _Column.getColumnMultiplicity(foundC), functionExpression.getSourceInformation(), processorSupport)), null, processorSupport)), ctx, observer);
+                ctx.register((GenericType) processorSupport.function_getFunctionType(foundFunction).getValueForMetaPropertyToMany("parameters").get(1).getValueForMetaPropertyToOne("genericType"), (GenericType) processorSupport.type_wrapGenericType(_RelationType.build(found.collect(foundC -> _Column.getColumnInstance(foundC._name(), false, _Column.getColumnType(foundC), _Column.getColumnMultiplicity(foundC), functionExpression.getSourceInformation(), processorSupport)), functionExpression.getSourceInformation(), processorSupport)), ctx, observer);
                 columnTypeInferenceSuccess = true;
             }
         }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/valuespecification/FunctionExpressionProcessor.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/valuespecification/FunctionExpressionProcessor.java
@@ -661,6 +661,8 @@ public class FunctionExpressionProcessor extends Processor<FunctionExpression>
                 handleTypeArgumentTypeInference(templateTypeArgument, concreteTypeArgument, observer, state);
             }
         });
+
+        // TODO handle when the template is Relation or Function type
     }
 
     private static boolean processEmptyColumnType(GenericType templateGenericType, ValueSpecification instance, ListIterable<? extends VariableExpression> paramsType, int z, SourceInformation sourceInformation, TypeInferenceObserver observer, ProcessorState state, ProcessorSupport processorSupport)

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/valuespecification/FunctionExpressionProcessor.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/postprocessing/processor/valuespecification/FunctionExpressionProcessor.java
@@ -616,7 +616,7 @@ public class FunctionExpressionProcessor extends Processor<FunctionExpression>
                                 TypeInferenceContext typeInferenceContext = state.getTypeInferenceContext();
                                 typeInferenceContext.register(templateReturnType, concreteGenericType, typeInferenceContext.getParent(), observer);
                             }
-                            else if (concreteGenericType != null)// type arguments might not be concreate
+                            else if (concreteGenericType != null)// type arguments might not be concrete
                             {
                                 handleTypeArgumentTypeInference(templateReturnType, concreteGenericType, observer, state);
                             }
@@ -650,15 +650,15 @@ public class FunctionExpressionProcessor extends Processor<FunctionExpression>
         templateReturnType._typeArguments().zip(concreteGenericType._typeArguments()).forEach(args ->
         {
             GenericType templateTypeArgument = args.getOne();
-            GenericType concreateTypeArgument = args.getTwo();
+            GenericType concreteTypeArgument = args.getTwo();
 
             if (!org.finos.legend.pure.m3.navigation.generictype.GenericType.isGenericTypeConcrete(templateTypeArgument))
             {
-                typeInferenceContext.register(templateTypeArgument, concreateTypeArgument, typeInferenceContext.getParent(), observer);
+                typeInferenceContext.register(templateTypeArgument, concreteTypeArgument, typeInferenceContext.getParent(), observer);
             }
-            else if (concreateTypeArgument != null)
+            else if (concreteTypeArgument != null)
             {
-                handleTypeArgumentTypeInference(templateTypeArgument, concreateTypeArgument, observer, state);
+                handleTypeArgumentTypeInference(templateTypeArgument, concreteTypeArgument, observer, state);
             }
         });
     }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/generictype/GenericType.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/generictype/GenericType.java
@@ -157,7 +157,7 @@ public class GenericType
                                     processorSupport
                             ),
                     Lists.mutable.empty()
-            ), null, processorSupport));
+            ), rel.getSourceInformation(), processorSupport));
         }
 
         if (FunctionType.isFunctionType(Instance.getValueForMetaPropertyToOneResolved(typeArgument, M3Properties.rawType, processorSupport), processorSupport))

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/shared/PCTTools.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/shared/PCTTools.java
@@ -113,8 +113,9 @@ public class PCTTools
     private static String cleanMessage(String message)
     {
         message = checkNullMessage(message);
-        boolean shouldCut = message.contains("Execution error at ") || message.contains("Assert failure at ");
-        message = shouldCut ? message.substring(message.indexOf("\"")) : message;
+        int quotes = message.indexOf("\"");
+        boolean shouldCut = quotes > -1 && (message.contains("Execution error at ") || message.contains("Assert failure at "));
+        message = shouldCut ? message.substring(quotes) : message;
         return message.replace("\"", "\\\"").replace("\n", "\\n");
     }
 

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-grammar/src/main/java/org/finos/legend/pure/m2/inlinedsl/tds/TDSExtension.java
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-grammar/src/main/java/org/finos/legend/pure/m2/inlinedsl/tds/TDSExtension.java
@@ -121,11 +121,6 @@ public class TDSExtension implements InlineDSL
         return null;
     }
 
-    public static TDS<?> parse(String text, ProcessorSupport processorSupport)
-    {
-        return parse(text, (SourceInformation) null, processorSupport);
-    }
-
     public static TDS<?> parse(String text, String fileName, ProcessorSupport processorSupport)
     {
         return parse(text, (fileName == null) ? null : getSourceInfo(text, fileName, 0, 0), processorSupport);

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-runtime-java-extension-compiled-dsl-tds/src/main/java/org/finos/legend/pure/runtime/java/extension/dsl/tds/compiled/TDSNativeImplementation.java
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-runtime-java-extension-compiled-dsl-tds/src/main/java/org/finos/legend/pure/runtime/java/extension/dsl/tds/compiled/TDSNativeImplementation.java
@@ -17,12 +17,13 @@ package org.finos.legend.pure.runtime.java.extension.dsl.tds.compiled;
 import org.finos.legend.pure.m2.inlinedsl.tds.TDSExtension;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.TDS;
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 import org.finos.legend.pure.runtime.java.compiled.execution.CompiledExecutionSupport;
 
 public class TDSNativeImplementation
 {
-    public static TDS<?> parse(String tdsString, ExecutionSupport compiledExecutionSupport)
+    public static TDS<?> parse(String tdsString, SourceInformation sourceInformation, ExecutionSupport compiledExecutionSupport)
     {
-        return TDSExtension.parse(tdsString, ((CompiledExecutionSupport) compiledExecutionSupport).getProcessorSupport());
+        return TDSExtension.parse(tdsString, sourceInformation, ((CompiledExecutionSupport) compiledExecutionSupport).getProcessorSupport());
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-runtime-java-extension-compiled-dsl-tds/src/main/java/org/finos/legend/pure/runtime/java/extension/dsl/tds/compiled/natives/StringToTDS.java
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-runtime-java-extension-compiled-dsl-tds/src/main/java/org/finos/legend/pure/runtime/java/extension/dsl/tds/compiled/natives/StringToTDS.java
@@ -15,12 +15,13 @@
 package org.finos.legend.pure.runtime.java.extension.dsl.tds.compiled.natives;
 
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.AbstractNativeFunctionGeneric;
 
 public class StringToTDS extends AbstractNativeFunctionGeneric
 {
     public StringToTDS()
     {
-        super("org.finos.legend.pure.runtime.java.extension.dsl.tds.compiled.TDSNativeImplementation.parse", new Class[]{String.class, ExecutionSupport.class}, false, true, false, "stringToTDS_String_1__TDS_1_");
+        super("org.finos.legend.pure.runtime.java.extension.dsl.tds.compiled.TDSNativeImplementation.parse", new Class[]{String.class, SourceInformation.class, ExecutionSupport.class}, true, true, false, "stringToTDS_String_1__TDS_1_");
     }
 }

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-runtime-java-extension-interpreted-dsl-tds/src/main/java/org/finos/legend/pure/runtime/java/extension/dsl/tds/interpreted/natives/StringToTDS.java
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-runtime-java-extension-interpreted-dsl-tds/src/main/java/org/finos/legend/pure/runtime/java/extension/dsl/tds/interpreted/natives/StringToTDS.java
@@ -45,6 +45,6 @@ public class StringToTDS extends NativeFunction
     public CoreInstance execute(ListIterable<? extends CoreInstance> params, Stack<MutableMap<String, CoreInstance>> resolvedTypeParameters, Stack<MutableMap<String, CoreInstance>> resolvedMultiplicityParameters, VariableContext variableContext, MutableStack<CoreInstance> functionExpressionCallStack, Profiler profiler, InstantiationContext instantiationContext, ExecutionSupport executionSupport, Context context, ProcessorSupport processorSupport) throws PureExecutionException
     {
         String tdsString = params.get(0).getValueForMetaPropertyToOne("values").getName();
-        return ValueSpecificationBootstrap.wrapValueSpecification(TDSExtension.parse(tdsString, processorSupport), false, processorSupport);
+        return ValueSpecificationBootstrap.wrapValueSpecification(TDSExtension.parse(tdsString, functionExpressionCallStack.peek().getSourceInformation(), processorSupport), false, processorSupport);
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/CoreHelper.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/CoreHelper.java
@@ -1156,6 +1156,6 @@ public class CoreHelper
         MutableList<Column<?,?>> columns = Lists.mutable.withAll(instance._columns());
         columns.withAll(Lists.mutable.withAll(((RelationType<?>)colSpecArray._classifierGenericType()._typeArguments().getFirst()._rawType())._columns()));
         MutableList<? extends CoreInstance> newColumns = columns.collect(c -> _Column.getColumnInstance(c._name(), c._nameWildCard(), _Column.getColumnType(c), _Column.getColumnMultiplicity(c), c.getSourceInformation(), processorSupport)).toList();
-        return _RelationType.build(newColumns, null, processorSupport);
+        return _RelationType.build(newColumns, colSpecArray.getSourceInformation(), processorSupport);
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/essentials/meta/type/relation/AddColumns.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/essentials/meta/type/relation/AddColumns.java
@@ -47,7 +47,7 @@ public class AddColumns extends NativeFunction
         MutableList<Column<?,?>> columns = Lists.mutable.withAll(((RelationType<?>) Instance.getValueForMetaPropertyToOneResolved(params.get(0), M3Properties.values, processorSupport))._columns());
         columns.withAll(Lists.mutable.withAll(((RelationType<?>)((ColSpecArrayInstance)((InstanceValueInstance)params.get(1))._values().getFirst())._classifierGenericType()._typeArguments().getFirst()._rawType())._columns()));
         MutableList<? extends CoreInstance> newColumns = columns.collect(c -> _Column.getColumnInstance(c._name(), c._nameWildCard(), _Column.getColumnType(c), _Column.getColumnMultiplicity(c), c.getSourceInformation(), processorSupport)).toList();
-        return ValueSpecificationBootstrap.wrapValueSpecification(_RelationType.build(newColumns, null, processorSupport), true, processorSupport);
+        return ValueSpecificationBootstrap.wrapValueSpecification(_RelationType.build(newColumns, functionExpressionCallStack.peek().getSourceInformation(), processorSupport), true, processorSupport);
     }
 }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/variant/AbstractTo.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/variant/AbstractTo.java
@@ -71,7 +71,7 @@ public abstract class AbstractTo extends NativeFunction
 
         if (targetRawType == processorSupport.package_getByUserPath(M3Paths.Variant))
         {
-            return VariantInstanceImpl.newVariant(jsonNode, this.repository, processorSupport);
+            return VariantInstanceImpl.newVariant(jsonNode, functionExpressionCallStack.peek().getSourceInformation(), processorSupport);
         }
 
         if (jsonNode.isNull())

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/variant/FromJson.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/variant/FromJson.java
@@ -44,6 +44,6 @@ public class FromJson extends NativeFunction
     public CoreInstance execute(ListIterable<? extends CoreInstance> params, Stack<MutableMap<String, CoreInstance>> resolvedTypeParameters, Stack<MutableMap<String, CoreInstance>> resolvedMultiplicityParameters, VariableContext variableContext, MutableStack<CoreInstance> functionExpressionCallStack, Profiler profiler, InstantiationContext instantiationContext, ExecutionSupport executionSupport, Context context, ProcessorSupport processorSupport) throws PureExecutionException
     {
         String json = PrimitiveUtilities.getStringValue(Instance.getValueForMetaPropertyToOneResolved(params.get(0), M3Properties.values, processorSupport));
-        return ValueSpecificationBootstrap.wrapValueSpecification(VariantInstanceImpl.newVariant(json, this.repository, processorSupport), true, processorSupport);
+        return ValueSpecificationBootstrap.wrapValueSpecification(VariantInstanceImpl.newVariant(json, functionExpressionCallStack.peek().getSourceInformation(), processorSupport), true, processorSupport);
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/variant/ToVariant.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/variant/ToVariant.java
@@ -46,7 +46,6 @@ public class ToVariant extends NativeFunction
         this.repository = repository;
     }
 
-
     @Override
     public CoreInstance execute(ListIterable<? extends CoreInstance> params, Stack<MutableMap<String, CoreInstance>> resolvedTypeParameters, Stack<MutableMap<String, CoreInstance>> resolvedMultiplicityParameters, VariableContext variableContext, MutableStack<CoreInstance> functionExpressionCallStack, Profiler profiler, InstantiationContext instantiationContext, ExecutionSupport executionSupport, Context context, ProcessorSupport processorSupport) throws PureExecutionException
     {
@@ -56,18 +55,18 @@ public class ToVariant extends NativeFunction
 
         if (values.isEmpty())
         {
-            variantInstance = VariantInstanceImpl.newVariant(VariantInstanceImpl.OBJECT_MAPPER.nullNode(), this.repository, processorSupport);
+            variantInstance = VariantInstanceImpl.newVariant(VariantInstanceImpl.OBJECT_MAPPER.nullNode(), functionExpressionCallStack.peek().getSourceInformation(), processorSupport);
         }
         else if (values.size() == 1)
         {
             JsonNode json = this.coreInstanceToJson(values.get(0), processorSupport);
-            variantInstance = VariantInstanceImpl.newVariant(json, this.repository, processorSupport);
+            variantInstance = VariantInstanceImpl.newVariant(json, functionExpressionCallStack.peek().getSourceInformation(), processorSupport);
         }
         else
         {
             ArrayNode arrayNode = VariantInstanceImpl.OBJECT_MAPPER.createArrayNode();
             values.forEach(x -> arrayNode.add(this.coreInstanceToJson(x, processorSupport)));
-            variantInstance = VariantInstanceImpl.newVariant(arrayNode, this.repository, processorSupport);
+            variantInstance = VariantInstanceImpl.newVariant(arrayNode, functionExpressionCallStack.peek().getSourceInformation(), processorSupport);
         }
 
         return ValueSpecificationBootstrap.wrapValueSpecification(variantInstance, true, processorSupport);

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-shared/src/main/java/org/finos/legend/pure/runtime/java/shared/variant/VariantInstanceImpl.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-shared/src/main/java/org/finos/legend/pure/runtime/java/shared/variant/VariantInstanceImpl.java
@@ -43,6 +43,12 @@ public class VariantInstanceImpl extends VariantCoreInstanceWrapper
     }
 
     @Override
+    public String getName()
+    {
+        return this.jsonNode.toString();
+    }
+
+    @Override
     public Variant copy()
     {
         return new VariantInstanceImpl(this.jsonNode.deepCopy(), ((Variant) this.instance).copy());

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-shared/src/main/java/org/finos/legend/pure/runtime/java/shared/variant/VariantInstanceImpl.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-shared/src/main/java/org/finos/legend/pure/runtime/java/shared/variant/VariantInstanceImpl.java
@@ -43,9 +43,9 @@ public class VariantInstanceImpl extends VariantCoreInstanceWrapper
     }
 
     @Override
-    public String getName()
+    public String toString()
     {
-        return this.jsonNode.toString();
+        return super.getName();
     }
 
     @Override

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-shared/src/main/java/org/finos/legend/pure/runtime/java/shared/variant/VariantInstanceImpl.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-shared/src/main/java/org/finos/legend/pure/runtime/java/shared/variant/VariantInstanceImpl.java
@@ -19,27 +19,33 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Objects;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.variant.VariantInstance;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.variant.Variant;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.variant.VariantCoreInstanceWrapper;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
-import org.finos.legend.pure.m4.ModelRepository;
-import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
 
-public class VariantInstanceImpl extends VariantInstance
+public class VariantInstanceImpl extends VariantCoreInstanceWrapper
 {
     public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final JsonNode jsonNode;
 
-    private VariantInstanceImpl(JsonNode jsonNode, CoreInstance classifier, ModelRepository repository)
+    private VariantInstanceImpl(JsonNode jsonNode, Variant wrapped)
     {
-        super(jsonNode.toString(), null, classifier, -1, repository, false);
+        super(wrapped);
         this.jsonNode = jsonNode;
     }
 
     public JsonNode getJsonNode()
     {
         return this.jsonNode;
+    }
+
+    @Override
+    public Variant copy()
+    {
+        return new VariantInstanceImpl(this.jsonNode.deepCopy(), ((Variant) this.instance).copy());
     }
 
     @Override
@@ -67,12 +73,12 @@ public class VariantInstanceImpl extends VariantInstance
         return Objects.hash(super.hashCode(), this.getName());
     }
 
-    public static VariantInstanceImpl newVariant(String json, ModelRepository modelRepository, ProcessorSupport processorSupport)
+    public static VariantInstanceImpl newVariant(String json, SourceInformation sourceInformation, ProcessorSupport processorSupport)
     {
         try
         {
             JsonNode parsed = OBJECT_MAPPER.readTree(json);
-            return newVariant(parsed, modelRepository, processorSupport);
+            return newVariant(parsed, sourceInformation, processorSupport);
         }
         catch (IOException e)
         {
@@ -80,8 +86,9 @@ public class VariantInstanceImpl extends VariantInstance
         }
     }
 
-    public static VariantInstanceImpl newVariant(JsonNode node, ModelRepository modelRepository, ProcessorSupport processorSupport)
+    public static VariantInstanceImpl newVariant(JsonNode node, SourceInformation sourceInformation, ProcessorSupport processorSupport)
     {
-        return new VariantInstanceImpl(node, processorSupport.package_getByUserPath(M3Paths.Variant), modelRepository);
+        Variant variant = (Variant) processorSupport.newCoreInstance(node.toString(), M3Paths.Variant, sourceInformation);
+        return new VariantInstanceImpl(node, variant);
     }
 }


### PR DESCRIPTION
These PR fixes and improve multiple miscellaneous areas:

- Improve type inference by recursively looking into Lambda return types.  For example, `V` will be inferred from the function parameter by recursively traverse the function return type:  `pkg::<V>testFunc(f: Function<{->List<Pair<String, V>>[1]}>[1]):Any[1]` 
- Ensure source information is assigned on RelationType instances, as its required for some visibility checks.
- Variant to use process support instance factory in shared code to ensure interpreted vs compile behavior is respected.  
- PCTTool - avoid index out of bounds when substring'ing.  
