### PR TITLE
Fix a bug in handling module dependencies in MetadataPelt

### DIFF
--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataPelt.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataPelt.java
@@ -34,6 +34,7 @@ import org.finos.legend.pure.m3.serialization.compiler.file.FilePathProvider;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ConcreteElementMetadata;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.MetadataIndex;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleBackReferenceIndex;
+import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleManifest;
 import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleMetadataSerializer;
 import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdResolver;
 import org.finos.legend.pure.m3.serialization.compiler.strings.StringIndexer;
@@ -284,9 +285,11 @@ public class MetadataPelt implements Metadata
                 String module = modulesToLoad.pollFirst();
                 if (modulesFound.add(module))
                 {
-                    metadataIndexBuilder.withModule((this.directory == null) ?
-                                                    fileDeserializer.deserializeModuleManifest(this.classLoader, module) :
-                                                    fileDeserializer.deserializeModuleManifest(this.directory, module));
+                    ModuleManifest manifest = (this.directory == null) ?
+                                              fileDeserializer.deserializeModuleManifest(this.classLoader, module) :
+                                              fileDeserializer.deserializeModuleManifest(this.directory, module);
+                    metadataIndexBuilder.withModule(manifest);
+                    modulesToLoad.addAll(manifest.getDependencies().castToList());
                     ModuleBackReferenceIndex backRefIndex = (this.directory == null) ?
                                                             fileDeserializer.deserializeModuleBackReferenceIndexIfPresent(this.classLoader, module) :
                                                             fileDeserializer.deserializeModuleBackReferenceIndexIfPresent(this.directory, module);

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/metadata/TestMetadataPelt.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/metadata/TestMetadataPelt.java
@@ -31,6 +31,7 @@ import org.finos.legend.pure.m3.serialization.compiler.reference.AbstractReferen
 import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdProvider;
 import org.finos.legend.pure.m3.serialization.compiler.reference.ReferenceIdProviders;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.CodeStorageTools;
 import org.finos.legend.pure.m3.tools.GraphTools;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
@@ -136,7 +137,7 @@ public class TestMetadataPelt extends AbstractReferenceTest
     {
         GraphTools.getTopLevelAndPackagedElements(repository).forEach(element ->
         {
-            if ((repos == null) || ((element.getSourceInformation() != null) && repos.contains(element.getSourceInformation().getSourceId())))
+            if ((repos == null) || ((element.getSourceInformation() != null) && repos.contains(CodeStorageTools.getInitialPathElement(element.getSourceInformation().getSourceId()))))
             {
                 String path = PackageableElement.getUserPathForPackageableElement(element);
                 String classifierPath = PackageableElement.getUserPathForPackageableElement(element.getClassifier());


### PR DESCRIPTION
Fix a bug in handling module dependencies in MetadataPelt introduced in commit 9b539c778031492b787fb6ea136f119eb7296b71. Also fix TestMetadataPelt, which should have caught this bug.