### PR TITLE
Add rem and mod documentation

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/operation/mod.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/operation/mod.pure
@@ -14,7 +14,7 @@
 
 import meta::pure::test::pct::*;
 
-native function <<PCT.function>> meta::pure::functions::math::mod(dividend:Integer[1], divisor:Integer[1]):Integer[1];
+native function <<PCT.function>> {doc.doc='Compute the modulo as defined mathematically.  The result is never negative.  This is different from the % operation on computer languages, where for negative inputs it will return negative numbers.  For that operation in Pure, please see the function reminder - rem()'} meta::pure::functions::math::mod(dividend:Integer[1], divisor:Integer[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::mod::testMod<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/operation/rem.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/operation/rem.pure
@@ -14,7 +14,7 @@
 
 import meta::pure::test::pct::*;
 
-native function <<PCT.function>> meta::pure::functions::math::rem(dividend:Number[1], divisor:Number[1]):Number[1];
+native function <<PCT.function>> {doc.doc='This is equivalent to what other computer languages refer to modulo and usually leverage the % operand.'} meta::pure::functions::math::rem(dividend:Number[1], divisor:Number[1]):Number[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::rem::testRem<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {


### PR DESCRIPTION
These two functions can behave the same when both inputs are positive, but they differ when one is negative.  Adding some docs to help users understand the difference, as it could be intuitive to think `mod` is equivalent to `%` when in reality `rem` is the equivalent function.