### PR TITLE
Fix a bug with writing externalizable API source to disk

### DIFF
--- a/legend-pure-maven/legend-pure-maven-generation-java/src/test/java/org/finos/legend/pure/maven/javaCompiled/TestPureCompiledJarMojo.java
+++ b/legend-pure-maven/legend-pure-maven-generation-java/src/test/java/org/finos/legend/pure/maven/javaCompiled/TestPureCompiledJarMojo.java
@@ -17,12 +17,14 @@ package org.finos.legend.pure.maven.javaCompiled;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.finos.legend.pure.maven.shared.MojoTestSupport;
+import org.finos.legend.pure.runtime.java.compiled.generation.JavaSourceCodeGenerator;
 import org.finos.legend.pure.runtime.java.compiled.generation.orchestrator.JavaCodeGeneration;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import javax.tools.JavaFileObject;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -179,22 +181,23 @@ public class TestPureCompiledJarMojo
     }
 
     @Test
-    public void testExecute_addExternalAPI_doesNotThrow() throws Exception
+    public void testExecute_addExternalAPI() throws Exception
     {
         File targetDir  = TMP.newFolder("exec-extapi-target");
         File classesDir = new File(targetDir, "classes");
-        classesDir.mkdir();
 
+        String externalAPIPackage = "org.finos.legend.pure.generated";
         PureCompiledJarMojo mojo = buildMojo(targetDir, classesDir, setOf("platform"));
         setField(mojo, "addExternalAPI",    true);
-        setField(mojo, "externalAPIPackage", "org.finos.legend.pure.generated");
+        setField(mojo, "externalAPIPackage", externalAPIPackage);
+        setField(mojo, "generateSources", true);
+        setField(mojo, "preventJavaCompilation", false);
         mojo.execute();
 
-        try (Stream<Path> stream = Files.walk(targetDir.toPath()))
-        {
-            long count = stream.filter(Files::isRegularFile).count();
-            Assert.assertTrue("addExternalAPI=true should produce output", count > 0);
-        }
+        Path expectedSource = targetDir.toPath().resolve("generated-sources/" + externalAPIPackage.replace('.', '/') + "/" + JavaSourceCodeGenerator.EXTERNAL_FUNCTIONS_CLASS_NAME + JavaFileObject.Kind.SOURCE.extension);
+        Assert.assertTrue(expectedSource.toString(), Files.exists(expectedSource));
+        Path expectedClass = classesDir.toPath().resolve(externalAPIPackage.replace('.', '/') + "/" + JavaSourceCodeGenerator.EXTERNAL_FUNCTIONS_CLASS_NAME + JavaFileObject.Kind.CLASS.extension);
+        Assert.assertTrue(expectedClass.toString(), Files.exists(expectedClass));
     }
 
     @Test

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaSourceCodeGenerator.java
@@ -18,6 +18,7 @@ import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.HashingStrategy;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
@@ -60,6 +61,7 @@ import org.finos.legend.pure.runtime.java.compiled.generation.processors.type._c
 import org.finos.legend.pure.runtime.java.compiled.generation.processors.type.measureUnit.MeasureProcessor;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -359,7 +361,12 @@ public final class JavaSourceCodeGenerator
                 e -> FunctionProcessor.buildExternalizableFunction(e, processorContext),
                 Lists.mutable.empty());
         String text = ExternalClassBuilder.buildExternalizableFunctionClass(pack, EXTERNAL_FUNCTIONS_CLASS_NAME, externalizableFunctionCode, this.codeStorage.getAllRepositories().collect(CodeRepository::getName), this.useLegacyMetadataForExternalAPI);
-        return Lists.immutable.with(StringJavaSource.newStringJavaSource(pack, EXTERNAL_FUNCTIONS_CLASS_NAME, text));
+        ImmutableList<StringJavaSource> javaSources = Lists.immutable.with(StringJavaSource.newStringJavaSource(pack, EXTERNAL_FUNCTIONS_CLASS_NAME, text));
+        if (this.writeFilesToDisk)
+        {
+            javaClassesToDisk(javaSources);
+        }
+        return javaSources;
     }
 
     private void javaClassesToDisk(Iterable<? extends StringJavaSource> javaClasses)
