### PR TITLE
Clean up tests for exceptions

### DIFF
--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/transaction/TestTransaction.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/transaction/TestTransaction.java
@@ -53,39 +53,35 @@ public class TestTransaction
     public void testCommitNonCommittable()
     {
         StubTransaction transaction = this.manager.newTransaction(false);
-        try
-        {
-            transaction.commit();
-            Assert.fail("Expected exception");
-        }
-        catch (IllegalStateException e)
-        {
-            Assert.assertEquals("Transaction is not committable", e.getMessage());
-        }
+        IllegalStateException e = Assert.assertThrows(IllegalStateException.class, transaction::commit);
+        Assert.assertEquals("Transaction is not committable", e.getMessage());
     }
 
-    @Test(expected = TransactionStateException.class)
+    @Test
     public void testCommitAfterCommit()
     {
         StubTransaction transaction = this.manager.newTransaction(true);
         transaction.commit();
-        transaction.commit();
+        TransactionStateException e = Assert.assertThrows(TransactionStateException.class, transaction::commit);
+        Assert.assertEquals("Unexpected transaction state while preparing to commit; expected: open; actual: committed", e.getMessage());
     }
 
-    @Test(expected = TransactionStateException.class)
+    @Test
     public void testRollbackAfterCommit()
     {
         StubTransaction transaction = this.manager.newTransaction(true);
         transaction.commit();
-        transaction.rollback();
+        TransactionStateException e = Assert.assertThrows(TransactionStateException.class, transaction::rollback);
+        Assert.assertEquals("Unexpected transaction state while preparing to roll back; expected: open; actual: committed", e.getMessage());
     }
 
-    @Test(expected = TransactionStateException.class)
+    @Test
     public void testOpenInThreadCurrentThreadAfterCommit()
     {
         StubTransaction transaction = this.manager.newTransaction(true);
         transaction.commit();
-        transaction.openInCurrentThread();
+        TransactionStateException e = Assert.assertThrows(TransactionStateException.class, transaction::openInCurrentThread);
+        Assert.assertEquals("Unexpected transaction state; expected: open; actual: committed", e.getMessage());
     }
 
     @Test
@@ -110,28 +106,31 @@ public class TestTransaction
         Assert.assertFalse(this.manager.isRegistered(transaction));
     }
 
-    @Test(expected = TransactionStateException.class)
+    @Test
     public void testCommitAfterRollback()
     {
         StubTransaction transaction = this.manager.newTransaction(true);
         transaction.rollback();
-        transaction.commit();
+        TransactionStateException e = Assert.assertThrows(TransactionStateException.class, transaction::commit);
+        Assert.assertEquals("Unexpected transaction state while preparing to commit; expected: open; actual: rolled back", e.getMessage());
     }
 
-    @Test(expected = TransactionStateException.class)
+    @Test
     public void testRollbackAfterRollback()
     {
         StubTransaction transaction = this.manager.newTransaction(true);
         transaction.rollback();
-        transaction.rollback();
+        TransactionStateException e = Assert.assertThrows(TransactionStateException.class, transaction::rollback);
+        Assert.assertEquals("Unexpected transaction state while preparing to roll back; expected: open; actual: rolled back", e.getMessage());
     }
 
-    @Test(expected = TransactionStateException.class)
+    @Test
     public void testOpenInThreadCurrentThreadAfterRollback()
     {
         StubTransaction transaction = this.manager.newTransaction(true);
         transaction.rollback();
-        transaction.openInCurrentThread();
+        TransactionStateException e = Assert.assertThrows(TransactionStateException.class, transaction::openInCurrentThread);
+        Assert.assertEquals("Unexpected transaction state; expected: open; actual: rolled back", e.getMessage());
     }
 
     @Test
