### PR TITLE
Fix eval in interpreted mode to handle upcast arguments

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/lang/AbstractTestEvaluate.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/function/base/lang/AbstractTestEvaluate.java
@@ -81,6 +81,21 @@ public abstract class AbstractTestEvaluate extends AbstractPureTestWithCoreCompi
     }
 
     @Test
+    public void testEvaluateWithUpcastArgument()
+    {
+        // The wrapper ValueSpecification carries the upcast static type (A), but the actual
+        // instance is a B; eval must accept it, as compiled mode dispatches on the instance.
+        compileTestSource("fromString.pure",
+                "Class test::A {}\n" +
+                        "Class test::B extends test::A {}\n" +
+                        "function test():Boolean[1]\n" +
+                        "{\n" +
+                        "   assert(^test::B()->cast(@test::A)->match([b:test::B[1] | {x:test::B[1]|true}->eval($b)]), |'');\n" +
+                        "}\n");
+        execute("test():Boolean[1]");
+    }
+
+    @Test
     public void testEvaluatePropertyWrongType()
     {
         compileTestSource("fromString.pure",

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/essentials/lang/eval/Evaluate.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/essentials/lang/eval/Evaluate.java
@@ -34,6 +34,7 @@ import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.navigation.generictype.GenericType;
 import org.finos.legend.pure.m3.navigation.generictype.match.GenericTypeMatch;
 import org.finos.legend.pure.m3.navigation.generictype.match.ParameterMatchBehavior;
+import org.finos.legend.pure.m3.navigation.measure.Measure;
 import org.finos.legend.pure.m3.navigation.multiplicity.Multiplicity;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.SourceInformation;
@@ -112,7 +113,8 @@ public class Evaluate extends NativeFunction
         CoreInstance valueGenericType = Instance.getValueForMetaPropertyToOneResolved(value, M3Properties.genericType, processorSupport);
         try
         {
-            if (!GenericTypeMatch.genericTypeMatches(signatureGenericType, valueGenericType, true, ParameterMatchBehavior.MATCH_ANYTHING, ParameterMatchBehavior.MATCH_CAUTIOUSLY, processorSupport))
+            if (!GenericTypeMatch.genericTypeMatches(signatureGenericType, valueGenericType, true, ParameterMatchBehavior.MATCH_ANYTHING, ParameterMatchBehavior.MATCH_CAUTIOUSLY, processorSupport)
+                    && !actualValuesMatch(value, signatureGenericType, processorSupport))
             {
                 throw new PureExecutionException(sourceInfo, "Error during dynamic function evaluation. The type " + GenericType.print(valueGenericType, processorSupport) + " is not compatible with the type " + GenericType.print(signatureGenericType, processorSupport), functionExpressionCallStack);
             }
@@ -121,5 +123,24 @@ public class Evaluate extends NativeFunction
         {
             throw new PureExecutionException(sourceInfo, "Error evaluating generic types: " + GenericType.print(valueGenericType, processorSupport) + ", " + GenericType.print(signatureGenericType, processorSupport), e, functionExpressionCallStack);
         }
+    }
+
+    /**
+     * The declared genericType of a value specification may be wider than the types of the actual
+     * values it holds (e.g. after an upcast, whose result keeps the cast target type on the wrapper).
+     * Dynamic evaluation must accept any value whose actual type conforms to the signature, as
+     * compiled mode dispatches on the runtime instance.
+     */
+    private static boolean actualValuesMatch(CoreInstance value, CoreInstance signatureGenericType, ProcessorSupport processorSupport)
+    {
+        ListIterable<? extends CoreInstance> values = Instance.getValueForMetaPropertyToManyResolved(value, M3Properties.values, processorSupport);
+        return values.allSatisfy(v -> GenericTypeMatch.genericTypeMatches(signatureGenericType, extractActualGenericType(v, processorSupport), true, ParameterMatchBehavior.MATCH_ANYTHING, ParameterMatchBehavior.MATCH_CAUTIOUSLY, processorSupport));
+    }
+
+    private static CoreInstance extractActualGenericType(CoreInstance instance, ProcessorSupport processorSupport)
+    {
+        return Measure.isUnitOrMeasureInstance(instance, processorSupport)
+                ? Instance.getValueForMetaPropertyToOneResolved(instance, M3Properties.genericType, processorSupport)
+                : Instance.extractGenericTypeFromInstance(instance, processorSupport);
     }
 }


### PR DESCRIPTION
In interpreted mode, Evaluate.validateValueToSignature checked an argument's
  wrapper genericType, which legitimately stays wider than the actual value
  after an upcast (e.g. cast(@SetImplementation) followed by match/parameter
  binding, which pass the wrapper through unchanged). Compiled mode dispatches
  on the runtime instance, so the same code succeeded there.

  Fall back to checking each actual value's extracted generic type when the
  wrapper check fails, mirroring Match dispatch and Cast down-cast validation.
  The change is strictly relaxing: genuinely incompatible values still throw.
