### PR TITLE
Serialize an index for which elements have back references in a module

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/file/FileDeserializer.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/file/FileDeserializer.java
@@ -17,6 +17,7 @@ package org.finos.legend.pure.m3.serialization.compiler.file;
 import org.finos.legend.pure.m3.serialization.compiler.element.ConcreteElementDeserializer;
 import org.finos.legend.pure.m3.serialization.compiler.element.DeserializedConcreteElement;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ElementBackReferenceMetadata;
+import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleBackReferenceIndex;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleExternalReferenceMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleFunctionNameMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleManifest;
@@ -919,6 +920,118 @@ public class FileDeserializer
         }
     }
 
+
+    // Deserialize module back reference index from directory
+
+    /**
+     * Deserialize module back reference index from a file in a directory. Returns null if the index file
+     * is not found (graceful fallback for older serialized data).
+     *
+     * @param directory  directory to search for the module back reference index file
+     * @param moduleName module name
+     * @return module back reference index, or null if not found
+     */
+    public ModuleBackReferenceIndex deserializeModuleBackReferenceIndexIfPresent(Path directory, String moduleName)
+    {
+        return deserializeModuleBackReferenceIndexIfPresent(directory, moduleName, this.filePathProvider.getDefaultVersion());
+    }
+
+    public ModuleBackReferenceIndex deserializeModuleBackReferenceIndexIfPresent(Path directory, String moduleName, int filePathVersion)
+    {
+        Objects.requireNonNull(directory, "directory is required");
+        Objects.requireNonNull(moduleName, "module name is required");
+
+        long start = System.nanoTime();
+        Path filePath = this.filePathProvider.getModuleBackReferenceIndexFilePath(directory, moduleName, filePathVersion);
+        LOGGER.debug("Deserializing module {} back reference index from {}", moduleName, filePath);
+        try (InputStream stream = new BufferedInputStream(Files.newInputStream(filePath)))
+        {
+            return this.moduleSerializer.deserializeBackReferenceIndex(stream);
+        }
+        catch (NoSuchFileException | FileNotFoundException e)
+        {
+            LOGGER.debug("Module {} back reference index not found at {}, will use fallback", moduleName, filePath);
+            return null;
+        }
+        catch (Exception e)
+        {
+            LOGGER.error("Error deserializing module {} back reference index from {}", moduleName, filePath, e);
+            if (Files.notExists(filePath))
+            {
+                LOGGER.debug("Module {} back reference index not found at {}, will use fallback", moduleName, filePath);
+                return null;
+            }
+            StringBuilder builder = new StringBuilder("Error deserializing back reference index for module ").append(moduleName).append(" from ").append(filePath);
+            String eMessage = e.getMessage();
+            if (eMessage != null)
+            {
+                builder.append(": ").append(eMessage);
+            }
+            throw (e instanceof IOException) ? new UncheckedIOException(builder.toString(), (IOException) e) : new RuntimeException(builder.toString(), e);
+        }
+        finally
+        {
+            long end = System.nanoTime();
+            LOGGER.debug("Finished deserializing module {} back reference index from {} in {}s", moduleName, filePath, (end - start) / 1_000_000_000.0);
+        }
+    }
+
+    // Deserialize module back reference index from ClassLoader
+
+    /**
+     * Deserialize module back reference index from a resource in a class loader. Returns null if the index
+     * resource is not found (graceful fallback for older serialized data).
+     *
+     * @param classLoader class loader to search for the module back reference index resource
+     * @param moduleName  module name
+     * @return module back reference index, or null if not found
+     */
+    public ModuleBackReferenceIndex deserializeModuleBackReferenceIndexIfPresent(ClassLoader classLoader, String moduleName)
+    {
+        return deserializeModuleBackReferenceIndexIfPresent(classLoader, moduleName, this.filePathProvider.getDefaultVersion());
+    }
+
+    public ModuleBackReferenceIndex deserializeModuleBackReferenceIndexIfPresent(ClassLoader classLoader, String moduleName, int filePathVersion)
+    {
+        Objects.requireNonNull(classLoader, "class loader is required");
+        Objects.requireNonNull(moduleName, "module name is required");
+
+        long start = System.nanoTime();
+        String resourceName = this.filePathProvider.getModuleBackReferenceIndexResourceName(moduleName, filePathVersion);
+        LOGGER.debug("Deserializing module {} back reference index from resource '{}'", moduleName, resourceName);
+        try
+        {
+            URL url = classLoader.getResource(resourceName);
+            if (url == null)
+            {
+                LOGGER.debug("Module {} back reference index not found at resource '{}', will use fallback", moduleName, resourceName);
+                return null;
+            }
+            LOGGER.debug("Deserializing module {} back reference index from resource '{}': {}", moduleName, resourceName, url);
+            try (InputStream stream = url.openStream())
+            {
+                return this.moduleSerializer.deserializeBackReferenceIndex(stream);
+            }
+            catch (Exception e)
+            {
+                LOGGER.error("Error deserializing module {} back reference index from resource '{}'", moduleName, resourceName, e);
+                StringBuilder builder = new StringBuilder("Error deserializing back reference index for module ").append(moduleName)
+                        .append(" from resource ").append(resourceName)
+                        .append(" (").append(url).append(")");
+                String eMessage = e.getMessage();
+                if (eMessage != null)
+                {
+                    builder.append(": ").append(eMessage);
+                }
+                throw (e instanceof IOException) ? new UncheckedIOException(builder.toString(), (IOException) e) : new RuntimeException(builder.toString(), e);
+            }
+        }
+        finally
+        {
+            long end = System.nanoTime();
+            LOGGER.debug("Finished deserializing module {} back reference index from resource '{}' in {}s", moduleName, resourceName, (end - start) / 1_000_000_000.0);
+        }
+    }
 
     // Deserialize module function name metadata from directory
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/file/FilePathProvider.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/file/FilePathProvider.java
@@ -226,6 +226,45 @@ public class FilePathProvider extends ExtensibleSerializer<FilePathProviderExten
     
     // Module function name metadata
 