@@ -142,15 +141,8 @@ public class TestTransaction
         try (ThreadLocalTransactionContext ignore = transaction.openInCurrentThread())
         {
             Assert.assertSame(transaction, this.manager.getThreadLocalTransaction());
-            final StubTransaction[] otherThreadResult = new StubTransaction[1];
-            Thread otherThread = new Thread(new Runnable()
-            {
-                @Override
-                public void run()
-                {
-                    otherThreadResult[0] = TestTransaction.this.manager.getThreadLocalTransaction();
-                }
-            });
+            StubTransaction[] otherThreadResult = new StubTransaction[1];
+            Thread otherThread = new Thread(() -> otherThreadResult[0] = TestTransaction.this.manager.getThreadLocalTransaction());
             otherThread.setDaemon(true);
             otherThread.start();
             otherThread.join();
@@ -162,30 +154,26 @@ public class TestTransaction
     @Test
     public void testOpenTransactionInOtherThread() throws Exception
     {
-        final Transaction transaction = this.manager.newTransaction(true);
+        Transaction transaction = this.manager.newTransaction(true);
         Assert.assertNull(this.manager.getThreadLocalTransaction());
 
-        final AtomicBoolean transactionOpened = new AtomicBoolean(false);
-        final AtomicBoolean transactionChecked = new AtomicBoolean(false);
+        AtomicBoolean transactionOpened = new AtomicBoolean(false);
+        AtomicBoolean transactionChecked = new AtomicBoolean(false);
         StubTransaction[] currentThreadResults = new StubTransaction[3];
-        final StubTransaction[] otherThreadResults = new StubTransaction[3];
-        Thread otherThread = new Thread(new Runnable()
+        StubTransaction[] otherThreadResults = new StubTransaction[3];
+        Thread otherThread = new Thread(() ->
         {
-            @Override
-            public void run()
+            otherThreadResults[0] = TestTransaction.this.manager.getThreadLocalTransaction();
+            try (ThreadLocalTransactionContext ignore = transaction.openInCurrentThread())
             {
-                otherThreadResults[0] = TestTransaction.this.manager.getThreadLocalTransaction();
-                try (ThreadLocalTransactionContext ignore = transaction.openInCurrentThread())
+                transactionOpened.set(true);
+                otherThreadResults[1] = TestTransaction.this.manager.getThreadLocalTransaction();
+                while (!transactionChecked.get())
                 {
-                    transactionOpened.set(true);
-                    otherThreadResults[1] = TestTransaction.this.manager.getThreadLocalTransaction();
-                    while (!transactionChecked.get())
-                    {
-                        // wait
-                    }
+                    // wait
                 }
-                otherThreadResults[2] = TestTransaction.this.manager.getThreadLocalTransaction();
             }
+            otherThreadResults[2] = TestTransaction.this.manager.getThreadLocalTransaction();
         });
         otherThread.setDaemon(true);
 
@@ -210,7 +198,7 @@ public class TestTransaction
     }
 
     @Test
-    public void testNestedOpenTransactionInCurrentThread() throws Exception
+    public void testNestedOpenTransactionInCurrentThread()
     {
         Transaction transaction = this.manager.newTransaction(true);
         Assert.assertNull(this.manager.getThreadLocalTransaction());
@@ -232,7 +220,7 @@ public class TestTransaction
     }
 
     @Test
-    public void testOpenDifferentTransactionsInSameThread() throws Exception
+    public void testOpenDifferentTransactionsInSameThread()
     {
         Transaction transaction1 = this.manager.newTransaction(false);
         Transaction transaction2 = this.manager.newTransaction(false);
@@ -247,14 +235,8 @@ public class TestTransaction
         try (ThreadLocalTransactionContext ignore1 = transaction1.openInCurrentThread())
         {
             Assert.assertSame(transaction1, this.manager.getThreadLocalTransaction());
-            try (ThreadLocalTransactionContext ignore2 = transaction2.openInCurrentThread())
-            {
-                Assert.fail("Expected exception");
-            }
-            catch (Exception e)
-            {
-                // expected
-            }
+            IllegalStateException e = Assert.assertThrows(IllegalStateException.class, transaction2::openInCurrentThread);
+            Assert.assertEquals("A different transaction is already registered for thread \"" + Thread.currentThread().getName() + "\" (id " + Thread.currentThread().getId() + ")", e.getMessage());
             Assert.assertSame(transaction1, this.manager.getThreadLocalTransaction());
         }
         Assert.assertNull(this.manager.getThreadLocalTransaction());
@@ -280,20 +262,22 @@ public class TestTransaction
         Assert.assertTrue(transaction.isInvalid());
     }
 
-    @Test(expected = TransactionStateException.class)
+    @Test
     public void testCommitAfterClearingManager()
     {
         StubTransaction transaction = this.manager.newTransaction(true);
         this.manager.clear();
-        transaction.commit();
+        TransactionStateException e = Assert.assertThrows(TransactionStateException.class, transaction::commit);
+        Assert.assertEquals("Unexpected transaction state while preparing to commit; expected: open; actual: invalid", e.getMessage());
     }
 
-    @Test(expected = TransactionStateException.class)
+    @Test
     public void testRollbackAfterClearingManager()
     {
         StubTransaction transaction = this.manager.newTransaction(true);
         this.manager.clear();
-        transaction.rollback();
+        TransactionStateException e = Assert.assertThrows(TransactionStateException.class, transaction::rollback);
+        Assert.assertEquals("Unexpected transaction state while preparing to roll back; expected: open; actual: invalid", e.getMessage());
     }
 
     private static class StubTransaction extends Transaction

--- a/legend-pure-maven/legend-pure-maven-compiler/src/test/java/org/finos/legend/pure/maven/compiler/TestPureCompilerMojo.java
+++ b/legend-pure-maven/legend-pure-maven-compiler/src/test/java/org/finos/legend/pure/maven/compiler/TestPureCompilerMojo.java
@@ -16,8 +16,6 @@ package org.finos.legend.pure.maven.compiler;
 
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.descriptor.MojoDescriptor;
-import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectDependenciesResolver;
 import org.finos.legend.pure.m3.serialization.compiler.element.ConcreteElementDeserializer;
@@ -34,10 +32,10 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -96,7 +94,7 @@ public class TestPureCompilerMojo
         PureCompilerMojo mojo = new PureCompilerMojo();
         setField(mojo, "compileIndividually", Boolean.TRUE);
 
-        Assert.assertTrue(mojo.shouldSerializeIndividually(setOf("a", "b")));
+        Assert.assertTrue(mojo.shouldSerializeIndividually(MojoTestSupport.setOf("a", "b")));
     }
 
     @Test
@@ -105,7 +103,7 @@ public class TestPureCompilerMojo
         PureCompilerMojo mojo = new PureCompilerMojo();
         setField(mojo, "compileIndividually", Boolean.FALSE);
 
-        Assert.assertFalse(mojo.shouldSerializeIndividually(setOf("a", "b")));
+        Assert.assertFalse(mojo.shouldSerializeIndividually(MojoTestSupport.setOf("a", "b")));
     }
 
     @Test
