### PR TITLE
Default PureJavaCompiler to release 8 for JDK 20 or higher

### DIFF
--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/compiler/PureJavaCompiler.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/compiler/PureJavaCompiler.java
@@ -141,7 +141,7 @@ public class PureJavaCompiler
         }
         else if (currentJavaVersion >= 20)
         {
-            resolvedVersion = currentJavaVersion;
+            resolvedVersion = 8;
         }
         else
         {


### PR DESCRIPTION
Default PureJavaCompiler to release 8 for JDK 20 or higher