@@ -377,7 +384,7 @@ public final class JavaSourceCodeGenerator
         }
         catch (IOException e)
         {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaCodeGeneration.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaCodeGeneration.java
@@ -52,6 +52,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -327,7 +328,7 @@ public class TestJavaCodeGeneration
         Assert.assertTrue(
                 "Package_Impl.java should always be generated for platform repository",
                 packageImpl.exists());
-        String packageImplSrc = new String(java.nio.file.Files.readAllBytes(packageImpl.toPath()));
+        String packageImplSrc = new String(Files.readAllBytes(packageImpl.toPath()));
         Assert.assertTrue(
                 "Package_Impl.java should declare the correct package",
                 packageImplSrc.contains("package org.finos.legend.pure.generated"));
@@ -372,13 +373,56 @@ public class TestJavaCodeGeneration
         Assert.assertTrue(
                 "PureCompiledLambda.java should always be generated in test-sources for platform",
                 lambdaFile.exists());
-        String lambdaSrc = new String(java.nio.file.Files.readAllBytes(lambdaFile.toPath()));
+        String lambdaSrc = new String(Files.readAllBytes(lambdaFile.toPath()));
         Assert.assertTrue(
                 "PureCompiledLambda.java should declare the correct package",
                 lambdaSrc.contains("package org.finos.legend.pure.generated"));
         Assert.assertTrue(
                 "PureCompiledLambda.java should declare class PureCompiledLambda",
                 lambdaSrc.contains("class PureCompiledLambda"));
+    }
+
+    @Test
+    public void testGenerateSources_writesExternalizableApiToDisk() throws Exception
+    {
+        String externalPackage = "org.finos.legend.pure.runtime.java.compiled";
+        File directory = TMP.newFolder();
+        File classesDir = new File(directory, "classes");
+
+        JavaCodeGeneration.doIt(
+                Sets.mutable.with("platform"),
+                Sets.fixedSize.empty(),
+                Sets.fixedSize.empty(),
+                GenerationType.monolithic,
+                false,
+                true,            // addExternalAPI=true
+                externalPackage, // externalAPIPackage
+                false,           // generateMetadata=false - fastest path
+                false,
+                true,            // generateSources=true
+                false,           // generateTest=false: generated-sources/
+                true,            // preventJavaCompilation
+                classesDir,
+                directory,
+                false,
+                new VoidLog());
+
+        // With addExternalAPI=true and writeJavaSourcesToDisk on, the externalizable API class
+        // (PureExternal.java) must be written into generated-sources/ under the external package.
+        File generatedSources = new File(directory, "generated-sources");
+        File pureExternal = new File(generatedSources,
+                externalPackage.replace('.', '/') + "/PureExternal.java");
+        Assert.assertTrue(
+                "PureExternal.java should be written to generated-sources/ when addExternalAPI=true",
+                pureExternal.exists());
+
+        String src = new String(Files.readAllBytes(pureExternal.toPath()), StandardCharsets.UTF_8);
+        Assert.assertTrue(
+                "PureExternal.java should declare the external package",
+                src.contains("package " + externalPackage));
+        Assert.assertTrue(
+                "PureExternal.java should declare class PureExternal",
+                src.contains("class PureExternal"));
     }
 
     // --- error / catch block ---

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/TestJavaStandaloneLibraryGenerator.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/TestJavaStandaloneLibraryGenerator.java
@@ -51,6 +51,7 @@ import org.junit.rules.TemporaryFolder;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -236,6 +237,31 @@ public class TestJavaStandaloneLibraryGenerator extends AbstractPureTestWithCore
         Generate generate = generator.generateOnly("test", false, sourcesDir);
         Assert.assertFalse(generate.getJavaSourcesByGroup().get("test").stream().filter(s -> s.toUri().getPath().equals("/org/finos/legend/pure/generated/test_standalone_tests.java")).collect(Collectors.toList()).get(0).getCode().contains("Root_test_standalone_simplePureTest__Boolean_1_"));
         Assert.assertTrue(generate.getJavaSourcesByGroup().get("test").stream().filter(s -> s.toUri().getPath().equals("/org/finos/legend/pure/generated/test_standalone_tests.java")).collect(Collectors.toList()).get(0).getCode().contains("Root_test_standalone_simplePureTestWithApplication__Boolean_1_"));
+    }
+
+    @Test
+    public void testExternalizableApiIsWrittenToDisk() throws Exception
+    {
+        String externalPackage = "org.finos.legend.pure.runtime.java.compiled";
+        JavaStandaloneLibraryGenerator generator = JavaStandaloneLibraryGenerator.newGenerator(runtime, CompiledExtensionLoader.extensions(), true, externalPackage, new VoidLog());
+        Path rootFolder = TMP.newFolder().toPath();
+        Path sourcesDir = Files.createDirectories(rootFolder.resolve("src").resolve("java"));
+
+        Generate generate = generator.generateOnly(true, sourcesDir);
+
+        // The externalizable API source is always produced in memory ...
+        Assert.assertNotEquals(Lists.immutable.empty(), generate.getExternalizableSources());
+
+        // ... and, because writeJavaSourcesToDisk=true, it must also be written to disk.
+        Path pureExternal = sourcesDir.resolve(externalPackage.replace('.', '/') + "/PureExternal.java");
+        Assert.assertTrue("PureExternal.java should be written to disk when writeJavaSourcesToDisk=true", Files.exists(pureExternal));
+
+        String code = new String(Files.readAllBytes(pureExternal), StandardCharsets.UTF_8);
+        Assert.assertTrue("PureExternal.java should declare the external package", code.contains("package " + externalPackage));
+        Assert.assertTrue("PureExternal.java should declare class PureExternal", code.contains("class PureExternal"));
+        // The <<access.externalizable>> functions from the fixture must be exposed by the generated API
+        Assert.assertTrue("PureExternal.java should expose joinWithCommas", code.contains("joinWithCommas"));
+        Assert.assertTrue("PureExternal.java should expose testWithReflection", code.contains("testWithReflection"));
     }
 
     @Test


### PR DESCRIPTION
Fix a bug with writing externalizable API source to disk. Previously, PureExternal.java was not being written to disk even when writeFilesToDisk was true. Now it is.