### PR TITLE
Replace monolithic distributed metadata with PELT

### DIFF
--- a/legend-pure-maven/legend-pure-maven-generation-java/src/main/java/org/finos/legend/pure/maven/javaCompiled/PureCompiledJarMojo.java
+++ b/legend-pure-maven/legend-pure-maven-generation-java/src/main/java/org/finos/legend/pure/maven/javaCompiled/PureCompiledJarMojo.java
@@ -74,6 +74,7 @@ public class PureCompiledJarMojo extends AbstractMojo
     @Parameter(defaultValue = "monolithic")
     private JavaCodeGeneration.GenerationType generationType;
 
+    @Deprecated
     @Parameter(defaultValue = "false")
     private boolean useSingleDir;
 
@@ -148,7 +149,7 @@ public class PureCompiledJarMojo extends AbstractMojo
         try (URLClassLoader cl = new URLClassLoader(dependencyUrls, savedClassLoader))
         {
             Thread.currentThread().setContextClassLoader(cl);
-            JavaCodeGeneration.doIt(this.repositories, this.excludedRepositories, this.extraRepositories, this.generationType, this.skip, this.addExternalAPI, this.externalAPIPackage, this.generateMetadata, this.useSingleDir, this.generateSources, false, this.preventJavaCompilation, this.classesDirectory, this.targetDirectory, this.generatePureTests, log);
+            JavaCodeGeneration.doIt(this.repositories, this.excludedRepositories, this.extraRepositories, this.generationType, this.skip, this.addExternalAPI, this.externalAPIPackage, this.generateMetadata, this.generateSources, false, this.preventJavaCompilation, this.classesDirectory, this.targetDirectory, this.generatePureTests, log);
         }
         catch (Exception e)
         {

--- a/legend-pure-maven/legend-pure-maven-generation-java/src/test/java/org/finos/legend/pure/maven/javaCompiled/TestPureCompiledJarMojo.java
+++ b/legend-pure-maven/legend-pure-maven-generation-java/src/test/java/org/finos/legend/pure/maven/javaCompiled/TestPureCompiledJarMojo.java
@@ -62,25 +62,9 @@ public class TestPureCompiledJarMojo
         PureCompiledJarMojo mojo = buildMojo(targetDir, classesDir, setOf("platform"));
         mojo.execute();
 
-        // Monolithic generation writes metadata to target/metadata-distributed.
-        // The serializer writes metadata/bin/*.bin and metadata/classifiers/*.idx inside it.
+        // Monolithic generation no longer writes metadata, but relies on it to already exist
         File metaDir = new File(targetDir, "metadata-distributed");
-        Assert.assertTrue("metadata-distributed directory should be created", metaDir.exists());
-
-        // metadata/bin/ and metadata/classifiers/ are structural invariants
-        File binDir        = new File(metaDir, "metadata/bin");
-        File classifiersDir = new File(metaDir, "metadata/classifiers");
-        Assert.assertTrue("metadata/bin should exist under metadata-distributed",        binDir.isDirectory());
-        Assert.assertTrue("metadata/classifiers should exist under metadata-distributed", classifiersDir.isDirectory());
-
-        // Package.idx is a stable landmark file always produced for the platform repository
-        File packageIdx = new File(classifiersDir, "Package.idx");
-        Assert.assertTrue(
-                "metadata/classifiers/Package.idx should always be generated for the platform repository",
-                packageIdx.exists());
-        Assert.assertTrue(
-                "Package.idx should be a non-empty file",
-                packageIdx.length() > 0);
+        Assert.assertFalse("metadata-distributed directory should not be created", metaDir.exists());
     }
 
     @Test
@@ -113,10 +97,13 @@ public class TestPureCompiledJarMojo
         Assert.assertFalse("Pre-condition: classesDir must not exist", classesDir.exists());
 
         PureCompiledJarMojo mojo = buildMojo(targetDir, classesDir, setOf("platform"));
+        setField(mojo, "generateSources", true);
+        setField(mojo, "preventJavaCompilation", false);
         mojo.execute();
 
         // JavaCodeGeneration creates targetDirectory; verify it now exists
         Assert.assertTrue("targetDirectory should be created by execute()", targetDir.exists());
+        Assert.assertTrue("classesDirectory should be created by execute()", classesDir.exists());
     }
 
     @Test
@@ -136,32 +123,6 @@ public class TestPureCompiledJarMojo
             long count = stream.filter(Files::isRegularFile).count();
             Assert.assertTrue("generateSources=true should produce at least one file", count > 0);
         }