@@ -114,7 +112,7 @@ public class TestPureCompilerMojo
         PureCompilerMojo mojo = new PureCompilerMojo();
         setField(mojo, "compileIndividually", null);
 
-        Assert.assertFalse(mojo.shouldSerializeIndividually(setOf("a", "b")));
+        Assert.assertFalse(mojo.shouldSerializeIndividually(MojoTestSupport.setOf("a", "b")));
     }
 
     @Test
@@ -132,7 +130,7 @@ public class TestPureCompilerMojo
         PureCompilerMojo mojo = new PureCompilerMojo();
         setField(mojo, "compileIndividually", null);
 
-        Assert.assertTrue(mojo.shouldSerializeIndividually(new HashSet<>()));
+        Assert.assertTrue(mojo.shouldSerializeIndividually(Collections.emptySet()));
     }
 
     // --- resolveRepositoriesToSerialize() tests ---
@@ -141,7 +139,7 @@ public class TestPureCompilerMojo
     public void testResolveRepos_explicitRepositories() throws Exception
     {
         PureCompilerMojo mojo = new PureCompilerMojo();
-        Set<String> repos = setOf("a", "b");
+        Set<String> repos = MojoTestSupport.setOf("a", "b");
         setField(mojo, "repositories", repos);
         setField(mojo, "excludedRepositories", null);
 
@@ -153,21 +151,22 @@ public class TestPureCompilerMojo
     public void testResolveRepos_explicitWithExclusion_noOverlap() throws Exception
     {
         PureCompilerMojo mojo = new PureCompilerMojo();
-        setField(mojo, "repositories", setOf("a", "b"));
-        setField(mojo, "excludedRepositories", setOf("c"));
+        setField(mojo, "repositories", MojoTestSupport.setOf("a", "b"));
+        setField(mojo, "excludedRepositories", MojoTestSupport.setOf("c"));
 
         Set<String> result = mojo.resolveRepositoriesToSerialize(DependencyResolutionScope.COMPILE_RESOLUTION_SCOPE);
-        Assert.assertEquals(setOf("a", "b"), result);
+        Assert.assertEquals(MojoTestSupport.setOf("a", "b"), result);
     }
 
-    @Test(expected = MojoExecutionException.class)
+    @Test
     public void testResolveRepos_explicitWithExclusion_overlap() throws Exception
     {
         PureCompilerMojo mojo = new PureCompilerMojo();
-        setField(mojo, "repositories", setOf("a", "b"));
-        setField(mojo, "excludedRepositories", setOf("a"));
+        setField(mojo, "repositories", MojoTestSupport.setOf("a", "b"));
+        setField(mojo, "excludedRepositories", MojoTestSupport.setOf("a"));
 
-        mojo.resolveRepositoriesToSerialize(DependencyResolutionScope.COMPILE_RESOLUTION_SCOPE);
+        MojoExecutionException e = Assert.assertThrows(MojoExecutionException.class, () -> mojo.resolveRepositoriesToSerialize(DependencyResolutionScope.COMPILE_RESOLUTION_SCOPE));
+        Assert.assertEquals("Invalid repository specification; the following are both included and excluded: a", e.getMessage());
     }
 
     @Test
@@ -201,7 +200,7 @@ public class TestPureCompilerMojo
 
         Set<String> result = mojo.resolveRepositoriesToSerialize(DependencyResolutionScope.COMPILE_RESOLUTION_SCOPE);
         Assert.assertNotNull(result);
-        Assert.assertEquals(setOf("my_repo", "other_repo"), result);
+        Assert.assertEquals(MojoTestSupport.setOf("my_repo", "other_repo"), result);
     }
 
     @Test
@@ -214,13 +213,13 @@ public class TestPureCompilerMojo
         writeDefinitionJson(outputDir, "other_repo", "other_repo", "(meta)(::.*)?", "my_repo");
 
         setField(mojo, "repositories", null);
