### PR TITLE
Replace modular distributed metadata with pelt metadata

### DIFF
--- a/legend-pure-maven/legend-pure-maven-generation-java/src/test/java/org/finos/legend/pure/maven/javaCompiled/TestPureCompiledJarMojo.java
+++ b/legend-pure-maven/legend-pure-maven-generation-java/src/test/java/org/finos/legend/pure/maven/javaCompiled/TestPureCompiledJarMojo.java
@@ -173,17 +173,9 @@ public class TestPureCompiledJarMojo
         setField(mojo, "generationType", JavaCodeGeneration.GenerationType.modular);
         mojo.execute();
 
-        // Modular generation scopes output by repository name.
-        // Bins at metadata/bin/platform/ and classifiers at metadata/classifiers/platform/.
-        File metaDir    = new File(targetDir, "metadata-distributed");
-        Assert.assertTrue("metadata-distributed directory should be created for modular generation",
-                metaDir.exists());
-        File binDir     = new File(metaDir, "metadata/bin/platform");
-        File packageIdx = new File(metaDir, "metadata/classifiers/platform/Package.idx");
-        Assert.assertTrue("modular generation should write metadata/bin/platform/ into metadata-distributed",
-                binDir.isDirectory() && binDir.list() != null && binDir.list().length > 0);
-        Assert.assertTrue("metadata/classifiers/platform/Package.idx should exist for modular platform generation",
-                packageIdx.exists() && packageIdx.length() > 0);
+        // Modular generation now uses pelt serialization, which must already exist; so there should be no metadata generation
+        File metaDir = new File(targetDir, "metadata-distributed");
+        Assert.assertFalse("metadata-distributed directory should not be created", metaDir.exists());
     }
 
     @Test
@@ -260,11 +252,9 @@ public class TestPureCompiledJarMojo
         String src = new String(java.nio.file.Files.readAllBytes(packageImpl.toPath()));
         Assert.assertTrue("Package_Impl.java should declare class Package_Impl", src.contains("class Package_Impl"));
 
-        // Metadata — modular + useSingleDir writes to classesDir/metadata/classifiers/platform/
-        File packageIdx = new File(classesDir, "metadata/classifiers/platform/Package.idx");
-        Assert.assertTrue(
-                "metadata/classifiers/platform/Package.idx should exist inside classesDirectory",
-                packageIdx.exists() && packageIdx.length() > 0);
+        // Modular generation now uses pelt serialization, which must already exist; so there should be no metadata generation
+        File metaDir = new File(targetDir, "metadata");
+        Assert.assertFalse("metadata directory should not be created", metaDir.exists());
     }
 
     // --- error path ---

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/orchestrator/JavaCodeGeneration.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/orchestrator/JavaCodeGeneration.java
@@ -20,6 +20,7 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.SetIterable;
+import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositorySet;
@@ -30,6 +31,7 @@ import org.finos.legend.pure.m3.serialization.grammar.Parser;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.inlinedsl.InlineDSL;
 import org.finos.legend.pure.m3.serialization.runtime.Message;
 import org.finos.legend.pure.m3.serialization.runtime.ParserService;
+import org.finos.legend.pure.m3.serialization.runtime.PureCompilerLoader;
 import org.finos.legend.pure.m3.serialization.runtime.PureRuntime;
 import org.finos.legend.pure.m3.serialization.runtime.PureRuntimeBuilder;
 import org.finos.legend.pure.m3.serialization.runtime.cache.CacheState;
@@ -412,18 +414,11 @@ public class JavaCodeGeneration
     {
         String writeMetadataStep = "writing distributed Pure metadata";
         long writeMetadataStart = startStep(writeMetadataStep, log);
-        for (String repository : repositoriesForMetadata)
+        PureCompilerLoader loader = PureCompilerLoader.newLoader(Thread.currentThread().getContextClassLoader());
+        if (!Iterate.allSatisfy(repositoriesForMetadata, loader::canLoad))
         {
-            generateModularMetadata(start, runtime, repository, distributedMetadataDirectory, log);
+            throw new RuntimeException(Iterate.reject(repositoriesForMetadata, loader::canLoad, Lists.mutable.empty()).sortThis().makeString("No modular metadata for the following repos: ", ", ", ""));
         }
-        completeStep(writeMetadataStep, writeMetadataStart, log);
-    }
-
-    private static void generateModularMetadata(long start, PureRuntime runtime, String repository, Path distributedMetadataDirectory, Log log)
-    {
-        String writeMetadataStep = "writing distributed Pure metadata for " + repository;
-        long writeMetadataStart = startStep(writeMetadataStep, log);
-        DistributedBinaryGraphSerializer.newSerializer(runtime, repository).serializeToDirectory(distributedMetadataDirectory);
         completeStep(writeMetadataStep, writeMetadataStart, log);
     }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/metadata/MetadataLazy.java