-    }
-
-    @Test
-    public void testExecute_useSingleDir_writesMetadataToClassesDirectory() throws Exception
-    {
-        File targetDir  = TMP.newFolder("exec-singledir-target");
-        File classesDir = new File(targetDir, "classes");
-        classesDir.mkdir();
-
-        PureCompiledJarMojo mojo = buildMojo(targetDir, classesDir, setOf("platform"));
-        setField(mojo, "useSingleDir", true);
-        mojo.execute();
-
-        // With useSingleDir=true metadata goes directly to classesDirectory.
-        // The serializer writes metadata/bin/*.bin and metadata/classifiers/*.idx inside it.
-        // Verify files exist under classesDir and no separate metadata-distributed was created.
-        File binDir         = new File(classesDir, "metadata/bin");
-        File classifiersDir = new File(classesDir, "metadata/classifiers");
-        Assert.assertTrue("useSingleDir=true should write metadata/bin into classesDirectory",
-                binDir.isDirectory() && binDir.list() != null && binDir.list().length > 0);
-        Assert.assertFalse("useSingleDir=true should NOT create a separate metadata-distributed directory",
-                new File(targetDir, "metadata-distributed").exists());
-        // Package.idx is a stable landmark always produced for the platform repository
-        File packageIdx = new File(classifiersDir, "Package.idx");
-        Assert.assertTrue("metadata/classifiers/Package.idx should exist inside classesDirectory",
-                packageIdx.exists() && packageIdx.length() > 0);
     }
 
     @Test
@@ -219,47 +180,6 @@ public class TestPureCompiledJarMojo
         }
     }
 
-    // --- engine production pattern: modular + useSingleDir + generateSources + preventJavaCompilation ---
-
-    @Test
-    public void testExecute_enginePattern_modularUseSingleDirWithSources() throws Exception
-    {
-        // This is the exact parameter combination used by all 139 engine modules:
-        //   generationType=modular, useSingleDir=true, generateSources=true, preventJavaCompilation=true
-        // All output (metadata + generated sources) goes into classesDirectory rather than
-        // a separate metadata-distributed/ directory.
-        File targetDir  = TMP.newFolder("exec-engine-pattern-target");
-        File classesDir = new File(targetDir, "classes");
-        classesDir.mkdir();
-
-        PureCompiledJarMojo mojo = buildMojo(targetDir, classesDir, setOf("platform"));
-        setField(mojo, "generationType",         JavaCodeGeneration.GenerationType.modular);
-        setField(mojo, "useSingleDir",           true);
-        setField(mojo, "generateSources",        true);
-        setField(mojo, "preventJavaCompilation", true);
-        mojo.execute();
-
-        // With useSingleDir=true, all output goes into classesDirectory — no separate metadata-distributed/
-        Assert.assertFalse(
-                "useSingleDir=true must not create a separate metadata-distributed/ directory",
-                new File(targetDir, "metadata-distributed").exists());
-
-        // Generated Java source — with useSingleDir=true, sources go to targetDir/generated-sources/
-        // (not inside classesDir); only metadata is written into classesDir
-        File packageImpl = new File(targetDir,
-                "generated-sources/org/finos/legend/pure/generated/Package_Impl.java");
-        Assert.assertTrue(
-                "Package_Impl.java should be generated in targetDir/generated-sources/ " +
-                "(useSingleDir=true routes metadata to classesDir but sources to targetDir/generated-sources/)",
-                packageImpl.exists());
-        String src = new String(java.nio.file.Files.readAllBytes(packageImpl.toPath()));
-        Assert.assertTrue("Package_Impl.java should declare class Package_Impl", src.contains("class Package_Impl"));
-
-        // Modular generation now uses pelt serialization, which must already exist; so there should be no metadata generation
-        File metaDir = new File(targetDir, "metadata");
-        Assert.assertFalse("metadata directory should not be created", metaDir.exists());
-    }
-
     // --- error path ---
 
     @Test
@@ -301,7 +221,6 @@ public class TestPureCompiledJarMojo
         setField(mojo, "addExternalAPI",           false);
         setField(mojo, "externalAPIPackage",       "org.finos.legend.pure.generated");
         setField(mojo, "generateMetadata",         true);