-        setField(mojo, "excludedRepositories", setOf("other_repo"));
+        setField(mojo, "excludedRepositories", MojoTestSupport.setOf("other_repo"));
         setField(mojo, "projectOutputDirectory", outputDir);
         setField(mojo, "mojoExecution", executionWithPhase("compile"));
 
         Set<String> result = mojo.resolveRepositoriesToSerialize(DependencyResolutionScope.COMPILE_RESOLUTION_SCOPE);
         Assert.assertNotNull(result);
-        Assert.assertEquals(setOf("my_repo"), result);
+        Assert.assertEquals(MojoTestSupport.setOf("my_repo"), result);
     }
 
     // --- forEachRepoDefinition() tests ---
@@ -234,7 +233,7 @@ public class TestPureCompilerMojo
         List<String> collected = new ArrayList<>();
         mojo.forEachRepoDefinition(emptyDir, collected::add);
 
-        Assert.assertTrue("Expected no repo names from empty directory", collected.isEmpty());
+        Assert.assertEquals("Expected no repo names from empty directory", Collections.emptyList(), collected);
     }
 
     @Test
@@ -248,7 +247,7 @@ public class TestPureCompilerMojo
         List<String> collected = new ArrayList<>();
         mojo.forEachRepoDefinition(dir, collected::add);
 
-        Assert.assertTrue("Expected no repo names when no .definition.json files", collected.isEmpty());
+        Assert.assertEquals("Expected no repo names when no .definition.json files", Collections.emptyList(), collected);
     }
 
     @Test
@@ -263,10 +262,10 @@ public class TestPureCompilerMojo
         // Also add a non-.definition.json file that should be ignored
         Files.write(dir.toPath().resolve("readme.txt"), "ignore me".getBytes(StandardCharsets.UTF_8));
 
-        List<String> collected = new ArrayList<>();
+        Set<String> collected = new HashSet<>();
         mojo.forEachRepoDefinition(dir, collected::add);
 
-        Assert.assertEquals(setOf("repo_alpha", "repo_beta"), new HashSet<>(collected));
+        Assert.assertEquals(MojoTestSupport.setOf("repo_alpha", "repo_beta"), collected);
     }
 
     // --- execute()-level tests ---
@@ -276,7 +275,7 @@ public class TestPureCompilerMojo
     {
         File outputDir = tempFolder.newFolder("exec-test-repo");
         PureCompilerMojo mojo = buildExecuteMojo(outputDir);
-        setField(mojo, "repositories", setOf("test_generic_repository"));
+        setField(mojo, "repositories", MojoTestSupport.setOf("test_generic_repository"));
 
         mojo.execute();
 
@@ -292,7 +291,7 @@ public class TestPureCompilerMojo
     {
         File outputDir = tempFolder.newFolder("exec-explicit-repos");
         PureCompilerMojo mojo = buildExecuteMojo(outputDir);
-        setField(mojo, "repositories", setOf("test_generic_repository"));
+        setField(mojo, "repositories", MojoTestSupport.setOf("test_generic_repository"));
 
         mojo.execute();
 
@@ -311,7 +310,7 @@ public class TestPureCompilerMojo
         Assert.assertFalse("Pre-condition: output dir must not exist", outputDir.exists());
 
         PureCompilerMojo mojo = buildExecuteMojo(outputDir);
-        setField(mojo, "repositories", setOf("test_generic_repository"));
+        setField(mojo, "repositories", MojoTestSupport.setOf("test_generic_repository"));
 
         mojo.execute();
 
@@ -328,8 +327,8 @@ public class TestPureCompilerMojo
         // test_generic_repository and platform should be compiled; other_test_generic_repository should not.
         File outputDir = tempFolder.newFolder("exec-excluded");
         PureCompilerMojo mojo = buildExecuteMojo(outputDir);
-        setField(mojo, "repositories",        setOf("test_generic_repository"));
-        setField(mojo, "excludedRepositories", setOf("other_test_generic_repository"));
+        setField(mojo, "repositories",        MojoTestSupport.setOf("test_generic_repository"));
+        setField(mojo, "excludedRepositories", MojoTestSupport.setOf("other_test_generic_repository"));
 
         mojo.execute();
 
@@ -414,10 +413,5 @@ public class TestPureCompilerMojo
     private static void setField(Object target, String fieldName, Object value) throws Exception
     {
         MojoTestSupport.setField(target, fieldName, value);
-    }
-
-    private static Set<String> setOf(String... values)
-    {
-        return MojoTestSupport.setOf(values);
     }
 }

--- a/legend-pure-maven/legend-pure-maven-generation-java/src/test/java/org/finos/legend/pure/maven/javaCompiled/TestPureCompiledJarMojo.java
+++ b/legend-pure-maven/legend-pure-maven-generation-java/src/test/java/org/finos/legend/pure/maven/javaCompiled/TestPureCompiledJarMojo.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.pure.maven.javaCompiled;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.finos.legend.pure.maven.shared.MojoTestSupport;
 import org.finos.legend.pure.runtime.java.compiled.generation.orchestrator.JavaCodeGeneration;
@@ -279,18 +280,11 @@ public class TestPureCompiledJarMojo
         classesDir.mkdir();
 
         PureCompiledJarMojo mojo = buildMojo(targetDir, classesDir, setOf("this_repository_does_not_exist"));
-        try
-        {
-            mojo.execute();
-            Assert.fail("Expected MojoExecutionException for unknown repository");
-        }
-        catch (org.apache.maven.plugin.MojoExecutionException e)
-        {
-            Assert.assertTrue(
-                    "Message should contain 'Error building Pure compiled mode jar', but was: " + e.getMessage(),
-                    e.getMessage().contains("Error building Pure compiled mode jar"));
-            Assert.assertNotNull("Cause must be preserved", e.getCause());
-        }
+        MojoExecutionException e = Assert.assertThrows(MojoExecutionException.class, mojo::execute);
+        Assert.assertTrue(
+                "Message should contain 'Error building Pure compiled mode jar', but was: " + e.getMessage(),
+                e.getMessage().contains("Error building Pure compiled mode jar"));
+        Assert.assertNotNull("Cause must be preserved", e.getCause());
     }
 
     // --- helpers ---

