### PR TITLE
Update PCTTools.getMessageFromError to give consistent NPE handling for different Java versions

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/shared/PCTTools.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/shared/PCTTools.java
@@ -15,16 +15,16 @@
 package org.finos.legend.pure.m3.pct.shared;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.eclipse.collections.api.factory.Sets;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.AnnotatedElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.AnnotationAccessor;
 import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation.profile.Profile;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.junit.Assert;
 
 import java.util.Set;
-
-import static org.junit.Assert.fail;
 
 public class PCTTools
 {
@@ -39,11 +39,10 @@ public class PCTTools
 
     public static Set<String> getPCTQualifiers(CoreInstance testFunction, ProcessorSupport processorSupport)
     {
-        return ((AnnotatedElement) testFunction)
-                ._stereotypes()
-                .select(x -> isTestQualifierProfile(x._profile(), processorSupport))
-                .collect(AnnotationAccessor::_value)
-                .toSet();
+        return ((AnnotatedElement) testFunction)._stereotypes().collectIf(
+                x -> isTestQualifierProfile(x._profile(), processorSupport),
+                AnnotationAccessor::_value,
+                Sets.mutable.empty());
     }
 
     public static boolean isTestQualifierProfile(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.Profile profile, ProcessorSupport processorSupport)
@@ -87,8 +86,7 @@ public class PCTTools
             else
             {
                 debugHelper(testFunction, pctExecutor, true, e);
-                fail("The PCT test runner expected an error containing: \"" + message + "\" but the the error was: \"" + getMessageFromError(e).replace("\"", "\\\"").replace("\n", "\\n") + "\"\nTrace:\n" + ExceptionUtils.getStackTrace(e))
-                ;
+                Assert.fail("The PCT test runner expected an error containing: \"" + message + "\" but the the error was: \"" + getMessageFromError(e).replace("\"", "\\\"").replace("\n", "\\n") + "\"\nTrace:\n" + ExceptionUtils.getStackTrace(e));
             }
         }
     }
@@ -139,7 +137,7 @@ public class PCTTools
     private static String cleanMessage(Throwable e)
     {
         String message = getMessageFromError(e);
-        int quotes = message.indexOf("\"");
+        int quotes = message.indexOf('"');
         boolean shouldCut = quotes > -1 && (message.contains("Execution error at ") || message.contains("Assert failure at "));
         message = shouldCut ? message.substring(quotes) : message;
         return message.replace("\"", "\\\"").replace("\n", "\\n");
@@ -148,7 +146,7 @@ public class PCTTools
     public static void displayExpectedErrorFailMessage(String message, CoreInstance testFunction, String pctExecutor)
     {
         debugHelper(testFunction, pctExecutor, false, null);
-        fail("The PCT test runner expected an error containing: \"" + message + "\" but the test succeeded!");
+        Assert.fail("The PCT test runner expected an error containing: \"" + message + "\" but the test succeeded!");
     }
 
     public static boolean isTest(CoreInstance node, ProcessorSupport processorSupport)

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/shared/PCTTools.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/shared/PCTTools.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.pure.m3.pct.shared;
 
-import java.util.Set;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.AnnotatedElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.extension.AnnotationAccessor;
@@ -22,6 +21,8 @@ import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation.profile.Profile;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+import java.util.Set;
 
 import static org.junit.Assert.fail;
 
@@ -107,29 +108,32 @@ public class PCTTools
 
     public static String getMessageFromError(Throwable e)
     {
-        String message = e.getMessage();
-        if (message == null)
+        if (e instanceof NullPointerException)
         {
             return "NullPointer exception";
         }
-        else
+        String message = e.getMessage();
+        if (message == null)
         {
-            int expectedStarts = message.indexOf("expected: '");
-            int expectedEnds = message.indexOf("'\nactual:");
-            int actualStarts = message.indexOf("'", expectedEnds);
-            int actualEnds = message.lastIndexOf("'");
-
-            if (expectedStarts >= 0 && actualStarts > 0 && expectedEnds > 0 && actualEnds > 0)
-            {
-                String before = message.substring(0, expectedStarts);
-                String expectedValue = message.substring(expectedStarts, expectedEnds);
-                String actualValue = message.substring(actualStarts, actualEnds);
-                String after = message.substring(actualEnds);
-                return before + expectedValue.replace("\\n", "\n") + actualValue.replace("\\n", "\n") + after;
-            }
-
-            return message;
+            // Maintaining this for backward compatibility. However, this is deceptive since we know this is not a
+            // NullPointerException. Consider returning something more informative, like e.getClass().getName().
+            return "NullPointer exception";
         }
+
+        int expectedStarts = message.indexOf("expected: '");
+        int expectedEnds = message.indexOf("'\nactual:");
+        int actualStarts = message.indexOf("'", expectedEnds);
+        int actualEnds = message.lastIndexOf("'");
+        if (expectedStarts >= 0 && actualStarts > 0 && expectedEnds > 0 && actualEnds > 0)
+        {
+            String before = message.substring(0, expectedStarts);
+            String expectedValue = message.substring(expectedStarts, expectedEnds);
+            String actualValue = message.substring(actualStarts, actualEnds);
+            String after = message.substring(actualEnds);
+            return before + expectedValue.replace("\\n", "\n") + actualValue.replace("\\n", "\n") + after;
+        }
+
+        return message;
     }
 
     private static String cleanMessage(Throwable e)


### PR DESCRIPTION
Update PCTTools.getMessageFromError to give consistent NPE handling for different Java versions. The previous logic tried to identify NPEs by checking for a null message, returning the message "NullPointer exception" in that case. In Java 11 (and earlier), this would catch NPEs, as they generally had no exception message. However, in Java 17+ the JVM includes a detailed message for NPEs, so most NPEs slip through. This PR changes the logic to use instanceof to identify NPEs, and so will give consistent behavior for NPEs between different JVM versions.

This PR leaves in place the logic for returning "NullPointer exception" for the case of a null message. This isn't really valid, as many different types of exceptions can have a null message. However, I'm leaving that change for now to maintain backward compatibility while upgrading Java versions, but it's something that should be addressed eventually.