### PR TITLE
Add optional PackageableElement access methods to MetadataAccessor

### DIFF
--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataAccessor.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataAccessor.java
@@ -15,6 +15,7 @@
 package org.finos.legend.pure.runtime.java.compiled.metadata;
 
 import org.finos.legend.pure.m3.coreinstance.Package;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
@@ -69,5 +70,20 @@ public interface MetadataAccessor
     default Class<Nil> getBottomType()
     {
         return (Class<Nil>) getClass(M3Paths.Nil);
+    }
+
+    default boolean supportsGetPackageableElement()
+    {
+        return false;
+    }
+
+    default boolean hasPackageableElement(String path)
+    {
+        return getPackageableElement(path) != null;
+    }
+
+    default PackageableElement getPackageableElement(String path)
+    {
+        throw new UnsupportedOperationException(getClass().getName() + " does not support getPackageableElement");
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataHolder.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataHolder.java
@@ -15,6 +15,7 @@
 package org.finos.legend.pure.runtime.java.compiled.metadata;
 
 import org.finos.legend.pure.m3.coreinstance.Package;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.ConcreteFunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
@@ -111,5 +112,23 @@ public class MetadataHolder implements MetadataAccessor
     public Profile getProfile(String path)
     {
         return (Profile) this.metadata.getMetadata(M3Paths.Profile, path);
+    }
+
+    @Override
+    public boolean supportsGetPackageableElement()
+    {
+        return this.metadata.supportsElementByPath();
+    }
+
+    @Override
+    public boolean hasPackageableElement(String path)
+    {
+        return this.metadata.hasElement(path);
+    }
+
+    @Override
+    public PackageableElement getPackageableElement(String path)
+    {
+        return (PackageableElement) this.metadata.getElementByPath(path);
     }
 }


### PR DESCRIPTION
Add optional PackageableElement access methods to MetadataAccessor that mirror the methods recently added to Metadata (commit 2e1c2c561327ab193428707de50737f91c52e46b).