--- a/legend-pure-maven/legend-pure-maven-generation-pct/src/test/java/org/finos/legend/pure/maven/pct/TestShared.java
+++ b/legend-pure-maven/legend-pure-maven-generation-pct/src/test/java/org/finos/legend/pure/maven/pct/TestShared.java
@@ -27,22 +27,25 @@ public class TestShared
 {
     // --- assertPresentOrNotEmpty ---
 
-    @Test(expected = MojoExecutionException.class)
-    public void testAssertPresentOrNotEmpty_null() throws MojoExecutionException
+    @Test
+    public void testAssertPresentOrNotEmpty_null()
     {
-        Shared.assertPresentOrNotEmpty("testParam", null);
+        MojoExecutionException e = Assert.assertThrows(MojoExecutionException.class, () -> Shared.assertPresentOrNotEmpty("testParam", null));
+        Assert.assertEquals("The property testParam must be defined", e.getMessage());
     }
 
-    @Test(expected = MojoExecutionException.class)
-    public void testAssertPresentOrNotEmpty_emptyList() throws MojoExecutionException
+    @Test
+    public void testAssertPresentOrNotEmpty_emptyList()
     {
-        Shared.assertPresentOrNotEmpty("testParam", Collections.emptyList());
+        MojoExecutionException e = Assert.assertThrows(MojoExecutionException.class, () -> Shared.assertPresentOrNotEmpty("testParam", Collections.emptyList()));
+        Assert.assertEquals("The property testParam must be defined", e.getMessage());
     }
 
-    @Test(expected = MojoExecutionException.class)
-    public void testAssertPresentOrNotEmpty_emptySet() throws MojoExecutionException
+    @Test
+    public void testAssertPresentOrNotEmpty_emptySet()
     {
-        Shared.assertPresentOrNotEmpty("testParam", Collections.emptySet());
+        MojoExecutionException e = Assert.assertThrows(MojoExecutionException.class, () -> Shared.assertPresentOrNotEmpty("testParam", Collections.emptySet()));
+        Assert.assertEquals("The property testParam must be defined", e.getMessage());
     }
 
     @Test
@@ -72,18 +75,8 @@ public class TestShared
     @Test
     public void testAssertPresentOrNotEmpty_exceptionMessage()
     {
-        try
-        {
-            Shared.assertPresentOrNotEmpty("myParamName", null);
-            Assert.fail("Expected MojoExecutionException");
-        }
-        catch (MojoExecutionException e)
-        {
-            Assert.assertTrue(
-                    "Exception message should contain parameter name, but was: " + e.getMessage(),
-                    e.getMessage().contains("myParamName")
-            );
-        }
+        MojoExecutionException e = Assert.assertThrows(MojoExecutionException.class, () -> Shared.assertPresentOrNotEmpty("myParamName", null));
+        Assert.assertEquals("The property myParamName must be defined", e.getMessage());
     }
 
     @Test
@@ -112,8 +105,7 @@ public class TestShared
         ClassLoader parent = Thread.currentThread().getContextClassLoader();
         try (URLClassLoader cl = Shared.buildClassLoader(project, parent, new SystemStreamLog()))
         {
-            Assert.assertSame("Parent classloader should be the one passed in",
-                    parent, cl.getParent());
+            Assert.assertSame("Parent classloader should be the one passed in", parent, cl.getParent());
         }
     }
 
@@ -126,8 +118,7 @@ public class TestShared
         {
             // A fresh MavenProject has no compile or test classpath elements,
             // so the classloader should have zero extra URLs of its own.
-            Assert.assertEquals("Empty project should produce zero extra classpath URLs",
-                    0, cl.getURLs().length);
+            Assert.assertEquals("Empty project should produce zero extra classpath URLs", 0, cl.getURLs().length);
         }
     }
 
