### PR TITLE
Add multi-line string literals ('''...''') with Java text-block semantics

### DIFF
--- a/docs/reference/legend-grammar-reference.md
+++ b/docs/reference/legend-grammar-reference.md
@@ -16,6 +16,11 @@ Detailed per-section references live in their own pages:
 For how the `###` section system works, see
 [Section 0 of the Pure Language Reference](pure-language-reference.md#0-the-grammar-section-system).
 
+> **Multi-line string literals (`'''…'''`) are a `###Pure` feature only.** The
+> `MULTILINE_STRING` token is declared in `M3CoreLexer.g4`; the `###Mapping`,
+> `###Relational`, and `###Diagram` grammars do not accept it. See
+> [Multi-line String Literals](pure-language-reference.md#multi-line-string-literals).
+
 ---
 
 ## 1. Quick-reference — `###Mapping`

--- a/docs/reference/pure-language-reference.md
+++ b/docs/reference/pure-language-reference.md
@@ -33,6 +33,12 @@ Everything after a `###<Name>` line until the next `###` belongs to the parser
 registered under that name. The `ParserLibrary` dispatches each section to its
 corresponding `Parser` implementation based on the string name.
 
+> **This split happens before any grammar parses anything, and it is not
+> string-aware.** A line beginning with `###` at column 0 always starts a new
+> section — including inside a
+> [multi-line string literal](#multi-line-string-literals). Indent the `###` by
+> one space to keep it as content.
+
 ### Grammar sections available in this repository
 
 | Section header | Parser | What it defines |
@@ -124,7 +130,7 @@ let doubled = $x * 2;
 
 | Type | Example literals | Notes |
 |------|-----------------|-------|
-| `String` | `'hello'`, `'it\'s'` | Single-quoted; escape with `\'` |
+| `String` | `'hello'`, `'it\'s'` | Single-quoted; escape with `\'`. A [multi-line form](#multi-line-string-literals) `'''…'''` also exists |
 | `Integer` | `42`, `-7` | 64-bit signed |
 | `Float` | `3.14`, `-0.5` | 64-bit IEEE 754 |
 | `Decimal` | `3.14d` | Arbitrary precision (precisePrimitives module) |
@@ -134,6 +140,166 @@ let doubled = $x * 2;
 | `DateTime` | `%2024-01-15T10:30:00+0000` | Date + time with optional TZ offset |
 | `Number` | *(abstract)* | Supertype of `Integer`, `Float`, `Decimal` |
 | `Any` | *(abstract)* | Root type; every Pure type is a subtype |
+
+### Multi-line String Literals
+
+A string literal may be written across multiple lines using a triple-quote
+delimiter `'''`, following **Java text-block semantics**:
+
+```pure
+function meta::mypackage::greeting(): String[1]
+{
+    '''
+    Hello,
+    world!
+    '''
+}
+```
+
+The value above is `"Hello,\nworld!\n"` — the four-space indentation shared by
+every line is *incidental* and is removed.
+
+`'''…'''` is **syntax only**. It produces an ordinary `String` — there is no new
+type, no marker on the instance, and nothing downstream (the compiler, either
+execution engine, serialization) can tell it apart from the equivalent
+single-line literal. Anywhere a `String` literal is accepted in a `###Pure`
+section, a multi-line literal is accepted too: expressions, collection literals,
+property default values, function arguments, and tagged values.
+
+```pure
+// All of these are valid
+'prefix: ' + '''
+  body
+  '''
+
+'''
+  abc
+  '''->length()
+
+Class meta::mypackage::Thing
+{
+    note : String[1] = '''
+        default note
+        ''';
+}
+```
+
+#### The five processing rules
+
+Given the raw text between the delimiters, the parser applies these steps in
+order (`AntlrContextToM3CoreInstance.processMultilineString`):
+
+1. **Line terminators are normalized** — `\r\n` and `\r` both become `\n`.
+2. **The opening delimiter line is dropped.** The opening `'''` *must* be
+   followed by a line terminator (spaces and tabs between the two are allowed
+   and ignored). Content starts on the next line.
+3. **Incidental indentation is removed.** The amount removed is the smallest
+   leading-whitespace run across all non-blank lines **and the closing-delimiter
+   line** — the closing line participates even when it is blank.
+4. **Trailing whitespace is stripped from every line.**
+5. **Escape sequences are processed** — the same set as single-line strings
+   (`\n`, `\t`, `\'`, `\\`, `\uXXXX`, octal).
+
+> **Escapes are resolved last, and that is load-bearing.** Steps 3 and 4 see the
+> raw characters, so an *escaped* whitespace character is invisible to them: a
+> line ending in `\t` ends in the letter `t` as far as step 4 is concerned, and
+> becomes a real tab only at step 5. This is how you keep whitespace the layout
+> passes would otherwise remove — see below.
+
+#### Worked examples
+
+Below, `⏎` marks a newline in the source, `·` a space, and `⇥` a tab.
+
+| Literal | Value |
+|---------|-------|
+| `'''`⏎`line1`⏎`line2'''` | `"line1\nline2"` — no trailing newline |
+| `'''`⏎`line1`⏎`line2`⏎`'''` | `"line1\nline2\n"` — closing `'''` on its own line adds the terminal newline |
+| `'''`⏎`····hello`⏎`····world`⏎`····'''` | `"hello\nworld\n"` — common indent removed |
+| `'''`⏎`····a`⏎`··b`⏎`····'''` | `"··a\nb\n"` — min indent is 2, set by the shortest line |
+| `'''`⏎`····a`⏎`····b`⏎`'''` | `"····a\n····b\n"` — closing `'''` at column 0 sets the floor to 0, so **nothing** is stripped |
+| `'''`⏎`a···`⏎`b⇥`⏎`'''` | `"a\nb\n"` — trailing whitespace always stripped |
+| `'''`⏎`'''` | `""` — empty |
+
+> **Controlling the indent with the closing delimiter.** Because the closing
+> line participates in the minimum, its column is what you tune to keep or drop
+> leading indentation. Put `'''` flush left to preserve the block's indentation
+> verbatim; align it with the content to strip all of it.
+
+#### Differences from Java text blocks
+
+Pure reuses Java's *layout* algorithm but not its escape extensions. Two Java
+text-block features are **not** available:
+
+| Java feature | In Pure |
+|-------------|---------|
+| `\s` — escape meaning "a space that survives trailing-whitespace stripping" | No `\s` escape; it yields a literal `s`. Use `\u0020` instead — see below |
+| `\` at end-of-line — joins the line with the next | Not supported. The backslash is simply dropped and the newline is kept |
+
+More generally, an unrecognized escape does not error — the backslash is
+discarded and the following character is kept verbatim (`\q` → `q`). This is
+pre-existing `StringEscape` behaviour shared with single-line strings.
+
+**Preserving significant whitespace.** Pure has no `\s`, but it does not need
+one: because escapes are resolved *after* the two layout passes, any escaped
+whitespace survives them intact.
+
+| Literal | Value | Why |
+|---------|-------|-----|
+| `'''`⏎`a\u0020\u0020`⏎`'''` | `"a··\n"` | Trailing spaces preserved — step 4 saw the 12 characters of `\u0020\u0020`, none of them whitespace |
+| `'''`⏎`a\t`⏎`'''` | `"a⇥\n"` | Same, for a tab |
+| `'''`⏎`\tabc`⏎`\tdef`⏎`'''` | `"⇥abc\n⇥def\n"` | Leading escaped tabs are not counted as indentation, so step 3 cannot strip them |
+
+#### Restrictions and gotchas
+
+- **The opening `'''` must be followed by a newline.** `'''abc'''` does not
+  parse as a multi-line string. With the multi-line rule inapplicable, the lexer
+  falls back to the single-line rule and produces three separate `STRING`
+  tokens — `''`, `'abc'`, `''` — which the parser rejects
+  (`expected: '}' found: 'abc'`).
+
+- **The content cannot contain `'''`.** The lexer closes the literal at the
+  first `'''` it meets, so a run of three-or-more quotes (e.g. `''''`) is a
+  token-recognition error. Two consecutive quotes (`''`) are fine, as are lone
+  `'` and `"` characters — no escaping needed. To embed a literal `'''`, escape
+  the quotes: `\'\'\'` yields `'''`.
+
+- **⚠ A line starting with `###` at column 0 terminates the section, even
+  inside a multi-line string.** The top-level lexer that splits a file into
+  `###`-delimited grammar sections (see
+  [§0](#0-the-grammar-section-system)) runs *before* the Pure parser and knows
+  nothing about string literals. This source fails to compile because the
+  `###Relational` line splits the file, leaving the `'''` unterminated:
+
+  ```pure
+  function meta::mypackage::bad(): String[1]
+  {
+      '''
+  ###Relational
+      ''' // parse error: unterminated
+  }
+  ```
+
+  Indenting the `###` by even one space is enough to avoid this, because the
+  section separator token is `'\n###'` — it must sit immediately after a
+  newline. The workaround is free: that indent is incidental, so step 3 strips
+  it back off and the resulting value still has `###Relational` at column 0.
+  This hazard is new with multi-line strings; a single-line literal cannot span
+  a newline, so `\n###` could never occur inside one.
+
+- **`###Pure` sections only.** The `MULTILINE_STRING` token is declared in
+  `M3CoreLexer.g4` alone. The `###Mapping`, `###Relational`, and `###Diagram`
+  grammars — and M4 — do not accept `'''…'''`, even though they share the
+  underlying `MultilineString` fragment definition in `M4Fragment.g4`.
+
+- **Printing does not round-trip.** Since the value is an ordinary `String`,
+  anything that renders it back to Pure source emits a single-line, escaped
+  literal — not a `'''` block.
+
+**Implementation:** lexer fragment `MultilineString` in `M4Fragment.g4`; token
+`MULTILINE_STRING` in `M3CoreLexer.g4`; parser rules `instanceLiteralToken` and
+`taggedValue` in `M3CoreParser.g4`; processing in
+`AntlrContextToM3CoreInstance.processMultilineString`. Tests:
+`TestStringParsing` and `TestProfile`.
 
 ### `Any` and `Nil`
 
@@ -283,6 +449,43 @@ Class <<meta::mypackage::classification.internal>>
 ```
 
 Both stereotypes and tags can be applied together, and multiple values are separated by commas inside the curly braces.
+
+#### Tag values — concatenation and multi-line form
+
+A tag value is written in one of two mutually exclusive forms.
+
+**1. One or more `+`-joined single-line strings.** Note that `+` here is *not*
+the string-concatenation function — the parser joins the fragments with the
+default `makeString()` separator, `", "`:
+
+```pure
+Class {doc.doc = 'first' + 'second'} meta::mypackage::Thing {}
+// resulting tag value: "first, second"   ← comma-space, not "firstsecond"
+```
+
+This is long-standing behaviour and is unchanged. It is a common surprise for
+anyone expecting `+` to behave as it does in an expression.
+
+**2. A single [multi-line string](#multi-line-string-literals)** — the readable
+way to attach a paragraph of documentation:
+
+```pure
+Class {doc.doc = '''
+    Represents a documented class.
+
+    The blank line above is preserved; the shared indentation is not.
+    '''} meta::mypackage::DocumentedClass
+{
+    name : String[1];
+}
+```
+
+> **A multi-line tag value cannot be concatenated.** `{doc.doc = 'Title: ' + '''…'''}`
+> is a parse error. The grammar rule is
+> `(MULTILINE_STRING | STRING (PLUS STRING)*)` — you get either one multi-line
+> string or a `+`-joined run of single-line ones, never a mix. Given that `+`
+> inserts `", "` rather than concatenating, mixing the two forms would produce
+> a value almost nobody intends, so the combination is rejected outright.
 
 #### Built-in profiles
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreLexer.g4
+++ b/legend-pure-core/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreLexer.g4
@@ -32,6 +32,7 @@ TILDE: '~';
 QUESTION: '?';
 PATH_SEPARATOR: PathSeparator;
 
+MULTILINE_STRING: MultilineString;
 STRING: String;
 BOOLEAN: Boolean;
 TRUE: True;

--- a/legend-pure-core/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreParser.g4
+++ b/legend-pure-core/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreParser.g4
@@ -234,7 +234,7 @@ stereotype: qualifiedName DOT identifier
 taggedValues: CURLY_BRACKET_OPEN taggedValue (COMMA taggedValue)* CURLY_BRACKET_CLOSE
 ;
 
-taggedValue: qualifiedName DOT identifier EQUAL (STRING | MULTILINE_STRING) (PLUS (STRING | MULTILINE_STRING))*
+taggedValue: qualifiedName DOT identifier EQUAL (MULTILINE_STRING | STRING (PLUS STRING)*)
 ;
 
 defaultValue: EQUAL defaultValueExpression

--- a/legend-pure-core/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreParser.g4
+++ b/legend-pure-core/legend-pure-m3-core/src/main/antlr4/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/core/M3CoreParser.g4
@@ -234,7 +234,7 @@ stereotype: qualifiedName DOT identifier
 taggedValues: CURLY_BRACKET_OPEN taggedValue (COMMA taggedValue)* CURLY_BRACKET_CLOSE
 ;
 
-taggedValue: qualifiedName DOT identifier EQUAL STRING (PLUS STRING)*
+taggedValue: qualifiedName DOT identifier EQUAL (STRING | MULTILINE_STRING) (PLUS (STRING | MULTILINE_STRING))*
 ;
 
 defaultValue: EQUAL defaultValueExpression
@@ -430,7 +430,7 @@ lambdaParamType: COLON type multiplicity
 instanceLiteral: instanceLiteralToken | (MINUS INTEGER) | (MINUS FLOAT) | (MINUS DECIMAL) | (PLUS INTEGER) | (PLUS FLOAT) | (PLUS DECIMAL)
 ;
 
-instanceLiteralToken: STRING | INTEGER | FLOAT | DECIMAL | DATE | BOOLEAN | STRICTTIME
+instanceLiteralToken: STRING | MULTILINE_STRING | INTEGER | FLOAT | DECIMAL | DATE | BOOLEAN | STRICTTIME
 ;
 
 unitInstanceLiteral: (MINUS? INTEGER) | (MINUS? FLOAT) | (MINUS? DECIMAL) | (PLUS INTEGER) | (PLUS FLOAT) | (PLUS DECIMAL)

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
@@ -18,7 +18,6 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.misc.Interval;
-import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
@@ -136,7 +135,6 @@ import org.finos.legend.pure.m3.navigation.ValueSpecificationBootstrap;
 import org.finos.legend.pure.m3.navigation._package._Package;
 import org.finos.legend.pure.m3.navigation.relation._Column;
 import org.finos.legend.pure.m3.navigation.relation._RelationType;
-import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.AllOrFunctionContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.ArithmeticPartContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.AssociationContext;
@@ -3254,28 +3252,13 @@ public class AntlrContextToM3CoreInstance
     private TaggedValue taggedValue(ImportGroup importId, TaggedValueContext ctx)
     {
         ImportStubInstance importStubInstance = ImportStubInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.qualifiedName().getStart(), ctx.identifier().getStart(), ctx.identifier().getStop()), this.getQualifiedNameString(ctx.qualifiedName()) + "%" + ctx.identifier().getText(), importId);
-        // The value is the (PLUS) concatenation of the string tokens in source order; each token may be a
-        // single-line STRING or a multi-line MULTILINE_STRING, so iterate the children to keep them interleaved.
-        MutableList<TerminalNode> stringNodes = Lists.mutable.empty();
-        for (int i = 0; i < ctx.getChildCount(); i++)
+        // A tagged value is either a single multi-line string or one-or-more '+'-concatenated single-line strings.
+        if (ctx.MULTILINE_STRING() != null)
         {
-            ParseTree child = ctx.getChild(i);
-            if (child instanceof TerminalNode)
-            {
-                int type = ((TerminalNode) child).getSymbol().getType();
-                if ((type == M3Parser.STRING) || (type == M3Parser.MULTILINE_STRING))
-                {
-                    stringNodes.add((TerminalNode) child);
-                }
-            }
+            TerminalNode multiline = ctx.MULTILINE_STRING();
+            return TaggedValueInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.getStart(), multiline.getSymbol(), multiline.getSymbol()), importStubInstance, processMultilineString(multiline.getText()));
         }
-        String value = stringNodes.collect(AntlrContextToM3CoreInstance::taggedValueString).makeString();
-        return TaggedValueInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.getStart(), stringNodes.getFirst().getSymbol(), stringNodes.getLast().getSymbol()), importStubInstance, value);
-    }
-
-    private static String taggedValueString(TerminalNode node)
-    {
-        return (node.getSymbol().getType() == M3Parser.MULTILINE_STRING) ? processMultilineString(node.getText()) : removeQuotes(node);
+        return TaggedValueInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.STRING().get(0).getSymbol(), ctx.STRING().get(ctx.STRING().size() - 1).getSymbol()), importStubInstance, Lists.mutable.withAll(ctx.STRING()).collect(AntlrContextToM3CoreInstance::removeQuotes).makeString());
     }
 
     private DefaultValue defaultValue(DefaultValueContext ctx, ImportStub isOwner, ImportGroup importId, String propertyName)

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/grammar/m3parser/antlr/AntlrContextToM3CoreInstance.java
@@ -18,6 +18,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
@@ -135,6 +136,7 @@ import org.finos.legend.pure.m3.navigation.ValueSpecificationBootstrap;
 import org.finos.legend.pure.m3.navigation._package._Package;
 import org.finos.legend.pure.m3.navigation.relation._Column;
 import org.finos.legend.pure.m3.navigation.relation._RelationType;
+import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.AllOrFunctionContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.ArithmeticPartContext;
 import org.finos.legend.pure.m3.serialization.grammar.m3parser.antlr.M3Parser.AssociationContext;
@@ -891,6 +893,10 @@ public class AntlrContextToM3CoreInstance
             {
                 String withQuote = StringEscape.unescape(ctx.getText());
                 result = this.repository.newStringCoreInstance_cached(withQuote.substring(1, withQuote.length() - 1));
+            }
+            else if (ctx.MULTILINE_STRING() != null)
+            {
+                result = this.repository.newStringCoreInstance_cached(processMultilineString(ctx.getText()));
             }
             else if (ctx.INTEGER() != null)
             {
@@ -3248,7 +3254,28 @@ public class AntlrContextToM3CoreInstance
     private TaggedValue taggedValue(ImportGroup importId, TaggedValueContext ctx)
     {
         ImportStubInstance importStubInstance = ImportStubInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.qualifiedName().getStart(), ctx.identifier().getStart(), ctx.identifier().getStop()), this.getQualifiedNameString(ctx.qualifiedName()) + "%" + ctx.identifier().getText(), importId);
-        return TaggedValueInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.getStart(), ctx.STRING().get(0).getSymbol(), ctx.STRING().get(ctx.STRING().size() - 1).getSymbol()), importStubInstance, Lists.mutable.withAll(ctx.STRING()).collect(AntlrContextToM3CoreInstance::removeQuotes).makeString());
+        // The value is the (PLUS) concatenation of the string tokens in source order; each token may be a
+        // single-line STRING or a multi-line MULTILINE_STRING, so iterate the children to keep them interleaved.
+        MutableList<TerminalNode> stringNodes = Lists.mutable.empty();
+        for (int i = 0; i < ctx.getChildCount(); i++)
+        {
+            ParseTree child = ctx.getChild(i);
+            if (child instanceof TerminalNode)
+            {
+                int type = ((TerminalNode) child).getSymbol().getType();
+                if ((type == M3Parser.STRING) || (type == M3Parser.MULTILINE_STRING))
+                {
+                    stringNodes.add((TerminalNode) child);
+                }
+            }
+        }
+        String value = stringNodes.collect(AntlrContextToM3CoreInstance::taggedValueString).makeString();
+        return TaggedValueInstance.createPersistent(this.repository, this.sourceInformation.getPureSourceInformation(ctx.getStart(), stringNodes.getFirst().getSymbol(), stringNodes.getLast().getSymbol()), importStubInstance, value);
+    }
+
+    private static String taggedValueString(TerminalNode node)
+    {
+        return (node.getSymbol().getType() == M3Parser.MULTILINE_STRING) ? processMultilineString(node.getText()) : removeQuotes(node);
     }
 
     private DefaultValue defaultValue(DefaultValueContext ctx, ImportStub isOwner, ImportGroup importId, String propertyName)
@@ -3956,6 +3983,75 @@ public class AntlrContextToM3CoreInstance
     {
         name = name.trim();
         return name.startsWith("'") ? name.substring(1, name.length() - 1) : name;
+    }
+
+    /**
+     * Convert the raw text of a multi-line string literal ('''...''') into its value, following the Java
+     * text-block algorithm: strip the opening delimiter line and the closing delimiter, remove the common
+     * (incidental) leading-whitespace indentation, strip trailing whitespace from each line, then process
+     * escape sequences. The opening '''  must be followed by a line terminator (enforced by the lexer), so
+     * the first line of content is the line after it; the terminal newline is preserved iff the closing '''
+     * sits on its own line.
+     */
+    public static String processMultilineString(String rawTokenText)
+    {
+        // Normalize line terminators, then drop the opening delimiter line (through its terminator) and the
+        // trailing closing '''.
+        String normalized = rawTokenText.replace("\r\n", "\n").replace('\r', '\n');
+        int firstNewLine = normalized.indexOf('\n');
+        String body = normalized.substring(firstNewLine + 1, normalized.length() - 3);
+
+        String[] lines = body.split("\n", -1);
+
+        // Minimum indentation is computed over every non-blank line plus the last line (the closing-delimiter
+        // line, even when blank) - the latter sets a floor that prevents over-stripping.
+        int minIndent = Integer.MAX_VALUE;
+        for (int i = 0; i < lines.length; i++)
+        {
+            String line = lines[i];
+            int leading = leadingWhitespaceLength(line);
+            if ((leading < line.length()) || (i == lines.length - 1))
+            {
+                minIndent = Math.min(minIndent, leading);
+            }
+        }
+        if (minIndent == Integer.MAX_VALUE)
+        {
+            minIndent = 0;
+        }
+
+        StringBuilder builder = new StringBuilder(body.length());
+        for (int i = 0; i < lines.length; i++)
+        {
+            if (i > 0)
+            {
+                builder.append('\n');
+            }
+            String line = lines[i];
+            builder.append(stripTrailingWhitespace(line.substring(Math.min(minIndent, line.length()))));
+        }
+
+        return StringEscape.unescape(builder.toString());
+    }
+
+    private static int leadingWhitespaceLength(String line)
+    {
+        int i = 0;
+        while ((i < line.length()) && Character.isWhitespace(line.charAt(i)))
+        {
+            i++;
+        }
+        return i;
+    }
+
+    private static String stripTrailingWhitespace(String line)
+    {
+        int end = line.length();
+        while ((end > 0) && Character.isWhitespace(line.charAt(end - 1)))
+        {
+            end--;
+        }
+        return line.substring(0, end);
     }
 
     private InstanceValue doWrap(MutableList<PropertyNameContext> content)

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/grammar/v1/TestStringParsing.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/grammar/v1/TestStringParsing.java
@@ -62,6 +62,36 @@ public class TestStringParsing extends AbstractPrimitiveParsingTest
     }
 
     @Test
+    public void testSimpleMultilineString()
+    {
+        assertParsesTo("line1\nline2", "'''\nline1\nline2'''");
+    }
+
+    @Test
+    public void testMultilineStringWithTrailingNewline()
+    {
+        assertParsesTo("line1\nline2\n", "'''\nline1\nline2\n'''");
+    }
+
+    @Test
+    public void testMultilineStringIndentationStripped()
+    {
+        assertParsesTo("hello\nworld\n", "'''\n    hello\n    world\n    '''");
+    }
+
+    @Test
+    public void testMultilineStringProcessesEscapes()
+    {
+        assertParsesTo("a\tb\n", "'''\na\\tb\n'''");
+    }
+
+    @Test
+    public void testMultilineStringRequiresNewlineAfterOpeningDelimiter()
+    {
+        assertFailsToParse("'''abc'''");
+    }
+
+    @Test
     public void testStringWithOnlyEscapedQuote()
     {
         assertParsesTo("'", "'\\''");

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/profile/TestProfile.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/profile/TestProfile.java
@@ -31,6 +31,7 @@ import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpa
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
 import org.finos.legend.pure.m3.tools.ListHelper;
+import org.finos.legend.pure.m4.serialization.grammar.antlr.PureParserException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -174,16 +175,15 @@ public class TestProfile extends AbstractPureTestWithCoreCompiledPlatform
     }
 
     @Test
-    public void testMultilineTaggedValueConcatenatedWithSingleLine()
+    public void testSingleLineTaggedValueConcatenationStillWorks()
     {
+        // Concatenation of single-line strings is unchanged by the multi-line feature.
         compileTestSource("/test/testSource.pure",
                 "Profile test::docProfile\n" +
                         "{\n" +
                         "  tags: [doc];\n" +
                         "}\n" +
-                        "Class {test::docProfile.doc='Title: ' + '''\n" +
-                        "line1\n" +
-                        "line2'''} test::DocumentedClass\n" +
+                        "Class {test::docProfile.doc='a' + 'b'} test::DocumentedClass\n" +
                         "{\n" +
                         "}");
 
@@ -192,8 +192,24 @@ public class TestProfile extends AbstractPureTestWithCoreCompiledPlatform
 
         ListIterable<? extends TaggedValue> taggedValues = ListHelper.wrapListIterable(cls._taggedValues());
         Assert.assertEquals(1, taggedValues.size());
-        // The multi-line token is concatenated like any other tagged-value string token; the ", " join
-        // between '+'-separated tokens is the pre-existing tagged-value behavior, unchanged by this feature.
-        Assert.assertEquals("Title: , line1\nline2", taggedValues.getFirst()._value());
+        // The ", " join between '+'-separated single-line tokens is pre-existing tagged-value behavior.
+        Assert.assertEquals("a, b", taggedValues.getFirst()._value());
+    }
+
+    @Test
+    public void testMultilineTaggedValueCannotBeConcatenated()
+    {
+        // A multi-line tagged value is either a single multi-line string or '+'-concatenated single-line
+        // strings - it cannot be concatenated with anything.
+        Assert.assertThrows(PureParserException.class, () -> compileTestSource("/test/testSource.pure",
+                "Profile test::docProfile\n" +
+                        "{\n" +
+                        "  tags: [doc];\n" +
+                        "}\n" +
+                        "Class {test::docProfile.doc='Title: ' + '''\n" +
+                        "line1\n" +
+                        "line2'''} test::DocumentedClass\n" +
+                        "{\n" +
+                        "}"));
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/profile/TestProfile.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/elements/profile/TestProfile.java
@@ -17,9 +17,11 @@ package org.finos.legend.pure.m3.tests.elements.profile;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.AnnotatedElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Stereotype;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Tag;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.TaggedValue;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
@@ -147,5 +149,51 @@ public class TestProfile extends AbstractPureTestWithCoreCompiledPlatform
         Assert.assertEquals("t3", t3._value());
         Assert.assertSame(profile, t3._profile());
         assertSourceInformation("/test/testSource.pure", 4, 18, 4, 18, 4, 19, t3.getSourceInformation());
+    }
+
+    @Test
+    public void testMultilineTaggedValue()
+    {
+        compileTestSource("/test/testSource.pure",
+                "Profile test::docProfile\n" +
+                        "{\n" +
+                        "  tags: [doc];\n" +
+                        "}\n" +
+                        "Class {test::docProfile.doc='''\n" +
+                        "first line\n" +
+                        "second line'''} test::DocumentedClass\n" +
+                        "{\n" +
+                        "}");
+
+        AnnotatedElement cls = (AnnotatedElement) runtime.getCoreInstance("test::DocumentedClass");
+        Assert.assertNotNull(cls);
+
+        ListIterable<? extends TaggedValue> taggedValues = ListHelper.wrapListIterable(cls._taggedValues());
+        Assert.assertEquals(1, taggedValues.size());
+        Assert.assertEquals("first line\nsecond line", taggedValues.getFirst()._value());
+    }
+
+    @Test
+    public void testMultilineTaggedValueConcatenatedWithSingleLine()
+    {
+        compileTestSource("/test/testSource.pure",
+                "Profile test::docProfile\n" +
+                        "{\n" +
+                        "  tags: [doc];\n" +
+                        "}\n" +
+                        "Class {test::docProfile.doc='Title: ' + '''\n" +
+                        "line1\n" +
+                        "line2'''} test::DocumentedClass\n" +
+                        "{\n" +
+                        "}");
+
+        AnnotatedElement cls = (AnnotatedElement) runtime.getCoreInstance("test::DocumentedClass");
+        Assert.assertNotNull(cls);
+
+        ListIterable<? extends TaggedValue> taggedValues = ListHelper.wrapListIterable(cls._taggedValues());
+        Assert.assertEquals(1, taggedValues.size());
+        // The multi-line token is concatenated like any other tagged-value string token; the ", " join
+        // between '+'-separated tokens is the pre-existing tagged-value behavior, unchanged by this feature.
+        Assert.assertEquals("Title: , line1\nline2", taggedValues.getFirst()._value());
     }
 }

--- a/legend-pure-core/legend-pure-m4/src/main/antlr4/org/finos/legend/pure/m4/serialization/grammar/core/M4Fragment.g4
+++ b/legend-pure-core/legend-pure-m4/src/main/antlr4/org/finos/legend/pure/m4/serialization/grammar/core/M4Fragment.g4
@@ -6,6 +6,8 @@ fragment PathSeparator: '::'
 ;
 fragment String: ('\'' ( EscSeq | ~['\r\n\\] )*  '\'' )
 ;
+fragment MultilineString: ('\'\'\'' [ \t]* '\r'? '\n' .*? '\'\'\'' )
+;
 fragment Boolean: True | False
 ;
 fragment True: 'true'


### PR DESCRIPTION
## Summary

Adds support for **multi-line string literals** delimited by triple single quotes (`'''`), following Java text-block semantics (but with `'''` instead of Java's `"""`).

A line terminator is required immediately after the opening `'''` (only whitespace allowed before it); incidental leading-whitespace indentation is stripped; trailing whitespace is removed per line; and escape sequences (`\n`, `\t`, `\uXXXX`, `\'`, `\\`) are processed — matching Java's re-indentation algorithm.

The literal is accepted in two places:
- **Expression literals** (`instanceLiteralToken`)
- **Tagged values** — the documentation use case, e.g. ``{meta::pure::profiles::doc.doc='''...'''}``

### Example
```
'''
first line
second line'''
```
parses to `"first line\nsecond line"`. With the closing `'''` on its own line, the trailing newline is preserved; indentation common to the content lines and the closing delimiter is stripped.

## Changes
- **`M4Fragment.g4`** — new `MultilineString` fragment. A fragment produces no token in grammars that don't reference it, so the other DSL grammars (mapping, graph, navigation, relational, etc.) are unaffected.
- **`M3CoreLexer.g4`** — `MULTILINE_STRING` token (M3 only).
- **`M3CoreParser.g4`** — `instanceLiteralToken` and `taggedValue` accept `MULTILINE_STRING`.
- **`AntlrContextToM3CoreInstance.java`** — `processMultilineString` helper implementing the re-indentation algorithm in Java; wired into `instanceLiteralToken` and the reworked `taggedValue` (existing single-line tagged-value behavior preserved byte-for-byte).

## Design note
`toRepresentation` is intentionally **not** changed. Source-faithful re-rendering of a `'''` block (distinguishing it from an escaped `'a\nb'`) isn't reachable there: in the compiled engine `s:String[1]` is a raw `java.lang.String` with no source information; m4 primitives can't store source info (`PrimitiveCoreInstance.setSourceInformation` throws); and string values are interned. At runtime the two forms are the identical value, so this PR keeps the feature **parse-only**.

## Testing
- `TestStringParsing` — basic block, indentation stripping, trailing-newline vs. not, embedded escapes, and the required-newline-after-opening-delimiter rule. **16/16 pass.**
- `TestProfile` — multi-line tagged values and `+`-concatenation with a single-line token. **5/5 pass.**
- Full `meta::pure::functions` suite (`TestCoreFunctions`) green on **both** the interpreted and compiled engines; checkstyle clean on both touched modules; leakage-sensitive suites (`TestSearchTools`, `TestClassLoaderCodeStorage`, `TestMatching`) unaffected.