### PR TITLE
Use vavr HAMT Map as the internal impl of PureMap

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/collection/AbstractTestMapCollection.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/collection/AbstractTestMapCollection.java
@@ -32,14 +32,125 @@ public abstract class AbstractTestMapCollection extends AbstractPureTestWithCore
     {
         compileTestSource("fromString.pure",
                 "function testGetIfAbsentPutWithKey():Any[*]\n" +
-                "{\n" +
-                "   let m = newMap([pair(1,'_1'), pair(2,'_2')]);\n" +
-                "   assert($m->get(3)->isEmpty(), |'');\n" +
-                "   assert('_3' == $m->getIfAbsentPutWithKey(3, {k:Integer[1]|'_'+$k->toString()}), |'');\n" +
-                "   assert('_3' == $m->get(3), |'');" +
-                "}\n");
+                        "{\n" +
+                        "   let m = newMap([pair(1,'_1'), pair(2,'_2')]);\n" +
+                        "   assert($m->get(3)->isEmpty(), |'');\n" +
+                        "   assert('_3' == $m->getIfAbsentPutWithKey(3, {k:Integer[1]|'_'+$k->toString()}), |'');\n" +
+                        "   assert('_3' == $m->get(3), |'');" +
+                        "}\n");
 
         this.execute("testGetIfAbsentPutWithKey():Any[*]");
+    }
+
+    @Test
+    public void testReplaceAll()
+    {
+        compileTestSource("fromString.pure",
+                "Class my::Class1" +
+                        "{" +
+                        "   <<equality.Key>> a:Integer[1];" +
+                        "   b:Integer[0..1];" +
+                        "}" +
+                        "" +
+                        "function testMapBehaviour():Any[*]\n" +
+                        "{\n" +
+                        "   let m = newMap([pair(^my::Class1(a = 1),'_1'), pair(^my::Class1(a = 2),'_2')]);\n" +
+                        "   let m2 = $m->replaceAll([pair(^my::Class1(a = 1),'_1_1'), pair(^my::Class1(a = 3),'_3')]);\n" +
+
+                        "   assert($m->keyValues()->size() == 2);\n" +
+                        "   assert($m2->keyValues()->size() == 2);\n" +
+
+                        "   assert($m->get(^my::Class1(a = 1, b = 1)) == '_1');\n" +
+                        "   assert($m->get(^my::Class1(a = 2, b = 1)) == '_2');\n" +
+
+                        "   assert($m2->get(^my::Class1(a = 1, b = 1)) == '_1_1');\n" +
+                        "   assert($m2->get(^my::Class1(a = 3, b = 1)) == '_3');\n" +
+                        "}\n");
+
+        this.execute("testMapBehaviour():Any[*]");
+    }
+
+    @Test
+    public void testMapPut()
+    {
+        compileTestSource("fromString.pure",
+                "Class my::Class1" +
+                        "{" +
+                        "   <<equality.Key>> a:Integer[1];" +
+                        "   b:Integer[0..1];" +
+                        "}" +
+                        "" +
+                        "function testMapBehaviour():Any[*]\n" +
+                        "{\n" +
+                        "   let m = newMap([pair(^my::Class1(a = 1),'_1'), pair(^my::Class1(a = 2),'_2')]);\n" +
+                        "   let m2 = $m->put(^my::Class1(a = 3), '_3');\n" +
+                        "   let m3 = $m->put(^my::Class1(a = 4), '_4');\n" +
+                        "   let m4 = $m3->put(^my::Class1(a = 1, b = 1), '_1_1');\n" + //put in a replacement
+
+                        "   assert($m->keyValues()->size() == 2);\n" +
+                        "   assert($m2->keyValues()->size() == 3);\n" +
+                        "   assert($m3->keyValues()->size() == 3);\n" +
+                        "   assert($m4->keyValues()->size() == 3);\n" +
+
+                        "   assert($m->get(^my::Class1(a = 1, b = 1)) == '_1');\n" +
+                        "   assert($m->get(^my::Class1(a = 2, b = 1)) == '_2');\n" +
+
+                        "   assert($m2->get(^my::Class1(a = 1, b = 1)) == '_1');\n" +
+                        "   assert($m2->get(^my::Class1(a = 2, b = 1)) == '_2');\n" +
+                        "   assert($m2->get(^my::Class1(a = 3, b = 1)) == '_3');\n" +
+
+                        "   assert($m3->get(^my::Class1(a = 1, b = 1)) == '_1');\n" +
+                        "   assert($m3->get(^my::Class1(a = 2, b = 1)) == '_2');\n" +
+                        "   assert($m3->get(^my::Class1(a = 4, b = 1)) == '_4');\n" +
+
+                        "   assert($m4->get(^my::Class1(a = 1)) == '_1_1');\n" +
+                        "   assert($m4->get(^my::Class1(a = 2)) == '_2');\n" +
+                        "   assert($m4->get(^my::Class1(a = 4)) == '_4');\n" +
+                        "}\n");
+
+        this.execute("testMapBehaviour():Any[*]");
+    }
+
+    @Test
+    public void testMapPutAll()
+    {
+        compileTestSource("fromString.pure",
+                "Class my::Class1\n" +
+                        "{\n" +
+                        "   <<equality.Key>> a:Integer[1];\n" +
+                        "   b:Integer[0..1];\n" +
+                        "}\n" +
+                        "" +
+                        "function testMapBehaviour():Any[*]\n" +
+                        "{\n" +
+                        "   let m = newMap([pair(^my::Class1(a = 1),'_1'), pair(^my::Class1(a = 2),'_2')]);\n" +
+                        "   let m2 = newMap([pair(^my::Class1(a = 1, b = 1),'_1_1'), pair(^my::Class1(a = 4),'_4')]);\n" +
+
+                        "   let m3 = $m->putAll($m2);\n" +
+                        "   let m4 = $m3->putAll([pair(^my::Class1(a = 2),'_2'), pair(^my::Class1(a = 3),'_3')]);\n" +
+
+                        "   assert($m->keyValues()->size() == 2);\n" +
+                        "   assert($m2->keyValues()->size() == 2);\n" +
+                        "   assert($m3->keyValues()->size() == 3);\n" +
+                        "   assert($m4->keyValues()->size() == 4);\n" +
+
+                        "   assert($m->get(^my::Class1(a = 1, b = 1)) == '_1');\n" +
+                        "   assert($m->get(^my::Class1(a = 2, b = 1)) == '_2');\n" +
+
+                        "   assert($m2->get(^my::Class1(a = 1, b = 1)) == '_1_1');\n" +
+                        "   assert($m2->get(^my::Class1(a = 4, b = 1)) == '_4');\n" +
+
+                        "   assert($m3->get(^my::Class1(a = 1, b = 1)) == '_1_1');\n" +
+                        "   assert($m3->get(^my::Class1(a = 2, b = 1)) == '_2');\n" +
+                        "   assert($m3->get(^my::Class1(a = 4, b = 1)) == '_4');\n" +
+
+                        "   assert($m4->get(^my::Class1(a = 1, b = 1)) == '_1_1');\n" +
+                        "   assert($m4->get(^my::Class1(a = 2, b = 1)) == '_2');\n" +
+                        "   assert($m4->get(^my::Class1(a = 3, b = 1)) == '_3');\n" +
+                        "   assert($m4->get(^my::Class1(a = 4, b = 1)) == '_4');\n" +
+                        "}\n");
+
+        this.execute("testMapBehaviour():Any[*]");
     }
 
     @Test

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/pom.xml
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/pom.xml
@@ -154,6 +154,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/CoreHelper.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/CoreHelper.java
@@ -19,17 +19,13 @@ import org.eclipse.collections.api.LazyIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.block.predicate.Predicate;
-import org.eclipse.collections.api.block.procedure.Procedure;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.factory.Stacks;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.ordered.ReversibleIterable;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.lazy.AbstractLazyIterable;
-import org.eclipse.collections.impl.map.strategy.mutable.UnifiedMapWithHashingStrategy;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.TreeNode;
@@ -64,16 +60,13 @@ import org.finos.legend.pure.runtime.java.compiled.generation.processors.support
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.Pure;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.map.PureEqualsHashingStrategy;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.map.PureMap;
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.map.VavrHamtMutableMapAdapter;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.type.FullJavaPaths;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.TimeZone;
-import java.util.function.Consumer;
 
 public class CoreHelper
 {
@@ -178,7 +171,6 @@ public class CoreHelper
         return result;
     }
     // TRIGO ------------------------------------------------------------------
-
 
     // DATE-TIME --------------------------------------------------------------
     private static final TimeZone GMT = TimeZone.getTimeZone("GMT");
@@ -830,14 +822,54 @@ public class CoreHelper
         result._childrenData(newChildren);
     }
 