+    public Path getModuleBackReferenceIndexFilePath(Path directory, String moduleName)
+    {
+        return directory.resolve(getModuleBackReferenceIndexFilePath(moduleName, getFSSeparator(directory)));
+    }
+
+    public Path getModuleBackReferenceIndexFilePath(Path directory, String moduleName, int version)
+    {
+        return directory.resolve(getModuleBackReferenceIndexFilePath(moduleName, getFSSeparator(directory), version));
+    }
+
+    public String getModuleBackReferenceIndexResourceName(String moduleName)
+    {
+        return getModuleBackReferenceIndexFilePath(moduleName, RESOURCE_FS_SEPARATOR);
+    }
+
+    public String getModuleBackReferenceIndexResourceName(String moduleName, int version)
+    {
+        return getModuleBackReferenceIndexFilePath(moduleName, RESOURCE_FS_SEPARATOR, version);
+    }
+
+    public String getModuleBackReferenceIndexFilePath(String moduleName, String fsSeparator)
+    {
+        return getModuleBackReferenceIndexFilePath(moduleName, fsSeparator, getDefaultExtension());
+    }
+
+    public String getModuleBackReferenceIndexFilePath(String moduleName, String fsSeparator, int version)
+    {
+        return getModuleBackReferenceIndexFilePath(moduleName, fsSeparator, getExtension(version));
+    }
+
+    private String getModuleBackReferenceIndexFilePath(String moduleName, String fsSeparator, FilePathProviderExtension extension)
+    {
+        return extension.getModuleBackReferenceIndexFilePath(
+                validateNonEmpty(moduleName, "module name"),
+                validateNonEmpty(fsSeparator, "file path separator"));
+    }
+
+    // Module function name metadata
+
     public Path getModuleFunctionNameMetadataFilePath(Path directory, String moduleName)
     {
         return directory.resolve(getModuleFunctionNameMetadataFilePath(moduleName, getFSSeparator(directory)));

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/file/FilePathProviderExtension.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/file/FilePathProviderExtension.java
@@ -80,6 +80,18 @@ public interface FilePathProviderExtension extends SerializerExtension
     String getModuleElementBackReferenceMetadataFilePath(String moduleName, String elementPath, String fsSeparator);
 
     /**
+     * Get the relative file path for the back-reference element index file for the given module. This index lists
+     * which element paths have back-reference data in the module. This should be a relative file path, and must not
+     * start with the path separator. It should never be null or empty. Each name in the path should be no longer than
+     * 255 bytes when encoded in UTF-16.
+     *
+     * @param moduleName  module name
+     * @param fsSeparator filesystem path separator
+     * @return relative file path
+     */
+    String getModuleBackReferenceIndexFilePath(String moduleName, String fsSeparator);
+
+    /**
      * Get the relative file path for the function name metadata file for the given module. This should be a relative
      * file path, and must not start with the path separator. It should never be null or empty. Each name in the path
      * should be no longer than 255 bytes when encoded in UTF-16.

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/file/FileSerializer.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/file/FileSerializer.java
@@ -17,6 +17,7 @@ package org.finos.legend.pure.m3.serialization.compiler.file;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.serialization.compiler.element.ConcreteElementSerializer;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ElementBackReferenceMetadata;
+import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleBackReferenceIndex;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleBackReferenceMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleExternalReferenceMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleFunctionNameMetadata;
@@ -402,6 +403,7 @@ public class FileSerializer
         try
         {
             moduleBackRefMetadata.getBackReferences().forEach(br -> serializeModuleElementBackReferenceMetadata(directory, moduleBackRefMetadata.getModuleName(), br, filePathVersion, serializerVersion));
+            serializeModuleBackReferenceIndex(directory, ModuleBackReferenceIndex.fromBackReferenceMetadata(moduleBackRefMetadata), filePathVersion, serializerVersion);
         }
         catch (Exception e)
         {
@@ -432,6 +434,7 @@ public class FileSerializer
         try
         {
             moduleBackRefMetadata.getBackReferences().forEach(br -> serializeModuleElementBackReferenceMetadata(zipStream, moduleBackRefMetadata.getModuleName(), br, filePathVersion, serializerVersion));
+            serializeModuleBackReferenceIndex(zipStream, ModuleBackReferenceIndex.fromBackReferenceMetadata(moduleBackRefMetadata), filePathVersion, serializerVersion);
         }
         catch (Exception e)
         {
@@ -525,6 +528,90 @@ public class FileSerializer
         return entryName;
     }
 
+
+    // Serialize module function name metadata to directory
+
+    // Serialize module back reference index to directory
+
+    public Path serializeModuleBackReferenceIndex(Path directory, ModuleBackReferenceIndex backReferenceIndex)
+    {
+        return serializeModuleBackReferenceIndex(directory, backReferenceIndex, this.filePathProvider.getDefaultVersion(), this.moduleSerializer.getDefaultVersion());
+    }
+
+    public Path serializeModuleBackReferenceIndex(Path directory, ModuleBackReferenceIndex backReferenceIndex, int filePathVersion, int serializerVersion)
+    {
+        Objects.requireNonNull(directory, "directory is required");
+        Objects.requireNonNull(backReferenceIndex, "back reference index is required");
+
+        long start = System.nanoTime();
+        Path filePath = this.filePathProvider.getModuleBackReferenceIndexFilePath(directory, backReferenceIndex.getModuleName(), filePathVersion);
+        LOGGER.debug("Serializing module {} back reference index to {}", backReferenceIndex.getModuleName(), filePath);
+        try
+        {
+            Files.createDirectories(filePath.getParent());
+            try (OutputStream stream = new BufferedOutputStream(Files.newOutputStream(filePath)))
+            {
+                this.moduleSerializer.serializeBackReferenceIndex(stream, backReferenceIndex, serializerVersion);
+            }
+        }
+        catch (Exception e)
+        {
+            LOGGER.error("Error serializing module {} back reference index to {}", backReferenceIndex.getModuleName(), filePath, e);
+            StringBuilder builder = new StringBuilder("Error serializing back reference index for module ").append(backReferenceIndex.getModuleName()).append(" to ").append(filePath);
+            String eMessage = e.getMessage();
+            if (eMessage != null)
+            {
+                builder.append(": ").append(eMessage);
+            }
+            throw (e instanceof IOException) ? new UncheckedIOException(builder.toString(), (IOException) e) : new RuntimeException(builder.toString(), e);
+        }
+        finally
+        {
+            long end = System.nanoTime();
+            LOGGER.debug("Finished serializing module {} back reference index to {} in {}s", backReferenceIndex.getModuleName(), filePath, (end - start) / 1_000_000_000.0);
+        }
+        return filePath;
+    }
+
+    // Serialize module back reference index to zip
+
+    public String serializeModuleBackReferenceIndex(ZipOutputStream zipStream, ModuleBackReferenceIndex backReferenceIndex)
+    {
+        return serializeModuleBackReferenceIndex(zipStream, backReferenceIndex, this.filePathProvider.getDefaultVersion(), this.moduleSerializer.getDefaultVersion());
+    }
+
+    public String serializeModuleBackReferenceIndex(ZipOutputStream zipStream, ModuleBackReferenceIndex backReferenceIndex, int filePathVersion, int serializerVersion)
+    {
+        Objects.requireNonNull(zipStream, "zip stream is required");
+        Objects.requireNonNull(backReferenceIndex, "back reference index is required");
+
+        long start = System.nanoTime();
+        String entryName = this.filePathProvider.getModuleBackReferenceIndexFilePath(backReferenceIndex.getModuleName(), "/", filePathVersion);
+        LOGGER.debug("Serializing module {} back reference index to zip entry '{}'", backReferenceIndex.getModuleName(), entryName);
+        try
+        {
+            zipStream.putNextEntry(new ZipEntry(entryName));
+            this.moduleSerializer.serializeBackReferenceIndex(zipStream, backReferenceIndex, serializerVersion);
+            zipStream.closeEntry();
+        }
+        catch (Exception e)
+        {
+            LOGGER.error("Error serializing module {} back reference index to zip entry '{}'", backReferenceIndex.getModuleName(), entryName, e);
+            StringBuilder builder = new StringBuilder("Error serializing back reference index for module ").append(backReferenceIndex.getModuleName()).append(" to ").append(entryName);
+            String eMessage = e.getMessage();
+            if (eMessage != null)
+            {
+                builder.append(": ").append(eMessage);
+            }
+            throw (e instanceof IOException) ? new UncheckedIOException(builder.toString(), (IOException) e) : new RuntimeException(builder.toString(), e);
+        }
+        finally
+        {
+            long end = System.nanoTime();
+            LOGGER.debug("Finished serializing module {} back reference index to zip entry '{}' in {}s", backReferenceIndex.getModuleName(), entryName, (end - start) / 1_000_000_000.0);
+        }
+        return entryName;
+    }
 
     // Serialize module function name metadata to directory
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/file/v1/FilePathProviderExtensionV1.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/file/v1/FilePathProviderExtensionV1.java
@@ -73,6 +73,12 @@ public class FilePathProviderExtensionV1 implements FilePathProviderExtension
     }
 
     @Override
+    public String getModuleBackReferenceIndexFilePath(String moduleName, String fsSeparator)
+    {
+        return getModuleMetadataFilePath(moduleName, fsSeparator, MODULE_ELEMENT_BACK_REF_FILE_EXTENSION);
+    }
+
+    @Override
     public String getModuleFunctionNameMetadataFilePath(String moduleName, String fsSeparator)
     {
         return getModuleMetadataFilePath(moduleName, fsSeparator, MODULE_FUNCTION_NAME_FILE_EXTENSION);

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/BaseModuleMetadataSerializerExtension.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/BaseModuleMetadataSerializerExtension.java
@@ -128,4 +128,12 @@ public abstract class BaseModuleMetadataSerializerExtension implements ModuleMet
         });
         return stringSet;
     }
+
+    protected static MutableSet<String> collectStrings(ModuleBackReferenceIndex backRefIndex)
+    {
+        MutableSet<String> stringSet = Sets.mutable.ofInitialCapacity(backRefIndex.size() + 1);
+        stringSet.add(backRefIndex.getModuleName());
+        stringSet.addAllIterable(backRefIndex.getElementPaths());
+        return stringSet;
+    }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/MetadataIndex.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/MetadataIndex.java
@@ -22,6 +22,8 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.api.set.SetIterable;
+import org.eclipse.collections.impl.utility.Iterate;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -37,14 +39,16 @@ public class MetadataIndex
     private final PackageIndex packages;
     private final MapIterable<String, String> elementModuleIndex;
     private final MapIterable<String, ImmutableList<String>> moduleReverseDependencyIndex;
+    private final MapIterable<String, SetIterable<String>> backReferenceIndexes;
 
-    MetadataIndex(Iterable<? extends ModuleManifest> modules)
+    MetadataIndex(Iterable<? extends ModuleManifest> modules, Iterable<? extends ModuleBackReferenceIndex> backReferenceIndexes)
     {
         this.modules = ModuleIndex.buildIndex(modules);
         this.elements = ElementIndex.buildIndex(this.modules);
         this.packages = PackageIndex.buildIndex(this.elements);
         this.elementModuleIndex = buildElementModuleIndex(this.modules);
         this.moduleReverseDependencyIndex = buildModuleReverseDependencyIndex(this.modules);
+        this.backReferenceIndexes = buildBackReferenceElementSets(backReferenceIndexes);
     }
 
     @Override
@@ -242,11 +246,26 @@ public class MetadataIndex
      * Get the module names that could have back-reference data for the given element path. For a concrete element, this
      * is the element's own module plus all modules that transitively depend on it. For a virtual package or unknown
      * element, this returns all module names.
+     * <p>
+     * If a per-module back-reference element index is available, only modules whose index contains the given element
+     * path are included. If no index is available for a module, it is included unconditionally (fallback to probing).
      *
      * @param elementPath element path
      * @return module names that could have back-reference data
      */
     public Iterable<String> getBackReferenceModuleNames(String elementPath)
+    {
+        Iterable<String> possibleModules = getPossibleBackReferenceModuleNames(elementPath);
+        return this.backReferenceIndexes.isEmpty() ?
+               possibleModules :
+               Iterate.select(possibleModules, candidate ->
+               {
+                   SetIterable<String> elementSet = this.backReferenceIndexes.get(candidate);
+                   return (elementSet == null) || elementSet.contains(elementPath);
+               }, Lists.mutable.empty());
+    }
+
+    private Iterable<String> getPossibleBackReferenceModuleNames(String elementPath)
     {
         String moduleName = this.elementModuleIndex.get(elementPath);
         if (moduleName != null)
@@ -257,7 +276,6 @@ public class MetadataIndex
                 return result;
             }
         }
