### PR TITLE
Update build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,23 @@ jobs:
     name: Build
     if: "!contains(github.event.head_commit.message, '[maven-release-plugin]')"
     runs-on: ubuntu-latest
+    outputs:
+      test-jdks: ${{ steps.test-matrix.outputs.jdks }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+
+      - name: Determine test JDK matrix
+        id: test-matrix
+        # Master builds of the canonical repo exercise every supported JDK.
+        # Everything else (PRs, forks, topic branches) sticks to the two
+        # boundary versions, which is what keeps ordinary CI turnaround short.
+        run: |
+          if [ "${{ github.repository }}" = "finos/legend-pure" ] && [ "${{ github.ref }}" = "refs/heads/master" ]; then
+            echo 'jdks=[25, 21, 17, 11, 8]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'jdks=[25, 8]' >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Cache Maven dependencies
         uses: actions/cache@v5
@@ -79,12 +93,6 @@ jobs:
           MAVEN_OPTS: -XX:MaxRAMPercentage=80.0
         run: mvn -B -e -DskipTests=true -T 4 install -Dorg.slf4j.simpleLogger.showThreadName=true
 
-      - name: Sonar
-        if: (github.repository == 'finos/legend-pure') && (github.ref == 'refs/heads/master')
-        env:
-          MAVEN_OPTS: -XX:MaxRAMPercentage=80.0
-        run: mvn -B -e -P sonar sonar:sonar
-
       - name: Archive build output
         # Bundle the whole workspace (compiled classes, generated sources, PAR
         # archives, etc.) into one file so the test jobs can reuse this build
@@ -118,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [25, 8]
+        jdk: ${{ fromJSON(needs.build.outputs.test-jdks) }}
     steps:
       - name: Download build output
         uses: actions/download-artifact@v7
@@ -146,10 +154,14 @@ jobs:
       - name: Set up JDKs
         uses: actions/setup-java@v5
         with:
+          # 25 always: Maven itself has to run on a JDK the enforcer accepts.
+          # The matrix JDK is what the forked test JVM will use. When the
+          # matrix leg *is* 25 the duplicate is a no-op (second install is a
+          # tool-cache hit).
           distribution: 'temurin'
           java-version: |
             25
-            8
+            ${{ matrix.jdk }}
 
       - name: Install project artifacts from this build
         # Inter-module dependencies resolve from ~/.m2 during surefire:test,
@@ -166,14 +178,11 @@ jobs:
         run: |
           # Maven itself must run on a JDK the enforcer plugin accepts (25),
           # regardless of which JDK we want to run the tests on. The compiled
-          # test classes already target Java 8 bytecode, so for the "8" leg
-          # we just point Surefire's forked test JVM at the JDK 8 install.
+          # test classes already target Java 8 bytecode, so every leg just
+          # points Surefire's forked test JVM at the matrix JDK's install.
           export JAVA_HOME="$JAVA_HOME_25_X64"
-          if [ "${{ matrix.jdk }}" = "8" ]; then
-            TEST_JVM="$JAVA_HOME_8_X64/bin/java"
-          else
-            TEST_JVM="$JAVA_HOME_25_X64/bin/java"
-          fi
+          test_jvm_home="JAVA_HOME_${{ matrix.jdk }}_X64"
+          TEST_JVM="${!test_jvm_home}/bin/java"
           mvn -B -e surefire:test -Djvm="${TEST_JVM}" -DargLine="-XX:MaxRAMPercentage=25.0" -DforkCount=3 -DreuseForks=true -Dsurefire.reports.directory=${GITHUB_WORKSPACE}/surefire-reports-aggregate-jdk${{ matrix.jdk }}
 
       - name: Upload Test Results
@@ -182,3 +191,83 @@ jobs:
         with:
           name: test-results-jdk${{ matrix.jdk }}
           path: ${{ github.workspace }}/surefire-reports-aggregate-jdk${{ matrix.jdk }}/*.xml
+
+  sonar:
+    name: Sonar
+    needs: [build, test]
+    # Runs after the tests so the analysis can consume their surefire reports.
+    # `always()` on purpose: the reports are uploaded even when a leg is red,
+    # and a failure on some other JDK shouldn't cost master its analysis.
+    if: >-
+      always()
+      && needs.build.result == 'success'
+      && github.repository == 'finos/legend-pure'
+      && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        # Full history: Sonar wants SCM blame for new-code detection.
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download build output
+        uses: actions/download-artifact@v7
+        with:
+          name: build-output
+
+      - name: Extract build output
+        # The tar excludes .git, so it layers cleanly over the checkout above.
+        run: tar -xf build-output.tar
+
+      - name: Download JDK 25 test results
+        # Tolerate a missing artifact: if the JDK 25 leg died before writing
+        # any reports we still want the rest of the analysis.
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: test-results-jdk25
+          path: ${{ github.workspace }}/surefire-reports-aggregate-jdk25
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v5
+        env:
+          cache-name: cache-mvn-deps
+        with:
+          # Never cache this project's own artifacts (see the build job).
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/finos/legend/pure
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 25
+          java-package: jdk
+
+      - name: Install project artifacts from this build
+        # Same reasoning as the test job: `sonar:sonar` runs without a
+        # lifecycle phase, so inter-module dependencies resolve from ~/.m2 and
+        # must be this run's jars.
+        run: |
+          rm -rf ~/.m2/repository/org/finos/legend/pure
+          mkdir -p ~/.m2/repository/org/finos/legend
+          cp -r project-artifacts ~/.m2/repository/org/finos/legend/pure
+
+      - name: Sonar
+        env:
+          MAVEN_OPTS: -XX:MaxRAMPercentage=80.0
+        run: |
+          # The test job aggregates every module's surefire XML into one
+          # directory rather than the per-module target/surefire-reports, so
+          # point every module at that absolute path; each one picks up the
+          # reports for the test classes it owns and ignores the rest.
+          reports="${GITHUB_WORKSPACE}/surefire-reports-aggregate-jdk25"
+          mkdir -p "${reports}"
+          mvn -B -e -P sonar sonar:sonar -Dsonar.junit.reportPaths="${reports}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,144 @@ on:
         required: true
 
 jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v5
+        env:
+          cache-name: cache-mvn-deps
+        with:
+          # Never cache this project's own artifacts: the cache is only
+          # refreshed when a pom.xml changes, so cached project jars go stale
+          # on Java-only commits and would shadow the current build's output.
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/finos/legend/pure
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 25
+          java-package: jdk
+
+      - name: Download deps and plugins
+        run: mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+        env:
+          MAVEN_OPTS: -XX:MaxRAMPercentage=90.0
+
+      - name: Build
+        env:
+          MAVEN_OPTS: -XX:MaxRAMPercentage=80.0
+        run: mvn -B -e -DskipTests=true -T 4 install -Dorg.slf4j.simpleLogger.showThreadName=true
+
+      - name: Archive build output
+        # Bundle the whole workspace (compiled classes, generated sources, PAR
+        # archives, etc.) into one file so the test jobs can reuse this build
+        # instead of recompiling. The .git dir isn't needed downstream.
+        # Also bundle the project's own artifacts that `mvn install` put in the
+        # local repository: `mvn surefire:test` resolves inter-module
+        # dependencies from ~/.m2, so the test jobs must get THIS build's jars
+        # rather than whatever project jars the Maven dependency cache carries.
+        run: |
+          cp -r ~/.m2/repository/org/finos/legend/pure project-artifacts
+          tar -cf build-output.tar --exclude='.git' .
+
+      - name: Upload build output
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-output
+          path: build-output.tar
+          retention-days: 1
+
+  test:
+    name: Test (JDK ${{ matrix.jdk }})
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [25, 21, 17, 11, 8]
+    steps:
+      - name: Download build output
+        uses: actions/download-artifact@v7
+        with:
+          name: build-output
+
+      - name: Extract build output
+        run: tar -xf build-output.tar
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v5
+        env:
+          cache-name: cache-mvn-deps
+        with:
+          # Never cache this project's own artifacts (see the build job).
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/finos/legend/pure
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Set up JDKs
+        uses: actions/setup-java@v5
+        with:
+          # 25 always: Maven itself has to run on a JDK the enforcer accepts.
+          # The matrix JDK is what the forked test JVM will use. When the
+          # matrix leg *is* 25 the duplicate is a no-op (second install is a
+          # tool-cache hit).
+          distribution: 'temurin'
+          java-version: |
+            25
+            ${{ matrix.jdk }}
+
+      - name: Install project artifacts from this build
+        # Inter-module dependencies resolve from ~/.m2 during surefire:test,
+        # so they must be the jars installed by this run's build job — never
+        # project jars left over in the restored dependency cache.
+        run: |
+          rm -rf ~/.m2/repository/org/finos/legend/pure
+          mkdir -p ~/.m2/repository/org/finos/legend
+          cp -r project-artifacts ~/.m2/repository/org/finos/legend/pure
+
+      - name: Test
+        env:
+          MAVEN_OPTS: -XX:MaxRAMPercentage=25.0
+        run: |
+          # Maven itself must run on a JDK the enforcer plugin accepts (25),
+          # regardless of which JDK we want to run the tests on. The compiled
+          # test classes already target Java 8 bytecode, so every leg just
+          # points Surefire's forked test JVM at the matrix JDK's install.
+          export JAVA_HOME="$JAVA_HOME_25_X64"
+          test_jvm_home="JAVA_HOME_${{ matrix.jdk }}_X64"
+          TEST_JVM="${!test_jvm_home}/bin/java"
+          mvn -B -e surefire:test -Djvm="${TEST_JVM}" -DargLine="-XX:MaxRAMPercentage=25.0" -DforkCount=3 -DreuseForks=true -Dsurefire.reports.directory=${GITHUB_WORKSPACE}/surefire-reports-aggregate-jdk${{ matrix.jdk }}
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-jdk${{ matrix.jdk }}
+          path: ${{ github.workspace }}/surefire-reports-aggregate-jdk${{ matrix.jdk }}/*.xml
+
   release:
+    name: Release
+    # Publish only once every JDK has gone green. The release itself rebuilds
+    # from scratch, which is cheap enough with tests skipped.
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -73,6 +210,9 @@ jobs:
           MAVEN_OPTS: -XX:MaxRAMPercentage=25.0
 
       - name: Perform release
-        run: mvn -B release:perform -P release
+        # `-Darguments` reaches the forked `deploy` build. Tests are skipped
+        # there because the `test` jobs above already ran the whole suite on
+        # every supported JDK; this fork only needs to compile and publish.
+        run: mvn -B release:perform -P release -Darguments="-DskipTests"
         env:
           MAVEN_OPTS: -XX:MaxRAMPercentage=90.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Group ID: `org.finos.legend.pure`. Current version: `5.81.1-SNAPSHOT` (root `pom
 
 ## Build & test commands
 
-Requires **JDK 11 or 17** (enforcer rejects anything else) and Maven 3.6+.
+Requires **JDK 11, 17, 21, or 25** (enforcer rejects anything else) and Maven 3.6+.
 
 ```bash
 # First build, skip tests (15–30 min warm repo, longer cold)


### PR DESCRIPTION
Update build workflow to run tests for JDKs 8, 11, 17, 21, and 25 for master, and JDKs 8 and 25 for everything else (PRs, forks, etc). Also, include surefire reports for JDK 25 when running sonar.

Update release workflow to run tests for JDKs 8, 11, 17, 21, and 25 before releasing.

Also, update CLAUDE.md to note that JDKs 21 and 25 can also be used.