@@ -30,7 +30,6 @@ import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.runtime.java.compiled.generation.JavaPackageAndImportBuilder;
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.type.EnumProcessor;
 import org.finos.legend.pure.runtime.java.compiled.serialization.binary.DistributedBinaryGraphDeserializer;
-import org.finos.legend.pure.runtime.java.compiled.serialization.binary.DistributedMetadataSpecification;
 import org.finos.legend.pure.runtime.java.compiled.serialization.model.EnumRef;
 import org.finos.legend.pure.runtime.java.compiled.serialization.model.Obj;
 import org.finos.legend.pure.runtime.java.compiled.serialization.model.ObjRef;
@@ -41,338 +40,29 @@ import org.finos.legend.pure.runtime.java.compiled.serialization.model.RValueVis
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 import java.util.Objects;
 
-public class MetadataLazy implements Metadata
+public abstract class MetadataLazy implements Metadata
 {
-    private final RValueVisitor<Object> valueToObjectVisitor = new RValueVisitor<Object>()
-    {
-        @Override
-        public Object visit(Primitive primitive)
-        {
-            return primitive.getValue();
-        }
-
-        @Override
-        public Object visit(ObjRef ref)
-        {
-            return toJavaObject(ref.getClassifierId(), ref.getId());
-        }
-
-        @Override
-        public Object visit(EnumRef enumRef)
-        {
-            return getEnum(enumRef.getEnumerationId(), enumRef.getEnumName());
-        }
-    };
-
-    private final ClassLoader classLoader;
-    private final DistributedBinaryGraphDeserializer deserializer;
-    private final ConcurrentMutableMap<String, Constructor<? extends CoreInstance>> constructors = ConcurrentHashMap.newMap();
-    private final ConcurrentMutableMap<String, ConcurrentMutableMap<String, CoreInstance>> instanceCache = ConcurrentHashMap.newMap();
-
-    private volatile Constructor<? extends CoreInstance> enumConstructor = null; //NOSONAR we actually want to protect the pointer
-
-    private MetadataLazy(ClassLoader classLoader, DistributedBinaryGraphDeserializer deserializer)
-    {
-        this.classLoader = classLoader;
-        this.deserializer = deserializer;
-    }
-
-    @Override
-    public void startTransaction()
-    {
-        throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public void commitTransaction()
-    {
-        throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public void rollbackTransaction()
-    {
-        throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
-    public CoreInstance getMetadata(String classifier, String id)
-    {
-        if (!hasClassifier(classifier))
-        {
-            return null;
-        }
-        // for backward compatibility
-        if (id.startsWith("Root::"))
-        {
-            id = id.substring(6);
-        }
-        return toJavaObject(classifier, this.deserializer.processId(id));
-    }
-
-    @Override
-    public MapIterable<String, CoreInstance> getMetadata(String classifier)
-    {
-        return hasClassifier(classifier) ? loadAllClassifierInstances(classifier).asUnmodifiable() : Maps.fixedSize.empty();
-    }
-
-    @Override
-    public RichIterable<CoreInstance> getClassifierInstances(String classifier)
-    {
-        return hasClassifier(classifier) ? loadAllClassifierInstances(classifier).valuesView() : Lists.immutable.empty();
-    }
-
-    @Override
-    public CoreInstance getEnum(String enumerationName, String enumName)
-    {
-        if (!hasClassifier(enumerationName))
-        {
-            throw new RuntimeException("Cannot find enum '" + enumName + "' in enumeration '" + enumerationName + "': unknown enumeration");
-        }
-
-        ConcurrentMutableMap<String, CoreInstance> cache = getClassifierInstanceCache(enumerationName);
-        String enumId = this.deserializer.processEnumId(enumerationName, enumName);
-        CoreInstance result = cache.get(enumId);
-        if (result == null)
-        {
-            //might not have loaded yet, so request full load and try again:
-            loadAllClassifierInstances(enumerationName);
-            result = cache.get(enumId);
-            if (result == null)
-            {
-                StringBuilder builder = new StringBuilder("Cannot find enum '").append(enumName).append("' in enumeration '").append(enumerationName).append("' unknown enum value");
-                if (cache.isEmpty())
-                {
-                    builder.append(" (no known values)");
-                }
-                else
-                {
-                    cache.keysView().appendString(builder, " (known values: '", "', '", "')");
-                }
-                throw new RuntimeException(builder.toString());
-            }
-        }
-        return result;
-    }
-
-    public Object valueToObject(RValue value)
-    {
-        return (value == null) ? null : value.visit(this.valueToObjectVisitor);
-    }
+    public abstract Object valueToObject(RValue value);
 
     public RichIterable<Object> valuesToObjects(ListIterable<RValue> values)
     {
         int size = (values == null) ? 0 : values.size();
-        if (size == 0)
+        switch (size)
         {
-            return Lists.immutable.empty();
-        }
-        if (size == 1)
-        {
-            return Lists.mutable.with(valueToObject(values.get(0)));
-        }
-
-        MutableMap<String, MutableSet<ObjRef>> objRefsByClassifier = Maps.mutable.empty();
-        Counter objRefCounter = new Counter();
-        values.forEach(new RValueConsumer()
-        {
-            @Override
-            protected void accept(Primitive primitive)
+            case 0:
             {
+                return Lists.immutable.empty();
             }
-
-            @Override
-            protected void accept(ObjRef objRef)
+            case 1:
             {
-                objRefsByClassifier.getIfAbsentPut(objRef.getClassifierId(), Sets.mutable::empty).add(objRef);
-                objRefCounter.increment();
+                return Lists.mutable.with(valueToObject(values.get(0)));
             }
-
-            @Override
-            protected void accept(EnumRef enumRef)
+            default:
             {
+                return values.collect(this::valueToObject, Lists.mutable.ofInitialCapacity(size));
             }
-        });
-        if (objRefsByClassifier.isEmpty())
-        {
-            return values.collect(this::valueToObject);
-        }
-
-        MutableMap<ObjRef, CoreInstance> objectByRef = Maps.mutable.withInitialCapacity(objRefCounter.getCount());
-        objRefsByClassifier.forEachKeyValue((classifier, objRefs) ->
-        {
-            MutableList<String> idsToDeserialize = Lists.mutable.withInitialCapacity(objRefs.size());
-            ConcurrentMutableMap<String, CoreInstance> classifierCache = getClassifierInstanceCache(classifier);
-            objRefs.forEach(objRef ->
-            {
-                String id = objRef.getId();
-                CoreInstance cachedInstance = classifierCache.get(id);
-                if (cachedInstance == null)
-                {
-                    idsToDeserialize.add(id);
-                }
-                else
-                {
-                    objectByRef.put(objRef, cachedInstance);
-                }
-            });
-            if (idsToDeserialize.notEmpty())
-            {
-                ListIterable<Obj> deserialized = getInstances(classifier, idsToDeserialize);
-                deserialized.forEach(obj ->
-                {
-                    CoreInstance cachedInstance = classifierCache.getIfAbsentPut(obj.getIdentifier(), () -> newInstance(classifier, obj));
-                    objectByRef.put(new ObjRef(obj.getClassifier(), obj.getIdentifier()), cachedInstance);
-                });
-            }
-        });
-        return values.collectWith(RValue::visit, new RValueVisitor<Object>()
-        {
-            @Override
-            public Object visit(Primitive primitive)
-            {
-                return primitive.getValue();
-            }
-
-            @Override
-            public Object visit(ObjRef objRef)
-            {
-                return objectByRef.get(objRef);
-            }
-
-            @Override
-            public Object visit(EnumRef enumRef)
-            {
-                return getEnum(enumRef.getEnumerationId(), enumRef.getEnumName());
-            }
-        });
-    }
-
-    private boolean hasClassifier(String classifier)
-    {
-        return this.deserializer.hasClassifier(classifier);
-    }
-
-    private RichIterable<String> getClassifierInstanceIds(String classifier)
-    {
-        return this.deserializer.getClassifierInstanceIds(classifier);
-    }
-
-    private Obj getInstance(String classifier, String id)
-    {
-        return this.deserializer.getInstance(classifier, id);
-    }
-
-    private ListIterable<Obj> getInstances(String classifier, Iterable<String> instanceIds)
-    {
-        return this.deserializer.getInstances(classifier, instanceIds);
-    }
-
-    private ConcurrentMutableMap<String, CoreInstance> loadAllClassifierInstances(String classifier)
-    {
-        RichIterable<String> instanceIds = getClassifierInstanceIds(classifier);
-        ConcurrentMutableMap<String, CoreInstance> classifierCache = getClassifierInstanceCache(classifier);
-        if (classifierCache.size() < instanceIds.size())
-        {
-            MutableList<String> notLoadedIds = instanceIds.reject(classifierCache::containsKey, Lists.mutable.empty());
-            if (notLoadedIds.notEmpty())
-            {
-                ListIterable<Obj> objs = getInstances(classifier, notLoadedIds);
-                objs.forEach(obj -> classifierCache.getIfAbsentPut(obj.getIdentifier(), () -> newInstance(classifier, obj)));
-            }
-        }
-        return classifierCache;
-    }
-
-    private CoreInstance toJavaObject(String classifier, String id)
-    {
-        return getClassifierInstanceCache(classifier).getIfAbsentPut(id, () -> newInstance(classifier, id));
-    }
-
-    private ConcurrentMutableMap<String, CoreInstance> getClassifierInstanceCache(String classifier)
-    {
-        return this.instanceCache.getIfAbsentPut(classifier, ConcurrentHashMap::newMap);
-    }
-
-    private CoreInstance newInstance(String classifier, String id)
-    {
-        Obj obj = getInstance(classifier, id);
-        return newInstance(classifier, obj);
-    }
-
-    private CoreInstance newInstance(String classifier, Obj obj)
-    {
-        Constructor<? extends CoreInstance> constructor = getConstructor(classifier, obj);
-        try
-        {
-            return constructor.newInstance(obj, this);
-        }
-        catch (InvocationTargetException | InstantiationException | IllegalAccessException e)
-        {
-            Throwable cause = (e instanceof InvocationTargetException) ? e.getCause() : e;
-            StringBuilder builder = new StringBuilder("Error instantiating ").append(obj).append(" (instance of ").append(classifier).append(")");
-            String eMessage = cause.getMessage();
-            if (eMessage != null)
-            {
-                builder.append(": ").append(eMessage);
-            }
-            throw new RuntimeException(builder.toString(), cause);
-        }
-    }
-
-    private Constructor<? extends CoreInstance> getConstructor(String classifier, Obj obj)
-    {
-        if (obj.isEnum())
-        {
-            Constructor<? extends CoreInstance> constructor = this.enumConstructor;
-            if (constructor == null)
-            {
-                synchronized (this)
-                {
-                    constructor = this.enumConstructor;
-                    if (constructor == null)
-                    {
-                        this.enumConstructor = constructor = getLazyImplEnumConstructor();
-                    }
-                }
-            }
-            return constructor;
-        }
-        return this.constructors.getIfAbsentPutWithKey(classifier, this::getLazyImplClassConstructor);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Constructor<? extends CoreInstance> getLazyImplClassConstructor(String classifier)
-    {
-        String lazyImplClassName = JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromUserPath(classifier);
-        try
-        {
-            Class<? extends CoreInstance> cls = (Class<? extends CoreInstance>) this.classLoader.loadClass(lazyImplClassName);
-            return cls.getConstructor(Obj.class, MetadataLazy.class);
-        }
-        catch (ReflectiveOperationException e)
-        {
-            throw new RuntimeException("Error getting constructor for " + classifier, e);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private Constructor<? extends CoreInstance> getLazyImplEnumConstructor()
-    {
-        String lazyImplEnumName = JavaPackageAndImportBuilder.rootPackage() + '.' + EnumProcessor.ENUM_LAZY_CLASS_NAME;
-        try
-        {
-            Class<? extends CoreInstance> cls = (Class<? extends CoreInstance>) this.classLoader.loadClass(lazyImplEnumName);
-            Constructor<? extends CoreInstance> constructor = cls.getDeclaredConstructor(Obj.class, MetadataLazy.class);
-            constructor.setAccessible(true);
-            return constructor;
-        }
-        catch (ReflectiveOperationException e)
-        {
-            throw new RuntimeException("Error getting constructor for " + lazyImplEnumName);
         }
     }
 
@@ -380,7 +70,7 @@ public class MetadataLazy implements Metadata
     {
         Objects.requireNonNull(classLoader, "class loader may not be null");
         Objects.requireNonNull(deserializer, "deserializer may not be null");
-        return new MetadataLazy(classLoader, deserializer);
+        return new LegacyMetadataLazy(classLoader, deserializer);
     }
 
     public static MetadataLazy fromClassLoader(ClassLoader classLoader)
@@ -390,7 +80,7 @@ public class MetadataLazy implements Metadata
                 .withNoMetadataName()
                 .withObjValidation()
                 .build();
-        return new MetadataLazy(classLoader, deserializer);
+        return new LegacyMetadataLazy(classLoader, deserializer);
     }
 
     public static MetadataLazy fromClassLoader(ClassLoader classLoader, String metadataName)
@@ -408,15 +98,419 @@ public class MetadataLazy implements Metadata
     public static MetadataLazy fromClassLoader(ClassLoader classLoader, Iterable<String> metadataNames)
     {
         Objects.requireNonNull(classLoader, "class loader may not be null");
-        Objects.requireNonNull(classLoader, "metadataNames may not be null");
-        List<DistributedMetadataSpecification> specs = DistributedMetadataSpecification.loadSpecifications(classLoader, metadataNames);
-        if (specs.isEmpty())
+        Objects.requireNonNull(metadataNames, "metadataNames may not be null");
+        MetadataPelt metadataPelt = MetadataPelt.fromClassLoader(classLoader, metadataNames);
+        return new PeltMetadataLazy(metadataPelt);
+    }
+
+    private static class PeltMetadataLazy extends MetadataLazy
+    {
+        private final MetadataPelt metadataPelt;
+
+        private PeltMetadataLazy(MetadataPelt metadataPelt)
         {
-            throw new IllegalArgumentException("metadata names are required");
+            this.metadataPelt = metadataPelt;
         }
-        DistributedBinaryGraphDeserializer.Builder builder = DistributedBinaryGraphDeserializer.newBuilder(classLoader).withObjValidation();
-        specs.forEach(spec -> builder.withMetadataName(spec.getName()));
-        DistributedBinaryGraphDeserializer deserializer = builder.build();
-        return new MetadataLazy(classLoader, deserializer);
+
+        @Override
+        public void startTransaction()
+        {
+            this.metadataPelt.startTransaction();
+        }
+
+        @Override
+        public void commitTransaction()
+        {
+            this.metadataPelt.commitTransaction();
+        }
+
+        @Override
+        public void rollbackTransaction()
+        {
+            this.metadataPelt.rollbackTransaction();
+        }
+
+        @Override
+        public CoreInstance getMetadata(String classifier, String id)
+        {
+            return this.metadataPelt.getMetadata(classifier, id);
+        }
+
+        @Override
+        public MapIterable<String, CoreInstance> getMetadata(String classifier)
+        {
+            return this.metadataPelt.getMetadata(classifier);
+        }
+
+        @Override
+        public RichIterable<CoreInstance> getClassifierInstances(String classifier)
+        {
+            return this.metadataPelt.getClassifierInstances(classifier);
+        }
+
+        @Override
+        public CoreInstance getEnum(String enumerationName, String enumName)
+        {
+            return this.metadataPelt.getEnum(enumerationName, enumName);
+        }
+
+        @Override
+        public boolean supportsElementByPath()
+        {
+            return this.metadataPelt.supportsElementByPath();
+        }
+
+        @Override
+        public boolean hasElement(String path)
+        {
+            return this.metadataPelt.hasElement(path);
+        }
+
+        @Override
+        public CoreInstance getElementByPath(String path)
+        {
+            return this.metadataPelt.getElementByPath(path);
+        }
+
+        @Override
+        public Object valueToObject(RValue value)
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class LegacyMetadataLazy extends MetadataLazy
+    {
+        private final RValueVisitor<Object> valueToObjectVisitor = new RValueVisitor<Object>()
+        {
+            @Override
+            public Object visit(Primitive primitive)
+            {
+                return primitive.getValue();
+            }
+
+            @Override
+            public Object visit(ObjRef ref)
+            {
+                return toJavaObject(ref.getClassifierId(), ref.getId());
+            }
+
+            @Override
+            public Object visit(EnumRef enumRef)
+            {
+                return getEnum(enumRef.getEnumerationId(), enumRef.getEnumName());
+            }
+        };
+
+        private final ClassLoader classLoader;
+        private final DistributedBinaryGraphDeserializer deserializer;
+        private final ConcurrentMutableMap<String, Constructor<? extends CoreInstance>> constructors = ConcurrentHashMap.newMap();
+        private final ConcurrentMutableMap<String, ConcurrentMutableMap<String, CoreInstance>> instanceCache = ConcurrentHashMap.newMap();
+
+        private volatile Constructor<? extends CoreInstance> enumConstructor = null; //NOSONAR we actually want to protect the pointer
+
+        private LegacyMetadataLazy(ClassLoader classLoader, DistributedBinaryGraphDeserializer deserializer)
+        {
+            this.classLoader = classLoader;
+            this.deserializer = deserializer;
+        }
+
+        @Override
+        public void startTransaction()
+        {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void commitTransaction()
+        {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void rollbackTransaction()
+        {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public CoreInstance getMetadata(String classifier, String id)
+        {
+            if (!hasClassifier(classifier))
+            {
+                return null;
+            }
+            // for backward compatibility
+            if (id.startsWith("Root::"))
+            {
+                id = id.substring(6);
+            }
+            return toJavaObject(classifier, this.deserializer.processId(id));
+        }
+
+        @Override
+        public MapIterable<String, CoreInstance> getMetadata(String classifier)
+        {
+            return hasClassifier(classifier) ? loadAllClassifierInstances(classifier).asUnmodifiable() : Maps.fixedSize.empty();
+        }
+
+        @Override
+        public RichIterable<CoreInstance> getClassifierInstances(String classifier)
+        {
+            return hasClassifier(classifier) ? loadAllClassifierInstances(classifier).valuesView() : Lists.immutable.empty();
+        }
+
+        @Override
+        public CoreInstance getEnum(String enumerationName, String enumName)
+        {
+            if (!hasClassifier(enumerationName))
+            {
+                throw new RuntimeException("Cannot find enum '" + enumName + "' in enumeration '" + enumerationName + "': unknown enumeration");
+            }
+
+            ConcurrentMutableMap<String, CoreInstance> cache = getClassifierInstanceCache(enumerationName);
+            String enumId = this.deserializer.processEnumId(enumerationName, enumName);
+            CoreInstance result = cache.get(enumId);
+            if (result == null)
+            {
+                //might not have loaded yet, so request full load and try again:
+                loadAllClassifierInstances(enumerationName);
+                result = cache.get(enumId);
+                if (result == null)
+                {
+                    StringBuilder builder = new StringBuilder("Cannot find enum '").append(enumName).append("' in enumeration '").append(enumerationName).append("' unknown enum value");
+                    if (cache.isEmpty())
+                    {
+                        builder.append(" (no known values)");
+                    }
+                    else
+                    {
+                        cache.keysView().appendString(builder, " (known values: '", "', '", "')");
+                    }
+                    throw new RuntimeException(builder.toString());
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public Object valueToObject(RValue value)
+        {
+            return (value == null) ? null : value.visit(this.valueToObjectVisitor);
+        }
+
+        @Override
+        public RichIterable<Object> valuesToObjects(ListIterable<RValue> values)
+        {
+            int size = (values == null) ? 0 : values.size();
+            if (size == 0)
+            {
+                return Lists.immutable.empty();
+            }
+            if (size == 1)
+            {
+                return Lists.mutable.with(valueToObject(values.get(0)));
+            }
+
+            MutableMap<String, MutableSet<ObjRef>> objRefsByClassifier = Maps.mutable.empty();
+            Counter objRefCounter = new Counter();
+            values.forEach(new RValueConsumer()
+            {
+                @Override
+                protected void accept(Primitive primitive)
+                {
+                }
+
+                @Override
+                protected void accept(ObjRef objRef)
+                {
+                    objRefsByClassifier.getIfAbsentPut(objRef.getClassifierId(), Sets.mutable::empty).add(objRef);
+                    objRefCounter.increment();
+                }
+
+                @Override
+                protected void accept(EnumRef enumRef)
+                {
+                }
+            });
+            if (objRefsByClassifier.isEmpty())
+            {
+                return values.collect(this::valueToObject);
+            }
+
+            MutableMap<ObjRef, CoreInstance> objectByRef = Maps.mutable.withInitialCapacity(objRefCounter.getCount());
+            objRefsByClassifier.forEachKeyValue((classifier, objRefs) ->
+            {
+                MutableList<String> idsToDeserialize = Lists.mutable.withInitialCapacity(objRefs.size());
+                ConcurrentMutableMap<String, CoreInstance> classifierCache = getClassifierInstanceCache(classifier);
+                objRefs.forEach(objRef ->
+                {
+                    String id = objRef.getId();
+                    CoreInstance cachedInstance = classifierCache.get(id);
+                    if (cachedInstance == null)
+                    {
+                        idsToDeserialize.add(id);
+                    }
+                    else
+                    {
+                        objectByRef.put(objRef, cachedInstance);
+                    }
+                });
+                if (idsToDeserialize.notEmpty())
+                {
+                    ListIterable<Obj> deserialized = getInstances(classifier, idsToDeserialize);
+                    deserialized.forEach(obj ->
+                    {
+                        CoreInstance cachedInstance = classifierCache.getIfAbsentPut(obj.getIdentifier(), () -> newInstance(classifier, obj));
+                        objectByRef.put(new ObjRef(obj.getClassifier(), obj.getIdentifier()), cachedInstance);
+                    });
+                }
+            });
+            return values.collectWith(RValue::visit, new RValueVisitor<Object>()
+            {
+                @Override
+                public Object visit(Primitive primitive)
+                {
+                    return primitive.getValue();
+                }
+
+                @Override
+                public Object visit(ObjRef objRef)
+                {
+                    return objectByRef.get(objRef);
+                }
+
+                @Override
+                public Object visit(EnumRef enumRef)
+                {
+                    return getEnum(enumRef.getEnumerationId(), enumRef.getEnumName());
+                }
+            });
+        }
+
+        private boolean hasClassifier(String classifier)
+        {
+            return this.deserializer.hasClassifier(classifier);
+        }
+
+        private RichIterable<String> getClassifierInstanceIds(String classifier)
+        {
+            return this.deserializer.getClassifierInstanceIds(classifier);
+        }
+
+        private Obj getInstance(String classifier, String id)
+        {
+            return this.deserializer.getInstance(classifier, id);
+        }
+
+        private ListIterable<Obj> getInstances(String classifier, Iterable<String> instanceIds)
+        {
+            return this.deserializer.getInstances(classifier, instanceIds);
+        }
+
+        private ConcurrentMutableMap<String, CoreInstance> loadAllClassifierInstances(String classifier)
+        {
+            RichIterable<String> instanceIds = getClassifierInstanceIds(classifier);
+            ConcurrentMutableMap<String, CoreInstance> classifierCache = getClassifierInstanceCache(classifier);
+            if (classifierCache.size() < instanceIds.size())
+            {
+                MutableList<String> notLoadedIds = instanceIds.reject(classifierCache::containsKey, Lists.mutable.empty());
+                if (notLoadedIds.notEmpty())
+                {
+                    ListIterable<Obj> objs = getInstances(classifier, notLoadedIds);
+                    objs.forEach(obj -> classifierCache.getIfAbsentPut(obj.getIdentifier(), () -> newInstance(classifier, obj)));
+                }
+            }
+            return classifierCache;
+        }
+
+        private CoreInstance toJavaObject(String classifier, String id)
+        {
+            return getClassifierInstanceCache(classifier).getIfAbsentPut(id, () -> newInstance(classifier, id));
+        }
+
+        private ConcurrentMutableMap<String, CoreInstance> getClassifierInstanceCache(String classifier)
+        {
+            return this.instanceCache.getIfAbsentPut(classifier, ConcurrentHashMap::newMap);
+        }
+
+        private CoreInstance newInstance(String classifier, String id)
+        {
+            Obj obj = getInstance(classifier, id);
+            return newInstance(classifier, obj);
+        }
+
+        private CoreInstance newInstance(String classifier, Obj obj)
+        {
+            Constructor<? extends CoreInstance> constructor = getConstructor(classifier, obj);
+            try
+            {
+                return constructor.newInstance(obj, this);
+            }
+            catch (InvocationTargetException | InstantiationException | IllegalAccessException e)
+            {
+                Throwable cause = (e instanceof InvocationTargetException) ? e.getCause() : e;
+                StringBuilder builder = new StringBuilder("Error instantiating ").append(obj).append(" (instance of ").append(classifier).append(")");
+                String eMessage = cause.getMessage();
+                if (eMessage != null)
+                {
+                    builder.append(": ").append(eMessage);
+                }
+                throw new RuntimeException(builder.toString(), cause);
+            }
+        }
+
+        private Constructor<? extends CoreInstance> getConstructor(String classifier, Obj obj)
+        {
+            if (obj.isEnum())
+            {
+                Constructor<? extends CoreInstance> constructor = this.enumConstructor;
+                if (constructor == null)
+                {
+                    synchronized (this)
+                    {
+                        constructor = this.enumConstructor;
+                        if (constructor == null)
+                        {
+                            this.enumConstructor = constructor = getLazyImplEnumConstructor();
+                        }
+                    }
+                }
+                return constructor;
+            }
+            return this.constructors.getIfAbsentPutWithKey(classifier, this::getLazyImplClassConstructor);
+        }
+
+        @SuppressWarnings("unchecked")
+        private Constructor<? extends CoreInstance> getLazyImplClassConstructor(String classifier)
+        {
+            String lazyImplClassName = JavaPackageAndImportBuilder.buildLazyImplClassReferenceFromUserPath(classifier);
+            try
+            {
+                Class<? extends CoreInstance> cls = (Class<? extends CoreInstance>) this.classLoader.loadClass(lazyImplClassName);
+                return cls.getConstructor(Obj.class, MetadataLazy.class);
+            }
+            catch (ReflectiveOperationException e)
+            {
+                throw new RuntimeException("Error getting constructor for " + classifier, e);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private Constructor<? extends CoreInstance> getLazyImplEnumConstructor()
+        {
+            String lazyImplEnumName = JavaPackageAndImportBuilder.rootPackage() + '.' + EnumProcessor.ENUM_LAZY_CLASS_NAME;
+            try
+            {
+                Class<? extends CoreInstance> cls = (Class<? extends CoreInstance>) this.classLoader.loadClass(lazyImplEnumName);
+                Constructor<? extends CoreInstance> constructor = cls.getDeclaredConstructor(Obj.class, MetadataLazy.class);
+                constructor.setAccessible(true);
+                return constructor;
+            }
+            catch (ReflectiveOperationException e)
+            {
+                throw new RuntimeException("Error getting constructor for " + lazyImplEnumName);
+            }
+        }
     }
 }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaCodeGeneration.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaCodeGeneration.java
@@ -161,16 +161,11 @@ public class TestJavaCodeGeneration
                 true,
                 new VoidLog());
 
-        // Modular generation writes metadata to directory/metadata-distributed.
-        // The serializer writes metadata/bin/*.bin and metadata/classifiers/*.idx inside it.
+        // Modular generation now uses pelt serialization, which must already exist; so there should be no metadata generation
         File metaDistributed = new File(directory, "metadata-distributed");
-        Assert.assertTrue("metadata-distributed directory should be created", metaDistributed.exists());
-        File binDir = new File(metaDistributed, "metadata/bin");
-        Assert.assertTrue(
-                "Modular generation should produce metadata/bin under metadata-distributed",
-                binDir.isDirectory() && binDir.list() != null && binDir.list().length > 0);
+        Assert.assertFalse("metadata-distributed directory should not be created", metaDistributed.exists());
 
-        executeDynamicNewTest(cl -> MetadataLazy.fromClassLoader(cl, "platform"), classesDirectory, metaDistributed);
+        executeDynamicNewTest(cl -> MetadataLazy.fromClassLoader(cl, "platform"), classesDirectory);
     }
 
     @Test
@@ -470,11 +465,9 @@ public class TestJavaCodeGeneration
         JavaCodeGeneration.main("platform", classesDir.getAbsolutePath(), directory.getAbsolutePath());
 
         // main() calls doIt() with: modular, useSingleDir=true, generateSources=true, generateTest=true
-        // Metadata goes to classesDir/metadata/classifiers/platform/ (useSingleDir=true + modular)
-        File packageIdx = new File(classesDir, "metadata/classifiers/platform/Package.idx");
-        Assert.assertTrue(
-                "main(repo, classesDir, targetDir) should write metadata/classifiers/platform/Package.idx into classesDir",
-                packageIdx.exists() && packageIdx.length() > 0);
+        // Modular generation now uses pelt serialization, which must already exist; so there should be no metadata generation
+        File metadataDir = new File(classesDir, "metadata");
+        Assert.assertFalse(metadataDir.exists());
 
         // Generated sources go to targetDir/generated-test-sources/ because main() passes generateTest=true
         File packageImpl = new File(directory,
@@ -501,9 +494,7 @@ public class TestJavaCodeGeneration
 
         // Package.idx still expected - verify it's produced the same as 3-arg form
         File packageIdx = new File(classesDir, "metadata/classifiers/platform/Package.idx");
-        Assert.assertTrue(
-                "Four-arg main() should still produce metadata/classifiers/platform/Package.idx",
-                packageIdx.exists() && packageIdx.length() > 0);
+        Assert.assertFalse(packageIdx.exists());
     }
 
     private static void executeDynamicNewTestWithEagerMetadata(File classesDir, String... repoNames) throws Exception


### PR DESCRIPTION
Replace modular distributed metadata with pelt metadata. The compiled jar plugin will no longer generated modular distributed metadata. Instead, it will check to make sure pelt metadata is available, and fail if it's not.

MetadataLazy will now delegate to MetadataPelt in the modular case, but will keep its previous behavior for the monolithic case.