### PR TITLE
Created mojo to execute M3CoreInstanceGenerator

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/generator/bootstrap/M3CoreInstanceGenerator.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/generator/bootstrap/M3CoreInstanceGenerator.java
@@ -49,9 +49,14 @@ public class M3CoreInstanceGenerator
         String fileNameStartsWith = args.length >= 4 ? args[3] : null;
 
         SetIterable<String> filePaths = fileNameStr == null ? Sets.immutable.empty() : Sets.mutable.with(fileNameStr.split("\\s*+,\\s*+"));
+        generate(outputDir, factoryNamePrefix, filePaths, fileNameStartsWith);
+    }
+
+    public static void generate(String outputDir, String factoryNamePrefix, SetIterable<String> filePaths, String fileNameStartsWith)
+    {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         RichIterable<CodeRepository> repositories = CodeRepositorySet.newBuilder().withCodeRepositories(CodeRepositoryProviderHelper.findCodeRepositories(classLoader, true)).build().getRepositories();
-        PureRuntime runtime = new PureRuntimeBuilder(new CompositeCodeStorage(new ClassLoaderCodeStorage(repositories))).setTransactionalByDefault(false).build();
+        PureRuntime runtime = new PureRuntimeBuilder(new CompositeCodeStorage(new ClassLoaderCodeStorage(classLoader, repositories))).setTransactionalByDefault(false).build();
 
         ModelRepository repository = runtime.getModelRepository();
         runtime.loadAndCompileCore();

--- a/legend-pure-maven/legend-pure-maven-generation-platform-java/pom.xml
+++ b/legend-pure-maven/legend-pure-maven-generation-platform-java/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.finos.legend.pure</groupId>
+        <artifactId>legend-pure-maven</artifactId>
+        <version>5.59.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>legend-pure-maven-generation-platform-java</artifactId>
+    <packaging>maven-plugin</packaging>
+    <name>Legend Pure - Maven - Plugin Generation Platform Java</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/legend-pure-maven/legend-pure-maven-generation-platform-java/src/main/java/org/finos/legend/pure/maven/platform/java/M3CoreInstanceGeneratorMojo.java
+++ b/legend-pure-maven/legend-pure-maven-generation-platform-java/src/main/java/org/finos/legend/pure/maven/platform/java/M3CoreInstanceGeneratorMojo.java
@@ -1,0 +1,183 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.maven.platform.java;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.Sets;
+import org.eclipse.collections.impl.set.mutable.SetAdapter;
+import org.finos.legend.pure.m3.generator.bootstrap.M3CoreInstanceGenerator;
+import org.finos.legend.pure.m3.generator.par.Log;
+
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Stream;
+
+@Mojo(name = "generate-m3-core-instances",
+        defaultPhase = LifecyclePhase.COMPILE,
+        requiresDependencyResolution = ResolutionScope.TEST,
+        threadSafe = true)
+public class M3CoreInstanceGeneratorMojo extends AbstractMojo
+{
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    protected MavenProject project;
+
+    @Parameter(defaultValue = "false")
+    private boolean skip;
+
+    @Parameter(property = "outputDir", required = true)
+    private String outputDir;
+
+    @Parameter(property = "factoryNamePrefix", required = true)
+    private String factoryNamePrefix;
+
+    @Parameter(property = "fileNameSet", required = true)
+    private Set<String> fileNameSet;
+
+    @Parameter(property = "fileNameStartsWith")
+    private String fileNameStartsWith;
+
+    @Parameter(defaultValue = "compile")
+    private String dependencyScope;
+
+    @Override
+    public void execute() throws MojoExecutionException
+    {
+        Log log = new Log()
+        {
+            @Override
+            public void info(String txt)
+            {
+                getLog().info(txt);
+            }
+
+            @Override
+            public void error(String txt, Exception e)
+            {
+                getLog().error(txt, e);
+            }
+
+        };
+
+        if (skip)
+        {
+            log.info("    Skipping M3 core instance generation");
+            return;
+        }
+        ClassLoader savedClassLoader = Thread.currentThread().getContextClassLoader();
+        try
+        {
+            Thread.currentThread().setContextClassLoader(buildClassLoader(savedClassLoader, log));
+            M3CoreInstanceGenerator.generate(outputDir, factoryNamePrefix, SetAdapter.adapt(fileNameSet), fileNameStartsWith);
+        }
+        catch (Exception e)
+        {
+            log.error("    Failed to generate M3 core instances", e);
+            throw new MojoExecutionException("Failed to generate M3 core instances", e);
+        }
+        finally
+        {
+            Thread.currentThread().setContextClassLoader(savedClassLoader);
+        }
+    }
+
+    private ClassLoader buildClassLoader(ClassLoader parent, Log log) throws MojoExecutionException
+    {
+        MutableList<String> classpathElements = Lists.mutable.empty();
+
+        classpathElements.add(this.project.getBuild().getOutputDirectory());
+
+        URL[] urlsForClassLoader = classpathElements.collect(mavenCompilePath ->
+        {
+            try
+            {
+                return Paths.get(mavenCompilePath).toUri().toURL();
+            }
+            catch (MalformedURLException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }).toArray(new URL[0]);
+        URL[] combinedURLs = Stream.concat(Arrays.stream(urlsForClassLoader), Arrays.stream(getDependencyURLs()))
+                .toArray(URL[]::new);
+        log.info("    Project classLoader URLs " + Arrays.toString(combinedURLs));
+        return new URLClassLoader(combinedURLs, parent);
+    }
+
+    private static URL toURL(Artifact artifact)
+    {
+        try
+        {
+            return artifact.getFile().toURI().toURL();
+        }
+        catch (MalformedURLException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private URL[] getDependencyURLs() throws MojoExecutionException
+    {
+        Set<String> dependencyFilter = getDependencyFilter();
+        return this.project.getArtifacts().stream()
+                .filter(artifact -> dependencyFilter == null || dependencyFilter.contains(artifact.getScope()))
+                .map(M3CoreInstanceGeneratorMojo::toURL)
+                .toArray(URL[]::new);
+    }
+
+    private Set<String> getDependencyFilter() throws MojoExecutionException
+    {
+        switch (this.dependencyScope)
+        {
+            case "compile":
+            {
+                return Sets.mutable.with("compile", "provided", "system");
+            }
+            case "compile+runtime":
+            {
+                return Sets.mutable.with("compile", "provided", "runtime", "system");
+            }
+            case "runtime":
+            {
+                return Sets.mutable.with("compile", "runtime");
+            }
+            case "runtime+system":
+            {
+                return Sets.mutable.with("compile", "runtime", "system");
+            }
+            case "test":
+            {
+                return null;
+            }
+            default:
+            {
+                throw new MojoExecutionException("Unknown scope: " + this.dependencyScope);
+            }
+        }
+    }
+}

--- a/legend-pure-maven/pom.xml
+++ b/legend-pure-maven/pom.xml
@@ -47,6 +47,7 @@
         <module>legend-pure-maven-generation-java</module>
         <module>legend-pure-maven-generation-par</module>
         <module>legend-pure-maven-generation-pct</module>
+        <module>legend-pure-maven-generation-platform-java</module>
         <module>legend-pure-maven-compiler</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -644,7 +644,17 @@
 
             <dependency>
                 <groupId>org.apache.maven</groupId>
+                <artifactId>maven-model</artifactId>
+                <version>${apache.maven.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
+                <version>${apache.maven.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact</artifactId>
                 <version>${apache.maven.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Created mojo to generate java classes for pure platform.
Will be used in places where currently the exec-maven-plugin is being used to generate these classes.