@@ -154,4 +145,3 @@ public class TestShared
         Assert.assertNotNull(Mode.Interpreted);
     }
 }
-

--- a/legend-pure-maven/legend-pure-maven-generation-platform-java/src/main/java/org/finos/legend/pure/maven/platform/java/M3CoreInstanceGeneratorMojo.java
+++ b/legend-pure-maven/legend-pure-maven-generation-platform-java/src/main/java/org/finos/legend/pure/maven/platform/java/M3CoreInstanceGeneratorMojo.java
@@ -178,7 +178,7 @@ public class M3CoreInstanceGeneratorMojo extends AbstractMojo
             }
             default:
             {
-                throw new MojoExecutionException("Unknown scope: " + this.dependencyScope);
+                throw new MojoExecutionException("Unknown scope: " + ((this.dependencyScope == null) ? resolvedDependencyScope : this.dependencyScope));
             }
         }
     }

--- a/legend-pure-maven/legend-pure-maven-generation-platform-java/src/test/java/org/finos/legend/pure/maven/platform/java/TestM3CoreInstanceGeneratorMojo.java
+++ b/legend-pure-maven/legend-pure-maven-generation-platform-java/src/test/java/org/finos/legend/pure/maven/platform/java/TestM3CoreInstanceGeneratorMojo.java
@@ -17,7 +17,6 @@ package org.finos.legend.pure.maven.platform.java;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.ProjectDependenciesResolver;
 import org.finos.legend.pure.maven.shared.MojoTestSupport;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -173,15 +172,14 @@ public class TestM3CoreInstanceGeneratorMojo
                 mojo.getDependencyFilter("test"));
     }
 
-    @Test(expected = MojoExecutionException.class)
+    @Test
     public void testGetDependencyFilter_unknownScope_throwsMojoExecutionException() throws Exception
     {
-        new M3CoreInstanceGeneratorMojo().getDependencyFilter("invalid");
+        MojoExecutionException e = Assert.assertThrows(MojoExecutionException.class, () -> new M3CoreInstanceGeneratorMojo().getDependencyFilter("invalid"));
+        Assert.assertEquals("Unknown scope: invalid", e.getMessage());
     }
 
     // --- execute()-level tests ---
-
-    private static final ProjectDependenciesResolver EMPTY_RESOLVER = MojoTestSupport.EMPTY_RESOLVER;
 
     @Test
     public void testExecute_skip_doesNothing() throws Exception
@@ -283,7 +281,7 @@ public class TestM3CoreInstanceGeneratorMojo
         setField(mojo, "projectBuildDirectory",           buildDir);
         setField(mojo, "projectOutputDirectory",          buildDir);
         setField(mojo, "projectTestOutputDirectory",      buildDir);
-        setField(mojo, "mavenProjectDependenciesResolver", EMPTY_RESOLVER);
+        setField(mojo, "mavenProjectDependenciesResolver", MojoTestSupport.EMPTY_RESOLVER);
         setField(mojo, "mavenRepoSession",                null);
         return mojo;
     }
@@ -305,4 +303,3 @@ public class TestM3CoreInstanceGeneratorMojo
         MojoTestSupport.setField(target, fieldName, value);
     }
 }
-

--- a/legend-pure-maven/legend-pure-maven-shared/src/main/java/org/finos/legend/pure/maven/shared/DependencyResolutionScope.java
+++ b/legend-pure-maven/legend-pure-maven-shared/src/main/java/org/finos/legend/pure/maven/shared/DependencyResolutionScope.java
@@ -19,7 +19,6 @@ import org.eclipse.aether.util.filter.ScopeDependencyFilter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 
@@ -67,16 +66,29 @@ public enum DependencyResolutionScope
 
     public static DependencyResolutionScope fromName(String name)
     {
-        for (DependencyResolutionScope scope: DependencyResolutionScope.values())
+        if (name != null)
         {
-            if (scope.getName().equalsIgnoreCase(name))
+            for (DependencyResolutionScope scope : DependencyResolutionScope.values())
             {
-                return scope;
+                if (name.equalsIgnoreCase(scope.getName()))
+                {
+                    return scope;
+                }
             }
         }
-        throw new IllegalArgumentException(String.format("Unknown dependency resolution scope: '%s'; valid values: %s",
-                name,
-                Arrays.stream(DependencyResolutionScope.values()).map(DependencyResolutionScope::getName).collect(Collectors.joining(", ", "[", "]")))
-        );
+        StringBuilder builder = new StringBuilder("Unknown dependency resolution scope: ");
+        if (name == null)
+        {
+            builder.append("null");
+        }
+        else
+        {
+            builder.append('\'').append(name).append('\'');
+        }
+        builder.append("; valid values: [");
+        Arrays.stream(DependencyResolutionScope.values()).forEach(v -> builder.append(v.getName()).append(", "));
+        builder.setLength(builder.length() - 2);
+        builder.append(']');
+        throw new IllegalArgumentException(builder.toString());
     }
 }

