### PR TITLE
Update GenericType.print to work with simple core instances

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/valuespecification/ValueSpecification.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/navigation/valuespecification/ValueSpecification.java
@@ -17,6 +17,7 @@ package org.finos.legend.pure.m3.navigation.valuespecification;
 import org.eclipse.collections.api.list.ListIterable;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Any;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
@@ -58,6 +59,19 @@ public class ValueSpecification
             return true;
         }
         return (!(instance instanceof Any) || (instance instanceof AbstractCoreInstanceWrapper)) && processorSupport.instance_instanceOf(instance, M3Paths.InstanceValue);
+    }
+
+    public static boolean isVariableExpression(CoreInstance instance, ProcessorSupport processorSupport)
+    {
+        if (instance == null)
+        {
+            return false;
+        }
+        if (instance instanceof VariableExpression)
+        {
+            return true;
+        }
+        return (!(instance instanceof Any) || (instance instanceof AbstractCoreInstanceWrapper)) && processorSupport.instance_instanceOf(instance, M3Paths.VariableExpression);
     }
 
     /**

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledProcessorSupport.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledProcessorSupport.java
@@ -112,8 +112,25 @@ public class CompiledProcessorSupport implements ProcessorSupport
         if (object instanceof ValCoreInstance)
         {
             String valType = ((ValCoreInstance) object).getType();
-            return typeName.equals(valType) ||
-                    (M3Paths.Date.equals(typeName) && (valType.equals(M3Paths.DateTime) || valType.equals(M3Paths.StrictDate) || valType.equals(M3Paths.LatestDate)));
+            if (typeName.equals(valType))
+            {
+                return true;
+            }
+            switch (typeName)
+            {
+                case M3Paths.Date:
+                {
+                    return valType.equals(M3Paths.DateTime) || valType.equals(M3Paths.StrictDate) || valType.equals(M3Paths.LatestDate);
+                }
+                case M3Paths.Number:
+                {
+                    return valType.equals(M3Paths.Integer) || valType.equals(M3Paths.Float) || valType.equals(M3Paths.Decimal);
+                }
+                default:
+                {
+                    return false;
+                }
+            }
         }
 
         return Instance.instanceOf(object, typeName, this);


### PR DESCRIPTION
Update GenericType.print to work with simple core instances. As part of this, fix CompiledProcessorSupport.instance_instanceOf for subtypes of Number.