### PR TITLE
Work around a bug with JarFile caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,17 +69,22 @@ jobs:
         with:
           theme: dark
 
-      - name: Build + Test
+      - name: Build
         if: (github.repository != 'finos/legend-pure') || (github.ref != 'refs/heads/master')
-        run: mvn -B -e install -DargLine="-XX:MaxRAMPercentage=25.0" -DforkCount=3 -DreuseForks=true -Dsurefire.reports.directory=${GITHUB_WORKSPACE}/surefire-reports-aggregate -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat="yyyy-MM-dd HH:mm:ss.SSSZ"
         env:
-          MAVEN_OPTS: -XX:MaxRAMPercentage=25.0
+          MAVEN_OPTS: -XX:MaxRAMPercentage=80.0
+        run: mvn -B -e -DskipTests=true -T 4 install -Dorg.slf4j.simpleLogger.showThreadName=true
 
-      - name: Build + Test + Sonar
+      - name: Build + Sonar
         if: (github.repository == 'finos/legend-pure') && (github.ref == 'refs/heads/master')
-        run: mvn -B -e install -Psonar -DargLine="-XX:MaxRAMPercentage=25.0" -DforkCount=3 -DreuseForks=true -Dsurefire.reports.directory=${GITHUB_WORKSPACE}/surefire-reports-aggregate -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat="yyyy-MM-dd HH:mm:ss.SSSZ"
+        env:
+          MAVEN_OPTS: -XX:MaxRAMPercentage=80.0
+        run: mvn -B -e -DskipTests=true -T 4 -P sonar install -Dorg.slf4j.simpleLogger.showThreadName=true
+
+      - name: Test
         env:
           MAVEN_OPTS: -XX:MaxRAMPercentage=25.0