--- a/legend-pure-maven/legend-pure-maven-shared/src/test/java/org/finos/legend/pure/maven/shared/TestDependencyResolutionScope.java
+++ b/legend-pure-maven/legend-pure-maven-shared/src/test/java/org/finos/legend/pure/maven/shared/TestDependencyResolutionScope.java
@@ -43,28 +43,18 @@ public class TestDependencyResolutionScope
         Assert.assertSame(DependencyResolutionScope.TEST_RESOLUTION_SCOPE, DependencyResolutionScope.fromName("TEST"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFromName_invalidName()
     {
-        DependencyResolutionScope.fromName("invalid");
+        IllegalArgumentException e = Assert.assertThrows(IllegalArgumentException.class, () -> DependencyResolutionScope.fromName("invalid"));
+        Assert.assertEquals("Unknown dependency resolution scope: 'invalid'; valid values: [compile, compile+runtime, runtime, runtime+system, test]", e.getMessage());
     }
 
     @Test
-    // TODO: fromName(null) currently throws NullPointerException (from equalsIgnoreCase)
-    // rather than IllegalArgumentException. Consider adding an explicit null check with
-    // a descriptive error message. See MAVEN_PLUGINS_REVIEW.md §4.4.
     public void testFromName_null()
     {
-        try
-        {
-            DependencyResolutionScope.fromName(null);
-            Assert.fail("Expected exception for null name");
-        }
-        catch (NullPointerException | IllegalArgumentException e)
-        {
-            // Current behaviour: NullPointerException is thrown.
-            // Either exception type is acceptable for documenting current behaviour.
-        }
+        IllegalArgumentException e = Assert.assertThrows(IllegalArgumentException.class, () -> DependencyResolutionScope.fromName(null));
+        Assert.assertEquals("Unknown dependency resolution scope: null; valid values: [compile, compile+runtime, runtime, runtime+system, test]", e.getMessage());
     }
 
     @Test
@@ -119,4 +109,3 @@ public class TestDependencyResolutionScope
         Assert.assertEquals(DependencyResolutionScope.values().length, names.size());
     }
 }
-

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaCodeGeneration.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaCodeGeneration.java
@@ -17,6 +17,8 @@ package org.finos.legend.pure.runtime.java.compiled.generation;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.set.MutableSet;
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
 import org.finos.legend.pure.m3.statelistener.VoidExecutionActivityListener;
@@ -40,6 +42,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 public class TestJavaCodeGeneration
@@ -236,8 +239,8 @@ public class TestJavaCodeGeneration
         }
 
         // Collect all relative file paths from each output directory
-        java.util.Set<Path> paths1 = new java.util.HashSet<>();
-        java.util.Set<Path> paths2 = new java.util.HashSet<>();
+        MutableSet<Path> paths1 = Sets.mutable.empty();
+        MutableSet<Path> paths2 = Sets.mutable.empty();
         try (Stream<Path> s1 = Files.walk(dir1.toPath());
              Stream<Path> s2 = Files.walk(dir2.toPath()))
         {
@@ -248,18 +251,18 @@ public class TestJavaCodeGeneration
         Assert.assertEquals("Idempotency: both runs should produce the same set of files", paths1, paths2);
 
         // Verify byte-for-byte equality for each file
-        java.util.List<Path> mismatch = new java.util.ArrayList<>();
+        MutableList<Path> mismatch = Lists.mutable.empty();
         for (Path rel : paths1)
         {
             byte[] b1 = Files.readAllBytes(dir1.toPath().resolve(rel));
             byte[] b2 = Files.readAllBytes(dir2.toPath().resolve(rel));
-            if (!java.util.Arrays.equals(b1, b2))
+            if (!Arrays.equals(b1, b2))
             {
                 mismatch.add(rel);
             }
         }
         Assert.assertEquals("Idempotency: generated files must be byte-for-byte identical across runs",
-                java.util.Collections.emptyList(), mismatch);
+                Lists.fixedSize.empty(), mismatch);
     }
 
     // --- generateSources paths ---