-        // Fall back to all modules for virtual packages or unknown elements
         return getAllModuleNames();
     }
 
@@ -271,6 +289,7 @@ public class MetadataIndex
     public static class Builder
     {
         private final MutableList<ModuleManifest> modules = Lists.mutable.empty();
+        private final MutableList<ModuleBackReferenceIndex> backReferenceIndexes = Lists.mutable.empty();
 
         private Builder()
         {
@@ -293,9 +312,21 @@ public class MetadataIndex
             return withModules(Arrays.asList(modules));
         }
 
+        public Builder withBackReferenceIndex(ModuleBackReferenceIndex index)
+        {
+            this.backReferenceIndexes.add(Objects.requireNonNull(index));
+            return this;
+        }
+
+        public Builder withBackReferenceIndexes(Iterable<? extends ModuleBackReferenceIndex> indexes)
+        {
+            indexes.forEach(this::withBackReferenceIndex);
+            return this;
+        }
+
         public MetadataIndex build()
         {
-            return new MetadataIndex(this.modules);
+            return new MetadataIndex(this.modules, this.backReferenceIndexes);
         }
     }
 
@@ -345,5 +376,12 @@ public class MetadataIndex
         });
 
         return result;
+    }
+
+    private static MapIterable<String, SetIterable<String>> buildBackReferenceElementSets(Iterable<? extends ModuleBackReferenceIndex> indexes)
+    {
+        MutableMap<String, SetIterable<String>> map = Maps.mutable.empty();
+        indexes.forEach(index -> map.put(index.getModuleName(), Sets.immutable.withAll(index.getElementPaths())));
+        return map;
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/ModuleBackReferenceIndex.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/ModuleBackReferenceIndex.java
@@ -1,0 +1,181 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.compiler.metadata;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.pure.m3.tools.ListHelper;
+import java.util.Objects;
+
+/**
+ * Index of element paths that have back-reference data in a module. This is used to avoid unnecessary
+ * {@code classLoader.getResource()} calls when loading back references: if the index is available for a module,
+ * only elements listed in the index need to be probed for back-reference files.
+ */
+public class ModuleBackReferenceIndex
+{
+    private final String moduleName;
+    private final ImmutableList<String> elementPaths;
+
+    private ModuleBackReferenceIndex(String moduleName, ImmutableList<String> elementPaths)
+    {
+        this.moduleName = moduleName;
+        this.elementPaths = elementPaths;
+    }
+
+    /**
+     * Get the module name.
+     *
+     * @return module name
+     */
+    public String getModuleName()
+    {
+        return this.moduleName;
+    }
+
+    /**
+     * Get the element paths that have back-reference data in this module.
+     *
+     * @return element paths with back-reference data
+     */
+    public ImmutableList<String> getElementPaths()
+    {
+        return this.elementPaths;
+    }
+
+
+    /**
+     * Check whether the given element path has back-reference data in this module.
+     *
+     * @param elementPath element path
+     * @return true if the element has back-reference data in this module
+     */
+    public boolean hasElement(String elementPath)
+    {
+        return this.elementPaths.contains(elementPath);
+    }
+
+    /**
+     * Get the number of element paths with back-reference data.
+     *
+     * @return number of element paths
+     */
+    public int size()
+    {
+        return this.elementPaths.size();
+    }
+
+    /**
+     * Check whether this index is empty (no elements have back-reference data).
+     *
+     * @return true if the index is empty
+     */
+    public boolean isEmpty()
+    {
+        return this.elementPaths.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (this == other)
+        {
+            return true;
+        }
+        if (!(other instanceof ModuleBackReferenceIndex))
+        {
+            return false;
+        }
+        ModuleBackReferenceIndex that = (ModuleBackReferenceIndex) other;
+        return this.moduleName.equals(that.moduleName) && this.elementPaths.equals(that.elementPaths);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return this.moduleName.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "<" + getClass().getSimpleName() + " module='" + this.moduleName + "' elements=" + this.elementPaths.size() + ">";
+    }
+
+    /**
+     * Create a back-reference index from a {@link ModuleBackReferenceMetadata}, extracting the element paths
+     * from its back references.
+     *
+     * @param metadata module back-reference metadata
+     * @return back-reference index for the module
+     */
+    public static ModuleBackReferenceIndex fromBackReferenceMetadata(ModuleBackReferenceMetadata metadata)
+    {
+        MutableList<String> paths = Lists.mutable.ofInitialCapacity(metadata.getBackReferences().size());
+        metadata.getBackReferences().forEach(br -> paths.add(br.getElementPath()));
+        return new ModuleBackReferenceIndex(metadata.getModuleName(), ListHelper.sortAndRemoveDuplicates(paths).toImmutable());
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static Builder builder(int elementCount)
+    {
+        return new Builder(elementCount);
+    }
+
+    public static class Builder
+    {
+        private String moduleName;
+        private final MutableList<String> elementPaths;
+
+        private Builder()
+        {
+            this.elementPaths = Lists.mutable.empty();
+        }
+
+        private Builder(int elementCount)
+        {
+            this.elementPaths = Lists.mutable.ofInitialCapacity(elementCount);
+        }
+
+        public Builder withModuleName(String moduleName)
+        {
+            this.moduleName = Objects.requireNonNull(moduleName);
+            return this;
+        }
+
+        public Builder addElementPath(String elementPath)
+        {
+            this.elementPaths.add(Objects.requireNonNull(elementPath));
+            return this;
+        }
+
+        public Builder addElementPaths(Iterable<String> elementPaths)
+        {
+            elementPaths.forEach(this::addElementPath);
+            return this;
+        }
+
+        public ModuleBackReferenceIndex build()
+        {
+            Objects.requireNonNull(this.moduleName, "module name is required");
+            return new ModuleBackReferenceIndex(this.moduleName, ListHelper.sortAndRemoveDuplicates(this.elementPaths).toImmutable());
+        }
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/ModuleMetadataSerializer.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/ModuleMetadataSerializer.java
@@ -31,6 +31,7 @@ public class ModuleMetadataSerializer extends ExtensibleSerializer<ModuleMetadat
     private static final long PURE_MODULE_SOURCE_METADATA_SIGNATURE = Long.parseLong("PureSource", 36);
     private static final long PURE_MODULE_EXT_REFS_SIGNATURE = Long.parseLong("PureExtRefs", 36);
     private static final long PURE_ELEMENT_BACK_REFS_SIGNATURE = Long.parseLong("PureBackRefs", 36);
+    private static final long PURE_BACK_REF_INDEX_SIGNATURE = Long.parseLong("PureBRIndex", 36);
     private static final long PURE_FUNCTION_NAMES_SIGNATURE = Long.parseLong("PureFuncName", 36);
 
     private final StringIndexer stringIndexer;
@@ -191,6 +192,44 @@ public class ModuleMetadataSerializer extends ExtensibleSerializer<ModuleMetadat
         }
         ModuleMetadataSerializerExtension extension = getExtension(version);
         return extension.deserializeBackReferenceMetadata(stream, this.stringIndexer);
+    }
+
+    // Back reference index
+
+    public void serializeBackReferenceIndex(OutputStream stream, ModuleBackReferenceIndex backReferenceIndex)
+    {
+        serializeBackReferenceIndex(stream, backReferenceIndex, getDefaultExtension());
+    }
+
+    public void serializeBackReferenceIndex(OutputStream stream, ModuleBackReferenceIndex backReferenceIndex, int version)
+    {
+        serializeBackReferenceIndex(stream, backReferenceIndex, getExtension(version));
+    }
+
+    private void serializeBackReferenceIndex(OutputStream stream, ModuleBackReferenceIndex backReferenceIndex, ModuleMetadataSerializerExtension extension)
+    {
+        try (Writer writer = BinaryWriters.newBinaryWriter(stream, false))
+        {
+            writer.writeLong(PURE_BACK_REF_INDEX_SIGNATURE);
+            writer.writeInt(extension.version());
+        }
+        extension.serializeBackReferenceIndex(stream, backReferenceIndex, this.stringIndexer);
+    }
+
+    public ModuleBackReferenceIndex deserializeBackReferenceIndex(InputStream stream)
+    {
+        int version;
+        try (Reader reader = BinaryReaders.newBinaryReader(stream, false))
+        {
+            long signature = reader.readLong();
+            if (signature != PURE_BACK_REF_INDEX_SIGNATURE)
+            {
+                throw new IllegalArgumentException("Invalid file format: not a Legend back reference index file");
+            }
+            version = reader.readInt();
+        }
+        ModuleMetadataSerializerExtension extension = getExtension(version);
+        return extension.deserializeBackReferenceIndex(stream, this.stringIndexer);
     }
     
     // Function name metadata

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/ModuleMetadataSerializerExtension.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/ModuleMetadataSerializerExtension.java
@@ -46,6 +46,12 @@ public interface ModuleMetadataSerializerExtension extends SerializerExtension
 
     ElementBackReferenceMetadata deserializeBackReferenceMetadata(InputStream stream, StringIndexer stringIndexer);
 
+    // Back reference index
+
+    void serializeBackReferenceIndex(OutputStream stream, ModuleBackReferenceIndex backReferenceIndex, StringIndexer stringIndexer);
+
+    ModuleBackReferenceIndex deserializeBackReferenceIndex(InputStream stream, StringIndexer stringIndexer);
+
     // Function name metadata
 
     void serializeFunctionNameMetadata(OutputStream stream, ModuleFunctionNameMetadata functionNameMetadata, StringIndexer stringIndexer);

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/v1/ModuleMetadataSerializerV1.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/v1/ModuleMetadataSerializerV1.java
@@ -25,6 +25,7 @@ import org.finos.legend.pure.m3.serialization.compiler.metadata.ElementBackRefer
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ElementBackReferenceMetadata.InstanceBackReferenceMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ElementExternalReferenceMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.FunctionsByName;
+import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleBackReferenceIndex;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleExternalReferenceMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleFunctionNameMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleManifest;
@@ -289,6 +290,36 @@ public class ModuleMetadataSerializerV1 extends BaseModuleMetadataSerializerExte
             for (int i = 0; i < functionCount; i++)
             {
                 builder.addFunctionsByName(readFunctionsByName(stringIndexedReader));
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public void serializeBackReferenceIndex(OutputStream stream, ModuleBackReferenceIndex backReferenceIndex, StringIndexer stringIndexer)
+    {
+        try (Writer writer = BinaryWriters.newBinaryWriter(stream, false))
+        {
+            Writer stringIndexedWriter = stringIndexer.writeStringIndex(writer, collectStrings(backReferenceIndex));
+            stringIndexedWriter.writeString(backReferenceIndex.getModuleName());
+            ImmutableList<String> elementPaths = backReferenceIndex.getElementPaths();
+            stringIndexedWriter.writeInt(elementPaths.size());
+            elementPaths.forEach(stringIndexedWriter::writeString);
+        }
+    }
+
+    @Override
+    public ModuleBackReferenceIndex deserializeBackReferenceIndex(InputStream stream, StringIndexer stringIndexer)
+    {
+        try (Reader reader = BinaryReaders.newBinaryReader(stream, false))
+        {
+            Reader stringIndexedReader = stringIndexer.readStringIndex(reader);
+            String moduleName = stringIndexedReader.readString();
+            int elementCount = stringIndexedReader.readInt();
+            ModuleBackReferenceIndex.Builder builder = ModuleBackReferenceIndex.builder(elementCount).withModuleName(moduleName);
+            for (int i = 0; i < elementCount; i++)
+            {
+                builder.addElementPath(stringIndexedReader.readString());
             }
             return builder.build();
         }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/v2/ModuleMetadataSerializerV2.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/v2/ModuleMetadataSerializerV2.java
@@ -22,6 +22,7 @@ import org.finos.legend.pure.m3.serialization.compiler.metadata.ConcreteElementM
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ElementBackReferenceMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ElementExternalReferenceMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.FunctionsByName;
+import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleBackReferenceIndex;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleExternalReferenceMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleFunctionNameMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleManifest;
@@ -294,6 +295,36 @@ public class ModuleMetadataSerializerV2 extends BaseModuleMetadataSerializerExte
             for (int i = 0; i < functionCount; i++)
             {
                 builder.addFunctionsByName(readFunctionsByName(stringIndexedReader));
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public void serializeBackReferenceIndex(OutputStream stream, ModuleBackReferenceIndex backReferenceIndex, StringIndexer stringIndexer)
+    {
+        try (Writer writer = BinaryWriters.newBinaryWriter(stream, false))
+        {
+            Writer stringIndexedWriter = stringIndexer.writeStringIndex(writer, collectStrings(backReferenceIndex));
+            stringIndexedWriter.writeString(backReferenceIndex.getModuleName());
+            ImmutableList<String> elementPaths = backReferenceIndex.getElementPaths();
+            stringIndexedWriter.writeInt(elementPaths.size());
+            elementPaths.forEach(stringIndexedWriter::writeString);
+        }
+    }
+
+    @Override
+    public ModuleBackReferenceIndex deserializeBackReferenceIndex(InputStream stream, StringIndexer stringIndexer)
+    {
+        try (Reader reader = BinaryReaders.newBinaryReader(stream, false))
+        {
+            Reader stringIndexedReader = stringIndexer.readStringIndex(reader);
+            String moduleName = stringIndexedReader.readString();
+            int elementCount = stringIndexedReader.readInt();
+            ModuleBackReferenceIndex.Builder builder = ModuleBackReferenceIndex.builder(elementCount).withModuleName(moduleName);
+            for (int i = 0; i < elementCount; i++)
+            {
+                builder.addElementPath(stringIndexedReader.readString());
             }
             return builder.build();
         }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/v3/ModuleMetadataSerializerV3.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/compiler/metadata/v3/ModuleMetadataSerializerV3.java
@@ -15,6 +15,7 @@
 package org.finos.legend.pure.m3.serialization.compiler.metadata.v3;
 
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ElementBackReferenceMetadata;
+import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleBackReferenceIndex;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleExternalReferenceMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleFunctionNameMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleManifest;
@@ -160,6 +161,30 @@ public class ModuleMetadataSerializerV3 implements ModuleMetadataSerializerExten
         try (CompressorPool.CloseableInflater inflater = CompressorPool.getInstance().borrowInflater(true))
         {
             return this.v2.deserializeFunctionNameMetadata(new InflaterInputStream(stream, inflater), stringIndexer);
+        }
+    }
+
+    @Override
+    public void serializeBackReferenceIndex(OutputStream stream, ModuleBackReferenceIndex backReferenceIndex, StringIndexer stringIndexer)
+    {
+        try (CompressorPool.CloseableDeflater deflater = CompressorPool.getInstance().borrowDeflater(COMPRESSION_LEVEL, true))
+        {
+            DeflaterOutputStream zipStream = new DeflaterOutputStream(stream, deflater);
+            this.v2.serializeBackReferenceIndex(zipStream, backReferenceIndex, stringIndexer);
+            zipStream.finish();
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public ModuleBackReferenceIndex deserializeBackReferenceIndex(InputStream stream, StringIndexer stringIndexer)
+    {
+        try (CompressorPool.CloseableInflater inflater = CompressorPool.getInstance().borrowInflater(true))
+        {
+            return this.v2.deserializeBackReferenceIndex(new InflaterInputStream(stream, inflater), stringIndexer);
         }
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/PureCompilerLoader.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/PureCompilerLoader.java
@@ -35,6 +35,7 @@ import org.finos.legend.pure.m3.serialization.compiler.element.ElementLoader.Bac
 import org.finos.legend.pure.m3.serialization.compiler.file.FileDeserializer;
 import org.finos.legend.pure.m3.serialization.compiler.file.FilePathProvider;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.MetadataIndex;
+import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleBackReferenceIndex;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleFunctionNameMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleManifest;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleMetadataSerializer;
@@ -296,9 +297,17 @@ public abstract class PureCompilerLoader
         {
             long metadataStart = System.nanoTime();
             LOGGER.debug("Loading metadata index");
-            MetadataIndex metadataIndex = MetadataIndex.builder()
-                    .withModules(LazyIterate.collect(repositories, this::loadModuleManifest))
-                    .build();
+            MetadataIndex.Builder metadataIndexBuilder = MetadataIndex.builder();
+            repositories.forEach(repo ->
+            {
+                metadataIndexBuilder.withModule(loadModuleManifest(repo));
+                ModuleBackReferenceIndex brIndex = loadModuleBackReferenceIndex(repo);
+                if (brIndex != null)
+                {
+                    metadataIndexBuilder.withBackReferenceIndex(brIndex);
+                }
+            });
+            MetadataIndex metadataIndex = metadataIndexBuilder.build();
             long metadataEnd = System.nanoTime();
             LOGGER.debug("Finished loading metadata index in {}ns", metadataEnd - metadataStart);
 
@@ -414,6 +423,14 @@ public abstract class PureCompilerLoader
 
     abstract ModuleFunctionNameMetadata loadModuleFunctionsByName(String repository);
 
+    /**
+     * Load the back-reference element index for a module. Returns null if not available (graceful fallback).
+     *
+     * @param repository repository name
+     * @return back-reference index, or null if not available
+     */
+    abstract ModuleBackReferenceIndex loadModuleBackReferenceIndex(String repository);
+
     public static PureCompilerLoader newLoader(ClassLoader classLoader, BiFunction<? super ClassLoader, ? super ModelRepository, ? extends ElementBuilder> elementBuilderFactory)
     {
         return new ClassLoaderPureCompilerLoader(classLoader, elementBuilderFactory);
@@ -464,6 +481,12 @@ public abstract class PureCompilerLoader
         {
             return this.fileDeserializer.deserializeModuleFunctionNameMetadata(this.classLoader, repository);
         }
+
+        @Override
+        ModuleBackReferenceIndex loadModuleBackReferenceIndex(String repository)
+        {
+            return this.fileDeserializer.deserializeModuleBackReferenceIndexIfPresent(this.classLoader, repository);
+        }
     }
 
     private static class DirectoryPureCompilerLoader extends PureCompilerLoader
@@ -498,6 +521,12 @@ public abstract class PureCompilerLoader
         ModuleFunctionNameMetadata loadModuleFunctionsByName(String repository)
         {
             return this.fileDeserializer.deserializeModuleFunctionNameMetadata(this.directory, repository);
+        }
+
+        @Override
+        ModuleBackReferenceIndex loadModuleBackReferenceIndex(String repository)
+        {
+            return this.fileDeserializer.deserializeModuleBackReferenceIndexIfPresent(this.directory, repository);
         }
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/metadata/TestMetadataIndex.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/metadata/TestMetadataIndex.java
@@ -559,4 +559,117 @@ public class TestMetadataIndex extends AbstractMetadataTest
                 Lists.mutable.withAll(index.getBackReferenceModuleNames("d::Element")).sortThis());
     }
 
+    @Test
+    public void testBackReferenceModulesWithIndex()
+    {
+        // Dependency chain: A <- B <- C
+        // Back-reference indexes: B has back refs for ElementA, C does not
+        ConcreteElementMetadata elementA = newClass("a::ElementA", "/a/source.pure", 1, 1, 5, 1);
+        ModuleManifest moduleA = ModuleManifest.builder("a").withElement(elementA).build();
+
+        ConcreteElementMetadata elementB = newClass("b::ElementB", "/b/source.pure", 1, 1, 5, 1);
+        ModuleManifest moduleB = ModuleManifest.builder("b").withDependency("a").withElement(elementB).build();
+
+        ConcreteElementMetadata elementC = newClass("c::ElementC", "/c/source.pure", 1, 1, 5, 1);
+        ModuleManifest moduleC = ModuleManifest.builder("c").withDependency("b").withElement(elementC).build();
+
+        // B has back refs for ElementA only
+        ModuleBackReferenceIndex indexB = ModuleBackReferenceIndex.builder()
+                .withModuleName("b")
+                .addElementPath("a::ElementA")
+                .build();
+
+        // C has no back refs for anything
+        ModuleBackReferenceIndex indexC = ModuleBackReferenceIndex.builder()
+                .withModuleName("c")
+                .build();
+
+        // A has back refs for ElementA (itself)
+        ModuleBackReferenceIndex indexA = ModuleBackReferenceIndex.builder()
+                .withModuleName("a")
+                .addElementPath("a::ElementA")
+                .build();
+
+        MetadataIndex index = MetadataIndex.builder()
+                .withModules(moduleA, moduleB, moduleC)
+                .withBackReferenceIndex(indexA)
+                .withBackReferenceIndex(indexB)
+                .withBackReferenceIndex(indexC)
+                .build();
+
+        // For ElementA: without index would be {a, b, c}. With index, C is excluded (no back refs for ElementA in C)
+        Assert.assertEquals(
+                Lists.mutable.with("a", "b"),
+                Lists.mutable.withAll(index.getBackReferenceModuleNames("a::ElementA")).sortThis());
+
+        // For ElementB: without index would be {b, c}. B's index doesn't have ElementB, C's index doesn't have ElementB
+        Assert.assertEquals(
+                Lists.mutable.empty(),
+                Lists.mutable.withAll(index.getBackReferenceModuleNames("b::ElementB")).sortThis());
+
+        // For ElementC: without index would be {c}. C's index is empty
+        Assert.assertEquals(
+                Lists.mutable.empty(),
+                Lists.mutable.withAll(index.getBackReferenceModuleNames("c::ElementC")).sortThis());
+    }
+
+    @Test
+    public void testBackReferenceModulesWithPartialIndex()
+    {
+        // When index is only available for some modules, modules without index should be included as fallback
+        ConcreteElementMetadata elementA = newClass("a::ElementA", "/a/source.pure", 1, 1, 5, 1);
+        ModuleManifest moduleA = ModuleManifest.builder("a").withElement(elementA).build();
+
+        ConcreteElementMetadata elementB = newClass("b::ElementB", "/b/source.pure", 1, 1, 5, 1);
+        ModuleManifest moduleB = ModuleManifest.builder("b").withDependency("a").withElement(elementB).build();
+
+        ConcreteElementMetadata elementC = newClass("c::ElementC", "/c/source.pure", 1, 1, 5, 1);
+        ModuleManifest moduleC = ModuleManifest.builder("c").withDependency("a").withElement(elementC).build();
+
+        // Only module B has a back-reference index (with ElementA); modules A and C do not
+        ModuleBackReferenceIndex indexB = ModuleBackReferenceIndex.builder()
+                .withModuleName("b")
+                .addElementPath("a::ElementA")
+                .build();
+
+        MetadataIndex index = MetadataIndex.builder()
+                .withModules(moduleA, moduleB, moduleC)
+                .withBackReferenceIndex(indexB)
+                .build();
+
+        // For ElementA: candidates are {a, b, c}
+        // A has no index -> included (fallback)
+        // B has index with ElementA -> included
+        // C has no index -> included (fallback)
+        Assert.assertEquals(
+                Lists.mutable.with("a", "b", "c"),
+                Lists.mutable.withAll(index.getBackReferenceModuleNames("a::ElementA")).sortThis());
+
+        // For ElementB: candidates are {b}
+        // B has index but doesn't have ElementB -> excluded
+        Assert.assertEquals(
+                Lists.mutable.empty(),
+                Lists.mutable.withAll(index.getBackReferenceModuleNames("b::ElementB")).sortThis());
+    }
+
+    @Test
+    public void testBackReferenceModulesNoIndexFallback()
+    {
+        // When no indexes are provided at all, should behave exactly as before
+        ConcreteElementMetadata elementA = newClass("a::ElementA", "/a/source.pure", 1, 1, 5, 1);
+        ModuleManifest moduleA = ModuleManifest.builder("a").withElement(elementA).build();
+
+        ConcreteElementMetadata elementB = newClass("b::ElementB", "/b/source.pure", 1, 1, 5, 1);
+        ModuleManifest moduleB = ModuleManifest.builder("b").withDependency("a").withElement(elementB).build();
+
+        MetadataIndex index = MetadataIndex.builder()
+                .withModules(moduleA, moduleB)
+                .build();
+
+        // Same as original behavior: element in A gets {a, b}
+        Assert.assertEquals(
+                Lists.mutable.with("a", "b"),
+                Lists.mutable.withAll(index.getBackReferenceModuleNames("a::ElementA")).sortThis());
+    }
+
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/metadata/TestModuleMetadataSerializer.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/compiler/metadata/TestModuleMetadataSerializer.java
@@ -234,6 +234,18 @@ public class TestModuleMetadataSerializer
             }
 
             @Override
+            public void serializeBackReferenceIndex(OutputStream stream, ModuleBackReferenceIndex backReferenceIndex, StringIndexer stringIndexer)
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ModuleBackReferenceIndex deserializeBackReferenceIndex(InputStream stream, StringIndexer stringIndexer)
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
             public void serializeFunctionNameMetadata(OutputStream stream, ModuleFunctionNameMetadata functionNameMetadata, StringIndexer stringIndexer)
             {
                 throw new UnsupportedOperationException();

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataPelt.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataPelt.java
@@ -33,7 +33,7 @@ import org.finos.legend.pure.m3.serialization.compiler.file.FileDeserializer;
 import org.finos.legend.pure.m3.serialization.compiler.file.FilePathProvider;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ConcreteElementMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.MetadataIndex;
-import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleManifest;
+import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleBackReferenceIndex;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleMetadataSerializer;
 import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdResolver;
 import org.finos.legend.pure.m3.serialization.compiler.strings.StringIndexer;
@@ -249,20 +249,7 @@ public class MetadataPelt implements Metadata
                         .withSerializers(elementDeserializer, moduleMetadataSerializer)
                         .build();
 
-                MutableMap<String, ModuleManifest> manifestsByModule = Maps.mutable.empty();
-                Deque<String> modulesToLoad = new ArrayDeque<>(this.repositories);
-                while (!modulesToLoad.isEmpty())
-                {
-                    manifestsByModule.getIfAbsentPutWithKey(modulesToLoad.pollFirst(), m ->
-                    {
-                        ModuleManifest manifest = (this.directory == null) ?
-                                fileDeserializer.deserializeModuleManifest(this.classLoader, m) :
-                                fileDeserializer.deserializeModuleManifest(this.directory, m);
-                        modulesToLoad.addAll(manifest.getDependencies().castToList());
-                        return manifest;
-                    });
-                }
-                MetadataIndex metadataIndex = MetadataIndex.builder().withModules(manifestsByModule.values()).build();
+                MetadataIndex metadataIndex = buildMetadataIndex(fileDeserializer);
                 ElementLoader.Builder elementLoaderBuilder = ElementLoader.builder()
                         .withMetadataIndex(metadataIndex)
                         .withFileDeserializer(fileDeserializer)
@@ -285,6 +272,31 @@ public class MetadataPelt implements Metadata
                 long end = System.nanoTime();
                 LOGGER.debug("Finished building metadata in {}s", (end - start) / 1_000_000_000.0);
             }
+        }
+
+        private MetadataIndex buildMetadataIndex(FileDeserializer fileDeserializer)
+        {
+            MetadataIndex.Builder metadataIndexBuilder = MetadataIndex.builder();
+            MutableSet<String> modulesFound = Sets.mutable.ofInitialCapacity(this.repositories.size());
+            Deque<String> modulesToLoad = new ArrayDeque<>(this.repositories);
+            while (!modulesToLoad.isEmpty())
+            {
+                String module = modulesToLoad.pollFirst();
+                if (modulesFound.add(module))
+                {
+                    metadataIndexBuilder.withModule((this.directory == null) ?
+                                                    fileDeserializer.deserializeModuleManifest(this.classLoader, module) :
+                                                    fileDeserializer.deserializeModuleManifest(this.directory, module));
+                    ModuleBackReferenceIndex backRefIndex = (this.directory == null) ?
+                                                            fileDeserializer.deserializeModuleBackReferenceIndexIfPresent(this.classLoader, module) :
+                                                            fileDeserializer.deserializeModuleBackReferenceIndexIfPresent(this.directory, module);
+                    if (backRefIndex != null)
+                    {
+                        metadataIndexBuilder.withBackReferenceIndex(backRefIndex);
+                    }
+                }
+            }
+            return metadataIndexBuilder.build();
         }
     }
 }


### PR DESCRIPTION
Serialize an index for which elements have back references in a module. This can speed up element loading substantially by reducing the number of files the system needs to try to load to find back references.