### PR TITLE
Change required dependency resolution scope for PureCompilerMojo

### DIFF
--- a/legend-pure-maven/legend-pure-maven-compiler/src/main/java/org/finos/legend/pure/maven/compiler/PureCompilerMojo.java
+++ b/legend-pure-maven/legend-pure-maven-compiler/src/main/java/org/finos/legend/pure/maven/compiler/PureCompilerMojo.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
 
 @Mojo(name = "compile-pure",
         defaultPhase = LifecyclePhase.COMPILE,
-        requiresDependencyResolution = ResolutionScope.COMPILE,
+        requiresDependencyResolution = ResolutionScope.TEST,
         threadSafe = true)
 public class PureCompilerMojo extends AbstractMojo
 {


### PR DESCRIPTION
Change required dependency resolution scope for PureCompilerMojo from compile to test. This is necessary in case "test "is given for the dependencyScope parameter.