@@ -267,8 +270,8 @@ public class TestJavaCodeGeneration
     @Test
     public void testGenerateSources_writesToGeneratedSourcesDirectory() throws Exception
     {
-        File directory     = TMP.newFolder();
-        File classesDir    = new File(directory, "classes");
+        File directory = TMP.newFolder();
+        File classesDir = new File(directory, "classes");
         classesDir.mkdir();
 
         JavaCodeGeneration.doIt(
@@ -313,8 +316,8 @@ public class TestJavaCodeGeneration
     @Test
     public void testGenerateTestSources_writesToGeneratedTestSourcesDirectory() throws Exception
     {
-        File directory     = TMP.newFolder();
-        File classesDir    = new File(directory, "classes");
+        File directory = TMP.newFolder();
+        File classesDir = new File(directory, "classes");
         classesDir.mkdir();
 
         JavaCodeGeneration.doIt(
@@ -360,76 +363,62 @@ public class TestJavaCodeGeneration
     @Test
     public void testDoIt_invalidRepository_wrapsException() throws Exception
     {
-        File directory  = TMP.newFolder();
+        File directory = TMP.newFolder();
         File classesDir = new File(directory, "classes");
         classesDir.mkdir();
 
-        try
-        {
-            JavaCodeGeneration.doIt(
-                    Sets.mutable.with("this_repository_does_not_exist"),
-                    Sets.fixedSize.empty(),
-                    Sets.fixedSize.empty(),
-                    GenerationType.monolithic,
-                    false,
-                    false,
-                    null,
-                    false,
-                    false,
-                    false,
-                    false,
-                    true,
-                    classesDir,
-                    directory,
-                    false,
-                    new VoidLog());
-            Assert.fail("Expected RuntimeException for unknown repository");
-        }
-        catch (RuntimeException e)
-        {
-            Assert.assertTrue(
-                    "Message should contain 'Error building Pure compiled mode jar', but was: " + e.getMessage(),
-                    e.getMessage().contains("Error building Pure compiled mode jar"));
-            // The original cause must be preserved so callers can diagnose the failure
-            Assert.assertNotNull("Exception must have a cause", e.getCause());
-        }
+        RuntimeException e = Assert.assertThrows(RuntimeException.class, () -> JavaCodeGeneration.doIt(
+                Sets.mutable.with("this_repository_does_not_exist"),
+                Sets.fixedSize.empty(),
+                Sets.fixedSize.empty(),
+                GenerationType.monolithic,
+                false,
+                false,
+                null,
+                false,
+                false,
+                false,
+                false,
+                true,
+                classesDir,
+                directory,
+                false,
+                new VoidLog()));
+        Assert.assertTrue(
+                "Message should contain 'Error building Pure compiled mode jar', but was: " + e.getMessage(),
+                e.getMessage().contains("Error building Pure compiled mode jar"));
+        // The original cause must be preserved so callers can diagnose the failure
+        Assert.assertNotNull("Exception must have a cause", e.getCause());
     }
 
     @Test
     public void testDoIt_unknownExtraRepository_wrapsException() throws Exception
     {
-        File directory  = TMP.newFolder();
+        File directory = TMP.newFolder();
         File classesDir = new File(directory, "classes");
         classesDir.mkdir();
 
-        try
-        {
-            JavaCodeGeneration.doIt(
-                    Sets.fixedSize.empty(),
-                    Sets.fixedSize.empty(),
-                    Sets.mutable.with("org.finos.legend.does.not.ExistRepository"),
-                    GenerationType.monolithic,
-                    false,
-                    false,
-                    null,
-                    false,
-                    false,
-                    false,
-                    false,
-                    true,
-                    classesDir,
-                    directory,
-                    false,
-                    new VoidLog());
-            Assert.fail("Expected RuntimeException for unknown extra repository");
-        }
-        catch (RuntimeException e)
-        {
-            Assert.assertTrue(
-                    "Message should contain 'Error building Pure compiled mode jar', but was: " + e.getMessage(),
-                    e.getMessage().contains("Error building Pure compiled mode jar"));
-            Assert.assertNotNull("Exception must have a cause", e.getCause());
-        }
+        RuntimeException e = Assert.assertThrows(RuntimeException.class, () -> JavaCodeGeneration.doIt(
+                Sets.fixedSize.empty(),
+                Sets.fixedSize.empty(),
+                Sets.mutable.with("org.finos.legend.does.not.ExistRepository"),
+                GenerationType.monolithic,
+                false,
+                false,
+                null,
+                false,
+                false,
+                false,
+                false,
+                true,
+                classesDir,
+                directory,
+                false,
+                new VoidLog()));
+        Assert.assertTrue(
+                "Message should contain 'Error building Pure compiled mode jar', but was: " + e.getMessage(),
+                e.getMessage().contains("Error building Pure compiled mode jar"));
+        Assert.assertNotNull("Exception must have a cause", e.getCause());
     }
 
     // --- main() entry point tests (exec:java invocation pattern) ---
@@ -444,7 +433,7 @@ public class TestJavaCodeGeneration
     @Test
     public void testMain_threeArgs_generatesModularOutput() throws Exception
     {
-        File directory  = TMP.newFolder();
+        File directory = TMP.newFolder();
         File classesDir = new File(directory, "classes");
         classesDir.mkdir();
 
@@ -471,7 +460,7 @@ public class TestJavaCodeGeneration
     public void testMain_fourArgs_externalApiPackageAccepted() throws Exception
     {
         // Four-arg form: args[3] is the externalAPIPackage — must not throw
-        File directory  = TMP.newFolder();
+        File directory = TMP.newFolder();
         File classesDir = new File(directory, "classes");
         classesDir.mkdir();
 


### PR DESCRIPTION
Clean up tests for exceptions. Principally, replace usages of an expected exception in the Test annotation with Assert.assertThrows.