### PR TITLE
Removed projectOutputDirectory from classpath for par generation

### DIFF
--- a/legend-pure-maven/legend-pure-maven-generation-par/src/main/java/org/finos/legend/pure/maven/par/PureJarMojo.java
+++ b/legend-pure-maven/legend-pure-maven-generation-par/src/main/java/org/finos/legend/pure/maven/par/PureJarMojo.java
@@ -116,8 +116,8 @@ public class PureJarMojo extends AbstractMojo
                     mavenProject,
                     mojoExecution,
                     mavenRepoSession,
-                    projectOutputDirectory,
-                    projectTestOutputDirectory,
+                    null,
+                    null,
                     mavenProjectDependenciesResolver
             );
             try (URLClassLoader classLoader = new URLClassLoader(dependencyUrls, Thread.currentThread().getContextClassLoader()))

--- a/legend-pure-maven/legend-pure-maven-shared/src/main/java/org/finos/legend/pure/maven/shared/ProjectDependencyResolution.java
+++ b/legend-pure-maven/legend-pure-maven-shared/src/main/java/org/finos/legend/pure/maven/shared/ProjectDependencyResolution.java
@@ -69,8 +69,11 @@ public class ProjectDependencyResolution
                 .setResolutionFilter(dependencyResolutionScope.getScopeDependencyFilter());
 
         List<File> classpath = new ArrayList<>();
-        classpath.add(projectOutputDirectory);
-        if (inTestPhase(mojoExecution) && dependencyResolutionScope.isTestScope())
+        if (projectOutputDirectory != null)
+        {
+            classpath.add(projectOutputDirectory);
+        }
+        if (projectOutputDirectory != null && inTestPhase(mojoExecution) && dependencyResolutionScope.isTestScope())
         {
             classpath.add(projectTestOutputDirectory);
         }


### PR DESCRIPTION
Removes the project's own build output directories from the classpath used during par generation.

- `PureJarMojo` now passes `null` for `projectOutputDirectory` and `projectTestOutputDirectory` when invoking dependency resolution.
- `ProjectDependencyResolution` guards classpath additions accordingly.