-        setField(mojo, "useSingleDir",             false);
         setField(mojo, "generateSources",          false);
         setField(mojo, "preventJavaCompilation",   true);
         setField(mojo, "generatePureTests",        false);

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaStandaloneLibraryGenerator.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/JavaStandaloneLibraryGenerator.java
@@ -377,7 +377,7 @@ public class JavaStandaloneLibraryGenerator
 
     public static JavaStandaloneLibraryGenerator newGenerator(PureRuntime runtime, Iterable<? extends CompiledExtension> extensions, boolean addExternalAPI, String externalAPIPackage, boolean generatePureTests, Log log)
     {
-        return newGenerator(runtime, extensions, addExternalAPI, externalAPIPackage, true, generatePureTests, log);
+        return newGenerator(runtime, extensions, addExternalAPI, externalAPIPackage, false, generatePureTests, log);
     }
 
     public static JavaStandaloneLibraryGenerator newGenerator(PureRuntime runtime, Iterable<? extends CompiledExtension> extensions, boolean addExternalAPI, String externalAPIPackage, Log log)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/orchestrator/JavaCodeGeneration.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/orchestrator/JavaCodeGeneration.java
@@ -20,7 +20,12 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.SetIterable;
-import org.eclipse.collections.impl.utility.Iterate;
+import org.finos.legend.pure.m3.serialization.compiler.PureCompilerSerializer;
+import org.finos.legend.pure.m3.serialization.compiler.element.ConcreteElementSerializer;
+import org.finos.legend.pure.m3.serialization.compiler.file.FilePathProvider;
+import org.finos.legend.pure.m3.serialization.compiler.file.FileSerializer;
+import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleMetadataGenerator;
+import org.finos.legend.pure.m3.serialization.compiler.metadata.ModuleMetadataSerializer;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositorySet;
@@ -42,7 +47,6 @@ import org.finos.legend.pure.runtime.java.compiled.extension.CompiledExtensionLo
 import org.finos.legend.pure.runtime.java.compiled.generation.Generate;
 import org.finos.legend.pure.runtime.java.compiled.generation.JavaPackageAndImportBuilder;
 import org.finos.legend.pure.runtime.java.compiled.generation.JavaStandaloneLibraryGenerator;
-import org.finos.legend.pure.runtime.java.compiled.serialization.binary.DistributedBinaryGraphSerializer;
 
 import java.io.File;
 import java.io.IOException;
@@ -101,7 +105,6 @@ public class JavaCodeGeneration
                 true,
                 true,
                 true,
-                true,
                 new File(args[1]),
                 new File(args[2]),
                 true,
@@ -109,6 +112,7 @@ public class JavaCodeGeneration
         );
     }
 
+    @Deprecated
     public static void doIt(Set<String> repositories,
                             Set<String> excludedRepositories,
                             Set<String> extraRepositories,
@@ -125,10 +129,10 @@ public class JavaCodeGeneration
                             File targetDirectory,
                             Log log)
     {
-        doIt(repositories,excludedRepositories,extraRepositories,generationType, skip,addExternalAPI,externalAPIPackage,generateMetadata,useSingleDir,generateSources,generateTest,preventJavaCompilation,classesDirectory,targetDirectory,true,log);
+        doIt(repositories, excludedRepositories, extraRepositories, generationType, skip, addExternalAPI, externalAPIPackage, generateMetadata, generateSources, generateTest, preventJavaCompilation, classesDirectory, targetDirectory, log);
     }
 
