### PR TITLE
Use legacy ids only when generating monolithic metadata

### DIFF
--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/orchestrator/JavaCodeGeneration.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/orchestrator/JavaCodeGeneration.java
@@ -337,7 +337,7 @@ public class JavaCodeGeneration
         {
             case monolithic:
             {
-                generate = generator.generateOnly(false, generateSources, codegenDirectory);
+                generate = generator.generateOnly(!generateMetadata, generateSources, codegenDirectory);
                 break;
             }
             case modular:


### PR DESCRIPTION
Use legacy ids only when generating monolithic metadata - meaning that not only is the generation type monolithic, but metadata will actually be generated. Previously, legacy ids were used whenever the generation type was monolithic, regardless of whether metadata was being generated.