+        run: mvn -B -e surefire:test -DargLine="-XX:MaxRAMPercentage=25.0" -DforkCount=3 -DreuseForks=true -Dsurefire.reports.directory=${GITHUB_WORKSPACE}/surefire-reports-aggregate
 
       - name: Upload Test Results
         if: always()

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/execution/XLSXOutputWriter.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/execution/XLSXOutputWriter.java
@@ -19,10 +19,12 @@ import org.apache.commons.io.IOUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URL;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class XLSXOutputWriter implements OutputWriter<Object>
 {
     private static final String XLSX_TEMPLATE = "/xlsx_template.xlsx";
@@ -38,7 +40,12 @@ public class XLSXOutputWriter implements OutputWriter<Object>
     @Override
     public void write(Object result, OutputStream outputStream) throws IOException
     {
-        try (InputStream is = XLSXOutputWriter.class.getResourceAsStream(XLSX_TEMPLATE);
+        URL url = XLSXOutputWriter.class.getResource(XLSX_TEMPLATE);
+        if (url == null)
+        {
+            throw new RuntimeException("Cannot find '" + XLSX_TEMPLATE + "'");
+        }
+        try (InputStream is = url.openStream();
              ZipInputStream zis = new ZipInputStream(is);
              ZipOutputStream zos = new ZipOutputStream(outputStream))
         {
@@ -53,7 +60,7 @@ public class XLSXOutputWriter implements OutputWriter<Object>
             ZipEntry sheet1 = new ZipEntry(SHEET_PATH);
             zos.putNextEntry(sheet1);
 
-            writer.write(result, zos);
+            this.writer.write(result, zos);
 
             zos.closeEntry();
             zos.finish();

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/shared/PCTManifestLoader.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/shared/PCTManifestLoader.java
@@ -20,6 +20,7 @@ import org.finos.legend.pure.m3.pct.shared.model.PCTManifest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.URL;
 
 /**
  * Loads a {@link PCTManifest} from a JSON resource.
@@ -47,12 +48,13 @@ public class PCTManifestLoader
     public static PCTManifest loadFromClasspath(String manifestPath)
     {
         String resourcePath = manifestPath.startsWith("/") ? manifestPath.substring(1) : manifestPath;
-        try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourcePath))
+        URL url = Thread.currentThread().getContextClassLoader().getResource(resourcePath);
+        if (url == null)
         {
-            if (is == null)
-            {
-                throw new IllegalArgumentException("PCT manifest file not found on classpath: " + manifestPath);
-            }
+            throw new IllegalArgumentException("PCT manifest file not found on classpath: " + manifestPath);
+        }
+        try (InputStream is = url.openStream())
+        {
             return loadFromStream(is, manifestPath);
         }
         catch (IOException e)

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/shared/provider/PCTReportProviderTool.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/shared/provider/PCTReportProviderTool.java
@@ -14,9 +14,15 @@
 
 package org.finos.legend.pure.m3.pct.shared.provider;
 
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.factory.Lists;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
 
 public class PCTReportProviderTool
 {
@@ -25,21 +31,27 @@ public class PCTReportProviderTool
         try
         {
             MutableList<T> result = Lists.mutable.empty();
+            ObjectReader reader = null;
             for (String location : locations)
             {
-                if (classLoader.getResource(location) != null)
+                URL url = classLoader.getResource(location);
+                if (url != null)
                 {
-                    result.add(JsonMapper.builder().build().readValue(
-                            classLoader.getResourceAsStream(location),
-                            _class
-                    ));
+                    if (reader == null)
+                    {
+                        reader = JsonMapper.builder().build().readerFor(_class);
+                    }
+                    try (InputStream stream = url.openStream())
+                    {
+                        result.add(reader.readValue(stream));
+                    }
                 }
             }
             return result;
         }
-        catch (Exception e)
+        catch (IOException e)
         {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/welcome/WelcomeCodeStorage.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/welcome/WelcomeCodeStorage.java
@@ -27,6 +27,8 @@ import org.finos.legend.pure.m3.serialization.runtime.Message;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -53,8 +55,13 @@ public class WelcomeCodeStorage implements MutableRepositoryCodeStorage
         Path welcomeFile = resolveWelcomePath();
         if (Files.notExists(welcomeFile))
         {
-            try (OutputStream outStream = Files.newOutputStream(welcomeFile);
-                 InputStream inStream = getClass().getResourceAsStream(WELCOME_RESOURCE_NAME))
+            URL url = getClass().getResource(WELCOME_RESOURCE_NAME);
+            if (url == null)
+            {
+                throw new RuntimeException("Cannot find resource: '" + WELCOME_RESOURCE_NAME + "'");
+            }
+            try (InputStream inStream = url.openStream();
+                 OutputStream outStream = Files.newOutputStream(welcomeFile))
             {
                 byte[] buffer = new byte[2048];
                 for (int read = inStream.read(buffer); read != -1; read = inStream.read(buffer))
@@ -64,7 +71,7 @@ public class WelcomeCodeStorage implements MutableRepositoryCodeStorage
             }
             catch (IOException e)
             {
-                throw new RuntimeException("Error creating /" + WELCOME_FILE_NAME, e);
+                throw new UncheckedIOException("Error creating /" + WELCOME_FILE_NAME, e);
             }
         }
     }
@@ -72,19 +79,19 @@ public class WelcomeCodeStorage implements MutableRepositoryCodeStorage
     @Override
     public RichIterable<CodeRepository> getAllRepositories()
     {
-        return repos;
+        return this.repos;
     }
 
     @Override
     public CodeRepository getRepository(String name)
     {
-        return name == null ? repos.getFirst() : null;
+        return name == null ? this.repos.getFirst() : null;
     }
 
     @Override
     public CodeRepository getRepositoryForPath(String path)
     {
-        return WELCOME_FILE_NAME.equals(path) ? repos.getFirst() : null;
+        return WELCOME_FILE_NAME.equals(path) ? this.repos.getFirst() : null;
     }
 
     @Override

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/serialization/binary/DistributedMetadataSpecification.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/serialization/binary/DistributedMetadataSpecification.java
@@ -410,6 +410,10 @@ public class DistributedMetadataSpecification
         try
         {
             JarURLConnection connection = (JarURLConnection) jarUrl.openConnection();
+            // Get a private JarFile that is safe to close: with caching enabled, getJarFile() returns
+            // an instance cached and shared JVM-wide, and closing it invalidates all open streams other
+            // threads have over the same jar (e.g., concurrent Maven mojo executions in a parallel build)
+            connection.setUseCaches(false);
             try (JarFile jarFile = connection.getJarFile())
             {
                 Enumeration<JarEntry> entries = jarFile.entries();


### PR DESCRIPTION
Work around a bug with JarFile caching, involving URLClassLoader and JarFileFactory. The method URLClassLoader.getResourceAsStream registers JarFiles from jar URLs to be closed when the URLClassLoader is closed. If the JarFile has come from the global JarFile cache (see JarFileFactory), this can result in the JarFile being closed while other threads are trying to read from it, which will cause IOExceptions in those other threads. This is a known bug in Java since JDK 8: https://bugs.openjdk.org/browse/JDK-8205976.

To work around this, we eliminate calls to ClassLoader.getResourceAsStream. Instead, we call ClassLoader.getResource, which returns a URL. Then we open the stream outside the context of the class loader. This prevents JarFiles from being closed when URLClassLoaders are closed.