-
+    @Deprecated
     public static void doIt(Set<String> repositories,
                             Set<String> excludedRepositories,
                             Set<String> extraRepositories,
@@ -138,6 +142,43 @@ public class JavaCodeGeneration
                             String externalAPIPackage,
                             boolean generateMetadata,
                             boolean useSingleDir,
+                            boolean generateSources,
+                            boolean generateTest,
+                            boolean preventJavaCompilation,
+                            File classesDirectory,
+                            File targetDirectory,
+                            boolean generatePureTests,
+                            Log log)
+    {
+        doIt(repositories, excludedRepositories, extraRepositories, generationType, skip, addExternalAPI, externalAPIPackage, generateMetadata, generateSources, generateTest, preventJavaCompilation, classesDirectory, targetDirectory, generatePureTests, log);
+    }
+
+    public static void doIt(Set<String> repositories,
+                            Set<String> excludedRepositories,
+                            Set<String> extraRepositories,
+                            JavaCodeGeneration.GenerationType generationType,
+                            boolean skip,
+                            boolean addExternalAPI,
+                            String externalAPIPackage,
+                            boolean generateMetadata,
+                            boolean generateSources,
+                            boolean generateTest,
+                            boolean preventJavaCompilation,
+                            File classesDirectory,
+                            File targetDirectory,
+                            Log log)
+    {
+        doIt(repositories, excludedRepositories, extraRepositories, generationType, skip, addExternalAPI, externalAPIPackage, generateMetadata, generateSources, generateTest, preventJavaCompilation, classesDirectory, targetDirectory, true, log);
+    }
+
+    public static void doIt(Set<String> repositories,
+                            Set<String> excludedRepositories,
+                            Set<String> extraRepositories,
+                            JavaCodeGeneration.GenerationType generationType,
+                            boolean skip,
+                            boolean addExternalAPI,
+                            String externalAPIPackage,
+                            boolean generateMetadata,
                             boolean generateSources,
                             boolean generateTest,
                             boolean preventJavaCompilation,
@@ -173,25 +214,6 @@ public class JavaCodeGeneration
             MutableSet<String> selectedRepositories = getSelectedRepositories(allRepositories, repositories, excludedRepositories);
             log.debug(selectedRepositories.makeString("  Selected repositories: ", ", ", ""));
 
-            Path distributedMetadataDirectory;
-            if (!generateMetadata)
-            {
-                distributedMetadataDirectory = null;
-                log.info("  Classes output directory: " + classesDirectory);
-                log.info("  No metadata output");
-            }
-            else if (useSingleDir)
-            {
-                distributedMetadataDirectory = classesDirectory.toPath();
-                log.info("  All in output directory: " + classesDirectory);
-            }
-            else
-            {
-                distributedMetadataDirectory = targetDirectory.toPath().resolve("metadata-distributed");
-                log.info("  Classes output directory: " + classesDirectory);
-                log.info("  Distributed metadata output directory: " + distributedMetadataDirectory);
-            }
-
             Path codegenDirectory;
             if (generateSources)
             {
@@ -204,7 +226,7 @@ public class JavaCodeGeneration
             }
 
             // Generate metadata and Java sources
-            Generate generate = generate(System.nanoTime(), allRepositories, selectedRepositories, distributedMetadataDirectory, codegenDirectory, generateMetadata, addExternalAPI, externalAPIPackage, generationType, generateSources, generatePureTests, log);
+            Generate generate = generate(System.nanoTime(), allRepositories, selectedRepositories, classesDirectory.toPath(), codegenDirectory, generateMetadata, addExternalAPI, externalAPIPackage, generationType, generateSources, generatePureTests, log);
 
             // Compile Java sources
             if (!preventJavaCompilation)
@@ -303,24 +325,24 @@ public class JavaCodeGeneration
         return selected;
     }
 
