### PR TITLE
Migrate to Maven CI-friendly versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build
-    if: "!contains(github.event.head_commit.message, '[maven-release-plugin]')"
+    if: "github.repository == 'finos/legend-pure'"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/clean-after-failed-release.yml
+++ b/.github/workflows/clean-after-failed-release.yml
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 
-# This action deletes the last two commits made on the master branch and the latest tag
-# This should only be run if a release failed and the remote staging repo has been dropped:
-# [ERROR]  * Dropping failed staging repository with ID "orgfinoslegend-..." ...
+# This action deletes the latest tag after a failed release.
+# With CI-friendly versions, there are no release commits to clean up — only the tag.
 name: Clean repo after failed release
 
 on: [workflow_dispatch]
@@ -39,5 +38,3 @@ jobs:
         run: |
           LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
           git push --delete origin $LATEST_TAG
-          git reset --hard HEAD~2
-          git push --force

--- a/.github/workflows/legend-stack-release.yml
+++ b/.github/workflows/legend-stack-release.yml
@@ -68,22 +68,29 @@ jobs:
         with:
           node-version: 14.x
 
-      - name: Compute next development version
-        run: |
-          releaseVersion=${{ github.event.client_payload.releaseVersion }}
-          n=${releaseVersion//[!0-9]/ }
-          a=(${n//\./ })
-          nextPatch=$((${a[2]} + 1))
-          developmentVersion="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
-          echo "DEVELOPMENT_VERSION=${developmentVersion}" >> $GITHUB_ENV
-
       - name: Collect Workflow Telemetry
         uses: runforesight/workflow-telemetry-action@v1
         with:
           theme: dark
 
-      - name: Prepare release
-        run: mvn -B -DpreparationGoals=clean release:prepare -DreleaseVersion=${{ github.event.client_payload.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -P release
+      - name: Build and deploy release
+        run: |
+          mvn -B -e -Drevision=${{ github.event.client_payload.releaseVersion }} \
+            deploy -P release
 
-      - name: Perform release
-        run: mvn -B release:perform -P release
+      - name: Create and push git tag
+        run: |
+          git tag ${{ github.event.repository.name }}-${{ github.event.client_payload.releaseVersion }}
+          git push origin ${{ github.event.repository.name }}-${{ github.event.client_payload.releaseVersion }}
+
+      - name: Compute and set next SNAPSHOT
+        run: |
+          releaseVersion=${{ github.event.client_payload.releaseVersion }}
+          n=${releaseVersion//[!0-9]/ }
+          a=(${n//\./ })
+          nextPatch=$((${a[2]} + 1))
+          nextSnapshot="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
+          sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
+          git add pom.xml
+          git commit -m "Bump version to ${nextSnapshot}"
+          git push origin master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,26 +53,29 @@ jobs:
           gpg-private-key: ${{ secrets.CI_GPG_PRIVATE_KEY }}
           gpg-passphrase: CI_GPG_PASSPHRASE
 
-      - name: Compute next development version
-        run: |
-          releaseVersion=${{ github.event.inputs.releaseVersion }}
-          n=${releaseVersion//[!0-9]/ }
-          a=(${n//\./ })
-          nextPatch=$((${a[2]} + 1))
-          developmentVersion="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
-          echo "DEVELOPMENT_VERSION=${developmentVersion}" >> $GITHUB_ENV
-
       - name: Collect Workflow Telemetry
         uses: runforesight/workflow-telemetry-action@v1
         with:
           theme: dark
 
-      - name: Prepare release
-        run: mvn -B -DpreparationGoals="clean -N" release:prepare -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ env.DEVELOPMENT_VERSION }} -DargLine="-XX:MaxRAMPercentage=25.0" -DforkCount=3 -DreuseForks=true -Dsurefire.reports.directory=${GITHUB_WORKSPACE}/surefire-reports-aggregate -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat="yyyy-MM-dd HH:mm:ss.SSSZ" -P release
-        env:
-          MAVEN_OPTS: -XX:MaxRAMPercentage=25.0
-
-      - name: Perform release
-        run: mvn -B release:perform -P release
+      - name: Build and deploy release
+        run: mvn -B -e -Drevision=${{ github.event.inputs.releaseVersion }} -DargLine="-XX:MaxRAMPercentage=25.0" -DforkCount=3 -DreuseForks=true -Dsurefire.reports.directory=${GITHUB_WORKSPACE}/surefire-reports-aggregate -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat="yyyy-MM-dd HH:mm:ss.SSSZ" deploy -P release
         env:
           MAVEN_OPTS: -XX:MaxRAMPercentage=90.0
+
+      - name: Create and push git tag
+        run: |
+          git tag ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
+          git push origin ${{ github.event.repository.name }}-${{ github.event.inputs.releaseVersion }}
+
+      - name: Compute and set next SNAPSHOT
+        run: |
+          releaseVersion=${{ github.event.inputs.releaseVersion }}
+          n=${releaseVersion//[!0-9]/ }
+          a=(${n//\./ })
+          nextPatch=$((${a[2]} + 1))
+          nextSnapshot="${a[0]}.${a[1]}.${nextPatch}-SNAPSHOT"
+          sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
+          git add pom.xml
+          git commit -m "Bump version to ${nextSnapshot}"
+          git push origin master

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 **/lib
 **/surefire-reports-aggregate
 **/dependency-reduced-pom.xml
+**/.flattened-pom.xml
 /.h2Start.sh.swp
 
 **/.DS_Store

--- a/legend-pure-core/legend-pure-m3-bootstrap-generator/pom.xml
+++ b/legend-pure-core/legend-pure-m3-bootstrap-generator/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-core</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-core/legend-pure-m3-core/pom.xml
+++ b/legend-pure-core/legend-pure-m3-core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-core</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-core/legend-pure-m3-precisePrimitives/pom.xml
+++ b/legend-pure-core/legend-pure-m3-precisePrimitives/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-core</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/legend-pure-core/legend-pure-m4/pom.xml
+++ b/legend-pure-core/legend-pure-m4/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-core</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-core/pom.xml
+++ b/legend-pure-core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-grammar/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-diagram</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-pure/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-m2-dsl-diagram-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-diagram</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-runtime-java-extension-compiled-dsl-diagram/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-diagram/legend-pure-runtime-java-extension-compiled-dsl-diagram/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-diagram</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/legend-pure-dsl/legend-pure-dsl-diagram/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-diagram/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-m2-dsl-graph-grammar/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-m2-dsl-graph-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-graph</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-m2-dsl-graph-pure/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-m2-dsl-graph-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-graph</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-runtime-java-extension-compiled-dsl-graph/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-graph/legend-pure-runtime-java-extension-compiled-dsl-graph/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-graph</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/legend-pure-dsl/legend-pure-dsl-graph/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-graph/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-mapping</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-pure-m2-dsl-mapping-grammar</artifactId>

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-pure/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-mapping</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-runtime-java-extension-compiled-dsl-mapping/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-runtime-java-extension-compiled-dsl-mapping/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-mapping</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-pure-runtime-java-extension-compiled-dsl-mapping</artifactId>

--- a/legend-pure-dsl/legend-pure-dsl-mapping/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-path/legend-pure-m2-dsl-path-grammar/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-path/legend-pure-m2-dsl-path-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-path</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-path/legend-pure-m2-dsl-path-pure/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-path/legend-pure-m2-dsl-path-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-path</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-path/legend-pure-runtime-java-extension-compiled-dsl-path/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-path/legend-pure-runtime-java-extension-compiled-dsl-path/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-path</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-pure-runtime-java-extension-compiled-dsl-path</artifactId>

--- a/legend-pure-dsl/legend-pure-dsl-path/legend-pure-runtime-java-extension-interpreted-dsl-path/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-path/legend-pure-runtime-java-extension-interpreted-dsl-path/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-path</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-pure-runtime-java-extension-interpreted-dsl-path</artifactId>

--- a/legend-pure-dsl/legend-pure-dsl-path/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-path/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-grammar/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-grammar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-store</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-pure/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-store/legend-pure-m2-dsl-store-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-store</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-store/legend-pure-runtime-java-extension-compiled-dsl-store/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-store/legend-pure-runtime-java-extension-compiled-dsl-store/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-store</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/legend-pure-dsl/legend-pure-dsl-store/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-store/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-grammar/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-tds</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-pure/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-m2-dsl-tds-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-tds</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-runtime-java-extension-compiled-dsl-tds/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-runtime-java-extension-compiled-dsl-tds/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-tds</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-runtime-java-extension-interpreted-dsl-tds/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-tds/legend-pure-runtime-java-extension-interpreted-dsl-tds/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl-tds</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/legend-pure-dsl/legend-pure-dsl-tds/pom.xml
+++ b/legend-pure-dsl/legend-pure-dsl-tds/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-dsl</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-dsl/pom.xml
+++ b/legend-pure-dsl/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-maven/legend-pure-maven-compiler/pom.xml
+++ b/legend-pure-maven/legend-pure-maven-compiler/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-maven</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-pure-maven-compiler</artifactId>

--- a/legend-pure-maven/legend-pure-maven-generation-java/pom.xml
+++ b/legend-pure-maven/legend-pure-maven-generation-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-maven</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-pure-maven-generation-java</artifactId>

--- a/legend-pure-maven/legend-pure-maven-generation-par/pom.xml
+++ b/legend-pure-maven/legend-pure-maven-generation-par/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-maven</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-pure-maven-generation-par</artifactId>

--- a/legend-pure-maven/legend-pure-maven-generation-pct/pom.xml
+++ b/legend-pure-maven/legend-pure-maven-generation-pct/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-maven</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-pure-maven-generation-pct</artifactId>

--- a/legend-pure-maven/legend-pure-maven-generation-platform-java/pom.xml
+++ b/legend-pure-maven/legend-pure-maven-generation-platform-java/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-maven</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-pure-maven-generation-platform-java</artifactId>

--- a/legend-pure-maven/legend-pure-maven-shared/pom.xml
+++ b/legend-pure-maven/legend-pure-maven-shared/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-maven</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>legend-pure-maven-shared</artifactId>

--- a/legend-pure-maven/pom.xml
+++ b/legend-pure-maven/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/pom.xml
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-runtime</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/pom.xml
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-runtime</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-shared/pom.xml
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-shared/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-runtime</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-runtime/pom.xml
+++ b/legend-pure-runtime/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/pom.xml
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-grammar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-store-relational</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-pure/pom.xml
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-store-relational</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-compiled-store-relational/pom.xml
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-compiled-store-relational/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-store-relational</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-interpreted-store-relational/pom.xml
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-interpreted-store-relational/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-store-relational</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/pom.xml
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-store-relational</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-store/legend-pure-store-relational/pom.xml
+++ b/legend-pure-store/legend-pure-store-relational/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure-store</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-pure-store/pom.xml
+++ b/legend-pure-store/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.pure</groupId>
         <artifactId>legend-pure</artifactId>
-        <version>5.81.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <name>Legend Pure</name>
     <groupId>org.finos.legend.pure</groupId>
     <artifactId>legend-pure</artifactId>
-    <version>5.81.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -38,6 +38,9 @@
     </modules>
 
     <properties>
+        <!-- CI-Friendly Version -->
+        <revision>5.81.1-SNAPSHOT</revision>
+
         <sonar.projectKey>legend-pure</sonar.projectKey>
         <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
         <sonar.organization>finos</sonar.organization>
@@ -259,6 +262,31 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>


### PR DESCRIPTION
Replace hardcoded version across all 51 POMs with ${revision}, add flatten-maven-plugin, and rewrite release workflows to use -Drevision= instead of maven-release-plugin. This eliminates the two-commit release dance, tag-checkout rebuild, and force-push recovery flow.