+    /**
+     * Creates a copy of the given map, preserving the hashing strategy if applicable.
+     * For HAMT-backed maps this is O(1) — the immutable trie is shared via structural sharing.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static MutableMap<Object, Object> copyMap(MutableMap map)
+    {
+        if (map instanceof VavrHamtMutableMapAdapter)
+        {
+            // O(1): shares the immutable trie reference — this is the whole point of HAMT
+            return ((VavrHamtMutableMapAdapter<Object, Object>) map).clone();
+        }
+        return VavrHamtMutableMapAdapter.fromMap(map);
+    }
+
+    /**
+     * Creates a new empty map with the same hashing strategy as the source.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static MutableMap<Object, Object> newEmptyLike(MutableMap map)
+    {
+        if (map instanceof VavrHamtMutableMapAdapter)
+        {
+            HashingStrategy strategy = ((VavrHamtMutableMapAdapter<Object, Object>) map).hashingStrategy();
+            return strategy != null
+                    ? VavrHamtMutableMapAdapter.withHashingStrategy(strategy)
+                    : new VavrHamtMutableMapAdapter<>();
+        }
+        return new VavrHamtMutableMapAdapter<>();
+    }
+
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static PureMap putAllPairs(PureMap pureMap, RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.Pair<?, ?>> pairs)
     {
         if (!pairs.isEmpty())
         {
-            Map map = pureMap.getMap();
-            MutableMap<Object, Object> newOne = (map instanceof UnifiedMapWithHashingStrategy) ? new UnifiedMapWithHashingStrategy<>(((UnifiedMapWithHashingStrategy) map).hashingStrategy(), map) : Maps.mutable.withMap(map);
-            pairs.forEach(p -> newOne.put(p._first(), p._second()));
+            MutableMap map = pureMap.getMap();
+            MutableMap<Object, Object> newOne = copyMap(map);
+            if (newOne instanceof VavrHamtMutableMapAdapter)
+            {
+                VavrHamtMutableMapAdapter<Object, Object> adapter = (VavrHamtMutableMapAdapter<Object, Object>) newOne;
+                pairs.forEach(p -> adapter.putNoReturn(p._first(), p._second()));
+            }
+            else
+            {
+                pairs.forEach(p -> newOne.put(p._first(), p._second()));
+            }
+
             return new PureMap(newOne);
         }
         else
@@ -851,9 +883,17 @@ public class CoreHelper
     {
         if (pair != null)
         {
-            Map map = pureMap.getMap();
-            MutableMap<Object, Object> newOne = (map instanceof UnifiedMapWithHashingStrategy) ? new UnifiedMapWithHashingStrategy<>(((UnifiedMapWithHashingStrategy) map).hashingStrategy(), map) : Maps.mutable.withMap(map);
-            newOne.put(pair._first(), pair._second());
+            MutableMap map = pureMap.getMap();
+            MutableMap<Object, Object> newOne = copyMap(map);
+            if (newOne instanceof VavrHamtMutableMapAdapter)
+            {
+                ((VavrHamtMutableMapAdapter<Object, Object>) newOne).putNoReturn(pair._first(), pair._second());
+            }
+            else
+            {
+                newOne.put(pair._first(), pair._second());
+            }
+
             return new PureMap(newOne);
         }
         else
@@ -865,45 +905,66 @@ public class CoreHelper
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static PureMap putAllMaps(PureMap pureMap, PureMap other)
     {
-        Map map = pureMap.getMap();
-        MutableMap<Object, Object> newOne = (map instanceof UnifiedMapWithHashingStrategy) ? new UnifiedMapWithHashingStrategy<>(((UnifiedMapWithHashingStrategy) map).hashingStrategy(), map) : Maps.mutable.withMap(map);
+        MutableMap map = pureMap.getMap();
+        MutableMap<Object, Object> newOne = copyMap(map);
         newOne.putAll(other.getMap());
+
         return new PureMap(newOne);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static PureMap replaceAll(PureMap pureMap, RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.Pair<?, ?>> pairs)
     {
-        Map map = pureMap.getMap();
-        MutableMap<Object, Object> newOne = map instanceof UnifiedMapWithHashingStrategy ? new UnifiedMapWithHashingStrategy<>(((UnifiedMapWithHashingStrategy) map).hashingStrategy()) : Maps.mutable.empty();
-        pairs.forEach(p -> newOne.put(p._first(), p._second()));
+        MutableMap map = pureMap.getMap();
+        MutableMap<Object, Object> newOne = newEmptyLike(map);
+        if (newOne instanceof VavrHamtMutableMapAdapter)
+        {
+            VavrHamtMutableMapAdapter<Object, Object> adapter = (VavrHamtMutableMapAdapter<Object, Object>) newOne;
+            pairs.forEach(p -> adapter.putNoReturn(p._first(), p._second()));
+        }
+        else
+        {
+            pairs.forEach(p -> newOne.put(p._first(), p._second()));
+        }
         return new PureMap(newOne);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static PureMap replaceAll(PureMap pureMap, org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.Pair<?, ?> pair)
     {
-        Map map = pureMap.getMap();
-        MutableMap<Object, Object> newOne = map instanceof UnifiedMapWithHashingStrategy ? new UnifiedMapWithHashingStrategy<>(((UnifiedMapWithHashingStrategy) map).hashingStrategy()) : Maps.mutable.empty();
-        newOne.put(pair._first(), pair._second());
+        MutableMap map = pureMap.getMap();
+        MutableMap<Object, Object> newOne = newEmptyLike(map);
+        if (newOne instanceof VavrHamtMutableMapAdapter)
+        {
+            ((VavrHamtMutableMapAdapter<Object, Object>) newOne).putNoReturn(pair._first(), pair._second());
+        }
+        else
+        {
+            newOne.put(pair._first(), pair._second());
+        }
         return new PureMap(newOne);
     }
 
     public static PureMap newMap(RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.Pair<?, ?>> pairs, ExecutionSupport es)
     {
-        MutableMap<Object, Object> map = PureEqualsHashingStrategy.newMutableMap();
-        pairs.forEach(p -> map.put(p._first(), p._second()));
+        HashingStrategy<Object> strategy = PureEqualsHashingStrategy.HASHING_STRATEGY;
+        // Batch build: collect into java.util.HashMap, then bulk-construct HAMT
+        java.util.HashMap<VavrHamtMutableMapAdapter.HamtKey<Object>, Object> temp = new java.util.HashMap<>();
+        pairs.forEach(p -> temp.put(new VavrHamtMutableMapAdapter.HamtKey<>(p._first(), strategy), p._second()));
+        MutableMap<Object, Object> map = VavrHamtMutableMapAdapter.fromJavaMap(temp, strategy);
+
         return new PureMap(map);
     }
 
     public static PureMap newMap(org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.Pair<?, ?> p, ExecutionSupport es)
     {
-        MutableMap<Object, Object> map = PureEqualsHashingStrategy.newMutableMap();
+        VavrHamtMutableMapAdapter<Object, Object> map = VavrHamtMutableMapAdapter.withHashingStrategy(PureEqualsHashingStrategy.HASHING_STRATEGY);
         if (p != null)
         {
-            map.put(p._first(), p._second());
+            map.putNoReturn(p._first(), p._second());
         }
-        return new PureMap(map);
+
+       return new PureMap(map);
     }
 
     private static class PropertyHashingStrategy implements HashingStrategy<Object>
@@ -949,33 +1010,41 @@ public class CoreHelper
 
     public static PureMap newMap(RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.Pair<?, ?>> pairs, Property<?, ?> property, ExecutionSupport es)
     {
-        MutableMap<Object, Object> map = UnifiedMapWithHashingStrategy.newMap(new PropertyHashingStrategy(property, es));
-        pairs.forEach(p -> map.put(p._first(), p._second()));
+        VavrHamtMutableMapAdapter<Object, Object> map = VavrHamtMutableMapAdapter.withHashingStrategy(new PropertyHashingStrategy(property, es));
+        pairs.forEach(p -> map.putNoReturn(p._first(), p._second()));
         return new PureMap(map);
     }
 
     public static PureMap newMap(org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.Pair<?, ?> pair, Property<?, ?> property, ExecutionSupport es)
     {
-        MutableMap<Object, Object> map = UnifiedMapWithHashingStrategy.newMap(new PropertyHashingStrategy(property, es));
+        VavrHamtMutableMapAdapter<Object, Object> map = VavrHamtMutableMapAdapter.withHashingStrategy(new PropertyHashingStrategy(property, es));
         if (pair != null)
         {
-            map.put(pair._first(), pair._second());
+            map.putNoReturn(pair._first(), pair._second());
         }
         return new PureMap(map);
     }
 
     public static PureMap newMap(RichIterable<? extends org.finos.legend.pure.m3.coreinstance.meta.pure.functions.collection.Pair<?, ?>> pairs, RichIterable<? extends Property<?, ?>> properties, Bridge bridge, ExecutionSupport es)
     {
-        MutableMap<Object, Object> map = UnifiedMapWithHashingStrategy.newMap(new PropertyHashingStrategy(properties, bridge, es));
-        pairs.forEach(p -> map.put(p._first(), p._second()));
+        VavrHamtMutableMapAdapter<Object, Object> map = VavrHamtMutableMapAdapter.withHashingStrategy(new PropertyHashingStrategy(properties, bridge, es));
+        pairs.forEach(p -> map.putNoReturn(p._first(), p._second()));
         return new PureMap(map);
     }
 
     public static PureMap put(PureMap pureMap, Object key, Object val)
     {
-        Map map = pureMap.getMap();
-        MutableMap<Object, Object> newOne = map instanceof UnifiedMapWithHashingStrategy ? new UnifiedMapWithHashingStrategy<>(((UnifiedMapWithHashingStrategy<?, ?>) map).hashingStrategy(), map) : Maps.mutable.withMap(map);
-        newOne.put(key, val);
+        MutableMap map = pureMap.getMap();
+        MutableMap<Object, Object> newOne = copyMap(map);
+        if (newOne instanceof VavrHamtMutableMapAdapter)
+        {
+            ((VavrHamtMutableMapAdapter<Object, Object>) newOne).putNoReturn(key, val);
+        }
+        else
+        {
+            newOne.put(key, val);
+        }
+
         return new PureMap(newOne);
     }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/map/PureEqualsHashingStrategy.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/map/PureEqualsHashingStrategy.java
@@ -17,7 +17,6 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.suppor
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.map.strategy.mutable.UnifiedMapWithHashingStrategy;
 import org.eclipse.collections.impl.set.strategy.mutable.UnifiedSetWithHashingStrategy;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.support.CompiledSupport;
 
@@ -47,6 +46,6 @@ public class PureEqualsHashingStrategy implements HashingStrategy<Object>
 
     public static <K, V> MutableMap<K, V> newMutableMap()
     {
-        return new UnifiedMapWithHashingStrategy<>(HASHING_STRATEGY);
+        return VavrHamtMutableMapAdapter.withHashingStrategy(HASHING_STRATEGY);
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/map/PureMap.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/map/PureMap.java
@@ -16,7 +16,6 @@ package org.finos.legend.pure.runtime.java.compiled.generation.processors.suppor
 
 import org.finos.legend.pure.runtime.java.shared.map.PureMapStats;
 import org.eclipse.collections.api.map.MutableMap;
-import org.eclipse.collections.impl.map.mutable.MapAdapter;
 
 import java.util.Map;
 import java.util.Objects;
@@ -31,12 +30,19 @@ public class PureMap
 
     public PureMap(Map map)
     {
-        this(MapAdapter.adapt(map));
+        this(VavrHamtMutableMapAdapter.fromMap(map));
     }
 
     public PureMap(MutableMap map)
     {
-        this.map = map;
+        if (map instanceof VavrHamtMutableMapAdapter || map instanceof PureCacheMap)
+        {
+            this.map = map;
+        }
+        else
+        {
+            this.map = VavrHamtMutableMapAdapter.fromMap(map);
+        }
         this.stats = new PureMapStats();
     }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/map/VavrHamtMutableMapAdapter.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/map/VavrHamtMutableMapAdapter.java
@@ -1,0 +1,537 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.map;
+
+import io.vavr.collection.HashMap;
+import org.eclipse.collections.api.LazyIterable;
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.block.HashingStrategy;
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.block.procedure.Procedure2;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.factory.Maps;
+import org.eclipse.collections.impl.map.mutable.AbstractMutableMap;
+import org.eclipse.collections.impl.tuple.Tuples;
+import org.eclipse.collections.impl.utility.LazyIterate;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A {@link MutableMap} adapter backed by a Vavr HAMT (Hash Array Mapped Trie) map.
+ * <p>
+ * Mutations update the internal immutable HAMT reference, giving persistent-data-structure
+ * semantics while satisfying the Eclipse Collections {@code MutableMap} contract required
+ * by generated code (e.g.&nbsp;{@code getIfAbsentPutWithKey}, {@code get}, {@code put}).
+ * <p>
+ * Read operations delegate directly to the HAMT; write operations swap the HAMT reference.
+ * An optional {@link HashingStrategy} is preserved so that maps created with
+ * {@code UnifiedMapWithHashingStrategy} (e.g.&nbsp;{@code PureEqualsHashingStrategy} or
+ * {@code PropertyHashingStrategy}) continue to use the same equality/hashCode semantics.
+ */
+public class VavrHamtMutableMapAdapter<K, V> extends AbstractMutableMap<K, V>
+{
+    private io.vavr.collection.Map<HamtKey<K>, V> hamtMap;
+    private final HashingStrategy<? super K> hashingStrategy;
+
+    // ---- Constructors -------------------------------------------------------
+
+    public VavrHamtMutableMapAdapter()
+    {
+        this(HashMap.empty(), null);
+    }
+
+    public VavrHamtMutableMapAdapter(HashingStrategy<? super K> hashingStrategy)
+    {
+        this(HashMap.empty(), hashingStrategy);
+    }
+
+    private VavrHamtMutableMapAdapter(io.vavr.collection.Map<HamtKey<K>, V> hamtMap, HashingStrategy<? super K> hashingStrategy)
+    {
+        this.hamtMap = hamtMap;
+        this.hashingStrategy = hashingStrategy;
+    }
+
+    // ---- Factory methods ----------------------------------------------------
+
+    /**
+     * Build a new adapter from an existing {@link Map}, preserving the hashing
+     * strategy if the source is a {@code UnifiedMapWithHashingStrategy}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <K, V> VavrHamtMutableMapAdapter<K, V> fromMap(Map<K, V> source)
+    {
+        if (source instanceof VavrHamtMutableMapAdapter)
+        {
+            VavrHamtMutableMapAdapter<K, V> src = (VavrHamtMutableMapAdapter<K, V>) source;
+            return new VavrHamtMutableMapAdapter<>(src.hamtMap, src.hashingStrategy);
+        }
+        HashingStrategy<? super K> strategy = null;
+        if (source instanceof org.eclipse.collections.impl.map.strategy.mutable.UnifiedMapWithHashingStrategy)
+        {
+            strategy = ((org.eclipse.collections.impl.map.strategy.mutable.UnifiedMapWithHashingStrategy<K, V>) source).hashingStrategy();
+        }
+        VavrHamtMutableMapAdapter<K, V> adapter = new VavrHamtMutableMapAdapter<>(HashMap.empty(), strategy);
+        source.forEach((k, v) -> adapter.hamtMap = adapter.hamtMap.put(adapter.wrap(k), v));
+        return adapter;
+    }
+
+    public static <K, V> VavrHamtMutableMapAdapter<K, V> withHashingStrategy(HashingStrategy<? super K> strategy)
+    {
+        return new VavrHamtMutableMapAdapter<>(HashMap.empty(), strategy);
+    }
+
+    public static <K, V> VavrHamtMutableMapAdapter<K, V> withHashingStrategy(HashingStrategy<? super K> strategy, Map<K, V> source)
+    {
+        VavrHamtMutableMapAdapter<K, V> adapter = new VavrHamtMutableMapAdapter<>(HashMap.empty(), strategy);
+        source.forEach((k, v) -> adapter.hamtMap = adapter.hamtMap.put(adapter.wrap(k), v));
+        return adapter;
+    }
+
+    /**
+     * Build a HAMT adapter by bulk-loading entries from a {@link java.util.HashMap}.
+     * This constructs the HAMT in a single pass via {@code HashMap.ofAll()},
+     * avoiding the overhead of individual path-copies for each entry.
+     */
+    public static <K, V> VavrHamtMutableMapAdapter<K, V> fromJavaMap(java.util.HashMap<HamtKey<K>, V> javaMap, HashingStrategy<? super K> strategy)
+    {
+        io.vavr.collection.Map<HamtKey<K>, V> hamt = HashMap.ofAll(javaMap);
+        return new VavrHamtMutableMapAdapter<>(hamt, strategy);
+    }
+
+    // ---- HashingStrategy accessor -------------------------------------------
+
+    public HashingStrategy<? super K> hashingStrategy()
+    {
+        return this.hashingStrategy;
+    }
+
+    // ---- Key wrapper that delegates equals/hashCode to the strategy ---------
+
+    private HamtKey<K> wrap(K key)
+    {
+        return new HamtKey<>(key, this.hashingStrategy);
+    }
+
+    /**
+     * Wraps a key using this adapter's hashing strategy.
+     * Exposed for use in batch-building scenarios (e.g. {@link #fromJavaMap}).
+     */
+    public HamtKey<K> wrapKey(K key)
+    {
+        return new HamtKey<>(key, this.hashingStrategy);
+    }
+
+    @SuppressWarnings("unchecked")
+    private HamtKey<K> wrapObject(Object key)
+    {
+        return new HamtKey<>((K) key, this.hashingStrategy);
+    }
+
+    /**
+     * A wrapper that delegates {@code equals} and {@code hashCode} to an optional
+     * {@link HashingStrategy}. When no strategy is present, the natural
+     * {@code Object.equals} / {@code Object.hashCode} are used.
+     */
+    public static final class HamtKey<K>
+    {
+        final K key;
+        private final HashingStrategy<? super K> strategy;
+
+        public HamtKey(K key, HashingStrategy<? super K> strategy)
+        {
+            this.key = key;
+            this.strategy = strategy;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            if (strategy != null)
+            {
+                return strategy.computeHashCode(key);
+            }
+            return Objects.hashCode(key);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public boolean equals(Object obj)
+        {
+            if (this == obj)
+            {
+                return true;
+            }
+            if (!(obj instanceof HamtKey))
+            {
+                return false;
+            }
+            K otherKey = ((HamtKey<K>) obj).key;
+            if (strategy != null)
+            {
+                return strategy.equals(key, otherKey);
+            }
+            return Objects.equals(key, otherKey);
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.valueOf(key);
+        }
+    }
+
+    // ---- Core Map read operations -------------------------------------------
+
+    @Override
+    public V get(Object key)
+    {
+        return this.hamtMap.get(wrapObject(key)).getOrElse((V) null);
+    }
+
+    @Override
+    public boolean containsKey(Object key)
+    {
+        return this.hamtMap.containsKey(wrapObject(key));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean containsValue(Object value)
+    {
+        return this.hamtMap.containsValue((V) value);
+    }
+
+    @Override
+    public int size()
+    {
+        return this.hamtMap.size();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return this.hamtMap.isEmpty();
+    }
+
+    @Override
+    public boolean notEmpty()
+    {
+        return !this.hamtMap.isEmpty();
+    }
+
+    // ---- Core Map write operations ------------------------------------------
+
+    @Override
+    public V put(K key, V value)
+    {
+        HamtKey<K> wrapped = wrap(key);
+        io.vavr.collection.Map<HamtKey<K>, V> prev = this.hamtMap;
+        this.hamtMap = prev.put(wrapped, value);
+        return prev.get(wrapped).getOrElse((V) null);
+    }
+
+    /**
+     * Inserts a key-value pair without returning the previous value.
+     * Use this when the caller discards the return value of {@code put},
+     * as it avoids a redundant HAMT traversal.
+     */
+    public void putNoReturn(K key, V value)
+    {
+        this.hamtMap = this.hamtMap.put(wrap(key), value);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void putAll(Map<? extends K, ? extends V> map)
+    {
+        if (map instanceof VavrHamtMutableMapAdapter)
+        {
+            VavrHamtMutableMapAdapter<K, V> other = (VavrHamtMutableMapAdapter<K, V>) map;
+            io.vavr.collection.Map<HamtKey<K>, V> current = this.hamtMap;
+            if (Objects.equals(this.hashingStrategy, other.hashingStrategy))
+            {
+                // Same strategy — reuse HamtKey wrappers directly, no re-wrapping
+                for (io.vavr.Tuple2<HamtKey<K>, V> tuple : other.hamtMap)
+                {
+                    current = current.put(tuple._1, tuple._2);
+                }
+            }
+            else
+            {
+                // Different strategy — must re-wrap keys
+                for (io.vavr.Tuple2<HamtKey<K>, V> tuple : other.hamtMap)
+                {
+                    current = current.put(wrap(tuple._1.key), tuple._2);
+                }
+            }
+            this.hamtMap = current;
+        }
+        else
+        {
+            io.vavr.collection.Map<HamtKey<K>, V> current = this.hamtMap;
+            for (Map.Entry<? extends K, ? extends V> entry : map.entrySet())
+            {
+                current = current.put(wrap(entry.getKey()), entry.getValue());
+            }
+            this.hamtMap = current;
+        }
+    }
+
+    @Override
+    public V removeKey(K key)
+    {
+        return this.remove(key);
+    }
+
+    @Override
+    public V remove(Object key)
+    {
+        HamtKey<K> wrapped = wrapObject(key);
+        V old = this.hamtMap.get(wrapped).getOrElse((V) null);
+        this.hamtMap = this.hamtMap.remove(wrapped);
+        return old;
+    }
+
+    @Override
+    public void clear()
+    {
+        this.hamtMap = HashMap.empty();
+    }
+
+    // ---- Eclipse Collections MutableMap contract ----------------------------
+
+    @Override
+    public V getIfAbsentPut(K key, Function0<? extends V> function)
+    {
+        HamtKey<K> wrapped = wrap(key);
+        io.vavr.control.Option<V> existing = this.hamtMap.get(wrapped);
+        if (existing.isDefined())
+        {
+            return existing.get();
+        }
+        V value = function.value();
+        this.hamtMap = this.hamtMap.put(wrapped, value);
+        return value;
+    }
+
+    @Override
+    public V getIfAbsentPut(K key, V value)
+    {
+        HamtKey<K> wrapped = wrap(key);
+        io.vavr.control.Option<V> existing = this.hamtMap.get(wrapped);
+        if (existing.isDefined())
+        {
+            return existing.get();
+        }
+        this.hamtMap = this.hamtMap.put(wrapped, value);
+        return value;
+    }
+
+    @Override
+    public <P> V getIfAbsentPutWith(K key, Function<? super P, ? extends V> function, P parameter)
+    {
+        HamtKey<K> wrapped = wrap(key);
+        io.vavr.control.Option<V> existing = this.hamtMap.get(wrapped);
+        if (existing.isDefined())
+        {
+            return existing.get();
+        }
+        V value = function.valueOf(parameter);
+        this.hamtMap = this.hamtMap.put(wrapped, value);
+        return value;
+    }
+
+    @Override
+    public V getIfAbsentPutWithKey(K key, Function<? super K, ? extends V> function)
+    {
+        HamtKey<K> wrapped = wrap(key);
+        io.vavr.control.Option<V> existing = this.hamtMap.get(wrapped);
+        if (existing.isDefined())
+        {
+            return existing.get();
+        }
+        V value = function.valueOf(key);
+        this.hamtMap = this.hamtMap.put(wrapped, value);
+        return value;
+    }
+
+    // ---- Iteration ----------------------------------------------------------
+
+    @Override
+    public void forEachKeyValue(Procedure2<? super K, ? super V> procedure)
+    {
+        this.hamtMap.forEach(tuple -> procedure.value(tuple._1.key, tuple._2));
+    }
+
+    @Override
+    public <E> MutableMap<K, V> collectKeysAndValues(Iterable<E> iterable, Function<? super E, ? extends K> keyFunction, Function<? super E, ? extends V> valueFunction)
+    {
+        for (E item : iterable)
+        {
+            this.put(keyFunction.valueOf(item), valueFunction.valueOf(item));
+        }
+        return this;
+    }
+
+    @Override
+    public Iterator<V> iterator()
+    {
+        return this.hamtMap.values().iterator();
+    }
+
+    // ---- View operations ----------------------------------------------------
+
+    @Override
+    public Set<K> keySet()
+    {
+        java.util.LinkedHashSet<K> result = new java.util.LinkedHashSet<>();
+        this.hamtMap.forEach(tuple -> result.add(tuple._1.key));
+        return result;
+    }
+
+    @Override
+    public Collection<V> values()
+    {
+        return this.hamtMap.values().toJavaList();
+    }
+
+    @Override
+    public Set<Map.Entry<K, V>> entrySet()
+    {
+        java.util.LinkedHashSet<Map.Entry<K, V>> result = new java.util.LinkedHashSet<>();
+        this.hamtMap.forEach(tuple -> result.add(new java.util.AbstractMap.SimpleEntry<>(tuple._1.key, tuple._2)));
+        return result;
+    }
+
+    @Override
+    public LazyIterable<V> valuesView()
+    {
+        return LazyIterate.adapt(this.hamtMap.values());
+    }
+
+    @Override
+    public LazyIterable<Pair<K, V>> keyValuesView()
+    {
+        return LazyIterate.adapt(this.hamtMap).collect(tuple -> Tuples.pair(tuple._1.key, tuple._2));
+    }
+
+    @Override
+    public LazyIterable<K> keysView()
+    {
+        return LazyIterate.adapt(this.hamtMap).collect(tuple -> tuple._1.key);
+    }
+
+    public RichIterable<K> keysWithDuplicates()
+    {
+        return this.keysView();
+    }
+
+    // ---- Copy / Clone -------------------------------------------------------
+
+    @Override
+    public MutableMap<K, V> newEmpty()
+    {
+        return new VavrHamtMutableMapAdapter<>(HashMap.empty(), this.hashingStrategy);
+    }
+
+    @Override
+    public <K1, V1> MutableMap<K1, V1> newEmpty(int capacity)
+    {
+        // capacity hint ignored — HAMT does not pre-allocate
+        return new VavrHamtMutableMapAdapter<>(HashMap.empty(), null);
+    }
+
+    @Override
+    public MutableMap<K, V> clone()
+    {
+        // HAMT is immutable so sharing the reference is safe
+        return new VavrHamtMutableMapAdapter<>(this.hamtMap, this.hashingStrategy);
+    }
+
+    @Override
+    public ImmutableMap<K, V> toImmutable()
+    {
+        MutableMap<K, V> copy = Maps.mutable.ofInitialCapacity(this.size());
+        this.forEachKeyValue(copy::put);
+        return copy.toImmutable();
+    }
+
+    // ---- equals / hashCode --------------------------------------------------
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (!(o instanceof Map))
+        {
+            return false;
+        }
+        Map<?, ?> other = (Map<?, ?>) o;
+        if (this.size() != other.size())
+        {
+            return false;
+        }
+        for (Map.Entry<?, ?> entry : other.entrySet())
+        {
+            HamtKey<K> wrapped = wrapObject(entry.getKey());
+            io.vavr.control.Option<V> val = this.hamtMap.get(wrapped);
+            if (val.isEmpty() || !Objects.equals(val.get(), entry.getValue()))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int h = 0;
+        for (io.vavr.Tuple2<HamtKey<K>, V> tuple : this.hamtMap)
+        {
+            h += Objects.hashCode(tuple._1.key) ^ Objects.hashCode(tuple._2);
+        }
+        return h;
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (io.vavr.Tuple2<HamtKey<K>, V> tuple : this.hamtMap)
+        {
+            if (!first)
+            {
+                sb.append(", ");
+            }
+            sb.append(tuple._1.key).append("=").append(tuple._2);
+            first = false;
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+}
+

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/map/TestVavrHamtMutableMapAdapter.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/map/TestVavrHamtMutableMapAdapter.java
@@ -1,0 +1,989 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.compiled.generation.processors.support.map;
+
+import org.eclipse.collections.api.LazyIterable;
+import org.eclipse.collections.api.block.HashingStrategy;
+import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.map.strategy.mutable.UnifiedMapWithHashingStrategy;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestVavrHamtMutableMapAdapter
+{
+    private VavrHamtMutableMapAdapter<String, Integer> map;
+
+    private static final HashingStrategy<String> CASE_INSENSITIVE_STRATEGY = new HashingStrategy<String>()
+    {
+        @Override
+        public int computeHashCode(String object)
+        {
+            return object == null ? 0 : object.toLowerCase().hashCode();
+        }
+
+        @Override
+        public boolean equals(String object1, String object2)
+        {
+            if (object1 == null)
+            {
+                return object2 == null;
+            }
+            return object1.equalsIgnoreCase(object2);
+        }
+    };
+
+    @Before
+    public void setUp()
+    {
+        map = new VavrHamtMutableMapAdapter<>();
+    }
+
+    // ---- Constructor tests --------------------------------------------------
+
+    @Test
+    public void testDefaultConstructor()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> m = new VavrHamtMutableMapAdapter<>();
+        Assert.assertTrue(m.isEmpty());
+        Assert.assertEquals(0, m.size());
+        Assert.assertNull(m.hashingStrategy());
+    }
+
+    @Test
+    public void testConstructorWithHashingStrategy()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> m = new VavrHamtMutableMapAdapter<>(CASE_INSENSITIVE_STRATEGY);
+        Assert.assertTrue(m.isEmpty());
+        Assert.assertSame(CASE_INSENSITIVE_STRATEGY, m.hashingStrategy());
+    }
+
+    // ---- Factory method tests -----------------------------------------------
+
+    @Test
+    public void testFromMapWithJavaMap()
+    {
+        HashMap<String, Integer> source = new HashMap<>();
+        source.put("a", 1);
+        source.put("b", 2);
+
+        VavrHamtMutableMapAdapter<String, Integer> adapter = VavrHamtMutableMapAdapter.fromMap(source);
+        Assert.assertEquals(2, adapter.size());
+        Assert.assertEquals(Integer.valueOf(1), adapter.get("a"));
+        Assert.assertEquals(Integer.valueOf(2), adapter.get("b"));
+        Assert.assertNull(adapter.hashingStrategy());
+    }
+
+    @Test
+    public void testFromMapWithVavrAdapter()
+    {
+        map.put("x", 10);
+        map.put("y", 20);
+
+        VavrHamtMutableMapAdapter<String, Integer> copy = VavrHamtMutableMapAdapter.fromMap(map);
+        Assert.assertEquals(2, copy.size());
+        Assert.assertEquals(Integer.valueOf(10), copy.get("x"));
+        Assert.assertEquals(Integer.valueOf(20), copy.get("y"));
+
+        // Verify it's a separate copy
+        copy.put("z", 30);
+        Assert.assertNull(map.get("z"));
+    }
+
+    @Test
+    public void testFromMapWithVavrAdapterPreservesStrategy()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> original = new VavrHamtMutableMapAdapter<>(CASE_INSENSITIVE_STRATEGY);
+        original.put("Hello", 1);
+
+        VavrHamtMutableMapAdapter<String, Integer> copy = VavrHamtMutableMapAdapter.fromMap(original);
+        Assert.assertSame(CASE_INSENSITIVE_STRATEGY, copy.hashingStrategy());
+        Assert.assertEquals(Integer.valueOf(1), copy.get("hello"));
+    }
+
+    @Test
+    public void testFromMapWithUnifiedMapWithHashingStrategy()
+    {
+        UnifiedMapWithHashingStrategy<String, Integer> unified = new UnifiedMapWithHashingStrategy<>(CASE_INSENSITIVE_STRATEGY);
+        unified.put("Key", 42);
+
+        VavrHamtMutableMapAdapter<String, Integer> adapter = VavrHamtMutableMapAdapter.fromMap(unified);
+        Assert.assertSame(CASE_INSENSITIVE_STRATEGY, adapter.hashingStrategy());
+        Assert.assertEquals(Integer.valueOf(42), adapter.get("key"));
+        Assert.assertEquals(Integer.valueOf(42), adapter.get("KEY"));
+    }
+
+    @Test
+    public void testWithHashingStrategy()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> m = VavrHamtMutableMapAdapter.withHashingStrategy(CASE_INSENSITIVE_STRATEGY);
+        Assert.assertTrue(m.isEmpty());
+        Assert.assertSame(CASE_INSENSITIVE_STRATEGY, m.hashingStrategy());
+    }
+
+    @Test
+    public void testWithHashingStrategyAndSource()
+    {
+        HashMap<String, Integer> source = new HashMap<>();
+        source.put("Abc", 1);
+        source.put("Def", 2);
+
+        VavrHamtMutableMapAdapter<String, Integer> m = VavrHamtMutableMapAdapter.withHashingStrategy(CASE_INSENSITIVE_STRATEGY, source);
+        Assert.assertEquals(2, m.size());
+        Assert.assertEquals(Integer.valueOf(1), m.get("abc"));
+        Assert.assertEquals(Integer.valueOf(2), m.get("DEF"));
+    }
+
+    @Test
+    public void testFromJavaMap()
+    {
+        java.util.HashMap<VavrHamtMutableMapAdapter.HamtKey<String>, Integer> javaMap = new java.util.HashMap<>();
+        VavrHamtMutableMapAdapter<String, Integer> temp = new VavrHamtMutableMapAdapter<>();
+        javaMap.put(temp.wrapKey("a"), 1);
+        javaMap.put(temp.wrapKey("b"), 2);
+
+        VavrHamtMutableMapAdapter<String, Integer> adapter = VavrHamtMutableMapAdapter.fromJavaMap(javaMap, null);
+        Assert.assertEquals(2, adapter.size());
+        Assert.assertEquals(Integer.valueOf(1), adapter.get("a"));
+        Assert.assertEquals(Integer.valueOf(2), adapter.get("b"));
+    }
+
+    @Test
+    public void testFromJavaMapWithStrategy()
+    {
+        java.util.HashMap<VavrHamtMutableMapAdapter.HamtKey<String>, Integer> javaMap = new java.util.HashMap<>();
+        VavrHamtMutableMapAdapter<String, Integer> temp = new VavrHamtMutableMapAdapter<>(CASE_INSENSITIVE_STRATEGY);
+        javaMap.put(temp.wrapKey("Hello"), 1);
+
+        VavrHamtMutableMapAdapter<String, Integer> adapter = VavrHamtMutableMapAdapter.fromJavaMap(javaMap, CASE_INSENSITIVE_STRATEGY);
+        Assert.assertEquals(1, adapter.size());
+        Assert.assertSame(CASE_INSENSITIVE_STRATEGY, adapter.hashingStrategy());
+    }
+
+    // ---- Core read operations -----------------------------------------------
+
+    @Test
+    public void testGetExistingKey()
+    {
+        map.put("key", 42);
+        Assert.assertEquals(Integer.valueOf(42), map.get("key"));
+    }
+
+    @Test
+    public void testGetNonExistentKey()
+    {
+        Assert.assertNull(map.get("missing"));
+    }
+
+    @Test
+    public void testContainsKeyTrue()
+    {
+        map.put("exists", 1);
+        Assert.assertTrue(map.containsKey("exists"));
+    }
+
+    @Test
+    public void testContainsKeyFalse()
+    {
+        Assert.assertFalse(map.containsKey("nope"));
+    }
+
+    @Test
+    public void testContainsValueTrue()
+    {
+        map.put("a", 100);
+        Assert.assertTrue(map.containsValue(100));
+    }
+
+    @Test
+    public void testContainsValueFalse()
+    {
+        map.put("a", 100);
+        Assert.assertFalse(map.containsValue(999));
+    }
+
+    @Test
+    public void testSize()
+    {
+        Assert.assertEquals(0, map.size());
+        map.put("a", 1);
+        Assert.assertEquals(1, map.size());
+        map.put("b", 2);
+        Assert.assertEquals(2, map.size());
+        map.put("a", 3); // overwrite
+        Assert.assertEquals(2, map.size());
+    }
+
+    @Test
+    public void testIsEmpty()
+    {
+        Assert.assertTrue(map.isEmpty());
+        map.put("a", 1);
+        Assert.assertFalse(map.isEmpty());
+    }
+
+    @Test
+    public void testNotEmpty()
+    {
+        Assert.assertFalse(map.notEmpty());
+        map.put("a", 1);
+        Assert.assertTrue(map.notEmpty());
+    }
+
+    // ---- Core write operations ----------------------------------------------
+
+    @Test
+    public void testPutReturnsOldValue()
+    {
+        Assert.assertNull(map.put("a", 1));
+        Assert.assertEquals(Integer.valueOf(1), map.put("a", 2));
+        Assert.assertEquals(Integer.valueOf(2), map.get("a"));
+    }
+
+    @Test
+    public void testPutNoReturn()
+    {
+        map.putNoReturn("fast", 99);
+        Assert.assertEquals(Integer.valueOf(99), map.get("fast"));
+        map.putNoReturn("fast", 100);
+        Assert.assertEquals(Integer.valueOf(100), map.get("fast"));
+    }
+
+    @Test
+    public void testPutAllFromJavaMap()
+    {
+        HashMap<String, Integer> source = new HashMap<>();
+        source.put("x", 10);
+        source.put("y", 20);
+
+        map.put("z", 30);
+        map.putAll(source);
+
+        Assert.assertEquals(3, map.size());
+        Assert.assertEquals(Integer.valueOf(10), map.get("x"));
+        Assert.assertEquals(Integer.valueOf(20), map.get("y"));
+        Assert.assertEquals(Integer.valueOf(30), map.get("z"));
+    }
+
+    @Test
+    public void testPutAllFromVavrAdapterSameStrategy()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> other = new VavrHamtMutableMapAdapter<>();
+        other.put("a", 1);
+        other.put("b", 2);
+
+        map.put("c", 3);
+        map.putAll(other);
+
+        Assert.assertEquals(3, map.size());
+        Assert.assertEquals(Integer.valueOf(1), map.get("a"));
+        Assert.assertEquals(Integer.valueOf(2), map.get("b"));
+        Assert.assertEquals(Integer.valueOf(3), map.get("c"));
+    }
+
+    @Test
+    public void testPutAllFromVavrAdapterDifferentStrategy()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> other = new VavrHamtMutableMapAdapter<>(CASE_INSENSITIVE_STRATEGY);
+        other.put("Hello", 1);
+
+        VavrHamtMutableMapAdapter<String, Integer> target = new VavrHamtMutableMapAdapter<>();
+        target.putAll(other);
+
+        Assert.assertEquals(1, target.size());
+        Assert.assertEquals(Integer.valueOf(1), target.get("Hello"));
+        // Without case-insensitive strategy on target, "hello" shouldn't match
+        Assert.assertNull(target.get("hello"));
+    }
+
+    @Test
+    public void testRemove()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        Assert.assertEquals(Integer.valueOf(1), map.remove("a"));
+        Assert.assertEquals(1, map.size());
+        Assert.assertNull(map.get("a"));
+    }
+
+    @Test
+    public void testRemoveNonExistent()
+    {
+        map.put("a", 1);
+        Assert.assertNull(map.remove("missing"));
+        Assert.assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testRemoveKey()
+    {
+        map.put("a", 1);
+        Assert.assertEquals(Integer.valueOf(1), map.removeKey("a"));
+        Assert.assertTrue(map.isEmpty());
+    }
+
+    @Test
+    public void testClear()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+        map.clear();
+        Assert.assertTrue(map.isEmpty());
+        Assert.assertEquals(0, map.size());
+    }
+
+    // ---- Eclipse Collections MutableMap contract ----------------------------
+
+    @Test
+    public void testGetIfAbsentPutWithFunction0_absent()
+    {
+        AtomicInteger callCount = new AtomicInteger(0);
+        Integer result = map.getIfAbsentPut("key", () ->
+        {
+            callCount.incrementAndGet();
+            return 42;
+        });
+        Assert.assertEquals(Integer.valueOf(42), result);
+        Assert.assertEquals(1, callCount.get());
+        Assert.assertEquals(Integer.valueOf(42), map.get("key"));
+    }
+
+    @Test
+    public void testGetIfAbsentPutWithFunction0_present()
+    {
+        map.put("key", 10);
+        AtomicInteger callCount = new AtomicInteger(0);
+        Integer result = map.getIfAbsentPut("key", () ->
+        {
+            callCount.incrementAndGet();
+            return 42;
+        });
+        Assert.assertEquals(Integer.valueOf(10), result);
+        Assert.assertEquals(0, callCount.get());
+    }
+
+    @Test
+    public void testGetIfAbsentPutWithValue_absent()
+    {
+        Integer result = map.getIfAbsentPut("key", 42);
+        Assert.assertEquals(Integer.valueOf(42), result);
+        Assert.assertEquals(Integer.valueOf(42), map.get("key"));
+    }
+
+    @Test
+    public void testGetIfAbsentPutWithValue_present()
+    {
+        map.put("key", 10);
+        Integer result = map.getIfAbsentPut("key", 42);
+        Assert.assertEquals(Integer.valueOf(10), result);
+    }
+
+    @Test
+    public void testGetIfAbsentPutWith_absent()
+    {
+        Integer result = map.getIfAbsentPutWith("key", String::length, "hello");
+        Assert.assertEquals(Integer.valueOf(5), result);
+        Assert.assertEquals(Integer.valueOf(5), map.get("key"));
+    }
+
+    @Test
+    public void testGetIfAbsentPutWith_present()
+    {
+        map.put("key", 10);
+        Integer result = map.getIfAbsentPutWith("key", String::length, "hello");
+        Assert.assertEquals(Integer.valueOf(10), result);
+    }
+
+    @Test
+    public void testGetIfAbsentPutWithKey_absent()
+    {
+        Integer result = map.getIfAbsentPutWithKey("abc", String::length);
+        Assert.assertEquals(Integer.valueOf(3), result);
+        Assert.assertEquals(Integer.valueOf(3), map.get("abc"));
+    }
+
+    @Test
+    public void testGetIfAbsentPutWithKey_present()
+    {
+        map.put("abc", 99);
+        Integer result = map.getIfAbsentPutWithKey("abc", String::length);
+        Assert.assertEquals(Integer.valueOf(99), result);
+    }
+
+    // ---- Iteration ----------------------------------------------------------
+
+    @Test
+    public void testForEachKeyValue()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        HashMap<String, Integer> collected = new HashMap<>();
+        map.forEachKeyValue(collected::put);
+
+        Assert.assertEquals(2, collected.size());
+        Assert.assertEquals(Integer.valueOf(1), collected.get("a"));
+        Assert.assertEquals(Integer.valueOf(2), collected.get("b"));
+    }
+
+    @Test
+    public void testCollectKeysAndValues()
+    {
+        java.util.List<String> items = java.util.Arrays.asList("abc", "de", "fghi");
+        map.collectKeysAndValues(items, s -> s, String::length);
+
+        Assert.assertEquals(3, map.size());
+        Assert.assertEquals(Integer.valueOf(3), map.get("abc"));
+        Assert.assertEquals(Integer.valueOf(2), map.get("de"));
+        Assert.assertEquals(Integer.valueOf(4), map.get("fghi"));
+    }
+
+    @Test
+    public void testIterator()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        java.util.Set<Integer> values = new java.util.HashSet<>();
+        Iterator<Integer> it = map.iterator();
+        while (it.hasNext())
+        {
+            values.add(it.next());
+        }
+        Assert.assertEquals(new java.util.HashSet<>(java.util.Arrays.asList(1, 2)), values);
+    }
+
+    // ---- View operations ----------------------------------------------------
+
+    @Test
+    public void testKeySet()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        Set<String> keys = map.keySet();
+        Assert.assertEquals(2, keys.size());
+        Assert.assertTrue(keys.contains("a"));
+        Assert.assertTrue(keys.contains("b"));
+    }
+
+    @Test
+    public void testValues()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        Collection<Integer> vals = map.values();
+        Assert.assertEquals(2, vals.size());
+        Assert.assertTrue(vals.contains(1));
+        Assert.assertTrue(vals.contains(2));
+    }
+
+    @Test
+    public void testEntrySet()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        Set<Map.Entry<String, Integer>> entries = map.entrySet();
+        Assert.assertEquals(2, entries.size());
+
+        HashMap<String, Integer> fromEntries = new HashMap<>();
+        for (Map.Entry<String, Integer> e : entries)
+        {
+            fromEntries.put(e.getKey(), e.getValue());
+        }
+        Assert.assertEquals(Integer.valueOf(1), fromEntries.get("a"));
+        Assert.assertEquals(Integer.valueOf(2), fromEntries.get("b"));
+    }
+
+    @Test
+    public void testValuesView()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        LazyIterable<Integer> view = map.valuesView();
+        java.util.Set<Integer> collected = new java.util.HashSet<>();
+        view.forEach(collected::add);
+        Assert.assertEquals(new java.util.HashSet<>(java.util.Arrays.asList(1, 2)), collected);
+    }
+
+    @Test
+    public void testKeyValuesView()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        LazyIterable<Pair<String, Integer>> view = map.keyValuesView();
+        HashMap<String, Integer> collected = new HashMap<>();
+        view.forEach(p -> collected.put(p.getOne(), p.getTwo()));
+
+        Assert.assertEquals(Integer.valueOf(1), collected.get("a"));
+        Assert.assertEquals(Integer.valueOf(2), collected.get("b"));
+    }
+
+    @Test
+    public void testKeysView()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        LazyIterable<String> view = map.keysView();
+        java.util.Set<String> collected = new java.util.HashSet<>();
+        view.forEach(collected::add);
+        Assert.assertEquals(new java.util.HashSet<>(java.util.Arrays.asList("a", "b")), collected);
+    }
+
+    @Test
+    public void testKeysWithDuplicates()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        java.util.Set<String> collected = new java.util.HashSet<>();
+        map.keysWithDuplicates().forEach(collected::add);
+        Assert.assertEquals(new java.util.HashSet<>(java.util.Arrays.asList("a", "b")), collected);
+    }
+
+    // ---- Copy / Clone -------------------------------------------------------
+
+    @Test
+    public void testNewEmpty()
+    {
+        map.put("a", 1);
+        MutableMap<String, Integer> empty = map.newEmpty();
+        Assert.assertTrue(empty.isEmpty());
+        Assert.assertTrue(empty instanceof VavrHamtMutableMapAdapter);
+    }
+
+    @Test
+    public void testNewEmptyPreservesStrategy()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> stratMap = new VavrHamtMutableMapAdapter<>(CASE_INSENSITIVE_STRATEGY);
+        MutableMap<String, Integer> empty = stratMap.newEmpty();
+        Assert.assertTrue(empty instanceof VavrHamtMutableMapAdapter);
+        Assert.assertSame(CASE_INSENSITIVE_STRATEGY, ((VavrHamtMutableMapAdapter<String, Integer>) empty).hashingStrategy());
+    }
+
+    @Test
+    public void testNewEmptyWithCapacity()
+    {
+        MutableMap<Integer, String> empty = map.newEmpty(100);
+        Assert.assertTrue(empty.isEmpty());
+        Assert.assertTrue(empty instanceof VavrHamtMutableMapAdapter);
+    }
+
+    @Test
+    public void testClone()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        MutableMap<String, Integer> cloned = map.clone();
+        Assert.assertEquals(2, cloned.size());
+        Assert.assertEquals(Integer.valueOf(1), cloned.get("a"));
+        Assert.assertEquals(Integer.valueOf(2), cloned.get("b"));
+
+        // Mutations on clone should not affect original
+        cloned.put("c", 3);
+        Assert.assertNull(map.get("c"));
+    }
+
+    @Test
+    public void testToImmutable()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        ImmutableMap<String, Integer> immutable = map.toImmutable();
+        Assert.assertEquals(2, immutable.size());
+        Assert.assertEquals(Integer.valueOf(1), immutable.get("a"));
+        Assert.assertEquals(Integer.valueOf(2), immutable.get("b"));
+    }
+
+    // ---- equals / hashCode --------------------------------------------------
+
+    @Test
+    public void testEqualsWithSameInstance()
+    {
+        map.put("a", 1);
+        Assert.assertEquals(map, map);
+    }
+
+    @Test
+    public void testEqualsWithJavaHashMap()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        HashMap<String, Integer> javaMap = new HashMap<>();
+        javaMap.put("a", 1);
+        javaMap.put("b", 2);
+
+        Assert.assertEquals(map, javaMap);
+        Assert.assertEquals(javaMap, map);
+    }
+
+    @Test
+    public void testEqualsWithDifferentValues()
+    {
+        map.put("a", 1);
+
+        HashMap<String, Integer> javaMap = new HashMap<>();
+        javaMap.put("a", 2);
+
+        Assert.assertNotEquals(map, javaMap);
+    }
+
+    @Test
+    public void testEqualsWithDifferentSizes()
+    {
+        map.put("a", 1);
+
+        HashMap<String, Integer> javaMap = new HashMap<>();
+        javaMap.put("a", 1);
+        javaMap.put("b", 2);
+
+        Assert.assertNotEquals(map, javaMap);
+    }
+
+    @Test
+    public void testEqualsWithNonMap()
+    {
+        Assert.assertNotEquals(map, "not a map");
+    }
+
+    @Test
+    public void testEqualsWithMissingKey()
+    {
+        map.put("a", 1);
+
+        HashMap<String, Integer> javaMap = new HashMap<>();
+        javaMap.put("b", 1);
+
+        Assert.assertNotEquals(map, javaMap);
+    }
+
+    @Test
+    public void testHashCodeConsistency()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+
+        HashMap<String, Integer> javaMap = new HashMap<>();
+        javaMap.put("a", 1);
+        javaMap.put("b", 2);
+
+        Assert.assertEquals(javaMap.hashCode(), map.hashCode());
+    }
+
+    @Test
+    public void testHashCodeEmpty()
+    {
+        Assert.assertEquals(0, map.hashCode());
+    }
+
+    // ---- toString -----------------------------------------------------------
+
+    @Test
+    public void testToStringEmpty()
+    {
+        Assert.assertEquals("{}", map.toString());
+    }
+
+    @Test
+    public void testToStringSingleEntry()
+    {
+        map.put("a", 1);
+        Assert.assertEquals("{a=1}", map.toString());
+    }
+
+    @Test
+    public void testToStringMultipleEntries()
+    {
+        map.put("a", 1);
+        map.put("b", 2);
+        String str = map.toString();
+        Assert.assertTrue(str.startsWith("{"));
+        Assert.assertTrue(str.endsWith("}"));
+        Assert.assertTrue(str.contains("a=1"));
+        Assert.assertTrue(str.contains("b=2"));
+    }
+
+    // ---- Hashing strategy behavior ------------------------------------------
+
+    @Test
+    public void testCaseInsensitiveGetAndPut()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> m = new VavrHamtMutableMapAdapter<>(CASE_INSENSITIVE_STRATEGY);
+        m.put("Hello", 1);
+
+        Assert.assertEquals(Integer.valueOf(1), m.get("hello"));
+        Assert.assertEquals(Integer.valueOf(1), m.get("HELLO"));
+        Assert.assertEquals(Integer.valueOf(1), m.get("Hello"));
+    }
+
+    @Test
+    public void testCaseInsensitiveOverwrite()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> m = new VavrHamtMutableMapAdapter<>(CASE_INSENSITIVE_STRATEGY);
+        m.put("Hello", 1);
+        m.put("hello", 2);
+
+        Assert.assertEquals(1, m.size());
+        Assert.assertEquals(Integer.valueOf(2), m.get("HELLO"));
+    }
+
+    @Test
+    public void testCaseInsensitiveContainsKey()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> m = new VavrHamtMutableMapAdapter<>(CASE_INSENSITIVE_STRATEGY);
+        m.put("Key", 1);
+
+        Assert.assertTrue(m.containsKey("key"));
+        Assert.assertTrue(m.containsKey("KEY"));
+        Assert.assertTrue(m.containsKey("Key"));
+    }
+
+    @Test
+    public void testCaseInsensitiveRemove()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> m = new VavrHamtMutableMapAdapter<>(CASE_INSENSITIVE_STRATEGY);
+        m.put("Key", 1);
+
+        Assert.assertEquals(Integer.valueOf(1), m.remove("key"));
+        Assert.assertTrue(m.isEmpty());
+    }
+
+    @Test
+    public void testCaseInsensitiveGetIfAbsentPutWithKey()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> m = new VavrHamtMutableMapAdapter<>(CASE_INSENSITIVE_STRATEGY);
+        m.put("Hello", 1);
+
+        Integer result = m.getIfAbsentPutWithKey("hello", String::length);
+        Assert.assertEquals(Integer.valueOf(1), result);
+        Assert.assertEquals(1, m.size());
+    }
+
+    // ---- HamtKey tests ------------------------------------------------------
+
+    @Test
+    public void testHamtKeyEqualsWithoutStrategy()
+    {
+        VavrHamtMutableMapAdapter.HamtKey<String> k1 = new VavrHamtMutableMapAdapter.HamtKey<>("abc", null);
+        VavrHamtMutableMapAdapter.HamtKey<String> k2 = new VavrHamtMutableMapAdapter.HamtKey<>("abc", null);
+        VavrHamtMutableMapAdapter.HamtKey<String> k3 = new VavrHamtMutableMapAdapter.HamtKey<>("xyz", null);
+
+        Assert.assertEquals(k1, k2);
+        Assert.assertNotEquals(k1, k3);
+    }
+
+    @Test
+    public void testHamtKeyEqualsWithStrategy()
+    {
+        VavrHamtMutableMapAdapter.HamtKey<String> k1 = new VavrHamtMutableMapAdapter.HamtKey<>("abc", CASE_INSENSITIVE_STRATEGY);
+        VavrHamtMutableMapAdapter.HamtKey<String> k2 = new VavrHamtMutableMapAdapter.HamtKey<>("ABC", CASE_INSENSITIVE_STRATEGY);
+
+        Assert.assertEquals(k1, k2);
+    }
+
+    @Test
+    public void testHamtKeyEqualsSameInstance()
+    {
+        VavrHamtMutableMapAdapter.HamtKey<String> k1 = new VavrHamtMutableMapAdapter.HamtKey<>("abc", null);
+        Assert.assertEquals(k1, k1);
+    }
+
+    @Test
+    public void testHamtKeyEqualsNonHamtKey()
+    {
+        VavrHamtMutableMapAdapter.HamtKey<String> k1 = new VavrHamtMutableMapAdapter.HamtKey<>("abc", null);
+        Assert.assertNotEquals(k1, "abc");
+    }
+
+    @Test
+    public void testHamtKeyHashCodeWithoutStrategy()
+    {
+        VavrHamtMutableMapAdapter.HamtKey<String> k1 = new VavrHamtMutableMapAdapter.HamtKey<>("abc", null);
+        VavrHamtMutableMapAdapter.HamtKey<String> k2 = new VavrHamtMutableMapAdapter.HamtKey<>("abc", null);
+
+        Assert.assertEquals(k1.hashCode(), k2.hashCode());
+    }
+
+    @Test
+    public void testHamtKeyHashCodeWithStrategy()
+    {
+        VavrHamtMutableMapAdapter.HamtKey<String> k1 = new VavrHamtMutableMapAdapter.HamtKey<>("abc", CASE_INSENSITIVE_STRATEGY);
+        VavrHamtMutableMapAdapter.HamtKey<String> k2 = new VavrHamtMutableMapAdapter.HamtKey<>("ABC", CASE_INSENSITIVE_STRATEGY);
+
+        Assert.assertEquals(k1.hashCode(), k2.hashCode());
+    }
+
+    @Test
+    public void testHamtKeyToString()
+    {
+        VavrHamtMutableMapAdapter.HamtKey<String> k = new VavrHamtMutableMapAdapter.HamtKey<>("hello", null);
+        Assert.assertEquals("hello", k.toString());
+    }
+
+    @Test
+    public void testHamtKeyToStringNull()
+    {
+        VavrHamtMutableMapAdapter.HamtKey<String> k = new VavrHamtMutableMapAdapter.HamtKey<>(null, null);
+        Assert.assertEquals("null", k.toString());
+    }
+
+    @Test
+    public void testHamtKeyHashCodeNull()
+    {
+        VavrHamtMutableMapAdapter.HamtKey<String> k = new VavrHamtMutableMapAdapter.HamtKey<>(null, null);
+        Assert.assertEquals(0, k.hashCode());
+    }
+
+    @Test
+    public void testHamtKeyEqualsNullKeys()
+    {
+        VavrHamtMutableMapAdapter.HamtKey<String> k1 = new VavrHamtMutableMapAdapter.HamtKey<>(null, null);
+        VavrHamtMutableMapAdapter.HamtKey<String> k2 = new VavrHamtMutableMapAdapter.HamtKey<>(null, null);
+        Assert.assertEquals(k1, k2);
+    }
+
+    // ---- wrapKey public accessor --------------------------------------------
+
+    @Test
+    public void testWrapKey()
+    {
+        VavrHamtMutableMapAdapter.HamtKey<String> wrapped = map.wrapKey("test");
+        Assert.assertEquals("test", wrapped.key);
+    }
+
+    // ---- Null value support -------------------------------------------------
+
+    @Test
+    public void testPutNullValue()
+    {
+        map.put("key", null);
+        Assert.assertTrue(map.containsKey("key"));
+        Assert.assertNull(map.get("key"));
+        Assert.assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testGetNullKeyWithoutStrategy()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> m = new VavrHamtMutableMapAdapter<>();
+        m.put(null, 42);
+        Assert.assertEquals(Integer.valueOf(42), m.get(null));
+        Assert.assertTrue(m.containsKey(null));
+    }
+
+    // ---- Large map ----------------------------------------------------------
+
+    @Test
+    public void testLargeMap()
+    {
+        int count = 10_000;
+        for (int i = 0; i < count; i++)
+        {
+            map.put("key" + i, i);
+        }
+        Assert.assertEquals(count, map.size());
+        for (int i = 0; i < count; i++)
+        {
+            Assert.assertEquals(Integer.valueOf(i), map.get("key" + i));
+        }
+    }
+
+    // ---- Overwrite semantics ------------------------------------------------
+
+    @Test
+    public void testPutOverwriteReturnsPrevious()
+    {
+        map.put("a", 1);
+        Integer old = map.put("a", 2);
+        Assert.assertEquals(Integer.valueOf(1), old);
+        Assert.assertEquals(Integer.valueOf(2), map.get("a"));
+    }
+
+    // ---- PutAll from VavrAdapter with same strategy -------------------------
+
+    @Test
+    public void testPutAllFromVavrAdapterWithSameNonNullStrategy()
+    {
+        VavrHamtMutableMapAdapter<String, Integer> source = new VavrHamtMutableMapAdapter<>(CASE_INSENSITIVE_STRATEGY);
+        source.put("Alpha", 1);
+        source.put("Beta", 2);
+
+        VavrHamtMutableMapAdapter<String, Integer> target = new VavrHamtMutableMapAdapter<>(CASE_INSENSITIVE_STRATEGY);
+        target.putAll(source);
+
+        Assert.assertEquals(2, target.size());
+        Assert.assertEquals(Integer.valueOf(1), target.get("alpha"));
+        Assert.assertEquals(Integer.valueOf(2), target.get("BETA"));
+    }
+
+    // ---- Edge cases ---------------------------------------------------------
+
+    @Test
+    public void testContainsValueNull()
+    {
+        map.put("a", null);
+        Assert.assertTrue(map.containsValue(null));
+    }
+
+    @Test
+    public void testRemoveFromEmptyMap()
+    {
+        Assert.assertNull(map.remove("nonexistent"));
+        Assert.assertEquals(0, map.size());
+    }
+
+    @Test
+    public void testClearAlreadyEmpty()
+    {
+        map.clear();
+        Assert.assertTrue(map.isEmpty());
+    }
+
+    @Test
+    public void testKeySetEmpty()
+    {
+        Assert.assertTrue(map.keySet().isEmpty());
+    }
+
+    @Test
+    public void testValuesEmpty()
+    {
+        Assert.assertTrue(map.values().isEmpty());
+    }
+
+    @Test
+    public void testEntrySetEmpty()
+    {
+        Assert.assertTrue(map.entrySet().isEmpty());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <deephaven-csv.version>0.18.0</deephaven-csv.version>
         <eclipsecollections.version>10.2.0</eclipsecollections.version>
         <guava.version>33.4.6-jre</guava.version>
+        <vavr.version>1.0.1</vavr.version>
         <h2.version>2.1.214</h2.version>
         <duckdb.version>1.0.0</duckdb.version>
         <jackson.version>2.10.5</jackson.version>
@@ -664,6 +665,11 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.vavr</groupId>
+                <artifactId>vavr</artifactId>
+                <version>${vavr.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Use vavr HAMT Map as the internal impl of PureMap - this significantly improves the performance due to shared hash table