-    private static Generate generate(long start, CodeRepositorySet allRepositories, SetIterable<String> selectedRepositories, Path distributedMetadataDirectory, Path codegenDirectory, boolean generateMetadata, boolean addExternalAPI, String externalAPIPackage, GenerationType generationType, boolean generateSources, boolean generatePureTests, Log log)
+    private static Generate generate(long start, CodeRepositorySet allRepositories, SetIterable<String> selectedRepositories, Path metadataDirectory, Path codegenDirectory, boolean generateMetadata, boolean addExternalAPI, String externalAPIPackage, GenerationType generationType, boolean generateSources, boolean generatePureTests, Log log)
     {
         // Initialize runtime
         PureRuntime runtime = initializeRuntime(start, allRepositories, selectedRepositories, log);
 
-        // Possibly write distributed metadata
+        // Validate that metadata exists
         if (generateMetadata)
         {
             switch (generationType)
             {
                 case monolithic:
                 {
-                    generateMetadata(start, runtime, distributedMetadataDirectory, log);
+                    generateMissingMetadata(runtime, metadataDirectory, log);
                     break;
                 }
                 case modular:
                 {
-                    generateModularMetadata(start, runtime, selectedRepositories, distributedMetadataDirectory, log);
+                    validateMetadata(selectedRepositories, log);
                     break;
                 }
                 default:
@@ -339,7 +361,7 @@ public class JavaCodeGeneration
         {
             case monolithic:
             {
-                generate = generator.generateOnly(!generateMetadata, generateSources, codegenDirectory);
+                generate = generator.generateOnly(true, generateSources, codegenDirectory);
                 break;
             }
             case modular:
@@ -402,24 +424,51 @@ public class JavaCodeGeneration
         }
     }
 
-    private static void generateMetadata(long start, PureRuntime runtime, Path distributedMetadataDirectory, Log log)
+    private static void validateMetadata(RichIterable<String> repositoriesForMetadata, Log log)
     {
-        String writeMetadataStep = "writing distributed Pure metadata";
-        long writeMetadataStart = startStep(writeMetadataStep, log);
-        DistributedBinaryGraphSerializer.newSerializer(runtime).serializeToDirectory(distributedMetadataDirectory);
-        completeStep(writeMetadataStep, writeMetadataStart, log);
+        String validateMetadataStep = "validating Pure metadata";
+        long validateMetadataStart = startStep(validateMetadataStep, log);
+        MutableList<String> missingMetadata = findReposWithoutMetadata(Thread.currentThread().getContextClassLoader(), repositoriesForMetadata);
+        if (missingMetadata.notEmpty())
+        {
+            throw new RuntimeException(missingMetadata.sortThis().makeString("No modular metadata for the following repos: ", ", ", ""));
+        }
+        completeStep(validateMetadataStep, validateMetadataStart, log);
     }
 
-    private static void generateModularMetadata(long start, PureRuntime runtime, Iterable<String> repositoriesForMetadata, Path distributedMetadataDirectory, Log log)
+    private static void generateMissingMetadata(PureRuntime runtime, Path outputDirectory, Log log)
     {
-        String writeMetadataStep = "writing distributed Pure metadata";
-        long writeMetadataStart = startStep(writeMetadataStep, log);
-        PureCompilerLoader loader = PureCompilerLoader.newLoader(Thread.currentThread().getContextClassLoader());
-        if (!Iterate.allSatisfy(repositoriesForMetadata, loader::canLoad))
+        String generateMetadataStep = "generating Pure metadata";
+        long generateMetadataStart = startStep(generateMetadataStep, log);
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        MutableList<String> allRepos = runtime.getCodeStorage().getAllRepositories().collect(CodeRepository::getName, Lists.mutable.empty());
+        MutableList<String> toGenerateMetadata = findReposWithoutMetadata(classLoader, allRepos);
+        if (toGenerateMetadata.isEmpty())
         {
-            throw new RuntimeException(Iterate.reject(repositoriesForMetadata, loader::canLoad, Lists.mutable.empty()).sortThis().makeString("No modular metadata for the following repos: ", ", ", ""));
+            log.info("    No metadata needs to be generated");
         }
-        completeStep(writeMetadataStep, writeMetadataStart, log);
+        else
+        {
+            log.info(toGenerateMetadata.sortThis().makeString("    Generating metadata for the following repos: ", ", ", ""));
+            FileSerializer fileSerializer = FileSerializer.builder()
+                    .withFilePathProvider(FilePathProvider.builder().withLoadedExtensions(classLoader).build())
+                    .withConcreteElementSerializer(ConcreteElementSerializer.builder(runtime.getProcessorSupport()).withLoadedExtensions(classLoader).build())
+                    .withModuleMetadataSerializer(ModuleMetadataSerializer.builder().withLoadedExtensions(classLoader).build())
+                    .build();
+            PureCompilerSerializer serializer = PureCompilerSerializer.builder()
+                    .withFileSerializer(fileSerializer)
+                    .withModuleMetadataGenerator(ModuleMetadataGenerator.fromPureRuntime(runtime))
+                    .withProcessorSupport(runtime.getProcessorSupport())
+                    .build();
+            serializer.serializeModules(outputDirectory, toGenerateMetadata);
+        }
+        completeStep(generateMetadataStep, generateMetadataStart, log);
+    }
+
+    private static MutableList<String> findReposWithoutMetadata(ClassLoader classLoader, RichIterable<String> repositoriesForMetadata)
+    {
+        PureCompilerLoader loader = PureCompilerLoader.newLoader(classLoader);
+        return repositoriesForMetadata.reject(loader::canLoad, Lists.mutable.empty());
     }
 
     private static PureJavaCompiler compileJavaSources(long start, Generate generate, boolean addExternalAPI, Log log)

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaCodeGeneration.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/TestJavaCodeGeneration.java
@@ -41,6 +41,7 @@ import org.finos.legend.pure.runtime.java.compiled.generation.orchestrator.VoidL
 import org.finos.legend.pure.runtime.java.compiled.metadata.Metadata;
 import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataEager;
 import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataLazy;
+import org.finos.legend.pure.runtime.java.compiled.metadata.MetadataPelt;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -81,7 +82,6 @@ public class TestJavaCodeGeneration
                 false,
                 null,
                 true,
-                true,
                 false,
                 false,
                 false,
@@ -89,7 +89,7 @@ public class TestJavaCodeGeneration
                 directory,
                 true,
                 new VoidLog());
-        executeDynamicNewTest(MetadataLazy::fromClassLoader, classesDirectory);
+        executeDynamicNewTest(cl -> MetadataPelt.fromClassLoader(cl, "platform"), classesDirectory);
     }
 
     @Test
