### PR TITLE
Add support for specifying Primary Keys on Relation Function Class Mappings

### DIFF
--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-pure/src/main/resources/platform_dsl_mapping/grammar/mapping.pure
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-pure/src/main/resources/platform_dsl_mapping/grammar/mapping.pure
@@ -224,6 +224,7 @@ Class meta::pure::mapping::aggregationAware::AggregateSpecificationValueSpecific
 Class meta::pure::mapping::relation::RelationFunctionInstanceSetImplementation extends InstanceSetImplementation
 {
   relationFunction: FunctionDefinition<{->Relation<Any>[1]}>[1];
+  primaryKey: meta::pure::metamodel::relation::Column<Nil,Any|*>[*];
 }
 
 Class meta::pure::mapping::relation::RelationFunctionPropertyMapping extends PropertyMapping


### PR DESCRIPTION
Adds primaryKey field to RelationalInstanceSetImplementation to support specifying Primary Keys for relation function mapping