@@ -108,7 +108,6 @@ public class TestJavaCodeGeneration
                 true,
                 externalPackage,
                 true,
-                true,
                 false,
                 false,
                 false,
@@ -116,6 +115,11 @@ public class TestJavaCodeGeneration
                 directory,
                 true,
                 new VoidLog());
+
+        // Monolithic generation now uses pelt serialization, which must already exist; so there should be no metadata generation
+        File metaDistributed = new File(directory, "metadata-distributed");
+        Assert.assertFalse("metadata-distributed directory should not be created", metaDistributed.exists());
+
         String externalClassName = externalPackage + ".PureExternal";
         ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
         try (TestClassLoader classLoader = new TestClassLoader(previousClassLoader, n -> externalClassName.equals(n) || n.startsWith(JavaPackageAndImportBuilder.rootPackage()), null, toURL(classesDirectory)))
@@ -153,7 +157,6 @@ public class TestJavaCodeGeneration
                 false,
                 null,
                 true,
-                false,  // useSingleDir=false so metadata goes to target/metadata-distributed
                 false,
                 false,
                 false,
@@ -185,7 +188,6 @@ public class TestJavaCodeGeneration
                 false,
                 null,
                 false,
-                true,
                 false,
                 false,
                 false,
@@ -212,7 +214,6 @@ public class TestJavaCodeGeneration
                 true,   // skip=true
                 false,
                 null,
-                true,
                 true,
                 false,
                 false,
@@ -251,7 +252,6 @@ public class TestJavaCodeGeneration
                     false,
                     false,
                     null,
-                    true,
                     true,
                     false,
                     false,
@@ -307,7 +307,6 @@ public class TestJavaCodeGeneration
                 false,
                 null,
                 false,   // generateMetadata=false - fastest path
-                false,
                 true,    // generateSources=true
                 false,   // generateTest=false: generated-sources/
                 true,    // preventJavaCompilation
@@ -353,7 +352,6 @@ public class TestJavaCodeGeneration
                 false,
                 null,
                 false,   // generateMetadata=false
-                false,
                 true,    // generateSources=true
                 true,    // generateTest=true: generated-test-sources/
                 true,    // preventJavaCompilation
@@ -445,7 +443,6 @@ public class TestJavaCodeGeneration
                 false,
                 false,
                 false,
-                false,
                 true,
                 classesDir,
                 directory,
@@ -473,7 +470,6 @@ public class TestJavaCodeGeneration
                 false,
                 false,
                 null,
-                false,
                 false,
                 false,
                 false,

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/TestJavaStandaloneLibraryGenerator.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/runtime/TestJavaStandaloneLibraryGenerator.java
@@ -268,7 +268,7 @@ public class TestJavaStandaloneLibraryGenerator extends AbstractPureTestWithCore
     public void testStandaloneLibraryExternalExecutionDistributedMetadata() throws Exception
     {
         String externalPackage = "org.finos.legend.pure.runtime.java.compiled";
-        JavaStandaloneLibraryGenerator generator = JavaStandaloneLibraryGenerator.newGenerator(runtime, CompiledExtensionLoader.extensions(), true, externalPackage, new VoidLog());
+        JavaStandaloneLibraryGenerator generator = JavaStandaloneLibraryGenerator.newGenerator(runtime, CompiledExtensionLoader.extensions(), true, externalPackage, true, false, new VoidLog());
         Path classesDir = TMP.newFolder().toPath();
         generator.serializeAndWriteDistributedMetadata(classesDir);
         generator.compileAndWriteClasses(classesDir, new VoidLog());


### PR DESCRIPTION
Replace monolithic distributed metadata with PELT. JavaCodeGeneration no longer generates monolithic distributed metadata. Instead, it will build PELT metadata as necessary. I.e., it will build PELT metadata for any repos it cannot find existing PELT metadata for on the class path.