### PR TITLE
Document every PCT function

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -158,6 +158,7 @@ paths are always equivalent from a user's perspective.
 | [Contributor Workflow Guide](guides/contributor-workflow.md) | How to add a new DSL extension, native function, or store connector |
 | [Exploration & Discovery](guides/exploration.md) | Systematic approach for new engineers exploring the codebase |
 | [Coding Standards & Style Guide](standards/coding-standards.md) | Checkstyle rules, naming conventions, Git workflow, and PR checklist |
+| [PCT Function Documentation](standards/pct-documentation.md) | How to write the published `'''…'''` documentation on PCT functions and tests |
 | [Testing Strategy](testing/testing-strategy.md) | Testing pyramid, frameworks, coverage thresholds, and how to run tests |
 | [Documentation Maintenance](maintenance/maintenance.md) | Keeping docs up to date, ownership, and review cadence |
 | [Module README Template](templates/module-readme-template.md) | Standard template for per-module README files |

--- a/docs/standards/coding-standards.md
+++ b/docs/standards/coding-standards.md
@@ -240,4 +240,18 @@ repository. API conventions apply to Java public APIs:
 
 ---
 
+## Documentation in Pure source
+
+Prose on `<<PCT.function>>` declarations and `<<PCT.test>>` cases is published to end users and has its
+own standard: [PCT Function Documentation](pct-documentation.md). Documentation is a `'''…'''` literal
+placed before the declaration, not a comment — see
+[Pure Language Reference § Documentation](../reference/pure-language-reference.md#documentation) for the
+mechanics.
+
+Two things to note: an element may not carry **both** documentation and an explicit `{doc.doc=…}` tagged
+value, and adding documentation shifts the lines below it, which breaks the position assertions some
+platform tests make. The standard lists the affected files.
+
+---
+
 *Back: [Build & CI Guide](../guides/build-and-ci.md) · Next: [Testing Strategy](../testing/testing-strategy.md)*

--- a/docs/standards/pct-documentation.md
+++ b/docs/standards/pct-documentation.md
@@ -1,0 +1,225 @@
+# Writing PCT function documentation
+
+This standard governs the `'''…'''` documentation on `<<PCT.function>>` declarations and
+`<<PCT.test>>` cases under `legend-pure-m3-core/src/main/resources/platform/pure/**`.
+
+These strings are **published to end users**. Write for someone using Pure to get work done, not for
+someone maintaining the compiler.
+
+For the language mechanics — where documentation attaches, how content is processed, the conflict with
+an explicit `doc.doc` — see
+[Pure Language Reference § Documentation](../reference/pure-language-reference.md#documentation). This
+document covers only *what to write*.
+
+---
+
+## Why it is worth writing
+
+Documentation is sugar over the `meta::pure::profiles::doc` `doc` tagged value, and the pipeline that
+publishes it already exists end to end:
+
+```
+.pure  '''markdown'''
+  → doc.doc tagged value
+  → PCTTools.getDoc()
+  → Signature.documentation             (per signature)
+  → FunctionDefinition.tests[].documentation   (per test)
+  → FUNCTIONS_<module>.json
+  → DocumentationGeneration.buildDocumentation()
+  → consumed downstream for published documentation
+```
+
+---
+
+## The template
+
+````pure
+'''
+One-sentence summary, ending in a period.
+
+Optional paragraph on semantics, edge cases, and empty/`[0..1]` behaviour.
+
+**Parameters**
+- `source` — what it is.
+- `toReplace` — what it is.
+
+**Returns** what comes back.
+
+**Examples**
+```pure
+'abcde'->replace('ab', 'fg')      // 'fgcde'
+'hello'->replace('z', 'y')        // 'hello'
+```
+
+**See also** `split(String[1], String[1]):String[*]`,
+`substring(String[1], Integer[1]):String[1]`
+'''
+native function
+    <<PCT.function>>
+    meta::pure::functions::string::replace(source:String[1], toReplace:String[1], replacement:String[1]):String[1];
+````
+
+The live reference implementation is
+[`platform/pure/essential/string/transformation/replace.pure`](../../legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/replace.pure).
+
+Put the delimiters on their own lines, even for a one-liner — `'''One line.'''` does not canonicalize
+the way you would expect:
+
+```pure
+'''
+Replacing a leading substring rewrites only that occurrence.
+'''
+function <<PCT.test>> meta::pure::functions::string::tests::replace::testReplace<Z|y>(…):Boolean[1]
+```
+
+Every function gets **at least one runnable example**. Prefer examples showing a normal case and at
+least one boundary — no match, empty collection, zero.
+
+---
+
+## Formatting rules
+
+1. **Keep the opening delimiter, the body and the closing delimiter at one indentation.** Content
+   indentation is measured relative to the closing delimiter, so a `'''` pulled left of the body leaves
+   that difference on every line — and 4+ spaces renders as a Markdown code block.
+
+2. **Use `-` for bullets.** Consistent with the corpus, and avoids any confusion with emphasis.
+
+3. **Never write `'''` inside the content** — it closes the literal. This is the only sequence that
+   needs avoiding; ordinary single quotes in Pure examples are fine.
+
+4. **Content is literal** — never unescaped, so `\n` is a backslash and an `n`. Write real line breaks.
+
+5. **Tag fenced blocks `pure`** so the published renderer can highlight them.
+
+6. **One documentation literal per declaration.** Two in a row is a parse error, and the message points
+   at the literal rather than at the duplication — easy to misread when it happens.
+
+---
+
+## Overloads
+
+`Signature.documentation` is per-signature, and the REPL shows the **first** signature that has
+documentation.
+
+> Put the **full** documentation on the first, most general signature — usually the one carrying the
+> stereotype block. Give each other overload a short comment stating only how it differs.
+
+Make the delta self-contained: name the signature being contrasted rather than writing "as above", since
+a renderer may show each signature on its own.
+
+```pure
+'''
+As `indexOf(String[1], String[1]):Integer[1]`, but begins searching at `fromIndex` rather than at the
+start of the string. Still returns `-1` when there is no occurrence at or after that position.
+'''
+```
+
+Note `greaterThanEqual` tags `(Number[0..1], Number[0..1])` where the other comparison operators tag
+`[1],[1]` — check which signature actually carries the stereotype block before assuming.
+
+---
+
+## Cross-references (`See also`)
+
+Reference other functions by **full signature**, never bare name, so a renderer can resolve exactly one
+target:
+
+```
+**See also** `split(String[1], String[1]):String[*]`
+```
+
+Two reasons from the current corpus: `substring` has two overloads, and `contains` exists in both
+`meta::pure::functions::string` and `meta::pure::functions::collection`.
+
+**Format** — match the `simple` field of `Signature` in `FUNCTIONS_*.json`: parameter types comma-space
+separated, return type after the colon. Strip the package when the target is in the same package as the
+function you are documenting; keep it otherwise.
+
+**Do not hand-write signatures.** Copy them from the generated JSON:
+
+```bash
+python3 -c "
+import json; d=json.load(open('legend-pure-core/legend-pure-m3-core/target/classes/pct-reports/FUNCTIONS_essential.json'))
+print('\n'.join(s['simple'] for f in d['functionDefinitions'] for s in f['signatures']))"
+```
+
+Hand-written references are wrong surprisingly often — `split` returns `String[*]` not `String[1]`, and
+`instanceOf` lives in `meta`, not `lang`.
+
+---
+
+## Before you document a file: check for position assertions
+
+Adding documentation **shifts every line below it**, and some tests assert the line and column of
+elements in `platform/pure`. The failure names a line number, not your documentation, so it reads as
+unrelated.
+
+The most productive grep is for `assertError` calls with numeric position arguments — those are
+**self-referential**, asserting the line they are written on:
+
+```bash
+grep -rn --include='*.pure' "assertError(.*',[[:space:]]*[0-9]" platform/pure
+```
+
+Java-side assertions come in two further shapes that a single pattern will not find:
+
+```bash
+grep -rn --include='*.java' "<file> line:" .                                    # error-message strings
+grep -rn --include='*.java' 'getSourceInformation()\.\(getLine\|getColumn\)' .  # integer assertions
+```
+
+Files carrying position assertions, as of writing:
+
+| File(s) | Asserted from |
+|---|---|
+| `essential/tests/assert.pure`, `fail.pure` | `TestPCTTools`, `TestFunctionExecutionStart` |
+| `essential/io/print.pure` | `TestSourceNavigation` (`getLine()`) |
+| `essential/meta/source/sourceInformation.pure` | itself — positions of elements **below** the declaration |
+| `essential/collection/index/at.pure` | itself, via `assertError` |
+| `essential/date/creation/date.pure`, `date/extract/{dayOfMonth,hour,minute,second}.pure` | themselves |
+| `essential/tests/{assert,assertEquals,assertError,assertFalse,assertNotEquals,assertSameElements}.pure` | themselves |
+
+Update the numbers in the same commit. Do not compute the offset by hand — make the edit, then re-read
+the file for the actual new positions. For a self-referential `assertError`, the expected value is simply
+the assertion's own new line number.
+
+---
+
+## Verifying: m3-core alone is not enough
+
+Documentation lives in `m3-core`, but **the tests that exercise it do not**. Both of these run only in
+the runtime engine modules:
+
+- `Test_*_PCT` — the `<<PCT.test>>` functions
+- `TestCoreFunctions` — the platform `<<test.Test>>` functions, and **it does not match `*_PCT`**, so a
+  filtered run silently skips it
+
+A green m3-core build therefore proves nothing about the position assertions above. Run both, in this
+order, and **never concurrently** — a second Maven `clean` deletes `target/` under the first and produces
+a flood of misleading "code repository can't be found" errors:
+
+```bash
+mvn clean install -pl legend-pure-core/legend-pure-m3-core
+
+mvn test -pl legend-pure-runtime/legend-pure-runtime-java-engine-interpreted
+```
+
+Run the whole interpreted module rather than filtering — filtering is what hid `TestCoreFunctions`.
+
+**Never verify with `-DskipTests`.** It proves the documentation parses and serializes; it cannot detect
+a broken position assertion.
+
+Then check the emitted JSON, which is the thing actually published:
+
+```bash
+python3 -c "
+import json; d=json.load(open('legend-pure-core/legend-pure-m3-core/target/classes/pct-reports/FUNCTIONS_essential.json'))
+print(json.dumps([f for f in d['functionDefinitions'] if f.get('name')=='replace'], indent=2))"
+```
+
+Confirm `signatures[].documentation` holds the intended Markdown with newlines preserved, and that tests
+appear under `tests` with their documentation attached.
+
+Documentation is parse-time sugar, so **no PCT result should change**. Treat any diff as a real
+regression.

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/functions/generation/FunctionsGeneration.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/functions/generation/FunctionsGeneration.java
@@ -34,6 +34,7 @@ import org.finos.legend.pure.m3.navigation.function.FunctionDescriptor;
 import org.finos.legend.pure.m3.pct.functions.model.FunctionDefinition;
 import org.finos.legend.pure.m3.pct.functions.model.Functions;
 import org.finos.legend.pure.m3.pct.functions.model.Signature;
+import org.finos.legend.pure.m3.pct.functions.model.TestDefinition;
 import org.finos.legend.pure.m3.pct.shared.PCTTools;
 import org.finos.legend.pure.m3.pct.shared.generation.Shared;
 import org.finos.legend.pure.m3.pct.shared.model.ReportScope;
@@ -136,13 +137,14 @@ public class FunctionsGeneration
     {
         FunctionDefinition functionInfo = functionsDB.get(_function.getSourceInformation().getSourceId());
         // FunctionDefinition can be null if the PCT Tests are meant to test functions composition.
+        // Documentation on such a test is dropped here, just as its count is.
         if (functionInfo != null)
         {
             if (functionInfo.signatures.get(0).platformOnly)
             {
                 throw new RuntimeException("The test " + _function._functionName() + " in the source " + _function.getSourceInformation().getSourceId() + " is a PCT test for platform-only functions.");
             }
-            functionInfo.pctTestCount++;
+            functionInfo.tests.add(testDefinition(_function, ps, true));
         }
     }
 
@@ -151,8 +153,14 @@ public class FunctionsGeneration
         FunctionDefinition functionInfo = functionsDB.get(_function.getSourceInformation().getSourceId());
         if (functionInfo != null)
         {
-            functionInfo.testCount++;
+            functionInfo.tests.add(testDefinition(_function, ps, false));
         }
+    }
+
+    private static TestDefinition testDefinition(PackageableFunction<?> _function, ProcessorSupport ps, boolean pct)
+    {
+        String documentation = PCTTools.getDoc(_function, ps);
+        return new TestDefinition(_function._functionName(), (documentation == null || documentation.isEmpty()) ? null : documentation, pct);
     }
 
     private static void addPCTFunctionToFunctionsDB(PackageableFunction<?> _function, MutableMap<String, FunctionDefinition> functionsDB, ProcessorSupport ps)

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/functions/model/FunctionDefinition.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/functions/model/FunctionDefinition.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.pure.m3.pct.functions.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.eclipse.collections.api.factory.Lists;
 
 import java.util.List;
@@ -25,8 +26,13 @@ public class FunctionDefinition
     public String sourceId;
 
     public List<Signature> signatures = Lists.mutable.empty();
-    public int testCount;
-    public int pctTestCount;
+
+    /**
+     * Every test exercising this function, PCT and non-PCT alike, documented or not. This is the
+     * sole representation of a function's tests; the counts below are derived from it on demand
+     * rather than stored, so they cannot drift out of step with the list.
+     */
+    public List<TestDefinition> tests = Lists.mutable.empty();
 
     public FunctionDefinition()
     {
@@ -35,5 +41,33 @@ public class FunctionDefinition
     public FunctionDefinition(String sourceId)
     {
         this.sourceId = sourceId;
+    }
+
+    /**
+     * The number of non-PCT ({@code <<test.Test>>}) tests. PCT tests are deliberately excluded,
+     * preserving the meaning this count has always had for downstream consumers.
+     * <p>
+     * Not serialized: {@link #tests} is what the report carries, and a derived value written into
+     * it could not be read back without a field to hold it.
+     */
+    @JsonIgnore
+    public int getTestCount()
+    {
+        return count(false);
+    }
+
+    /**
+     * The number of {@code <<PCT.test>>} tests. Not serialized, for the same reason as
+     * {@link #getTestCount()}.
+     */
+    @JsonIgnore
+    public int getPctTestCount()
+    {
+        return count(true);
+    }
+
+    private int count(boolean pct)
+    {
+        return (int) this.tests.stream().filter(t -> t.pct == pct).count();
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/functions/model/TestDefinition.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/pct/functions/model/TestDefinition.java
@@ -1,0 +1,47 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.pct.functions.model;
+
+/**
+ * A test exercising the function it is listed against.
+ * <p>
+ * Every test is recorded, whether or not it is documented, so that {@link FunctionDefinition#tests}
+ * is the sole representation of a function's tests - counts are obtained by filtering that list
+ * rather than being tracked alongside it.
+ */
+public class TestDefinition
+{
+    public String name;
+
+    /** The test's documentation comment, or null when it has none. */
+    public String documentation;
+
+    /**
+     * Whether this is a {@code <<PCT.test>>}, run against every adapter, or a plain
+     * {@code <<test.Test>>}.
+     */
+    public boolean pct;
+
+    public TestDefinition()
+    {
+    }
+
+    public TestDefinition(String name, String documentation, boolean pct)
+    {
+        this.name = name;
+        this.documentation = documentation;
+        this.pct = pct;
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/list/list.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/list/list.pure
@@ -14,6 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Wraps a collection in a `List` object.
+
+Pure collections are values with a multiplicity, not objects; a `List` is a single object holding
+them. Wrapping is what lets you build a collection *of* collections — a `List<X>[*]` — which a bare
+`X[*]` cannot express because collections do not nest.
+
+**Parameters**
+- `vals` — the values to wrap.
+
+**Returns** a `List` whose `values` are `vals`.
+
+**Examples**
+```pure
+list([1, 2, 3])          // ^List(values=[1, 2, 3])
+list([1, 2, 3]).values   // [1, 2, 3]
+```
+
+**See also** `meta::pure::functions::collection::groupBy(X[*], Function<{X[1]->K[1]}>[1]):Map<K, List<X>>[1]`,
+`pair(U[1], V[1]):Pair<U, V>[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::collection::list<U>(vals:U[*]):List<U>[1]
 {
    ^List<U>(values = $vals);

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/getIfAbsentPutWithKey.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/getIfAbsentPutWithKey.pure
@@ -15,6 +15,32 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::asserts::*;
 
+'''
+Looks up a key, computing and storing a value if it is not already present.
+
+Unlike most collection functions this **mutates the map**: on a miss the computed value is inserted,
+so a later lookup of the same key returns it. `func` receives the key and is called only on a miss —
+a second call with a different `func` returns the stored value and ignores the new function. That
+makes this the building block for memoisation and lazy caches.
+
+**Parameters**
+- `m` — the map to read and, on a miss, update.
+- `key` — the key to look up.
+- `func` — computes the value from the key, called only when the key is absent.
+
+**Returns** the existing value, or the newly computed and stored one.
+
+**Examples**
+```pure
+let m = newMap([pair(1, '_1')]);
+$m->getIfAbsentPutWithKey(3, {k | '_' + $k->toString()});   // '_3', now stored
+$m->get(3);                                                 // '_3'
+$m->getIfAbsentPutWithKey(3, {k | 'something else'});       // '_3' -- func not called
+```
+
+**See also** `newMap(Pair<U, V>[*]):Map<U, V>[1]`,
+`getMapStats(Map<U, V>[1]):MapStats[0..1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::collection::getIfAbsentPutWithKey<U,V>(m:Map<U,V>[1], key:U[1], func:Function<{U[1]->V[0..1]}>[1]):V[0..1];
 
 function <<test.Test>> meta::pure::functions::collection::tests::map::testGetIfAbsentPutWithKey():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/getMapStats.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/getMapStats.pure
@@ -15,6 +15,27 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::asserts::*;
 
+'''
+Diagnostic counters for a map: its size, and how many times a value has been computed on a miss.
+
+Intended for inspecting cache behaviour when a map is used with
+`getIfAbsentPutWithKey(Map<U, V>[1], U[1], Function<{U[1]->V[0..1]}>[1]):V[0..1]` — a rising
+`getIfAbsentCounter` relative to `size` indicates repeated misses. The result is `[0..1]`, so a map
+that keeps no statistics yields an empty value.
+
+**Parameters**
+- `m` — the map to inspect.
+
+**Returns** the map's statistics, or an empty value if none are recorded.
+
+**Examples**
+```pure
+$m->getMapStats().size
+$m->getMapStats().getIfAbsentCounter
+```
+
+**See also** `getIfAbsentPutWithKey(Map<U, V>[1], U[1], Function<{U[1]->V[0..1]}>[1]):V[0..1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::collection::getMapStats<U,V>(m:Map<U,V>[1]):MapStats[0..1];
 
 Class meta::pure::functions::collection::MapStats

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/groupBy.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/groupBy.pure
@@ -15,6 +15,29 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::collection::tests::model::*;
 
+'''
+Groups a collection into a map, keyed by a value derived from each element.
+
+Every element is placed in the bucket for its key, so no element is discarded and the buckets
+partition the input. The values are `List` objects rather than bare collections, because a map
+cannot hold a collection per key directly — reach the elements through `.values`.
+
+**Parameters**
+- `set` — the collection to group.
+- `f` — derives the grouping key for each element.
+
+**Returns** a map from key to the `List` of elements having that key.
+
+**Examples**
+```pure
+$people->groupBy(p | $p.lastName)                  // {'Smith' -> List(…), 'Doe' -> List(…)}
+$people->groupBy(p | $p.lastName)->get('Smith').values
+```
+
+**See also** `newMap(Pair<U, V>[*]):Map<U, V>[1]`,
+`removeDuplicatesBy(T[*], Function<{T[1]->Any[1]}>[1]):T[*]`,
+`list(U[*]):List<U>[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::collection::groupBy<X,K>(set:X[*], f:Function<{X[1]->K[1]}>[1]):Map<K,List<X>>[1];
 //{
 //   $set->fold({value,map|let key = $f->eval($value);

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/keyValues.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/keyValues.pure
@@ -14,6 +14,26 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The entries of a map, as a collection of key/value pairs.
+
+The inverse of `newMap(Pair<U, V>[*]):Map<U, V>[1]`, and the usual way to iterate a map: convert to
+pairs, then `map`, `filter` or `fold` over them. The order of the entries is unspecified.
+
+**Parameters**
+- `m` — the map to read.
+
+**Returns** one pair per entry, in unspecified order.
+
+**Examples**
+```pure
+$m->keyValues()->map(p | $p.first)      // the keys
+$m->keyValues()->filter(p | $p.second > 10)
+```
+
+**See also** `newMap(Pair<U, V>[*]):Map<U, V>[1]`,
+`pair(U[1], V[1]):Pair<U, V>[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::collection::keyValues<U,V>(m:Map<U,V>[1]):Pair<U,V>[*];
 //{
 //    $m._values;

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/newMap.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/newMap.pure
@@ -14,11 +14,39 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Builds a `Map` from a collection of key/value pairs.
+
+Each pair's `first` becomes a key and its `second` the value. Where two pairs share a key, the later
+one wins. An empty collection gives an empty map.
+
+**Parameters**
+- `pairs` — the entries to populate the map with.
+
+**Returns** the map.
+
+**Examples**
+```pure
+[pair('a', 1), pair('b', 2)]->newMap()   // {'a' -> 1, 'b' -> 2}
+[]->newMap()                             // empty map
+```
+
+**See also** `newMap(Pair<U, V>[*], Property<U, Any|1>[*]):Map<U, V>[1]`,
+`pair(U[1], V[1]):Pair<U, V>[1]`,
+`keyValues(Map<U, V>[1]):Pair<U, V>[*]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::collection::newMap<U,V>(pairs:Pair<U,V>[*]):Map<U,V>[1];
 //{
 //   $pairs->fold({a,b|$b->put($a.first, $a.second)},^Map<U,V>());
 //}
 
+'''
+As `newMap(Pair<U, V>[*]):Map<U, V>[1]`, but keys are compared using the given properties rather
+than by default equality.
+
+Supply the properties that identify a key object, and two keys agreeing on all of them are treated
+as the same entry. Use this when the keys are objects and you want them matched structurally.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::collection::newMap<U,V>(pairs:Pair<U,V>[*], p:Property<U,Any|1>[*]):Map<U,V>[1];
 //{
 //   $pairs->fold({a,b|$b->put($a.first, $a.second)},^Map<U,V>(_func=$f));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/replaceAll.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/replaceAll.pure
@@ -14,6 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Returns a map with the given entries added, replacing any that share a key.
+
+Keys present in `pairs` take the new value; keys absent from `pairs` keep theirs. The key-comparison
+behaviour of the original map — including any properties it was built with — is carried over.
+
+**Parameters**
+- `m` — the map to start from.
+- `pairs` — the entries to add or overwrite.
+
+**Returns** the updated map.
+
+**Examples**
+```pure
+$m->replaceAll([pair('a', 9)])   // 'a' now maps to 9; other keys untouched
+$m->replaceAll([])               // unchanged
+```
+
+**See also** `newMap(Pair<U, V>[*]):Map<U, V>[1]`,
+`getIfAbsentPutWithKey(Map<U, V>[1], U[1], Function<{U[1]->V[0..1]}>[1]):V[0..1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::collection::replaceAll<U,V>(m:Map<U,V>[1], pairs:Pair<U,V>[*]):Map<U,V>[1];
 //{
 //   $pairs->fold({a,b|$b->put($a.first, $a.second)}, ^Map<U,V>(_func= $m._func));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/replaceAll.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/map/replaceAll.pure
@@ -15,24 +15,27 @@
 import meta::pure::test::pct::*;
 
 '''
-Returns a map with the given entries added, replacing any that share a key.
+Returns a map holding exactly the given entries, discarding those of the original map.
 
-Keys present in `pairs` take the new value; keys absent from `pairs` keep theirs. The key-comparison
-behaviour of the original map — including any properties it was built with — is carried over.
+Despite the name this is not a merge: entries of `m` whose keys are absent from `pairs` are dropped.
+The key-comparison behaviour of the original map — including any properties it was built with — is
+carried over. Use `putAll(Map<U, V>[1], Pair<U, V>[*]):Map<U, V>[1]` to add entries while keeping
+the ones already present.
 
 **Parameters**
-- `m` — the map to start from.
-- `pairs` — the entries to add or overwrite.
+- `m` — the map whose key-comparison behaviour is reused.
+- `pairs` — the entries the new map holds.
 
-**Returns** the updated map.
+**Returns** a new map containing only `pairs`.
 
 **Examples**
 ```pure
-$m->replaceAll([pair('a', 9)])   // 'a' now maps to 9; other keys untouched
-$m->replaceAll([])               // unchanged
+// $m maps 1 -> '_1' and 2 -> '_2'
+$m->replaceAll([pair(1, '_1_1'), pair(3, '_3')])   // {1 -> '_1_1', 3 -> '_3'} -- key 2 is gone
 ```
 
-**See also** `newMap(Pair<U, V>[*]):Map<U, V>[1]`,
+**See also** `putAll(Map<U, V>[1], Pair<U, V>[*]):Map<U, V>[1]`,
+`newMap(Pair<U, V>[*]):Map<U, V>[1]`,
 `getIfAbsentPutWithKey(Map<U, V>[1], U[1], Function<{U[1]->V[0..1]}>[1]):V[0..1]`
 '''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::collection::replaceAll<U,V>(m:Map<U,V>[1], pairs:Pair<U,V>[*]):Map<U,V>[1];

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/pair/pair.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/pair/pair.pure
@@ -14,6 +14,28 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Builds a `Pair` holding two values, which may be of different types.
+
+A convenience for `^Pair(first=…, second=…)`. Pairs are the entries a `Map` is built from and the
+elements `zip` produces.
+
+**Parameters**
+- `first` — the first component.
+- `second` — the second component.
+
+**Returns** the pair.
+
+**Examples**
+```pure
+pair('a', 1)                          // ^Pair(first='a', second=1)
+[pair('a', 1), pair('b', 2)]->newMap()
+```
+
+**See also** `newMap(Pair<U, V>[*]):Map<U, V>[1]`,
+`zip(T[*], U[*]):Pair<T, U>[*]`,
+`keyValues(Map<U, V>[1]):Pair<U, V>[*]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::collection::pair<U,V>(first:U[1], second:V[1]):Pair<U,V>[1]
 {
    ^Pair<U,V>(first=$first, second=$second);

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/tree/replaceTreeNode.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/anonymous/tree/replaceTreeNode.pure
@@ -14,4 +14,23 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Returns a tree with one node substituted for another.
+
+Searches `root` for `target` and puts `value` in its place, rebuilding the branch above it. The
+original tree is not modified. `target` is matched as a node within the tree, so it must be a node
+taken from `root` rather than an equal-looking copy.
+
+**Parameters**
+- `root` — the tree to rewrite.
+- `target` — the node to replace.
+- `value` — the node to put in its place.
+
+**Returns** the rewritten tree.
+
+**Examples**
+```pure
+$tree->replaceTreeNode($oldNode, $newNode)
+```
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::collection::replaceTreeNode(root:TreeNode[1], target:TreeNode[1], value:TreeNode[1]):TreeNode[1];

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/boolean/contains.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/boolean/contains.pure
@@ -17,11 +17,45 @@ import meta::pure::test::pct::*;
 import meta::pure::functions::collection::tests::contains::*;
 import meta::pure::functions::collection::tests::model::*;
 
+'''
+Whether a collection contains a given value, compared with `==`.
+
+The collection is untyped, so a mixed collection may be searched for a value of any type. An empty
+collection contains nothing.
+
+**Parameters**
+- `collection` — the collection to search.
+- `value` — the value to look for.
+
+**Returns** `true` if any element equals `value`.
+
+**Examples**
+```pure
+[1, 2, 5]->contains(2)         // true
+['a', 'b']->contains('z')      // false
+```
+
+**See also** `contains(Z[*], Z[1], Function<{Z[1], Z[1]->Boolean[1]}>[1]):Boolean[1]`,
+`exists(T[*], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`,
+`indexOf(T[*], T[1]):Integer[1]`
+'''
 function <<PCT.function>> meta::pure::functions::collection::contains(collection:Any[*], value:Any[1]):Boolean[1]
 {
     $collection->exists(x | $value == $x)
 }
 
+'''
+Whether a collection contains a given value, compared with a supplied equality function.
+
+Use this when `==` is not the comparison you want — for example matching objects on one property,
+or comparing strings case-insensitively. The comparator is called as
+`comparator($value, $element)`.
+
+**Examples**
+```pure
+$people->contains($target, {a, b | $a.lastName == $b.lastName})
+```
+'''
 function <<PCT.function>> meta::pure::functions::collection::contains<Z>(collection:Z[*], value:Z[1], comparator:Function<{Z[1],Z[1]->Boolean[1]}>[1]):Boolean[1]
 {
     $collection->exists(x | $comparator->eval($value, $x))

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/boolean/quantification/exists.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/boolean/quantification/exists.pure
@@ -16,6 +16,29 @@ import meta::pure::test::pct::*;
 
 import meta::pure::functions::collection::tests::model::*;
 
+'''
+Whether at least one element of a collection satisfies a predicate.
+
+An empty collection returns `false` — there is no element to satisfy it. Use this rather than
+`filter(…)->isNotEmpty()` when you only care whether a match exists.
+
+**Parameters**
+- `value` — the collection to test.
+- `func` — the predicate applied to each element.
+
+**Returns** `true` if the predicate holds for any element.
+
+**Examples**
+```pure
+[1, 2, 3]->exists(e | $e > 2)   // true
+[1, 2, 3]->exists(e | $e > 5)   // false
+[]->exists(e | true)            // false
+```
+
+**See also** `forAll(T[*], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`,
+`filter(T[*], Function<{T[1]->Boolean[1]}>[1]):T[*]`,
+`contains(Any[*], Any[1]):Boolean[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::collection::exists<T>(value:T[*], func:Function<{T[1]->Boolean[1]}>[1]):Boolean[1];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::exists::testExists<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/boolean/quantification/forAll.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/boolean/quantification/forAll.pure
@@ -14,6 +14,28 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether every element of a collection satisfies a predicate.
+
+An empty collection returns `true`, following the usual convention for universal quantification:
+there is no element that fails the test.
+
+**Parameters**
+- `value` — the collection to test.
+- `func` — the predicate applied to each element.
+
+**Returns** `true` if the predicate holds for every element.
+
+**Examples**
+```pure
+[1, 2, 3]->forAll(e | $e > 0)   // true
+[1, 2, 3]->forAll(e | $e > 1)   // false
+[]->forAll(e | $e == 0)         // true  -- vacuously
+```
+
+**See also** `exists(T[*], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`,
+`filter(T[*], Function<{T[1]->Boolean[1]}>[1]):T[*]`
+'''
 native function <<PCT.function>> meta::pure::functions::collection::forAll<T>(value:T[*], func:Function<{T[1]->Boolean[1]}>[1]):Boolean[1];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::forall::testforAllOnEmptySet<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/index/at.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/index/at.pure
@@ -15,11 +15,31 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::asserts::*;
 
+'''
+The element at a zero-based position in a collection.
+
+The result has multiplicity `[1]`, so unlike most collection accessors this always yields exactly
+one value — an index outside the collection is an error rather than an empty result. A single value
+behaves as a one-element collection, so `'a'->at(0)` is `'a'`.
+
+**Parameters**
+- `set` — the collection to read from.
+- `key` — zero-based position of the element to return.
+
+**Returns** the element at that position.
+
+**Examples**
+```pure
+['a', 'b', 'c']->at(0)   // 'a'
+['a', 'b', 'c']->at(2)   // 'c'
+```
+
+**See also** `indexOf(T[*], T[1]):Integer[1]`,
+`slice(T[*], Integer[1], Integer[1]):T[*]`,
+`meta::pure::functions::collection::first(T[*]):T[0..1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::collection::at<T>(set:T[*], key:Integer[1]):T[1];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::at::testAt<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
@@ -49,5 +69,5 @@ function <<PCT.test>> meta::pure::functions::collection::tests::at::testAtWithVa
 }
 function <<PCT.test>> meta::pure::functions::collection::tests::at::testAtError<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
-    assertError(| $f->eval(|[1, 2]->at(2)), 'The system is trying to get an element at offset 2 where the collection is of size 2', 52, 37);
+    assertError(| $f->eval(|[1, 2]->at(2)), 'The system is trying to get an element at offset 2 where the collection is of size 2', 72, 37);
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/index/indexOf.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/index/indexOf.pure
@@ -14,6 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The zero-based position of the first occurrence of a value in a collection, or `-1` if absent.
+
+Because a miss returns `-1` rather than an empty value, test the result explicitly rather than
+relying on it being empty.
+
+**Parameters**
+- `set` — the collection to search.
+- `value` — the element to locate.
+
+**Returns** the index of the first occurrence, or `-1` when there is none.
+
+**Examples**
+```pure
+['a', 'b', 'c', 'd']->indexOf('c')   // 2
+['a', 'b']->indexOf('z')             // -1
+```
+
+**See also** `at(T[*], Integer[1]):T[1]`,
+`contains(Any[*], Any[1]):Boolean[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::collection::indexOf<T>(set:T[*], value:T[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::indexof::testIndexOf<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/iteration/find.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/iteration/find.pure
@@ -16,6 +16,27 @@ import meta::pure::test::pct::*;
 
 import meta::pure::functions::collection::tests::model::*;
 
+'''
+The first element satisfying a predicate, or nothing if none does.
+
+Stops at the first match, so prefer it to `filter(…)->first()` when only one result is wanted. The
+`[0..1]` result means no match yields an empty value rather than an error.
+
+**Parameters**
+- `value` — the collection to search.
+- `func` — the predicate applied to each element.
+
+**Returns** the first matching element, or an empty value.
+
+**Examples**
+```pure
+['Smith', 'Doe', 'Oth']->find(s | $s->length() == 3)   // 'Doe'
+['Smith', 'Doe']->find(s | $s == 'Zzz')                // empty
+```
+
+**See also** `filter(T[*], Function<{T[1]->Boolean[1]}>[1]):T[*]`,
+`exists(T[*], Function<{T[1]->Boolean[1]}>[1]):Boolean[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::collection::find<T>(value:T[*], func:Function<{T[1]->Boolean[1]}>[1]):T[0..1];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::find::testFindLiteral<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/iteration/fold.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/iteration/fold.pure
@@ -16,28 +16,33 @@ import meta::pure::test::pct::*;
 import meta::pure::functions::collection::tests::fold::*;
 
 '''
-Reduces a collection to a single value by combining its elements one at a time.
+Combines the elements of a collection into an accumulated result, one element at a time.
 
 `func` receives the current element and the accumulated value, and returns the new accumulated
 value. It is applied left to right, so the first element is combined with `accumulator` first. An
 empty collection returns `accumulator` unchanged.
+
+The accumulator is not restricted to a single value. Its multiplicity `m` is carried through to the
+result, so folding into a collection accumulator yields a collection — `fold` builds up a result of
+whatever shape the seed has, rather than always reducing to one value.
 
 Note the argument order: the element comes first, the accumulator second. This matters when the
 operation is not commutative — `{x, y | $y + $x}` concatenates in collection order, while
 `{x, y | $x + $y}` reverses it.
 
 **Parameters**
-- `value` — the collection to reduce.
+- `value` — the collection to fold over.
 - `func` — combines an element with the accumulated value.
 - `accumulator` — the starting value, and the result for an empty collection.
 
-**Returns** the final accumulated value.
+**Returns** the final accumulated value, with the same multiplicity as `accumulator`.
 
 **Examples**
 ```pure
-[1, 2, 3, 4]->fold({x, y | $x + $y}, 0)         // 10
-[1, 2, 3, 4]->fold({x, y | $x + $y}, 7)         // 17  -- the seed participates
-['a', 'b', 'c']->fold({x, y | $y + $x}, '')     // 'abc'
+[1, 2, 3, 4]->fold({x, y | $x + $y}, 0)              // 10
+[1, 2, 3, 4]->fold({x, y | $x + $y}, 7)              // 17  -- the seed participates
+['a', 'b', 'c']->fold({x, y | $y + $x}, '')          // 'abc'
+[1, 2, 3, 4]->fold({x, y | $y->add($x)}, [-1, 0])    // [-1, 0, 1, 2, 3, 4]  -- collection accumulator
 ```
 
 **See also** `map(T[m], Function<{T[1]->V[1]}>[1]):V[m]`,

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/iteration/fold.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/iteration/fold.pure
@@ -15,11 +15,37 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::collection::tests::fold::*;
 
+'''
+Reduces a collection to a single value by combining its elements one at a time.
+
+`func` receives the current element and the accumulated value, and returns the new accumulated
+value. It is applied left to right, so the first element is combined with `accumulator` first. An
+empty collection returns `accumulator` unchanged.
+
+Note the argument order: the element comes first, the accumulator second. This matters when the
+operation is not commutative — `{x, y | $y + $x}` concatenates in collection order, while
+`{x, y | $x + $y}` reverses it.
+
+**Parameters**
+- `value` — the collection to reduce.
+- `func` — combines an element with the accumulated value.
+- `accumulator` — the starting value, and the result for an empty collection.
+
+**Returns** the final accumulated value.
+
+**Examples**
+```pure
+[1, 2, 3, 4]->fold({x, y | $x + $y}, 0)         // 10
+[1, 2, 3, 4]->fold({x, y | $x + $y}, 7)         // 17  -- the seed participates
+['a', 'b', 'c']->fold({x, y | $y + $x}, '')     // 'abc'
+```
+
+**See also** `map(T[m], Function<{T[1]->V[1]}>[1]):V[m]`,
+`filter(T[*], Function<{T[1]->Boolean[1]}>[1]):T[*]`,
+`meta::pure::functions::string::joinStrings(String[*], String[1]):String[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::collection::fold<T,V|m>(value:T[*], func:Function<{T[1],V[m]->V[m]}>[1], accumulator:V[m]):V[m];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::fold::testIntegerSum<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/order/reverse.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/order/reverse.pure
@@ -14,6 +14,26 @@
 
 import meta::pure::test::pct::*;
 
+'''
+A collection with its elements in the opposite order.
+
+The multiplicity is preserved, so reversing a `[1]` value gives a `[1]` value and reversing an empty
+collection gives an empty collection.
+
+**Parameters**
+- `set` — the collection to reverse.
+
+**Returns** the elements in reverse order.
+
+**Examples**
+```pure
+['a', 'b', 'c']->reverse()   // ['c', 'b', 'a']
+[]->reverse()                // []
+```
+
+**See also** `sort(T[m]):T[m]`,
+`meta::pure::functions::string::reverseString(String[1]):String[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::collection::reverse<T|m>(set:T[m]):T[m];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::reverse::testReverse<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/order/sort.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/order/sort.pure
@@ -14,18 +14,65 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Sorts a collection, optionally by a derived key and optionally with a custom comparator.
+
+This is the most general form; the shorter overloads delegate to it. Both function arguments are
+`[0..1]`, so passing `[]` for either falls back to the default: elements are compared directly when
+no `key` is given, and in natural ascending order when no `comp` is given.
+
+Supplying a `key` is the usual way to sort objects by one of their properties, and avoids writing a
+comparator by hand.
+
+**Parameters**
+- `col` — the collection to sort.
+- `key` — extracts the value to compare on, or `[]` to compare elements directly.
+- `comp` — compares two keys, returning a negative number, zero, or a positive number, or `[]` for
+  natural ascending order.
+
+**Returns** the elements in sorted order; the multiplicity is preserved.
+
+**Examples**
+```pure
+[3, 1, 2]->sort([], [])                     // [1, 2, 3]
+$people->sort(p | $p.lastName, [])          // by a derived key
+$people->sort([], {a, b | $b.age - $a.age}) // custom comparator: descending
+```
+
+**See also** `sort(T[m]):T[m]`,
+`sort(T[m], Function<{T[1], T[1]->Integer[1]}>[0..1]):T[m]`,
+`reverse(T[m]):T[m]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::collection::sort<T,U|m>(col:T[m], key:Function<{T[1]->U[1]}>[0..1], comp:Function<{U[1],U[1]->Integer[1]}>[0..1]):T[m];
 
+'''
+Sorts a collection into natural ascending order, comparing elements directly.
+
+The common case; equivalent to `sort($col, [], [])`.
+
+**Examples**
+```pure
+[3, 1, 2]->sort()   // [1, 2, 3]
+```
+'''
 function <<PCT.function>> meta::pure::functions::collection::sort<T|m>(col:T[m]):T[m]
 {
     sort($col, [], [])
 }
 
+'''
+Sorts a collection using a custom comparator applied to the elements themselves.
+
+Equivalent to `sort($col, [], $comp)`. The comparator returns a negative number, zero, or a positive
+number as its first argument sorts before, with, or after its second.
+
+**Examples**
+```pure
+[3, 1, 2]->sort({a, b | $b - $a})   // [3, 2, 1]
+```
+'''
 function <<PCT.function>> meta::pure::functions::collection::sort<T|m>(col:T[m], comp:Function<{T[1],T[1]->Integer[1]}>[0..1]):T[m]
 {
     sort($col, [], $comp)

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/slice/drop.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/slice/drop.pure
@@ -14,6 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+A collection with its first `count` elements removed.
+
+The complement of `take(T[*], Integer[1]):T[*]`. Out-of-range counts are clamped rather than
+rejected: a negative or zero `count` returns the collection unchanged, and a `count` beyond the end
+returns an empty collection.
+
+**Parameters**
+- `set` — the collection to drop from.
+- `count` — how many leading elements to discard.
+
+**Returns** the remaining elements.
+
+**Examples**
+```pure
+[1, 2, 3]->drop(1)    // [2, 3]
+[1, 2, 3]->drop(0)    // [1, 2, 3]
+[1, 2, 3]->drop(-1)   // [1, 2, 3]
+[1, 2, 3]->drop(10)   // []
+```
+
+**See also** `take(T[*], Integer[1]):T[*]`,
+`slice(T[*], Integer[1], Integer[1]):T[*]`
+'''
 native function <<PCT.function>> meta::pure::functions::collection::drop<T>(set:T[*], count:Integer[1]):T[*];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::drop::testDropNegativeOnEmptyList<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/slice/last.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/slice/last.pure
@@ -14,7 +14,27 @@
 
 import meta::pure::test::pct::*;
 
-// Return the last element of the collection, or nothing if the collection is empty
+'''
+The last element of a collection, or nothing when it is empty.
+
+The result has multiplicity `[0..1]`, so an empty collection yields an empty result rather than an
+error. Use `toOne(…)` when you need to assert that a value is present.
+
+**Parameters**
+- `set` — the collection to read from.
+
+**Returns** the final element, or an empty value for an empty collection.
+
+**Examples**
+```pure
+['a', 'b', 'c']->last()   // 'c'
+['a']->last()             // 'a'
+[]->last()                // empty
+```
+
+**See also** `meta::pure::functions::collection::first(T[*]):T[0..1]`,
+`at(T[*], Integer[1]):T[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::collection::last<T>(set:T[*]):T[0..1];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::last::testLast<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/slice/slice.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/slice/slice.pure
@@ -15,6 +15,28 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::asserts::*;
 
+'''
+The elements between two positions: from `start` inclusive to `end` exclusive.
+
+Both indexes are zero-based, so the result holds `end - start` elements. Ranges reaching past the
+end of the collection are clamped rather than rejected.
+
+**Parameters**
+- `set` — the collection to slice.
+- `start` — zero-based index of the first element to keep.
+- `end` — zero-based index just past the last element to keep.
+
+**Returns** the elements in that range.
+
+**Examples**
+```pure
+[1, 2, 3, 4, 5, 6]->slice(1, 4)   // [2, 3, 4]
+[]->slice(2, 3)                   // []
+```
+
+**See also** `take(T[*], Integer[1]):T[*]`, `drop(T[*], Integer[1]):T[*]`,
+`at(T[*], Integer[1]):T[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::collection::slice<T>(set:T[*], start:Integer[1], end:Integer[1]):T[*];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/slice/take.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/slice/take.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The first `count` elements of a collection.
+
+Out-of-range counts are clamped rather than rejected: a negative or zero `count` yields an empty
+collection, and a `count` beyond the end yields the whole collection.
+
+**Parameters**
+- `set` — the collection to take from.
+- `count` — how many leading elements to keep.
+
+**Returns** the first `count` elements, or fewer if the collection is shorter.
+
+**Examples**
+```pure
+[1, 2, 3]->take(2)    // [1, 2]
+[1, 2, 3]->take(0)    // []
+[1, 2, 3]->take(-1)   // []
+[1, 2, 3]->take(10)   // [1, 2, 3]
+```
+
+**See also** `drop(T[*], Integer[1]):T[*]`,
+`slice(T[*], Integer[1], Integer[1]):T[*]`
+'''
 native function <<PCT.function>> meta::pure::functions::collection::take<T>(set:T[*], count:Integer[1]):T[*];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::take::testTakeNegativeOnEmptyList<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/transformation/add.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/transformation/add.pure
@@ -14,13 +14,45 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Inserts a value into a collection at a given position, returning a new collection.
+
+The input is not modified — Pure collections are immutable, so the original is unchanged and the
+result is a new collection. `offset` is zero-based: `0` places the value at the front, and the
+collection's size places it at the end.
+
+The `[1..*]` result records that the outcome always holds at least the inserted value.
+
+**Parameters**
+- `set` — the collection to insert into.
+- `offset` — zero-based position at which the value should appear.
+- `val` — the value to insert.
+
+**Returns** a new collection with `val` at `offset`.
+
+**Examples**
+```pure
+['a', 'b']->add(0, 'c')   // ['c', 'a', 'b']
+['a', 'b']->add(1, 'c')   // ['a', 'c', 'b']
+```
+
+**See also** `add(T[*], T[1]):T[1..*]`,
+`concatenate(T[*], T[*]):T[*]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::collection::add<T>(set:T[*], offset:Integer[1], val:T[1]):T[1..*];
 
+'''
+Appends a value to the end of a collection, returning a new collection.
+
+Equivalent to inserting at the collection's size. The original is unchanged.
+
+**Examples**
+```pure
+['a', 'b']->add('c')   // ['a', 'b', 'c']
+```
+'''
 native function <<PCT.function>> meta::pure::functions::collection::add<T>(set:T[*], val:T[1]):T[1..*];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::add::testAdd<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/transformation/concatenate.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/transformation/concatenate.pure
@@ -15,11 +15,30 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::collection::tests::model::*;
 
+'''
+Joins two collections end to end.
+
+Order is preserved: every element of `set1` comes before every element of `set2`. Duplicates are
+kept — nothing is de-duplicated.
+
+**Parameters**
+- `set1` — the leading collection.
+- `set2` — the collection appended to it.
+
+**Returns** the combined collection.
+
+**Examples**
+```pure
+concatenate([1, 2, 3], [4, 5])   // [1, 2, 3, 4, 5]
+concatenate([1], [])             // [1]
+```
+
+**See also** `add(T[*], T[1]):T[1..*]`,
+`removeDuplicates(T[*]):T[*]`,
+`zip(T[*], U[*]):Pair<T, U>[*]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::collection::concatenate<T>(set1:T[*], set2:T[*]):T[*];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::concatenate::testConcatenateSimple<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/transformation/removeAllOptimized.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/transformation/removeAllOptimized.pure
@@ -15,6 +15,28 @@
 import meta::pure::functions::collection::tests::removeAllOptimized::*;
 import meta::pure::test::pct::*;
 
+'''
+Removes from a collection every element that appears in another collection.
+
+Set difference, using a hash-based lookup rather than a scan, so it stays efficient when `other` is
+large. Elements are matched by equality — for classes carrying `<<equality.Key>>` properties, that
+means the key properties rather than object identity.
+
+**Parameters**
+- `set` — the collection to remove from.
+- `other` — the elements to remove.
+
+**Returns** the elements of `set` that do not appear in `other`.
+
+**Examples**
+```pure
+[1, 2, 3, 4]->removeAllOptimized([2, 4])   // [1, 3]
+[1, 2]->removeAllOptimized([])             // [1, 2]
+```
+
+**See also** `removeDuplicates(T[*]):T[*]`,
+`filter(T[*], Function<{T[1]->Boolean[1]}>[1]):T[*]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::collection::removeAllOptimized<T>(set:T[*], other:T[*]):T[*];
 
 Class meta::pure::functions::collection::tests::removeAllOptimized::TestClassWithEquality

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/transformation/removeDuplicates.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/transformation/removeDuplicates.pure
@@ -15,18 +15,66 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::collection::tests::removeDuplicates::*;
 
+'''
+Removes duplicate elements from a collection, optionally comparing by a derived key and optionally
+with a custom equality function.
+
+**The order of the result is unspecified** — sort afterwards if you need a stable order.
+
+This is the most general form; the shorter overloads delegate to it. Both function arguments are
+`[0..1]`, so passing `[]` for either falls back to the default: elements are compared directly when
+no `key` is given, and with the default equality when no `eql` is given. When a `key` is supplied,
+duplicates are decided by comparing keys rather than elements.
+
+Of any group of duplicates, the first one encountered is the one kept.
+
+**Parameters**
+- `col` — the collection to de-duplicate.
+- `key` — derives the value to compare on, or `[]` to compare elements directly.
+- `eql` — compares two elements (or two keys), or `[]` for the default equality.
+
+**Returns** the collection with duplicates removed, in unspecified order.
+
+**Examples**
+```pure
+[1, 2, 1, 3]->removeDuplicates([], [])                  // [1, 2, 3]
+[1, '1', 2]->removeDuplicates([], {a, b | $a->toString() == $b->toString()})   // [1, 2]
+```
+
+**See also** `removeDuplicates(T[*]):T[*]`,
+`removeDuplicatesBy(T[*], Function<{T[1]->Any[1]}>[1]):T[*]`,
+`sort(T[m]):T[m]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc='Returns a collection of elements with duplicates removed. The order of elements is unspecified. If a key function is provided, it is used to compute the key for each element and duplicates are determined based on the keys. If an equality function is provided, it is used to compare elements (or keys if a key function is provided) for equality. If no equality function is provided, the default equality comparison is used.'
-    }
     meta::pure::functions::collection::removeDuplicates<T,V>(col:T[*], key:Function<{T[1]->V[1]}>[0..1], eql:Function<{V[1],V[1]->Boolean[1]}>[0..1]):T[*];
 
+'''
+Removes duplicates using a custom equality function applied to the elements themselves.
+
+Equivalent to `removeDuplicates($col, [], $eql)`. The order of the result is unspecified.
+
+**Examples**
+```pure
+[1, '1', 2]->removeDuplicates({a, b | $a->toString() == $b->toString()})   // [1, 2]
+```
+'''
 function <<PCT.function>> meta::pure::functions::collection::removeDuplicates<T>(col:T[*], eql:Function<{T[1],T[1]->Boolean[1]}>[1]):T[*]
 {
     $col->removeDuplicates([], $eql)
 }
 
+'''
+Removes duplicates using the default equality.
+
+The common case; equivalent to `removeDuplicates($col, [], [])`. The order of the result is
+unspecified, so sort afterwards if order matters.
+
+**Examples**
+```pure
+[1, 2, 1, 3, 3]->removeDuplicates()->sort()   // [1, 2, 3]
+```
+'''
 function <<PCT.function>> meta::pure::functions::collection::removeDuplicates<T>(col:T[*]):T[*]
 {
     $col->removeDuplicates([], [])

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/transformation/removeDuplicatesBy.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/transformation/removeDuplicatesBy.pure
@@ -15,6 +15,30 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::collection::tests::removeDuplicates::*;
 
+'''
+Removes elements whose derived key has already been seen.
+
+Equivalent to `removeDuplicates($col, $key, [])`, and usually the most readable way to de-duplicate
+objects by one of their properties. Of any group sharing a key, the first encountered is kept.
+
+**The order of the result is unspecified** — sort afterwards if you need a stable order.
+
+**Parameters**
+- `col` — the collection to de-duplicate.
+- `key` — derives the value that decides equality.
+
+**Returns** the collection with key-duplicates removed.
+
+**Examples**
+```pure
+[1, 2, '1', '3', 1, 3]->removeDuplicatesBy({x | $x->toString()})       // [1, 2, '3']
+['hello', 'helloWorld', 'world']->removeDuplicatesBy(x:String[1] | $x->substring(0, 1))
+                                                                      // ['hello', 'world']
+```
+
+**See also** `removeDuplicates(T[*]):T[*]`,
+`meta::pure::functions::collection::groupBy(X[*], Function<{X[1]->K[1]}>[1]):Map<K, List<X>>[1]`
+'''
 function <<PCT.function>> meta::pure::functions::collection::removeDuplicatesBy<T>(col:T[*], key:Function<{T[1]->Any[1]}>[1]):T[*]
 {
     $col->removeDuplicates($key, [])

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/transformation/zip.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/collection/transformation/zip.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Pairs up two collections element by element.
+
+The result is as long as the *shorter* input — surplus elements of the longer one are discarded, so
+zipping against an empty collection gives an empty result. The two collections may hold different
+types.
+
+**Parameters**
+- `set1` — supplies the first element of each pair.
+- `set2` — supplies the second.
+
+**Returns** the pairs, in order.
+
+**Examples**
+```pure
+[1, 2, 3]->zip(['a', 'b', 'c'])   // [^Pair(1,'a'), ^Pair(2,'b'), ^Pair(3,'c')]
+[1, 2, 3]->zip(['a'])             // [^Pair(1,'a')]  -- truncated to the shorter
+[]->zip(['a', 'b'])               // []
+```
+
+**See also** `pair(U[1], V[1]):Pair<U, V>[1]`,
+`meta::pure::functions::collection::keyValues(Map<U, V>[1]):Pair<U, V>[*]`
+'''
 native function <<PCT.function>> meta::pure::functions::collection::zip<T,U>(set1:T[*], set2:U[*]):Pair<T,U>[*];
 
 function <<PCT.test>> meta::pure::functions::collection::tests::zip::testZipBothListsEmpty<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/creation/date.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/creation/date.pure
@@ -15,11 +15,72 @@
 import meta::pure::test::pct::*;
 
 // Functions for constructing dates
+'''
+Builds a date from its numeric components.
+
+Use this when the components are computed at runtime; write a literal such as `%2015-04-15` when they are
+known. **How many arguments you pass decides both the granularity and the resulting type**, which is why
+there are six overloads:
+
+| Arguments | Result type |
+|---|---|
+| year | `Date` |
+| year, month | `Date` |
+| year, month, day | `StrictDate` — a date with no time |
+| year, month, day, hour (and beyond) | `DateTime` |
+
+Components are validated, so an out-of-range value fails rather than rolling over: month `13` gives
+`Invalid month: 13` rather than becoming January of the next year.
+
+**Parameters**
+- `year` — the year.
+
+**Returns** a date with year granularity.
+
+**Examples**
+```pure
+date(2015)                       // %2015
+date(2016, 13)                   // fails: Invalid month: 13
+date(2016, 12, 32)               // fails: Invalid day: 2016-12-32
+date(2016, 12, 31, 24)           // fails: Invalid hour: 24
+```
+
+**See also** `date(Integer[1], Integer[1], Integer[1]):StrictDate[1]`,
+`adjust(Date[1], Integer[1], DurationUnit[1]):Date[1]`,
+`meta::pure::functions::string::parseDate(String[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::date(year:Integer[1]):Date[1];
+'''
+Builds a date with year and month granularity, as `Date`.
+
+The month is validated: a value outside 1 to 12 fails rather than rolling into an adjacent year.
+'''
 native function <<PCT.function>> meta::pure::functions::date::date(year:Integer[1], month:Integer[1]):Date[1];
+'''
+Builds a calendar day, as `StrictDate` — a date that carries no time component.
+
+The narrower return type is the point: `StrictDate` states in the type system that there is no
+time-of-day, so `hasHour(Date[1]):Boolean[1]` is false and `hour(Date[1]):Integer[1]` would fail. The day
+is validated against the month and year, so 29 February is accepted only in a leap year.
+'''
 native function <<PCT.function>> meta::pure::functions::date::date(year:Integer[1], month:Integer[1], day:Integer[1]):StrictDate[1];
+'''
+Builds an instant with hour granularity, as `DateTime`.
+
+The hour is on a 24-hour clock and validated to 0 through 23, so `24` fails rather than becoming midnight
+of the following day.
+'''
 native function <<PCT.function>> meta::pure::functions::date::date(year:Integer[1], month:Integer[1], day:Integer[1], hour:Integer[1]):DateTime[1];
+'''
+Builds an instant with minute granularity, as `DateTime`.
+'''
 native function <<PCT.function>> meta::pure::functions::date::date(year:Integer[1], month:Integer[1], day:Integer[1], hour:Integer[1], minute:Integer[1]):DateTime[1];
+'''
+Builds an instant with second or sub-second granularity, as `DateTime`.
+
+`second` is a `Number`, not an `Integer`, so a fractional value carries sub-second precision — `21.398`
+gives the same instant as the literal `%…T…:21.398`, and `hasSubsecond(Date[1]):Boolean[1]` is then true.
+'''
 native function <<PCT.function>> meta::pure::functions::date::date(year:Integer[1], month:Integer[1], day:Integer[1], hour:Integer[1], minute:Integer[1], second:Number[1]):DateTime[1];
 
 
@@ -68,7 +129,7 @@ function <<PCT.test>> meta::pure::functions::date::tests::testDateFromSubSecond<
 
 function <<PCT.test>> meta::pure::functions::date::tests::testNewDateError<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
-    assertError(| $f->eval(|date(2016, 13)), 'Invalid month: 13', 71, 29);
-    assertError(| $f->eval(|date(2016, 12, 32)), 'Invalid day: 2016-12-32', 72, 29);
-    assertError(| $f->eval(|date(2016, 12, 31, 24)), 'Invalid hour: 24', 73, 29);
+    assertError(| $f->eval(|date(2016, 13)), 'Invalid month: 13', 132, 29);
+    assertError(| $f->eval(|date(2016, 12, 32)), 'Invalid day: 2016-12-32', 133, 29);
+    assertError(| $f->eval(|date(2016, 12, 31, 24)), 'Invalid hour: 24', 134, 29);
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/datePart.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/datePart.pure
@@ -15,6 +15,31 @@
 import meta::pure::test::pct::*;
 
 // Returns the date part of a date, i.e., the year, month, and day. For dates that are month or year precision, the date is returned unchanged.
+'''
+A date with any time-of-day component removed.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. The **granularity of the date portion is preserved**, so `%1973-11` comes back as `%1973-11`
+rather than being padded to a day. Only the time is dropped; a date that already has no time is returned
+unchanged.
+
+Useful for grouping timestamps by day, since two instants on the same day share a `datePart`.
+
+**Parameters**
+- `d` — the date to truncate.
+
+**Returns** the date without its time component.
+
+**Examples**
+```pure
+%1973-11-05T13:01:25->datePart()             // %1973-11-05
+%2015-08-29T22:22:22.9914234->datePart()     // %2015-08-29
+%1973-11-05->datePart()                      // %1973-11-05
+%1973-11->datePart()                         // %1973-11   -- granularity kept
+```
+
+**See also** `hasHour(Date[1]):Boolean[1]`, `year(Date[1]):Integer[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::datePart(d:Date[1]):Date[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testDatePart<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/dayOfMonth.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/dayOfMonth.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The day-of-month component of a date, from 1 to 31.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. A date with no day — `%2015` or `%2015-04` — **fails rather than returning empty**, with an error
+such as `Cannot get day of month for 2017`. Guard with `hasDay(Date[1]):Boolean[1]` when the granularity
+is not known.
+
+**Parameters**
+- `d` — the date to read.
+
+**Returns** the day of the month.
+
+**Examples**
+```pure
+%2015-04-15->dayOfMonth()                  // 15
+%2015-04-15T17:09:21.398->dayOfMonth()     // 15
+%2017->dayOfMonth()                        // fails: Cannot get day of month for 2017
+```
+
+**See also** `hasDay(Date[1]):Boolean[1]`, `monthNumber(Date[1]):Integer[1]`,
+`datePart(Date[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::dayOfMonth(d:Date[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testDayOfMonth<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
@@ -27,5 +50,5 @@ function <<PCT.test>> meta::pure::functions::date::tests::testDayOfMonth<Z|y>(f:
 
 function <<PCT.test>> meta::pure::functions::date::tests::testDayOfMonthError<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
-    assertError(| $f->eval(|%2017->dayOfMonth()), 'Cannot get day of month for 2017', 30, 36);
+    assertError(| $f->eval(|%2017->dayOfMonth()), 'Cannot get day of month for 2017', 53, 36);
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/hour.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/hour.pure
@@ -14,6 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The hour component of a date.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. A date that carries no time — or a time less precise than the hour — **fails rather than
+returning empty**, with an error such as `Cannot get hour for 2017`. Guard with `hasHour(Date[1]):Boolean[1]`
+when the granularity is not known.
+
+**Parameters**
+- `d` — the date to read.
+
+**Returns** its hour.
+
+**Examples**
+```pure
+%2015-04-15T17:09:21.398->hour()
+%2017->hour()   // fails: Cannot get hour for 2017
+```
+
+**See also** `hasHour(Date[1]):Boolean[1]`, `datePart(Date[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::hour(d:Date[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testHour<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
@@ -26,5 +47,5 @@ function <<PCT.test>> meta::pure::functions::date::tests::testHour<Z|y>(f:Functi
 
 function <<PCT.test>> meta::pure::functions::date::tests::testHourError<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
-    assertError(| $f->eval(|%2017->hour()), 'Cannot get hour for 2017', 29, 36);
+    assertError(| $f->eval(|%2017->hour()), 'Cannot get hour for 2017', 50, 36);
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/minute.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/minute.pure
@@ -14,6 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The minute component of a date.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. A date that carries no time — or a time less precise than the minute — **fails rather than
+returning empty**, with an error such as `Cannot get minute for 2017`. Guard with `hasMinute(Date[1]):Boolean[1]`
+when the granularity is not known.
+
+**Parameters**
+- `d` — the date to read.
+
+**Returns** its minute.
+
+**Examples**
+```pure
+%2015-04-15T17:09:21.398->minute()
+%2017->minute()   // fails: Cannot get minute for 2017
+```
+
+**See also** `hasMinute(Date[1]):Boolean[1]`, `datePart(Date[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::minute(d:Date[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testMinute<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
@@ -25,5 +46,5 @@ function <<PCT.test>> meta::pure::functions::date::tests::testMinute<Z|y>(f:Func
 
 function <<PCT.test>> meta::pure::functions::date::tests::testMinuteError<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
-    assertError(| $f->eval(|%2017->minute()), 'Cannot get minute for 2017', 28, 36);
+    assertError(| $f->eval(|%2017->minute()), 'Cannot get minute for 2017', 49, 36);
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/monthNumber.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/monthNumber.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The month of a date, as a number from 1 to 12.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. A date with no month — a bare `%2015` — has no month to return, so **this fails rather than
+returning empty**. Guard with `hasMonth(Date[1]):Boolean[1]` when the granularity is not known.
+
+January is `1`, not `0`.
+
+**Parameters**
+- `d` — the date to read.
+
+**Returns** the month, 1 through 12.
+
+**Examples**
+```pure
+%2015-04->monthNumber()                    // 4
+%2015-04-15T17:09:21.398->monthNumber()    // 4
+```
+
+**See also** `hasMonth(Date[1]):Boolean[1]`, `year(Date[1]):Integer[1]`,
+`dayOfMonth(Date[1]):Integer[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::monthNumber(d:Date[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testMonthNumber<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/second.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/second.pure
@@ -14,6 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The second component of a date.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. A date that carries no time — or a time less precise than the second — **fails rather than
+returning empty**, with an error such as `Cannot get second for 2017`. Guard with `hasSecond(Date[1]):Boolean[1]`
+when the granularity is not known.
+
+**Parameters**
+- `d` — the date to read.
+
+**Returns** its second.
+
+**Examples**
+```pure
+%2015-04-15T17:09:21.398->second()
+%2017->second()   // fails: Cannot get second for 2017
+```
+
+**See also** `hasSecond(Date[1]):Boolean[1]`, `datePart(Date[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::second(d:Date[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testSecond<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
@@ -24,5 +45,5 @@ function <<PCT.test>> meta::pure::functions::date::tests::testSecond<Z|y>(f:Func
 
 function <<PCT.test>> meta::pure::functions::date::tests::testSecondError<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
-    assertError(| $f->eval(|%2017->second()), 'Cannot get second for 2017', 27, 36);
+    assertError(| $f->eval(|%2017->second()), 'Cannot get second for 2017', 48, 36);
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/year.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/extract/year.pure
@@ -14,6 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The year component of a date.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. Every date has a year, so this is the one extractor that never fails.
+
+**Parameters**
+- `d` — the date to read.
+
+**Returns** its year.
+
+**Examples**
+```pure
+%2015->year()                        // 2015
+%2015-04->year()                     // 2015
+%2015-04-15T17:09:21.398->year()     // 2015
+```
+
+**See also** `monthNumber(Date[1]):Integer[1]`, `dayOfMonth(Date[1]):Integer[1]`,
+`hasMonth(Date[1]):Boolean[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::year(d:Date[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testYear<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasDay.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasDay.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether a date carries a day of month component.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. Extractors such as `dayOfMonth` **fail** on a date that lacks the component they read, so
+this is the guard to call first when the granularity is not known — for example when the date came from
+parsing or from user input.
+
+True for `%2015-04-15` and anything more precise.
+
+**Parameters**
+- `d` — the date to test.
+
+**Returns** `true` when the day of month component is present.
+
+**Examples**
+```pure
+%2015-04-15T17:09:21.398->hasDay()
+%2015->hasDay()                       // false
+```
+
+**See also** `dayOfMonth(Date[1]):Integer[1]`, `datePart(Date[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::hasDay(d:Date[1]):Boolean[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testHasDay<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasHour.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasHour.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether a date carries a hour component.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. Extractors such as `hour` **fail** on a date that lacks the component they read, so
+this is the guard to call first when the granularity is not known — for example when the date came from
+parsing or from user input.
+
+True for `%2015-04-15T17` and anything more precise.
+
+**Parameters**
+- `d` — the date to test.
+
+**Returns** `true` when the hour component is present.
+
+**Examples**
+```pure
+%2015-04-15T17:09:21.398->hasHour()
+%2015->hasHour()                       // false
+```
+
+**See also** `hour(Date[1]):Integer[1]`, `datePart(Date[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::hasHour(d:Date[1]):Boolean[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testHasHour<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasMinute.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasMinute.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether a date carries a minute component.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. Extractors such as `minute` **fail** on a date that lacks the component they read, so
+this is the guard to call first when the granularity is not known — for example when the date came from
+parsing or from user input.
+
+True for `%2015-04-15T17:09` and anything more precise.
+
+**Parameters**
+- `d` — the date to test.
+
+**Returns** `true` when the minute component is present.
+
+**Examples**
+```pure
+%2015-04-15T17:09:21.398->hasMinute()
+%2015->hasMinute()                       // false
+```
+
+**See also** `minute(Date[1]):Integer[1]`, `datePart(Date[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::hasMinute(d:Date[1]):Boolean[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testHasMinute<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasMonth.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasMonth.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether a date carries a month component.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. Extractors such as `monthNumber` **fail** on a date that lacks the component they read, so
+this is the guard to call first when the granularity is not known — for example when the date came from
+parsing or from user input.
+
+True for `%2015-04` and anything more precise.
+
+**Parameters**
+- `d` — the date to test.
+
+**Returns** `true` when the month component is present.
+
+**Examples**
+```pure
+%2015-04-15T17:09:21.398->hasMonth()
+%2015->hasMonth()                       // false
+```
+
+**See also** `monthNumber(Date[1]):Integer[1]`, `datePart(Date[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::hasMonth(d:Date[1]):Boolean[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testHasMonth<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasSecond.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasSecond.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether a date carries a second component.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. Extractors such as `second` **fail** on a date that lacks the component they read, so
+this is the guard to call first when the granularity is not known — for example when the date came from
+parsing or from user input.
+
+True for `%2015-04-15T17:09:21` and anything more precise.
+
+**Parameters**
+- `d` — the date to test.
+
+**Returns** `true` when the second component is present.
+
+**Examples**
+```pure
+%2015-04-15T17:09:21.398->hasSecond()
+%2015->hasSecond()                       // false
+```
+
+**See also** `second(Date[1]):Integer[1]`, `datePart(Date[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::hasSecond(d:Date[1]):Boolean[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testHasSecond<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasSubsecond.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasSubsecond.pure
@@ -18,9 +18,8 @@ import meta::pure::test::pct::*;
 Whether a date carries a sub-second component.
 
 Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
-so on are all valid `Date` values, each knowing only as much as was written. Extractors such as `hasSubsecondWithAtLeastPrecision` **fail** on a date that lacks the component they read, so
-this is the guard to call first when the granularity is not known — for example when the date came from
-parsing or from user input.
+so on are all valid `Date` values, each knowing only as much as was written. This is the guard to call
+first when the granularity is not known — for example when the date came from parsing or from user input.
 
 True for a date written with a fractional second, such as `%2015-04-15T17:09:21.398`.
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasSubsecond.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasSubsecond.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether a date carries a sub-second component.
+
+Pure dates carry **variable granularity** — `%2015`, `%2015-04`, `%2015-04-15`, `%2015-04-15T17` and
+so on are all valid `Date` values, each knowing only as much as was written. Extractors such as `hasSubsecondWithAtLeastPrecision` **fail** on a date that lacks the component they read, so
+this is the guard to call first when the granularity is not known — for example when the date came from
+parsing or from user input.
+
+True for a date written with a fractional second, such as `%2015-04-15T17:09:21.398`.
+
+**Parameters**
+- `d` — the date to test.
+
+**Returns** `true` when the sub-second component is present.
+
+**Examples**
+```pure
+%2015-04-15T17:09:21.398->hasSubsecond()
+%2015->hasSubsecond()                       // false
+```
+
+**See also** `hasSubsecondWithAtLeastPrecision(Date[1], Integer[1]):Boolean[1]`, `datePart(Date[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::hasSubsecond(d:Date[1]):Boolean[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testHasSubsecond<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasSubsecondWithAtLeastPrecision.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/has/hasSubsecondWithAtLeastPrecision.pure
@@ -14,6 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether a date's fractional second is given to at least a number of decimal places.
+
+Stricter than `hasSubsecond(Date[1]):Boolean[1]`, which only asks whether *any* fractional second is
+present. Use this when downstream processing needs a minimum precision — millisecond, microsecond — and a
+coarser timestamp would silently lose information.
+
+`minPrecision` counts decimal places, so a date written `.398` satisfies 1, 2 and 3 but not 4.
+
+**Parameters**
+- `d` — the date to test.
+- `minPrecision` — the minimum number of fractional-second digits required.
+
+**Returns** `true` when the fractional second has at least that many digits.
+
+**Examples**
+```pure
+%2015-04-15T17:09:21.398->hasSubsecondWithAtLeastPrecision(3)   // true
+%2015-04-15T17:09:21.398->hasSubsecondWithAtLeastPrecision(4)   // false
+%2015-04-15T17:09:21->hasSubsecondWithAtLeastPrecision(1)       // false -- no fraction at all
+```
+
+**See also** `hasSubsecond(Date[1]):Boolean[1]`, `hasSecond(Date[1]):Boolean[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::hasSubsecondWithAtLeastPrecision(d:Date[1], minPrecision:Integer[1]):Boolean[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testHasSubsecondWithAtLeastPrecision<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/operation/adjust.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/operation/adjust.pure
@@ -14,6 +14,37 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Shifts a date by a number of duration units.
+
+A negative `number` moves backwards. The unit comes from the `DurationUnit` enumeration — `YEARS`,
+`MONTHS`, `WEEKS`, `DAYS`, `HOURS`, `MINUTES`, `SECONDS` and finer.
+
+**Out-of-range results are clamped to the end of the month rather than rolling over.** Adding one year to
+29 February 2012 gives 28 February 2013, because 2013 has no 29th; adding four years gives 29 February
+2016, which does. Calendar arithmetic, not fixed-length arithmetic — so adding `1, MONTHS` moves to the
+same day of the next month where possible, not forward by 30 days.
+
+The granularity of the input is preserved.
+
+**Parameters**
+- `date` — the date to shift.
+- `number` — how many units to add; negative moves backwards.
+- `unit` — the unit to shift by.
+
+**Returns** the shifted date.
+
+**Examples**
+```pure
+%2015->adjust(1, DurationUnit.YEARS)          // %2016
+%2015->adjust(-4, DurationUnit.YEARS)         // %2011
+%2012-02-29->adjust(1, DurationUnit.YEARS)    // %2013-02-28  -- clamped
+%2012-02-29->adjust(4, DurationUnit.YEARS)    // %2016-02-29  -- leap year
+```
+
+**See also** `dateDiff(Date[1], Date[1], DurationUnit[1]):Integer[1]`,
+`date(Integer[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::adjust(date:Date[1], number:Integer[1], unit:DurationUnit[1]):Date[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testAdjustByYears<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/operation/dateDiff.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/operation/dateDiff.pure
@@ -14,6 +14,40 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The number of duration-unit boundaries between two dates, signed.
+
+**This counts calendar boundaries crossed, not elapsed time** — the single most common source of surprise
+here. `%2016-02-01` to `%2016-02-29` is `0` months, because both fall in the same calendar month, even
+though they are 28 days apart. Conversely `%2015-12-31T23:59:59` to `%2016-01-01T00:00:01` is `1` year,
+two seconds apart, because a year boundary lies between them.
+
+If you need elapsed duration rather than boundaries crossed, difference in a finer unit and convert.
+
+The result is **signed and directional**: `$d1->dateDiff($d2, …)` is positive when `d2` is later, negative
+when earlier, and `0` for two dates in the same interval.
+
+**Parameters**
+- `d1` — the starting date.
+- `d2` — the ending date.
+- `du` — the unit whose boundaries are counted.
+
+**Returns** the signed number of boundaries from `d1` to `d2`.
+
+**Examples**
+```pure
+%2015->dateDiff(%2016, DurationUnit.YEARS)                    // 1
+%2016->dateDiff(%2015, DurationUnit.YEARS)                    // -1
+%2015->dateDiff(%2015, DurationUnit.YEARS)                    // 0
+%2016-02-01->dateDiff(%2016-02-29, DurationUnit.MONTHS)       // 0   -- same month
+%2016-02-01->dateDiff(%2016-03-01, DurationUnit.MONTHS)       // 1
+%2015-01-01T00:00:00->dateDiff(%2015-12-31T23:59:59, DurationUnit.YEARS)   // 0
+%2015-12-31T23:59:59->dateDiff(%2016-01-01T00:00:01, DurationUnit.YEARS)   // 1
+```
+
+**See also** `adjust(Date[1], Integer[1], DurationUnit[1]):Date[1]`,
+`datePart(Date[1]):Date[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::date::dateDiff(d1:Date[1], d2:Date[1], du:DurationUnit[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::date::tests::testDateDiffYears<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/operation/dateDiff.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/operation/dateDiff.pure
@@ -24,8 +24,10 @@ two seconds apart, because a year boundary lies between them.
 
 If you need elapsed duration rather than boundaries crossed, difference in a finer unit and convert.
 
-The result is **signed and directional**: `$d1->dateDiff($d2, …)` is positive when `d2` is later, negative
-when earlier, and `0` for two dates in the same interval.
+The result is **signed and directional**: `$d1->dateDiff($d2, …)` is positive when `d2` is later, zero or
+negative when earlier, and `0` for two dates in the same interval. Swapping the two dates does not always
+just flip the sign: `%2015-07-04->dateDiff(%2015-07-05, DurationUnit.WEEKS)` is `1`, while
+`%2015-07-05->dateDiff(%2015-07-04, DurationUnit.WEEKS)` is `0`.
 
 **Parameters**
 - `d1` — the starting date.

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/operation/dateDiff.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/date/operation/dateDiff.pure
@@ -20,9 +20,9 @@ The number of duration-unit boundaries between two dates, signed.
 **This counts calendar boundaries crossed, not elapsed time** — the single most common source of surprise
 here. `%2016-02-01` to `%2016-02-29` is `0` months, because both fall in the same calendar month, even
 though they are 28 days apart. Conversely `%2015-12-31T23:59:59` to `%2016-01-01T00:00:01` is `1` year,
-two seconds apart, because a year boundary lies between them.
+even though they are just two seconds apart, because a year boundary lies between them.
 
-If you need elapsed duration rather than boundaries crossed, difference in a finer unit and convert.
+If you need elapsed duration rather than boundaries crossed, compute the difference in a finer unit and then convert.
 
 The result is **signed and directional**: `$d1->dateDiff($d2, …)` is positive when `d2` is later, zero or
 negative when earlier, and `0` for two dates in the same interval. Swapping the two dates does not always

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/io/print.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/io/print.pure
@@ -14,8 +14,49 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Writes a value to standard output, following object references to a bounded depth.
+
+`max` limits how far object graphs are expanded: at depth `1` an object's own properties are shown but
+referenced objects are summarised rather than expanded. Raising it reveals more of the graph, at the
+cost of much larger output — and it is what stops a cyclic model printing forever.
+
+The return type is `Nil[0]`, meaning nothing: this is called for its side effect, so it cannot be used
+as a value. Intended for debugging, not for building output — use
+`meta::pure::functions::string::format(String[1], Any[*]):String[1]` to produce a string.
+
+Adds no trailing newline; use `println(Any[*], Integer[1]):Nil[0]` for that.
+
+**Parameters**
+- `param` — the values to write.
+- `max` — how many levels of object reference to expand.
+
+**Returns** nothing.
+
+**Examples**
+```pure
+print('hello', 1)
+print($person, 1)   // the person's own properties
+print($person, 3)   // and three levels of referenced objects
+```
+
+**See also** `println(Any[*], Integer[1]):Nil[0]`,
+`meta::pure::functions::string::toString(Any[1]):String[1]`,
+`meta::pure::functions::string::toRepresentation(Any[1]):String[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::io::print(param:Any[*], max:Integer[1]):Nil[0];
 
+'''
+Writes a value to standard output, expanding object references one level deep.
+
+Equivalent to `print($param, 1)`. Pass an explicit depth via
+`print(Any[*], Integer[1]):Nil[0]` when you need to see further into a graph.
+
+**Examples**
+```pure
+print('hello')
+```
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::io::print(param:Any[*]):Nil[0]
 {
     print($param, 1);

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/io/println.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/io/println.pure
@@ -14,12 +14,48 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Writes a value to standard output followed by a newline, following object references to a bounded
+depth.
+
+As `print(Any[*], Integer[1]):Nil[0]`, but terminates the line. `max` limits how far object graphs are
+expanded: at depth `1` an object's own properties are shown but referenced objects are summarised
+rather than expanded.
+
+The return type is `Nil[0]`, meaning nothing: this is called for its side effect, so it cannot be used
+as a value. Intended for debugging, not for building output.
+
+**Parameters**
+- `param` — the values to write.
+- `max` — how many levels of object reference to expand.
+
+**Returns** nothing.
+
+**Examples**
+```pure
+println('hello', 1)
+println($person, 3)   // three levels of referenced objects
+```
+
+**See also** `print(Any[*], Integer[1]):Nil[0]`,
+`meta::pure::functions::string::format(String[1], Any[*]):String[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::io::println(param:Any[*], max:Integer[1]):Nil[0]
 {
     print($param, $max);
     print('\n');
 }
 
+'''
+Writes a value and a newline to standard output, expanding object references one level deep.
+
+Equivalent to `println($param, 1)`, and the usual form for quick debugging output.
+
+**Examples**
+```pure
+println('hello')
+```
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::io::println(param:Any[*]):Nil[0]
 {
     println($param, 1);

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/cast/cast.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/cast/cast.pure
@@ -16,17 +16,19 @@ import meta::pure::test::pct::*;
 import meta::pure::functions::lang::tests::cast::*;
 
 '''
-Reinterprets a value as a more specific type.
+Reinterprets a value under a different declared type.
 
 The target type is given as a type literal, written `@Type`, rather than as a value. The cast is
 checked at runtime: if the value is not actually an instance of that type, execution fails rather
 than returning an empty result. Multiplicity is carried through unchanged, so casting a `[*]` gives
 a `[*]`.
 
-Casting narrows the *static* type so that subtype properties become reachable; it does not convert
-between unrelated types. For numeric conversion use
-`meta::pure::functions::math::toFloat(Number[1]):Float[1]` or
-`meta::pure::functions::math::toDecimal(Number[1]):Decimal[1]`.
+**A cast never changes the value — only its declared type.** Narrowing to a subtype is the common
+case, and is what makes subtype properties reachable, but a cast need not narrow: it may widen to a
+more general type, which is unusual but does happen, or move to a type bearing no direct relation to
+the declared one, which is useful because Pure supports multiple inheritance. Contrast the numeric
+conversions `meta::pure::functions::math::toFloat(Number[1]):Float[1]` and
+`meta::pure::functions::math::toDecimal(Number[1]):Decimal[1]`, which do change the value.
 
 **Parameters**
 - `source` — the value to reinterpret.

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/cast/cast.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/cast/cast.pure
@@ -15,6 +15,35 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::lang::tests::cast::*;
 
+'''
+Reinterprets a value as a more specific type.
+
+The target type is given as a type literal, written `@Type`, rather than as a value. The cast is
+checked at runtime: if the value is not actually an instance of that type, execution fails rather
+than returning an empty result. Multiplicity is carried through unchanged, so casting a `[*]` gives
+a `[*]`.
+
+Casting narrows the *static* type so that subtype properties become reachable; it does not convert
+between unrelated types. For numeric conversion use
+`meta::pure::functions::math::toFloat(Number[1]):Float[1]` or
+`meta::pure::functions::math::toDecimal(Number[1]):Decimal[1]`.
+
+**Parameters**
+- `source` — the value to reinterpret.
+- `object` — a type literal, `@Type`, naming the target type.
+
+**Returns** the same value, typed as `T`.
+
+**Examples**
+```pure
+$anyValue->cast(@Person).firstName    // reach a Person property
+1->cast(@P8)                          // narrow to a Primitive extension
+```
+
+**See also** `match(Any[*], Function<{Nil[n]->T[m]}>[1..*]):T[m]`,
+`toMultiplicity(T[*], Any[z]):T[z]`,
+`meta::pure::functions::meta::instanceOf(Any[1], Type[1]):Boolean[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::lang::cast<T|m>(source:Any[m], object:T[1]):T[m];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/cast/toDecimal.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/cast/toDecimal.pure
@@ -14,6 +14,31 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Converts any number to a `Decimal`.
+
+Accepts `Integer`, `Float` and `Decimal`. `Decimal` is exact base-10 arithmetic, so this is the
+conversion to reach for with monetary amounts and anywhere rounding error is unacceptable. Note that
+converting *from* `Float` cannot recover precision the float has already lost — parse or construct as
+`Decimal` from the outset when exactness matters.
+
+Decimal literals are written with a `D` suffix, as in `3.8D`.
+
+**Parameters**
+- `number` — the value to convert.
+
+**Returns** the value as a `Decimal`.
+
+**Examples**
+```pure
+toDecimal(8)      // 8D
+toDecimal(3.8)    // 3.8D
+toDecimal(3.8D)   // 3.8D
+```
+
+**See also** `meta::pure::functions::math::toFloat(Number[1]):Float[1]`,
+`meta::pure::functions::string::parseDecimal(String[1]):Decimal[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::toDecimal(number: Number[1]): Decimal[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::toDecimal::testDoubleToDecimal<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/cast/toFloat.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/cast/toFloat.pure
@@ -14,6 +14,28 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Converts any number to a `Float`.
+
+Accepts `Integer`, `Float` and `Decimal`. Because `Float` is binary floating point, converting from
+`Decimal` may lose precision — a decimal that cannot be represented exactly is rounded to the nearest
+representable float. Convert in the other direction, or stay in `Decimal`, when exactness matters.
+
+**Parameters**
+- `number` — the value to convert.
+
+**Returns** the value as a `Float`.
+
+**Examples**
+```pure
+toFloat(8)      // 8.0
+toFloat(3.8)    // 3.8
+toFloat(3.8D)   // 3.8   -- from Decimal; may round
+```
+
+**See also** `meta::pure::functions::math::toDecimal(Number[1]):Decimal[1]`,
+`meta::pure::functions::string::parseFloat(String[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::toFloat(number: Number[1]): Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::toFloat::testDoubleToFloat<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/cast/toMultiplicity.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/cast/toMultiplicity.pure
@@ -15,17 +15,20 @@
 import meta::pure::test::pct::*;
 
 '''
-Narrows a collection's multiplicity, checking the size at runtime.
+Reinterprets a collection under a different declared multiplicity, checking the size at runtime.
 
 The target multiplicity is given as a multiplicity literal, written `@[1]`, `@[0..1]`, `@[1..*]` and
-so on. Where `cast(Any[m], T[1]):T[m]` narrows the *type* and leaves multiplicity alone, this narrows
-the *multiplicity* and leaves the type alone.
+so on. Where `cast(Any[m], T[1]):T[m]` changes the declared *type* and leaves multiplicity alone,
+this changes the declared *multiplicity* and leaves the type alone.
+
+**The values themselves never change — only the declared multiplicity.** Narrowing is the common
+case, but it need not be a narrowing: the target may equally be the same multiplicity or a wider one.
 
 The check is enforced: a collection whose size does not fit the target fails with
 `Cannot cast a collection of size N to multiplicity [BOUNDS]` rather than being truncated or padded.
 
 **Parameters**
-- `source` — the collection to narrow.
+- `source` — the collection to reinterpret.
 - `object` — a multiplicity literal, `@[…]`, naming the target multiplicity.
 
 **Returns** the same values, with multiplicity `z`.

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/cast/toMultiplicity.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/cast/toMultiplicity.pure
@@ -14,6 +14,31 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Narrows a collection's multiplicity, checking the size at runtime.
+
+The target multiplicity is given as a multiplicity literal, written `@[1]`, `@[0..1]`, `@[1..*]` and
+so on. Where `cast(Any[m], T[1]):T[m]` narrows the *type* and leaves multiplicity alone, this narrows
+the *multiplicity* and leaves the type alone.
+
+The check is enforced: a collection whose size does not fit the target fails with
+`Cannot cast a collection of size N to multiplicity [BOUNDS]` rather than being truncated or padded.
+
+**Parameters**
+- `source` — the collection to narrow.
+- `object` — a multiplicity literal, `@[…]`, naming the target multiplicity.
+
+**Returns** the same values, with multiplicity `z`.
+
+**Examples**
+```pure
+['a']->toMultiplicity(@[1])        // 'a', now typed [1]
+['a', 'b']->toMultiplicity(@[1])   // fails: size 2 does not fit [1]
+```
+
+**See also** `cast(Any[m], T[1]):T[m]`,
+`meta::pure::functions::multiplicity::toOne(T[*]):T[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::toMultiplicity<T|z>(source:T[*], object:Any[z]):T[z];
 
 // ----------------------------------------------------------------------------

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/creation/dynamicNew.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/creation/dynamicNew.pure
@@ -21,11 +21,74 @@ Class meta::pure::functions::lang::KeyValue
     value : Any[*];
 }
 
+'''
+Creates an instance of a class chosen at runtime, with its properties supplied as name/value pairs.
+
+The reflective counterpart of the `^Class(prop=…)` literal. Use it when the class or the set of
+properties is not known when the code is written — generic deserialization, data-driven construction,
+tooling. Prefer `^Class(…)` whenever the shape *is* known, since that form is type-checked at compile
+time while this one is not.
+
+Properties are given as `KeyValue` objects pairing a property name with its value, so a property that
+holds a collection simply takes a collection as its `value`. Names not matching a property of the
+class, or values of the wrong type, fail at runtime.
+
+The result is typed `Any[1]`, so callers normally `cast` it to the expected class.
+
+**Parameters**
+- `class` — the class to instantiate.
+- `keyExpressions` — the property values, as name/value pairs.
+
+**Returns** the new instance, as `Any[1]`.
+
+**Examples**
+```pure
+dynamicNew(D_A, [^KeyValue(key='a', value='hello')])->cast(@D_A).a   // 'hello'
+```
+
+**See also** `dynamicNew(GenericType[1], KeyValue[*]):Any[1]`,
+`cast(Any[m], T[1]):T[m]`,
+`meta::pure::functions::meta::newUnit(Unit[1], Number[1]):Any[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::dynamicNew(class:Class<Any>[1], keyExpressions:KeyValue[*]):Any[1];
+
+'''
+As `dynamicNew(Class<Any>[1], KeyValue[*]):Any[1]`, but takes a `GenericType` so that type arguments
+can be supplied.
+
+Use this for a generic class, where naming the class alone would leave its parameters unbound.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::dynamicNew(genericType:GenericType[1], keyExpressions:KeyValue[*]):Any[1];
+'''
+As `dynamicNew(Class<Any>[1], KeyValue[*]):Any[1]`, but the instance intercepts property reads and
+manages its own constraints.
+
+The two getter-override functions are called instead of reading stored state — one for `[0..1]`
+properties, one for `[*]` — which is how lazily-loaded or computed instances are built. `hiddenPayload`
+carries arbitrary state for those overrides to consult without being a property of the class, and
+`constraintsManager` replaces the default constraint checking. Every override is `[0..1]`, so pass `[]`
+for any you do not need.
+
+`rawEvalProperty(Property<Nil, V|m>[1], Any[1]):V[m]` reads past these overrides when the stored value
+is what you want.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::dynamicNew(class:Class<Any>[1], keyExpressions:KeyValue[*], getterOverrideToOne:Function<{Any[1],Property<Nil,Any|0..1>[1]->Any[0..1]}>[0..1], getterOverrideToMany : Function<{Any[1],Property<Nil,Any|*>[1]->Any[*]}>[0..1], hiddenPayload:Any[0..1],constraintsManager:Function<{Any[1]->Any[1]}>[0..1]):Any[1];
+
+'''
+As `dynamicNew(Class<Any>[1], KeyValue[*], Function<{Any[1], Property<Nil, Any|0..1>[1]->Any[0..1]}>[0..1], Function<{Any[1], Property<Nil, Any|*>[1]->Any[*]}>[0..1], Any[0..1], Function<{Any[1]->Any[1]}>[0..1]):Any[1]`,
+but takes a `GenericType` so type arguments can be supplied.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::dynamicNew(genericType:GenericType[1], keyExpressions:KeyValue[*], getterOverrideToOne:Function<{Any[1],Property<Nil,Any|0..1>[1]->Any[0..1]}>[0..1], getterOverrideToMany : Function<{Any[1],Property<Nil,Any|*>[1]->Any[*]}>[0..1], hiddenPayload:Any[0..1],constraintsManager:Function<{Any[1]->Any[1]}>[0..1]):Any[1];
+
+'''
+As the six-argument form, but leaves constraint checking at its default — supply the getter overrides
+and `hiddenPayload` only.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::dynamicNew(class:Class<Any>[1], keyExpressions:KeyValue[*], getterOverrideToOne:Function<{Any[1],Property<Nil,Any|0..1>[1]->Any[0..1]}>[0..1], getterOverrideToMany : Function<{Any[1],Property<Nil,Any|*>[1]->Any[*]}>[0..1], hiddenPayload:Any[0..1]):Any[1];
+
+'''
+As the five-argument `Class` form, but takes a `GenericType` so type arguments can be supplied.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::dynamicNew(genericType:GenericType[1], keyExpressions:KeyValue[*], getterOverrideToOne:Function<{Any[1],Property<Nil,Any|0..1>[1]->Any[0..1]}>[0..1], getterOverrideToMany : Function<{Any[1],Property<Nil,Any|*>[1]->Any[*]}>[0..1], hiddenPayload:Any[0..1]):Any[1];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/eval/eval.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/eval/eval.pure
@@ -15,20 +15,68 @@
 import meta::pure::functions::lang::tests::eval::*;
 import meta::pure::test::pct::*;
 
+'''
+Calls a function value, supplying its arguments.
+
+Functions are first-class in Pure: a lambda such as `{x | $x + 1}`, a zero-argument thunk written
+`|expression`, or a reference to a named function can all be held in a variable and invoked later
+with `eval`. This overload takes no arguments and so evaluates a thunk.
+
+There is one overload per arity, up to seven arguments; the compiler selects the one matching the
+number of arguments you pass. The argument types and multiplicities must match the function's
+signature, and the result carries the function's own return type and multiplicity.
+
+**Parameters**
+- `func` — the function to call.
+
+**Returns** whatever `func` returns.
+
+**Examples**
+```pure
+{|1 + 1}->eval()                       // 2
+{x | $x + 1}->eval(5)                  // 6
+{x, y | $x + $y}->eval(1, 2)           // 3
+length_String_1__Integer_1_->eval('hello')   // 5 -- a named function reference
+```
+
+**See also** `evaluate(Function<Any>[1], List<Any>[*]):Any[*]`,
+`meta::pure::functions::collection::map(T[m], Function<{T[1]->V[1]}>[1]):V[m]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::eval<V|m>(func:Function<{->V[m]}>[1]):V[m];
 
+'''
+Calls a function taking one argument. See `eval(Function<{->V[m]}>[1]):V[m]` for details.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::eval<T,V|m,n>(func:Function<{T[n]->V[m]}>[1], param:T[n]):V[m];
 
+'''
+Calls a function taking two arguments. See `eval(Function<{->V[m]}>[1]):V[m]` for details.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::eval<T,U,V|m,n,p>(func:Function<{T[n],U[p]->V[m]}>[1], param1:T[n], param2:U[p]):V[m];
 
+'''
+Calls a function taking three arguments. See `eval(Function<{->V[m]}>[1]):V[m]` for details.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::eval<T,U,V,W|m,n,p,q>(func:Function<{T[n],U[p],W[q]->V[m]}>[1], param1:T[n], param2:U[p], param3:W[q]):V[m];
 
+'''
+Calls a function taking four arguments. See `eval(Function<{->V[m]}>[1]):V[m]` for details.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::eval<T,U,V,W,X|m,n,p,q,r>(func:Function<{T[n],U[p],W[q],X[r]->V[m]}>[1], param1:T[n], param2:U[p], param3:W[q], param4:X[r]):V[m];
 
+'''
+Calls a function taking five arguments. See `eval(Function<{->V[m]}>[1]):V[m]` for details.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::eval<T,U,V,W,X,Y|m,n,p,q,r,s>(func:Function<{T[n],U[p],W[q],X[r],Y[s]->V[m]}>[1], param1:T[n], param2:U[p], param3:W[q], param4:X[r], param5:Y[s]):V[m];
 
+'''
+Calls a function taking six arguments. See `eval(Function<{->V[m]}>[1]):V[m]` for details.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::eval<T,U,V,W,X,Y,Z|m,n,p,q,r,s,t>(func:Function<{T[n],U[p],W[q],X[r],Y[s],Z[t]->V[m]}>[1], param1:T[n], param2:U[p], param3:W[q], param4:X[r], param5:Y[s], param6:Z[t]):V[m];
 
+'''
+Calls a function taking seven arguments. See `eval(Function<{->V[m]}>[1]):V[m]` for details.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::eval<S,T,V,U,W,X,Y,Z|m,n,o,p,q,r,s,t>(func:Function<{S[n],T[o],U[p],W[q],X[r],Y[s],Z[t]->V[m]}>[1], param1:S[n], param2:T[o], param3:U[p], param4:W[q], param5:X[r], param6:Y[s], param7:Z[t]):V[m];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/eval/evaluate.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/eval/evaluate.pure
@@ -15,6 +15,32 @@
 import meta::pure::functions::lang::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+Calls a function whose arity is not known until runtime, passing its arguments as a collection.
+
+Where `eval(Function<{->V[m]}>[1]):V[m]` has a separate overload per arity and checks argument types
+at compile time, this takes the arguments as `List` objects and so accepts any number of them. Reach
+for it only when the arity genuinely varies — reflection over `Function` values, or generic
+dispatch — and prefer `eval` otherwise, since `eval` keeps its type checking.
+
+Each argument is wrapped in a `List`, which is what allows an argument to itself be a collection. The
+result is `Any[*]`, so the caller usually casts it to the expected type.
+
+**Parameters**
+- `func` — the function to call.
+- `params` — one `List` per argument, in order.
+
+**Returns** whatever `func` returns, as `Any[*]`.
+
+**Examples**
+```pure
+$someFunction->evaluate([list('a'), list(1)])
+```
+
+**See also** `eval(Function<{->V[m]}>[1]):V[m]`,
+`meta::pure::functions::collection::list(U[*]):List<U>[1]`,
+`cast(Any[m], T[1]):T[m]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::evaluate(func:Function<Any>[1], params:List<Any>[*]):Any[*];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/eval/rawEvalProperty.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/eval/rawEvalProperty.pure
@@ -14,5 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Reads a property off an object, bypassing any getter override.
+
+`eval` on a `Property` respects overrides that the object may carry, so a value can be computed or
+substituted rather than read. This function ignores that machinery and returns the stored value
+directly, which is why it is "raw".
+
+Use it when you need the underlying state — serialization, diffing, or diagnosing an override — and
+`eval` otherwise, since normal reads should honour overrides.
+
+**Parameters**
+- `p` — the property to read.
+- `a` — the object to read it from.
+
+**Returns** the property's stored value.
+
+**Examples**
+```pure
+$myProperty->rawEvalProperty($object)
+```
+
+**See also** `eval(Function<{T[n]->V[m]}>[1], T[n]):V[m]`,
+`evaluate(Function<Any>[1], List<Any>[*]):Any[*]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::rawEvalProperty<V|m>(p:Property<Nil,V|m>[1], a:Any[1]):V[m];
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/flow/if.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/flow/if.pure
@@ -14,13 +14,54 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Chooses between two values according to a condition.
+
+Both branches are passed as zero-argument functions, written `|expression`, so **only the chosen
+branch is evaluated**. That laziness is the point: the untaken branch may safely be expensive, or
+invalid for the current data.
+
+Both branches must share a type and multiplicity, which becomes the result's.
+
+**Parameters**
+- `test` — the condition.
+- `valid` — evaluated when `test` is true.
+- `invalid` — evaluated when `test` is false.
+
+**Returns** the value of whichever branch was taken.
+
+**Examples**
+```pure
+if(true, |'yes', |'no')                         // 'yes'
+if($x->isEmpty(), |0, |$x->toOne())             // the second branch is never evaluated when empty
+```
+
+**See also** `if(Pair<Function<{->Boolean[1]}>, Function<{->T[m]}>>[*], Function<{->T[m]}>[1]):T[m]`,
+`match(Any[*], Function<{Nil[n]->T[m]}>[1..*]):T[m]`,
+`meta::pure::functions::collection::filter(T[*], Function<{T[1]->Boolean[1]}>[1]):T[*]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::lang::if<T|m>(test:Boolean[1], valid:Function<{->T[m]}>[1], invalid:Function<{->T[m]}>[1]):T[m];
 
+'''
+Chooses among many conditions, returning the value for the first that holds — an if/else-if chain.
+
+Each pair couples a condition with the value to use when it is true. The conditions are tested in
+order and evaluation stops at the first match; `last` supplies the fallback when none match. As with
+the two-branch form, everything is lazy, so only the matching branch is evaluated.
+
+**Parameters**
+- `condList` — condition/value pairs, tested in order.
+- `last` — the fallback when no condition holds.
+
+**Returns** the value paired with the first true condition, or `last`.
+
+**Examples**
+```pure
+if([pair(|$n < 0, |'negative'), pair(|$n == 0, |'zero')], |'positive')
+```
+'''
 function <<PCT.function>> meta::pure::functions::lang::if<T|m>(condList:Pair<Function<{->Boolean[1]}>, Function<{->T[m]}>>[*], last:Function<{->T[m]}>[1]):T[m]
 {
   let matchCond = $condList->find(f|$f.first->eval());

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/flow/match.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/flow/match.pure
@@ -17,13 +17,59 @@ import meta::pure::functions::lang::tests::match::*;
 import meta::pure::functions::lang::tests::model::*;
 
 
+'''
+Dispatches on the runtime type of a value, choosing the first branch whose parameter type it fits.
+
+Each branch is a one-argument lambda whose parameter type declares what it handles, as in
+`s:String[1] | …`. Branches are tried **in declaration order**, so put more specific types before
+more general ones — a leading `a:Any[1]` branch would swallow everything after it.
+
+Prefer this to a chain of `instanceOf` tests and casts: the matched value arrives already typed, so
+its properties are directly reachable. Matching also dispatches on multiplicity, which is why a
+branch may be declared `[*]` or `[0..1]` to catch collection or empty cases.
+
+If no branch matches, execution fails; add a final `Any` branch to make the fallback explicit.
+
+**Parameters**
+- `var` — the value to dispatch on.
+- `functions` — the candidate branches, tried in order.
+
+**Returns** the value produced by the matching branch.
+
+**Examples**
+```pure
+$value->match([
+  s:String[1]  | 'string: ' + $s,
+  i:Integer[1] | 'int: ' + $i->toString(),
+  a:Any[1]     | 'something else'
+])
+```
+
+**See also** `match(Any[*], Function<{Nil[n], P[o]->T[m]}>[1..*], P[o]):T[m]`,
+`if(Boolean[1], Function<{->T[m]}>[1], Function<{->T[m]}>[1]):T[m]`,
+`cast(Any[m], T[1]):T[m]`,
+`meta::pure::functions::meta::instanceOf(Any[1], Type[1]):Boolean[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::lang::match<T|m,n>(var:Any[*], functions:Function<{Nil[n]->T[m]}>[1..*]):T[m];
 
+'''
+As `match(Any[*], Function<{Nil[n]->T[m]}>[1..*]):T[m]`, but threads an extra value through to every
+branch.
+
+Each branch takes two parameters — the matched value and `with` — which lets the branches share
+context without capturing it from the enclosing scope. Useful when the branch bodies are defined
+elsewhere, or when the same set of branches is reused with different context.
+
+**Examples**
+```pure
+$value->match([
+  {s:String[1],  prefix:String[1] | $prefix + $s},
+  {i:Integer[1], prefix:String[1] | $prefix + $i->toString()}
+], 'value: ')
+```
+'''
 native function <<PCT.function>> meta::pure::functions::lang::match<T,P|m,n,o>(var:Any[*], functions:Function<{Nil[n],P[o]->T[m]}>[1..*], with:P[o]):T[m];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/unit/getUnitValue.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/unit/getUnitValue.pure
@@ -15,6 +15,29 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+Extracts the plain magnitude from a unit-carrying value, discarding the unit.
+
+The inverse of `meta::pure::functions::meta::newUnit(Unit[1], Number[1]):Any[1]`. No conversion is
+performed — the number returned is the one the value was created with, in its own unit, so a value in
+`Cubitum` yields its Cubitum magnitude rather than a canonical one.
+
+Because the unit is dropped, mixing results from different units silently discards the distinction;
+convert first if the values are not already in the same unit.
+
+**Parameters**
+- `unit` — the unit-carrying value.
+
+**Returns** its magnitude, keeping the original numeric type.
+
+**Examples**
+```pure
+getUnitValue(5 RomanLength~Pes)           // 5
+getUnitValue(10.5D RomanLength~Cubitum)   // 10.5D
+```
+
+**See also** `meta::pure::functions::meta::newUnit(Unit[1], Number[1]):Any[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::getUnitValue(unit:Any[1]):Number[1];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/unit/newUnit.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/lang/unit/newUnit.pure
@@ -15,6 +15,30 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+Builds a unit-carrying value from a unit and a plain number.
+
+The programmatic equivalent of the literal form `5 RomanLength~Pes`. A unit is referenced as
+`Measure~Unit`, so `RomanLength~Pes` names the `Pes` unit of the `RomanLength` measure. Use this when
+the unit is chosen at runtime and cannot be written as a literal.
+
+The magnitude keeps the numeric type it was given, so passing a `Decimal` yields a decimal-valued
+quantity.
+
+**Parameters**
+- `type` — the unit, written `Measure~Unit`.
+- `value` — the magnitude.
+
+**Returns** the value in that unit.
+
+**Examples**
+```pure
+newUnit(RomanLength~Pes, 5)            // 5 RomanLength~Pes
+newUnit(RomanLength~Cubitum, 10.5D)    // 10.5D RomanLength~Cubitum
+```
+
+**See also** `meta::pure::functions::meta::getUnitValue(Any[1]):Number[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::newUnit(type:Unit[1], value:Number[1]):Any[1];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/exponential/exp.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/exponential/exp.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Euler's number *e* raised to a power.
+
+The inverse of `log(Number[1]):Float[1]`, so `$x->exp()->log()` recovers `$x` to within floating-point
+tolerance. `exp(1)` is *e* itself, approximately `2.718281828459045`.
+
+The result is always a `Float`, whatever the input type, and carries the usual floating-point
+representation error — compare with a tolerance rather than exact equality.
+
+**Parameters**
+- `exponent` — the power to raise *e* to.
+
+**Returns** *e* raised to `exponent`.
+
+**Examples**
+```pure
+exp(1)     // 2.718281828459045
+exp(1.0)   // 2.718281828459045
+4->exp()->log()   // 4.0, within tolerance
+```
+
+**See also** `log(Number[1]):Float[1]`, `pow(Number[1], Number[1]):Number[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::exp(exponent:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::exp::testNumberExp<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/exponential/log.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/exponential/log.pure
@@ -14,6 +14,28 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The natural logarithm of a number — logarithm to base *e*, not base 10.
+
+The inverse of `exp(Number[1]):Float[1]`, so `log(4->exp())` recovers `4.0` to within floating-point
+tolerance. For base 10 use `log10(Number[1]):Float[1]`.
+
+The result is always a `Float` and carries the usual floating-point representation error — compare with a
+tolerance rather than exact equality.
+
+**Parameters**
+- `value` — the number whose natural logarithm is wanted.
+
+**Returns** the natural logarithm of `value`.
+
+**Examples**
+```pure
+log(2.718281828459045)   // 1.0
+log(4->exp())            // 4.0, within tolerance
+```
+
+**See also** `exp(Number[1]):Float[1]`, `log10(Number[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::log(value:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::log::testNumberLog<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/exponential/log10.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/exponential/log10.pure
@@ -14,6 +14,28 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The base-10 logarithm of a number.
+
+Use this rather than `log(Number[1]):Float[1]`, which is the *natural* logarithm, whenever you want
+orders of magnitude — digit counts, decibels, scientific notation.
+
+The result is always a `Float` and carries the usual floating-point representation error — compare with a
+tolerance rather than exact equality.
+
+**Parameters**
+- `value` — the number whose base-10 logarithm is wanted.
+
+**Returns** the base-10 logarithm of `value`.
+
+**Examples**
+```pure
+log10(10)    // 1.0
+log10(100)   // 2.0
+```
+
+**See also** `log(Number[1]):Float[1]`, `exp(Number[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::log10(value:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::log10::testNumberLog10<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/operation/abs.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/operation/abs.pure
@@ -14,17 +14,47 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The magnitude of a number, discarding its sign.
+
+There is one overload per numeric type, each returning that same type, so `abs` never widens or narrows
+what you pass it — an `Integer` stays an `Integer`, a `Decimal` stays exact. That is why the overloads
+exist rather than a single `Number` version.
+
+**Parameters**
+- `int` — the value whose magnitude is wanted.
+
+**Returns** the value without its sign.
+
+**Examples**
+```pure
+abs(-2)                     // 2
+abs(2)                      // 2
+abs(-123456789123456789)    // 123456789123456789
+```
+
+**See also** `sign(Number[1]):Integer[1]`,
+`abs(Decimal[1]):Decimal[1]`,
+`abs(Float[1]):Float[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::math::abs(int:Integer[1]):Integer[1];
 
+'''
+The magnitude of a `Float`, returning a `Float`. See `abs(Integer[1]):Integer[1]` for details.
+'''
 native function <<PCT.function>> meta::pure::functions::math::abs(float:Float[1]):Float[1];
 
+'''
+The magnitude of any number, keeping only the general `Number` type. Prefer a type-specific overload
+such as `abs(Integer[1]):Integer[1]` when the input type is known, so the result stays that type.
+'''
 native function <<PCT.function>> meta::pure::functions::math::abs(number:Number[1]):Number[1];
 
+'''
+The magnitude of a `Decimal`, returning an exact `Decimal`. See `abs(Integer[1]):Integer[1]` for details.
+'''
 native function <<PCT.function>> meta::pure::functions::math::abs(decimal:Decimal[1]):Decimal[1];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/operation/sign.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/operation/sign.pure
@@ -14,6 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The sign of a number, as `-1`, `0` or `1`.
+
+Always an `Integer` regardless of the input type, so the sign of a float or decimal is still one of three
+integer values. Zero has sign `0`, giving a three-way result rather than a boolean — useful for
+comparators, which expect exactly this convention.
+
+**Parameters**
+- `number` — the value whose sign is wanted.
+
+**Returns** `-1` for negative, `0` for zero, `1` for positive.
+
+**Examples**
+```pure
+sign(-10)     // -1
+sign(0)       // 0
+sign(10)      // 1
+sign(-10.5)   // -1
+sign(0.5)     // 1
+```
+
+**See also** `abs(Integer[1]):Integer[1]`,
+`meta::pure::functions::collection::sort(T[m], Function<{T[1], T[1]->Integer[1]}>[0..1]):T[m]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::sign(number:Number[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::sign::testSign<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/power/cbrt.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/power/cbrt.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The cube root of a number.
+
+Always returns a `Float`, even for a perfect cube — `cbrt(27)` is `3.0`, not `3`. Unlike a square root, a
+cube root is defined for negative numbers.
+
+Results carry floating-point representation error, so compare with a tolerance rather than exact
+equality.
+
+**Parameters**
+- `number` — the number whose cube root is wanted.
+
+**Returns** the cube root, as a `Float`.
+
+**Examples**
+```pure
+cbrt(0)       // 0.0
+cbrt(27)      // 3.0, within tolerance
+cbrt(0.001)   // 0.1, within tolerance
+```
+
+**See also** `sqrt(Number[1]):Float[1]`, `pow(Number[1], Number[1]):Number[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::cbrt(number:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::testCubeRoot<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/power/pow.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/power/pow.pure
@@ -15,6 +15,33 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::asserts::*;
 
+'''
+Raises a number to a power.
+
+**The result is floating point even when both arguments are integers** — `pow(2, 2)` is `4.0`, not `4`.
+The declared return type is `Number`, so if you need an `Integer` you must round or cast; comparing the
+result directly against an integer literal will not match.
+
+Because the computation goes through floating point, results are subject to the usual representation
+error: comparisons on non-trivial exponents should use a tolerance rather than exact equality.
+
+**Parameters**
+- `base` — the number to raise.
+- `exponent` — the power to raise it to.
+
+**Returns** `base` raised to `exponent`, as a floating-point number.
+
+**Examples**
+```pure
+pow(2, 2)         // 4.0   -- not 4
+2->pow(2)         // 4.0
+2->pow(2)->pow(2) // 16.0
+4.0->pow(2.0)     // 16.0
+```
+
+**See also** `sqrt(Number[1]):Float[1]`, `cbrt(Number[1]):Float[1]`,
+`exp(Number[1]):Float[1]`, `round(Number[1]):Integer[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::pow(base:Number[1], exponent:Number[1]):Number[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::pow::testSimplePow<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/power/sqrt.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/power/sqrt.pure
@@ -15,6 +15,26 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::asserts::*;
 
+'''
+The square root of a number.
+
+Always returns a `Float`, even for a perfect square of integers — `sqrt(9)` is `3.0`, not `3`. Equivalent
+to `pow($n, 0.5)` but clearer at the call site.
+
+**Parameters**
+- `number` — the number whose square root is wanted.
+
+**Returns** the square root, as a `Float`.
+
+**Examples**
+```pure
+sqrt(0)      // 0.0
+sqrt(9)      // 3.0   -- not 3
+sqrt(0.01)   // 0.1
+```
+
+**See also** `cbrt(Number[1]):Float[1]`, `pow(Number[1], Number[1]):Number[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::sqrt(number:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::testSquareRoot<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/random.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/random.pure
@@ -14,4 +14,26 @@
 
 import meta::pure::test::pct::*;
 
+'''
+A pseudo-random number in the half-open interval from 0 inclusive to 1 exclusive.
+
+Marked as a side-effecting function because it returns a different value on each call: it is not
+referentially transparent, so an expression containing it cannot be assumed to be repeatable or safely
+cached.
+
+Scale it to the range you need — `$lo + random() * ($hi - $lo)` — and note that `1.0` never occurs, so
+`floor(random() * $n)` yields `0` to `n - 1`.
+
+Not suitable for cryptographic use.
+
+**Returns** a pseudo-random value in `[0, 1)`.
+
+**Examples**
+```pure
+random()                           // e.g. 0.7208...
+floor(random() * 6) + 1            // a die roll, 1 to 6
+```
+
+**See also** `floor(Number[1]):Integer[1]`
+'''
 native function <<functionType.SideEffectFunction, PCT.function>> meta::pure::functions::math::random():Float[1];

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/round/ceiling.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/round/ceiling.pure
@@ -14,6 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The smallest integer not less than a number — rounding toward positive infinity.
+
+Unconditional, unlike `round(Number[1]):Integer[1]`: any fractional part at all moves the result up, so
+`17.01` gives `18`. For negatives, "up" means toward zero, so `-17.9` gives `-17`.
+
+An integer input is returned unchanged.
+
+**Parameters**
+- `number` — the value to round up.
+
+**Returns** the smallest integer that is not less than `number`.
+
+**Examples**
+```pure
+ceiling(17.01)   // 18
+ceiling(17.5)    // 18
+ceiling(17.9)    // 18
+ceiling(17)      // 17
+ceiling(-17)     // -17
+```
+
+**See also** `floor(Number[1]):Integer[1]`, `round(Number[1]):Integer[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::ceiling(number:Number[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::ceiling::testPositiveIntegerCeiling<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/round/floor.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/round/floor.pure
@@ -14,6 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The largest integer not greater than a number — rounding toward negative infinity.
+
+Unconditional, unlike `round(Number[1]):Integer[1]`: the fractional part is simply discarded for positive
+values, so `17.9` gives `17`. For negatives, "down" means away from zero, so `-17.1` gives `-18`.
+
+An integer input is returned unchanged.
+
+**Parameters**
+- `number` — the value to round down.
+
+**Returns** the largest integer that is not greater than `number`.
+
+**Examples**
+```pure
+floor(17.01)   // 17
+floor(17.5)    // 17
+floor(17.9)    // 17
+floor(17)      // 17
+floor(-17)     // -17
+```
+
+**See also** `ceiling(Number[1]):Integer[1]`, `round(Number[1]):Integer[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::floor(number:Number[1]):Integer[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::floor::testPositiveIntegerFloor<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/round/round.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/round/round.pure
@@ -14,10 +14,61 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Rounds a number to the nearest integer, breaking ties toward the even neighbour.
+
+**Rounding is half-even**, also called banker's rounding — not the half-up rule most people expect. A
+value exactly halfway between two integers goes to whichever neighbour is even, so `17.5` rounds to `18`
+but `16.5` rounds to `16`. This holds for negatives too: `-16.5` gives `-16`, `-17.5` gives `-18`.
+
+Half-even avoids the upward bias half-up introduces when summing many rounded values, which is why it is
+the usual choice for financial arithmetic.
+
+To round to a number of decimal places and keep the number's own type, use
+`round(Decimal[1], Integer[1]):Decimal[1]` or `round(Float[1], Integer[1]):Float[1]`.
+
+**Parameters**
+- `number` — the value to round.
+
+**Returns** the nearest integer, ties going to the even neighbour.
+
+**Examples**
+```pure
+round(17.6)       // 18
+round(17.4)       // 17
+round(17.5)       // 18   -- tie: 18 is even
+round(16.5)       // 16   -- tie: 16 is even
+round(-17.5)      // -18  -- tie: -18 is even
+round(-16.5)      // -16
+round(3.14159d)   // 3
+```
+
+**See also** `ceiling(Number[1]):Integer[1]`, `floor(Number[1]):Integer[1]`,
+`round(Decimal[1], Integer[1]):Decimal[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::round(number:Number[1]):Integer[1];
 
+'''
+Rounds a `Decimal` to a given number of decimal places, returning a `Decimal`.
+
+Unlike `round(Number[1]):Integer[1]`, the type is preserved and the fractional part is kept, so this is
+the form to reach for with monetary amounts. A `scale` of `0` rounds to a whole number while still
+returning a `Decimal`.
+'''
 native function <<PCT.function>> meta::pure::functions::math::round(decimal:Decimal[1], scale:Integer[1]):Decimal[1];
 
+'''
+Rounds a `Float` to a given number of decimal places, returning a `Float`.
+
+As `round(Decimal[1], Integer[1]):Decimal[1]` but for binary floating point, so the result is subject to
+the usual float representation limits — prefer the `Decimal` form when exactness matters.
+
+**Examples**
+```pure
+round(17.3, 0)     // 17.0
+round(-17.36, 1)   // -17.4
+```
+'''
 native function <<PCT.function>> meta::pure::functions::math::round(float:Float[1], scale:Integer[1]):Float[1];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/acos.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/acos.pure
@@ -15,6 +15,30 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::asserts::*;
 
+'''
+The arc cosine of a value — the angle whose cosine it is.
+
+The inverse of `cos(Number[1]):Float[1]`. The input must be between -1 and 1. The result is an angle **in
+radians**, in the range 0 to π — note this differs from `asin(Number[1]):Float[1]`, which is centred on
+zero.
+
+The result is always a `Float` and carries floating-point representation error, so compare with a
+tolerance rather than exact equality.
+
+**Parameters**
+- `number` — a value between -1 and 1.
+
+**Returns** the angle in radians, between 0 and π.
+
+**Examples**
+```pure
+acos(0)     // 1.570796326794   -- π/2
+acos(-1)    // 3.141592653589   -- π
+acos(0.5)   // 1.047197551196
+```
+
+**See also** `cos(Number[1]):Float[1]`, `asin(Number[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::acos(number:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::trigonometry::testArcCosine<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/asin.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/asin.pure
@@ -15,6 +15,30 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::asserts::*;
 
+'''
+The arc sine of a value — the angle whose sine it is.
+
+The inverse of `sin(Number[1]):Float[1]`. The input must be between -1 and 1, since no angle has a sine
+outside that range. The result is an angle **in radians**, in the range -π/2 to π/2.
+
+The result is always a `Float` and carries floating-point representation error, so compare with a
+tolerance rather than exact equality.
+
+**Parameters**
+- `number` — a value between -1 and 1.
+
+**Returns** the angle in radians, between -π/2 and π/2.
+
+**Examples**
+```pure
+asin(0)      // 0.0
+asin(1)      // 1.570796326794   -- π/2
+asin(-0.5)   // -0.523598775598
+```
+
+**See also** `sin(Number[1]):Float[1]`, `acos(Number[1]):Float[1]`,
+`atan2(Number[1], Number[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::asin(number:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::trigonometry::testArcSine<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/atan.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/atan.pure
@@ -14,6 +14,32 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The arc tangent of a value — the angle whose tangent it is.
+
+The inverse of `tan(Number[1]):Float[1]`. Accepts any number, since tangent is unbounded, and returns an
+angle **in radians** approaching but never reaching ±π/2.
+
+Because a single ratio cannot distinguish opposite quadrants, prefer
+`atan2(Number[1], Number[1]):Float[1]` when converting a coordinate pair to an angle.
+
+The result is always a `Float` and carries floating-point representation error, so compare with a
+tolerance rather than exact equality.
+
+**Parameters**
+- `number` — the tangent value.
+
+**Returns** the angle in radians, strictly between -π/2 and π/2.
+
+**Examples**
+```pure
+atan(0)     // 0.0
+atan(1.5)   // 0.982793723247
+atan(100)   // 1.560796660108   -- approaching π/2
+```
+
+**See also** `atan2(Number[1], Number[1]):Float[1]`, `tan(Number[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::atan(number:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::trigonometry::testArcTangent<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/atan2.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/atan2.pure
@@ -14,6 +14,35 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The angle to the point `(x, y)` from the positive x-axis, given y and x separately.
+
+**Note the argument order: y comes first, then x.** `atan2(1, 0)` is π/2, the angle straight up.
+
+Preferred over `atan(Number[1]):Float[1]` for converting coordinates to an angle, because keeping y and x
+apart preserves the quadrant — a single ratio cannot distinguish `(1, 1)` from `(-1, -1)`. It also handles
+`x = 0` without dividing by zero.
+
+The result is **in radians**, over the full circle from -π to π.
+
+The result is always a `Float` and carries floating-point representation error, so compare with a
+tolerance rather than exact equality.
+
+**Parameters**
+- `number1` — the y coordinate.
+- `number2` — the x coordinate.
+
+**Returns** the angle in radians, between -π and π.
+
+**Examples**
+```pure
+atan2(0, 1)       // 0.0              -- along the positive x-axis
+atan2(1, 0)       // 1.570796326794   -- π/2, straight up
+atan2(0.5, 3.5)   // 0.141897054604
+```
+
+**See also** `atan(Number[1]):Float[1]`, `asin(Number[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::atan2(number1:Number[1], number2:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::trigonometry::testArcTangent2<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/cos.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/cos.pure
@@ -14,6 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The cosine of an angle.
+
+**Angles are in radians, not degrees.** Convert with `$degrees * 3.141592653589793 / 180` if your
+input is in degrees.
+
+The result is always a `Float` and carries floating-point representation error, so compare with a
+tolerance rather than exact equality.
+
+**Parameters**
+- `number` — the angle, in radians.
+
+**Returns** its cosine, between -1 and 1.
+
+**Examples**
+```pure
+cos(0)      // 1.0
+cos(-1)     // 0.540302305868
+cos(-1.5)   // 0.070737201667
+```
+
+**See also** `sin(Number[1]):Float[1]`, `tan(Number[1]):Float[1]`,
+`acos(Number[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::cos(number:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::trigonometry::testCosine<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/cot.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/cot.pure
@@ -14,6 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The cotangent of an angle — the reciprocal of its tangent.
+
+**Angles are in radians, not degrees.** Convert with `$degrees * 3.141592653589793 / 180` if your
+input is in degrees.
+
+Undefined at multiples of π, where the tangent is zero, and unbounded as the angle approaches them.
+
+The result is always a `Float` and carries floating-point representation error, so compare with a
+tolerance rather than exact equality.
+
+**Parameters**
+- `number` — the angle, in radians.
+
+**Returns** its cotangent.
+
+**Examples**
+```pure
+cot(1)     // 0.642092615934
+cot(1.5)   // 0.070914844302
+```
+
+**See also** `tan(Number[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::cot(number:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::trigonometry::testCoTangent<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/sin.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/sin.pure
@@ -14,6 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The sine of an angle.
+
+**Angles are in radians, not degrees.** Convert with `$degrees * 3.141592653589793 / 180` if your
+input is in degrees.
+
+The result is always a `Float` and carries floating-point representation error, so compare with a
+tolerance rather than exact equality.
+
+**Parameters**
+- `number` — the angle, in radians.
+
+**Returns** its sine, between -1 and 1.
+
+**Examples**
+```pure
+sin(0)     // 0.0
+sin(1)     // 0.841470984807
+sin(1.5)   // 0.997494986604
+```
+
+**See also** `cos(Number[1]):Float[1]`, `tan(Number[1]):Float[1]`,
+`asin(Number[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::sin(number:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::trigonometry::testSine<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/tan.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/math/trigonometry/tan.pure
@@ -14,6 +14,33 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The tangent of an angle.
+
+**Angles are in radians, not degrees.** Convert with `$degrees * 3.141592653589793 / 180` if your
+input is in degrees.
+
+Unlike sine and cosine, tangent is unbounded: it grows without limit as the angle approaches an odd
+multiple of π/2, where it is mathematically undefined. Expect very large magnitudes near those points
+rather than a clean error.
+
+The result is always a `Float` and carries floating-point representation error, so compare with a
+tolerance rather than exact equality.
+
+**Parameters**
+- `number` — the angle, in radians.
+
+**Returns** its tangent.
+
+**Examples**
+```pure
+tan(0)   // 0.0
+tan(2)   // -2.185039863262
+```
+
+**See also** `cot(Number[1]):Float[1]`, `sin(Number[1]):Float[1]`,
+`atan(Number[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::math::tan(number:Number[1]):Float[1];
 
 function <<PCT.test>> meta::pure::functions::math::tests::trigonometry::testTangent<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementPath.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementPath.pure
@@ -1,0 +1,126 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::functions::meta::tests::model::*;
+import meta::pure::test::pct::*;
+
+'''
+The chain of elements containing a packageable element, from the top-level package down to the element
+itself.
+
+Where `elementToPath(PackageableElement[1]):String[1]` renders that chain as a string, this returns the
+elements themselves: first the top-level package — `Root` for elements in the graph — then each package
+below it, and last the element that was passed in. An element that sits at the top level with no package
+at all, such as `Integer` or `Package`, is a chain of one. The result is never empty, since it always ends
+with the element itself.
+
+The chain is followed through the `package` property, so it works for elements assembled on the fly as
+well as for elements in the graph: an ephemeral element under an ephemeral package sitting under a package
+named `Other` has that package, not `Root`, at the head of its chain.
+
+**Parameters**
+- `element` — the element whose containing chain is wanted.
+
+**Returns** the containing elements from the top-level package down to `element`, inclusive.
+
+**Examples**
+```pure
+elementPath(::)          // [::]
+elementPath(Integer)     // [Integer]
+elementPath(meta)        // [::, meta]
+elementPath(CC_Person)   // [::, meta, meta::pure, meta::pure::functions, meta::pure::functions::meta,
+                         //  meta::pure::functions::meta::tests,
+                         //  meta::pure::functions::meta::tests::model, CC_Person]
+```
+
+**See also** `elementToPath(PackageableElement[1]):String[1]`,
+`pathToElement(String[1]):PackageableElement[1]`
+'''
+native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::elementPath(element:PackageableElement[1]):PackageableElement[1..*];
+
+
+function <<test.Test>> meta::pure::functions::meta::tests::elementPath::testTopLevelElementPath():Boolean[1]
+{
+    assertEquals([Package], elementPath(Package));
+    assertEquals([Number], elementPath(Number));
+    assertEquals([Boolean], elementPath(Boolean));
+    assertEquals([Date], elementPath(Date));
+    assertEquals([Float], elementPath(Float));
+    assertEquals([Integer], elementPath(Integer));
+    assertEquals([String], elementPath(String));
+}
+
+function <<test.Test>> meta::pure::functions::meta::tests::elementPath::testRootElementPath():Boolean[1]
+{
+    assertEquals([::], elementPath(::));
+}
+
+function <<test.Test>> meta::pure::functions::meta::tests::elementPath::testElementPath():Boolean[1]
+{
+    assertEquals(
+        [
+         ::,
+         meta,
+         meta::pure,
+         meta::pure::functions,
+         meta::pure::functions::meta,
+         meta::pure::functions::meta::tests,
+         meta::pure::functions::meta::tests::model,
+         meta::pure::functions::meta::tests::model::CC_Person
+        ],
+        elementPath(CC_Person));
+    assertEquals(
+        [
+         ::,
+         meta,
+         meta::pure,
+         meta::pure::functions,
+         meta::pure::functions::meta,
+         meta::pure::functions::meta::tests,
+         meta::pure::functions::meta::tests::model,
+         meta::pure::functions::meta::tests::model::CC_GeographicEntityType
+        ],
+        elementPath(CC_GeographicEntityType));
+    assertEquals(
+        [
+         ::,
+         meta,
+         meta::pure,
+         meta::pure::functions
+        ],
+        elementPath(meta::pure::functions));
+    assertEquals(
+        [
+         ::,
+         meta
+        ],
+        elementPath(meta));
+}
+
+function <<test.Test>> meta::pure::functions::meta::tests::elementPath::testEphemeralPackageableElement():Boolean[1]
+{
+    let rootPkg = ^Package(name='Root');
+    let pkgPkg = ^Package(name='pkg', package=$rootPkg);
+    let element = ^PackageableElement(name='MyElement', package=$pkgPkg);
+    assertEquals([$rootPkg], $rootPkg->elementPath());
+    assertEquals([$rootPkg, $pkgPkg], $pkgPkg->elementPath());
+    assertEquals([$rootPkg, $pkgPkg, $element], $element->elementPath());
+
+    let otherRootPkg = ^Package(name='Other');
+    let otherPkgPkg = ^Package(name='pkg', package=$otherRootPkg);
+    let otherElement = ^PackageableElement(name='MyElement', package=$otherPkgPkg);
+    assertEquals([$otherRootPkg], $otherRootPkg->elementPath());
+    assertEquals([$otherRootPkg, $otherPkgPkg], $otherPkgPkg->elementPath());
+    assertEquals([$otherRootPkg, $otherPkgPkg, $otherElement], $otherElement->elementPath());
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementToPath.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementToPath.pure
@@ -16,14 +16,113 @@ import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
 '''
-The fully-qualified path of a model element, as a string.
+The fully-qualified path of a packageable element, as a string.
 
-For a packageable element — a class, enumeration, function, profile — this is the `::`-separated path
-that identifies it, such as `meta::pure::functions::meta::type`. For a property or a relation column,
-which live inside a class rather than in a package, it is the bare member name.
+A packageable element — a class, an enumeration, a profile, a function definition, a package — is
+identified by the chain of packages that contains it. This is that chain, `::`-separated and ending in the
+element's own name, such as `meta::pure::functions::meta::tests::model::CC_Person`.
+
+The name of the top-level package is left out, so the path of the root package itself is the empty string
+and every other path starts at the first package below the root. An element that sits at the top level
+with no package at all, such as `Integer` or `Package`, is just its own name.
 
 The inverse of `pathToElement(String[1]):PackageableElement[1]`, so the two together let an element be
-written out as text and looked up again.
+written out as text and looked up again. The round trip holds for any separator that cannot occur inside
+an element name: `::` and `.` are safe, `_` is not.
+
+**Parameters**
+- `element` — the element to name.
+
+**Returns** its `::`-separated path, empty for the root package.
+
+**Examples**
+```pure
+elementToPath(meta::pure::functions::meta)    // 'meta::pure::functions::meta'
+elementToPath(CC_Person.package->at(0))       // 'meta::pure::functions::meta::tests::model'
+elementToPath(::)                             // '' — the root package
+```
+
+**See also** `pathToElement(String[1]):PackageableElement[1]`,
+`elementPath(PackageableElement[1]):PackageableElement[1..*]`,
+`id(Any[1]):String[1]`,
+`enumName(Enumeration<T>[1]):String[1]`
+'''
+function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::elementToPath(element:PackageableElement[1]):String[1]
+{
+    $element->elementToPath('::')
+}
+
+'''
+As `elementToPath(PackageableElement[1]):String[1]`, but `includeRoot` decides whether the name of the
+top-level package appears at the head of the path. With it set to true,
+`elementToPath(meta::pure::functions::meta, true)` gives `Root::meta::pure::functions::meta`, and the root
+package itself gives `Root` rather than the empty string. Elements with no package at all, such as
+`Integer`, are unaffected.
+'''
+function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::elementToPath(element:PackageableElement[1], includeRoot:Boolean[1]):String[1]
+{
+    $element->elementToPath('::', $includeRoot)
+}
+
+'''
+As `elementToPath(PackageableElement[1]):String[1]`, but joins the path with `separator` instead of `::` —
+`elementToPath(CC_Person.package->at(0), '_')` gives `meta_pure_functions_meta_tests_model`. The name of
+the top-level package is still left out.
+
+A separator that can occur inside an element name, `_` among them, makes the result ambiguous and no
+longer safe to feed back to `pathToElement(String[1], String[1]):PackageableElement[1]`.
+'''
+function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::elementToPath(element:PackageableElement[1], separator:String[1]):String[1]
+{
+    $element->elementToPath($separator, false)
+}
+
+'''
+As `elementToPath(PackageableElement[1]):String[1]`, but takes both the `separator` used to join the path
+and the `includeRoot` flag that decides whether the name of the top-level package appears at the head of
+it — `elementToPath(CC_Person.package->at(0), '$', true)` gives
+`Root$meta$pure$functions$meta$tests$model`. The other packageable-element variants are conveniences over
+this one, with `separator` defaulting to `::` and `includeRoot` to false.
+'''
+native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::elementToPath(element:PackageableElement[1], separator:String[1], includeRoot:Boolean[1]):String[1];
+
+'''
+As `elementToPath(PackageableElement[1]):String[1]`, for a statically-typed `Type`. Kept for backward
+compatibility: `Type` used to be a subtype of `PackageableElement`, and most types — classes,
+enumerations, primitive types — still are packageable elements. Units are not, and are handled by
+`elementToPath(Type[1], String[1]):String[1]`, to which this delegates with `::`.
+'''
+function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::elementToPath(element:Type[1]):String[1]
+{
+    $element->elementToPath('::')
+}
+
+'''
+As `elementToPath(PackageableElement[1], String[1]):String[1]`, for a statically-typed `Type`: the path,
+joined with `separator` rather than `::`.
+
+This is also the variant that gives a unit its path. A unit is a `Type` but not a packageable element, so
+it is named by the path of its measure, a `~`, and the unit name — `elementToPath(RomanLength~Pes)`, which
+delegates here with `::`, gives `meta::pure::functions::meta::tests::model::RomanLength~Pes`.
+'''
+function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::elementToPath(element:Type[1], separator:String[1]):String[1]
+{
+    $element->match(
+        [
+            p : PackageableElement[1] | $p->elementToPath($separator),
+            u : Unit[1] | $u.measure->elementToPath($separator) + '~' + $u.name->toOne()
+        ]
+    )
+}
+
+'''
+As `elementToPath(PackageableElement[1]):String[1]`, for a statically-typed `Function`. Kept for backward
+compatibility: `Function` used to be a subtype of `PackageableElement`, and code holding a statically-typed
+function still resolves to it. A function that is a packageable element delegates to
+`elementToPath(PackageableElement[1], String[1]):String[1]` with `::`.
+
+Properties and relation columns are functions but not packageable elements: they live inside a class or a
+relation rather than in a package, so for them the result is the bare member name.
 
 **Parameters**
 - `element` — the element to name.
@@ -32,7 +131,7 @@ written out as text and looked up again.
 
 **Examples**
 ```pure
-CC_Person->elementToPath()   // 'meta::pure::functions::meta::tests::model::CC_Person'
+CC_Person->elementToPath()       // 'meta::pure::functions::meta::tests::model::CC_Person'
 $someProperty->elementToPath()   // 'firstName'
 ```
 
@@ -50,42 +149,6 @@ function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::element
         ]
     )
 }
-
-function meta::pure::functions::meta::elementToPath(element:Type[1]):String[1]
-{
-    $element->elementToPath('::')
-}
-
-function meta::pure::functions::meta::elementToPath(element:Type[1], separator:String[1]):String[1]
-{
-    $element->match(
-        [
-            p : PackageableElement[1] | $p->elementToPath($separator),
-            u : Unit[1] | $u.measure->elementToPath($separator) + '~' + $u.name->toOne()
-        ]
-    )
-}
-
-function meta::pure::functions::meta::elementToPath(element:PackageableElement[1]):String[1]
-{
-    $element->elementToPath('::')
-}
-
-function meta::pure::functions::meta::elementToPath(element:PackageableElement[1], includeRoot:Boolean[1]):String[1]
-{
-    $element->elementToPath('::', $includeRoot)
-}
-
-function meta::pure::functions::meta::elementToPath(element:PackageableElement[1], separator:String[1]):String[1]
-{
-    $element->elementToPath($separator, false)
-}
-
-native function meta::pure::functions::meta::elementToPath(element:PackageableElement[1], separator:String[1], includeRoot:Boolean[1]):String[1];
-
-native function meta::pure::functions::meta::elementPath(element:PackageableElement[1]):PackageableElement[1..*];
-
-
 
 
 function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testElementToPath():Boolean[1]
@@ -159,81 +222,6 @@ function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testEp
 
     assertEquals('', ^PackageableElement()->elementToPath());
     assertEquals('', ^PackageableElement()->elementToPath(true));
-}
-
-function <<test.Test>> meta::pure::functions::meta::tests::elementPath::testTopLevelElementPath():Boolean[1]
-{
-    assertEquals([Package], elementPath(Package));
-    assertEquals([Number], elementPath(Number));
-    assertEquals([Boolean], elementPath(Boolean));
-    assertEquals([Date], elementPath(Date));
-    assertEquals([Float], elementPath(Float));
-    assertEquals([Integer], elementPath(Integer));
-    assertEquals([String], elementPath(String));
-}
-
-function <<test.Test>> meta::pure::functions::meta::tests::elementPath::testRootElementPath():Boolean[1]
-{
-    assertEquals([::], elementPath(::));
-}
-
-function <<test.Test>> meta::pure::functions::meta::tests::elementPath::testElementPath():Boolean[1]
-{
-    assertEquals(
-        [
-         ::,
-         meta,
-         meta::pure,
-         meta::pure::functions,
-         meta::pure::functions::meta,
-         meta::pure::functions::meta::tests,
-         meta::pure::functions::meta::tests::model,
-         meta::pure::functions::meta::tests::model::CC_Person
-        ],
-        elementPath(CC_Person));
-    assertEquals(
-        [
-         ::,
-         meta,
-         meta::pure,
-         meta::pure::functions,
-         meta::pure::functions::meta,
-         meta::pure::functions::meta::tests,
-         meta::pure::functions::meta::tests::model,
-         meta::pure::functions::meta::tests::model::CC_GeographicEntityType
-        ],
-        elementPath(CC_GeographicEntityType));
-    assertEquals(
-        [
-         ::,
-         meta,
-         meta::pure,
-         meta::pure::functions
-        ],
-        elementPath(meta::pure::functions));
-    assertEquals(
-        [
-         ::,
-         meta
-        ],
-        elementPath(meta));
-}
-
-function <<test.Test>> meta::pure::functions::meta::tests::elementPath::testEphemeralPackageableElement():Boolean[1]
-{
-    let rootPkg = ^Package(name='Root');
-    let pkgPkg = ^Package(name='pkg', package=$rootPkg);
-    let element = ^PackageableElement(name='MyElement', package=$pkgPkg);
-    assertEquals([$rootPkg], $rootPkg->elementPath());
-    assertEquals([$rootPkg, $pkgPkg], $pkgPkg->elementPath());
-    assertEquals([$rootPkg, $pkgPkg, $element], $element->elementPath());
-
-    let otherRootPkg = ^Package(name='Other');
-    let otherPkgPkg = ^Package(name='pkg', package=$otherRootPkg);
-    let otherElement = ^PackageableElement(name='MyElement', package=$otherPkgPkg);
-    assertEquals([$otherRootPkg], $otherRootPkg->elementPath());
-    assertEquals([$otherRootPkg, $otherPkgPkg], $otherPkgPkg->elementPath());
-    assertEquals([$otherRootPkg, $otherPkgPkg, $otherElement], $otherElement->elementPath());
 }
 
 function <<test.Test>> meta::pure::functions::meta::tests::elementToPath::testElementToPathRoundTrip():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementToPath.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/elementToPath.pure
@@ -15,6 +15,31 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+The fully-qualified path of a model element, as a string.
+
+For a packageable element — a class, enumeration, function, profile — this is the `::`-separated path
+that identifies it, such as `meta::pure::functions::meta::type`. For a property or a relation column,
+which live inside a class rather than in a package, it is the bare member name.
+
+The inverse of `pathToElement(String[1]):PackageableElement[1]`, so the two together let an element be
+written out as text and looked up again.
+
+**Parameters**
+- `element` — the element to name.
+
+**Returns** its `::`-separated path, or its name for a property or column.
+
+**Examples**
+```pure
+CC_Person->elementToPath()   // 'meta::pure::functions::meta::tests::model::CC_Person'
+$someProperty->elementToPath()   // 'firstName'
+```
+
+**See also** `pathToElement(String[1]):PackageableElement[1]`,
+`id(Any[1]):String[1]`,
+`enumName(Enumeration<T>[1]):String[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::elementToPath(element:Function<Any>[1]):String[1]
 {
     $element->match(

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/lenientPathToElement.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/lenientPathToElement.pure
@@ -1,0 +1,70 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::functions::meta::tests::model::*;
+import meta::pure::test::pct::*;
+
+'''
+Looks up a model element by its fully-qualified path, yielding empty when the path does not resolve.
+
+As `pathToElement(String[1]):PackageableElement[1]`, except for the return multiplicity: an unresolvable
+path is an error there, whereas here the return type is `[0..1]` and the result is simply empty. Any
+segment of the path can be the one that fails — a package part that names no package empties the result
+just as a final part that names no element does.
+
+Use it when the path comes from configuration, user input, or generated code, and a miss is an expected
+outcome rather than a bug.
+
+**Parameters**
+- `path` — the `::`-separated path to resolve.
+
+**Returns** the element at that path, or empty if there is none.
+
+**Examples**
+```pure
+lenientPathToElement('meta::pure::functions::meta::tests::model::CC_Person')    // the CC_Person class
+lenientPathToElement('meta::pure::functions::meta::tests::model::CCC_Person')   // empty — no such element
+lenientPathToElement('meta::pure::functions::meta::tests::models::CC_Person')   // empty — no such package
+```
+
+**See also** `pathToElement(String[1]):PackageableElement[1]`,
+`elementToPath(PackageableElement[1]):String[1]`
+'''
+function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::lenientPathToElement(path:String[1]):PackageableElement[0..1]
+{
+    $path->lenientPathToElement('::')
+}
+
+'''
+As `lenientPathToElement(String[1]):PackageableElement[0..1]`, but splits `path` on `separator` instead of
+`::` — `lenientPathToElement('meta.pure.functions.meta.tests.model.CC_Person', '.')` resolves the same
+class, and an unresolvable segment likewise gives empty rather than an error.
+'''
+native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::lenientPathToElement(path:String[1], separator:String[1]):PackageableElement[0..1];
+
+
+function <<test.Test>> meta::pure::functions::meta::tests::lenientPathToElement::testLenientPathToElement():Boolean[1]
+{
+    assertIs(CC_Person, lenientPathToElement('meta::pure::functions::meta::tests::model::CC_Person')->toOne());
+    assertIs(CC_Person, lenientPathToElement('meta.pure.functions.meta.tests.model.CC_Person', '.')->toOne());
+    assertEmpty(lenientPathToElement('meta::pure::functions::meta::tests::model::CCC_Person'));
+    assertEmpty(lenientPathToElement('meta.pure.functions.meta.tests.model.CCC_Person', '.'));
+    assertEmpty(lenientPathToElement('meta::pure::functions::meta::tests::models::CC_Person'));
+    assertEmpty(lenientPathToElement('meta.pure.functions.meta.tests.models.CC_Person', '.'));
+
+    assertIs(CC_Person.package->toOne(), lenientPathToElement('meta::pure::functions::meta::tests::model')->toOne());
+    assertIs(CC_Person.package->toOne(), lenientPathToElement('meta_pure_functions_meta_tests_model', '_')->toOne());
+    assertEmpty(lenientPathToElement('meta::pure::functions::metal::tests::model'));
+    assertEmpty(lenientPathToElement('meta_pure_functions_metal_tests_model', '_'));
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/pathToElement.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/pathToElement.pure
@@ -15,6 +15,30 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+Looks up a model element by its fully-qualified path.
+
+The inverse of `elementToPath(Function<Any>[1]):String[1]`, and the way to reach an element named at
+runtime — from configuration, user input, or generated code — rather than written as a literal.
+
+The path is `::`-separated. **A path that resolves to nothing is an error, not an empty result**, since
+the return multiplicity is `[1]`; use `lenientPathToElement` in the same package when a missing element
+should yield empty instead.
+
+**Parameters**
+- `path` — the `::`-separated path to resolve.
+
+**Returns** the element at that path.
+
+**Examples**
+```pure
+'meta::pure::functions::meta::tests::model::CC_Person'->pathToElement()
+$className->pathToElement()->cast(@Class<Any>)
+```
+
+**See also** `elementToPath(Function<Any>[1]):String[1]`,
+`meta::pure::functions::lang::cast(Any[m], T[1]):T[m]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::pathToElement(path:String[1]):PackageableElement[1]
 {
     $path->pathToElement('::')

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/pathToElement.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/graph/pathToElement.pure
@@ -18,12 +18,12 @@ import meta::pure::test::pct::*;
 '''
 Looks up a model element by its fully-qualified path.
 
-The inverse of `elementToPath(Function<Any>[1]):String[1]`, and the way to reach an element named at
+The inverse of `elementToPath(PackageableElement[1]):String[1]`, and the way to reach an element named at
 runtime — from configuration, user input, or generated code — rather than written as a literal.
 
 The path is `::`-separated. **A path that resolves to nothing is an error, not an empty result**, since
-the return multiplicity is `[1]`; use `lenientPathToElement` in the same package when a missing element
-should yield empty instead.
+the return multiplicity is `[1]`; use `lenientPathToElement(String[1]):PackageableElement[0..1]` when a
+missing element should yield empty instead.
 
 **Parameters**
 - `path` — the `::`-separated path to resolve.
@@ -44,14 +44,12 @@ function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::pathToE
     $path->pathToElement('::')
 }
 
-native function meta::pure::functions::meta::pathToElement(path:String[1], separator:String[1]):PackageableElement[1];
-
-function meta::pure::functions::meta::lenientPathToElement(path:String[1]):PackageableElement[0..1]
-{
-    $path->lenientPathToElement('::')
-}
-
-native function meta::pure::functions::meta::lenientPathToElement(path:String[1], separator:String[1]):PackageableElement[0..1];
+'''
+As `pathToElement(String[1]):PackageableElement[1]`, but splits `path` on `separator` instead of `::` —
+`pathToElement('meta.pure.functions.meta.tests.model.CC_Person', '.')` resolves the same class as the
+`::`-separated form. A path that resolves to nothing is still an error rather than an empty result.
+'''
+native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::pathToElement(path:String[1], separator:String[1]):PackageableElement[1];
 
 
 function <<test.Test>> meta::pure::functions::meta::tests::pathToElement::testPathToElement():Boolean[1]
@@ -61,21 +59,6 @@ function <<test.Test>> meta::pure::functions::meta::tests::pathToElement::testPa
     assertIs(CC_Person.package->toOne(), pathToElement('meta::pure::functions::meta::tests::model'));
     assertIs(CC_Person.package->toOne(), pathToElement('meta_pure_functions_meta_tests_model', '_'));
     assertIs(RomanLength, pathToElement('meta::pure::functions::meta::tests::model::RomanLength'));
-}
-
-function <<test.Test>> meta::pure::functions::meta::tests::pathToElement::testLenientPathToElement():Boolean[1]
-{
-    assertIs(CC_Person, lenientPathToElement('meta::pure::functions::meta::tests::model::CC_Person')->toOne());
-    assertIs(CC_Person, lenientPathToElement('meta.pure.functions.meta.tests.model.CC_Person', '.')->toOne());
-    assertEmpty(lenientPathToElement('meta::pure::functions::meta::tests::model::CCC_Person'));
-    assertEmpty(lenientPathToElement('meta.pure.functions.meta.tests.model.CCC_Person', '.'));
-    assertEmpty(lenientPathToElement('meta::pure::functions::meta::tests::models::CC_Person'));
-    assertEmpty(lenientPathToElement('meta.pure.functions.meta.tests.models.CC_Person', '.'));
-
-    assertIs(CC_Person.package->toOne(), lenientPathToElement('meta::pure::functions::meta::tests::model')->toOne());
-    assertIs(CC_Person.package->toOne(), lenientPathToElement('meta_pure_functions_meta_tests_model', '_')->toOne());
-    assertEmpty(lenientPathToElement('meta::pure::functions::metal::tests::model'));
-    assertEmpty(lenientPathToElement('meta_pure_functions_metal_tests_model', '_'));
 }
 
 function <<test.Test>> meta::pure::functions::meta::tests::pathToElement::testRootPathToElement():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/instance/getHiddenPayload.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/instance/getHiddenPayload.pure
@@ -14,6 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The hidden payload carried by an instance created with getter overrides.
+
+`meta::pure::functions::lang::dynamicNew(Class<Any>[1], KeyValue[*], Function<{Any[1], Property<Nil, Any|0..1>[1]->Any[0..1]}>[0..1], Function<{Any[1], Property<Nil, Any|*>[1]->Any[*]}>[0..1], Any[0..1]):Any[1]`
+can attach arbitrary state to an instance that is not a property of its class — typically the context a
+getter override needs, such as a row handle or a connection. This reads that state back.
+
+**Only meaningful for an instance that actually has an override.** Calling it on an ordinary instance
+fails rather than returning empty, so guard accordingly.
+
+**Parameters**
+- `o` — the instance to read.
+
+**Returns** its hidden payload.
+
+**Examples**
+```pure
+$lazyInstance->getHiddenPayload()
+```
+
+**See also** `meta::pure::functions::lang::removeOverride(T[1]):T[1]`,
+`meta::pure::functions::lang::rawEvalProperty(Property<Nil, V|m>[1], Any[1]):V[m]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::getHiddenPayload(o:Any[1]):Any[1]
 {
    $o.elementOverride->toOne()->cast(@GetterOverride).hiddenPayload->toOne();

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/instance/id.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/instance/id.pure
@@ -15,6 +15,32 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+The identifier of a value: its simple name for a model element, or its literal form for a primitive.
+
+For a packageable element this is the last segment of its path — `CC_Person`, not the full path, which is
+what `elementToPath(Function<Any>[1]):String[1]` gives. For a primitive it is the value written out, so a
+date becomes `'2017-01-01'` and the integer `1` becomes `'1'`.
+
+Because a string's identifier is the string itself, `'CC_Person'->id()` is `'CC_Person'` — the same result
+as for the class of that name. Do not use `id` alone to decide whether something is an element.
+
+**Parameters**
+- `instance` — the value to identify.
+
+**Returns** its identifier.
+
+**Examples**
+```pure
+CC_Person->id()        // 'CC_Person'  -- simple name, not the full path
+%2017-01-01->id()      // '2017-01-01'
+1->id()                // '1'
+```
+
+**See also** `elementToPath(Function<Any>[1]):String[1]`,
+`meta::pure::functions::string::toString(Any[1]):String[1]`,
+`meta::pure::functions::string::toRepresentation(Any[1]):String[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::id(instance:Any[1]):String[1];
 
 function <<test.Test>> meta::pure::functions::meta::tests::id::testId():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/getLowerBound.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/getLowerBound.pure
@@ -14,6 +14,32 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The minimum number of values a multiplicity permits.
+
+Multiplicities are metamodel objects, reached by reflecting over a property or function parameter, and
+the named constants `PureZero`, `ZeroOne`, `PureOne`, `ZeroMany` and `OneMany` correspond to the
+familiar `[0]`, `[0..1]`, `[1]`, `[*]` and `[1..*]`.
+
+A lower bound of `0` means the value is optional; `1` or more means at least that many are required.
+
+**Parameters**
+- `multiplicity` — the multiplicity to inspect.
+
+**Returns** the lower bound.
+
+**Examples**
+```pure
+PureZero->getLowerBound()   // 0
+ZeroOne->getLowerBound()    // 0
+PureOne->getLowerBound()    // 1
+ZeroMany->getLowerBound()   // 0
+OneMany->getLowerBound()    // 1
+```
+
+**See also** `getUpperBound(Multiplicity[1]):Integer[1]`,
+`isToOne(Multiplicity[1]):Boolean[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::getLowerBound(multiplicity:Multiplicity[1]):Integer[1]
 {
     $multiplicity.lowerBound->toOne().value->toOne()

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/getUpperBound.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/getUpperBound.pure
@@ -19,7 +19,7 @@ The maximum number of values a multiplicity permits.
 
 **Only meaningful when the multiplicity actually has an upper bound** — test with
 `hasUpperBound(Multiplicity[1]):Boolean[1]` first. For an unbounded multiplicity such as `ZeroMany` or
-`OneMany` there is no upper bound to report, so the result is not a usable count.
+`OneMany` there is no upper bound to report, so the call fails rather than returning a count.
 
 **Parameters**
 - `multiplicity` — the multiplicity to inspect.

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/getUpperBound.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/getUpperBound.pure
@@ -14,6 +14,31 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The maximum number of values a multiplicity permits.
+
+**Only meaningful when the multiplicity actually has an upper bound** — test with
+`hasUpperBound(Multiplicity[1]):Boolean[1]` first. For an unbounded multiplicity such as `ZeroMany` or
+`OneMany` there is no upper bound to report, so the result is not a usable count.
+
+**Parameters**
+- `multiplicity` — the multiplicity to inspect.
+
+**Returns** the upper bound, for a multiplicity that has one.
+
+**Examples**
+```pure
+PureZero->getUpperBound()   // 0
+ZeroOne->getUpperBound()    // 1
+PureOne->getUpperBound()    // 1
+
+if($m->hasUpperBound(), |$m->getUpperBound()->toString(), |'unbounded')
+```
+
+**See also** `hasUpperBound(Multiplicity[1]):Boolean[1]`,
+`getLowerBound(Multiplicity[1]):Integer[1]`,
+`isToMany(Multiplicity[1]):Boolean[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::getUpperBound(multiplicity:Multiplicity[1]):Integer[1]
 {
     $multiplicity.upperBound->toOne().value->toOne()

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/hasToOneUpperBound.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/hasToOneUpperBound.pure
@@ -14,6 +14,31 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether a multiplicity permits at most one value.
+
+True for `[0..1]` and `[1]`, which are the multiplicities that hold a single value or none. Says nothing
+about whether a value is *required* — for that, add a lower-bound check, which is exactly what
+`isToOne(Multiplicity[1]):Boolean[1]` does.
+
+`PureZero` (`[0]`) is false: its upper bound is `0`, not `1`.
+
+**Parameters**
+- `multiplicity` — the multiplicity to inspect.
+
+**Returns** `true` when the upper bound is exactly one.
+
+**Examples**
+```pure
+ZeroOne->hasToOneUpperBound()    // true
+PureOne->hasToOneUpperBound()    // true
+PureZero->hasToOneUpperBound()   // false -- upper bound is 0
+ZeroMany->hasToOneUpperBound()   // false -- unbounded
+```
+
+**See also** `isToOne(Multiplicity[1]):Boolean[1]`,
+`hasUpperBound(Multiplicity[1]):Boolean[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::hasToOneUpperBound(multiplicity:Multiplicity[1]):Boolean[1]
 {
     $multiplicity->hasUpperBound() && eq($multiplicity->getUpperBound(), 1)

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/hasUpperBound.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/hasUpperBound.pure
@@ -14,6 +14,31 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether a multiplicity is bounded above.
+
+The guard to call before `getUpperBound(Multiplicity[1]):Integer[1]`, since an unbounded multiplicity
+has no upper bound to report. Note that `PureZero` (`[0]`) *is* bounded — its upper bound is `0` — so
+"has an upper bound" is not the same as "can hold a value".
+
+**Parameters**
+- `multiplicity` — the multiplicity to inspect.
+
+**Returns** `true` when there is a concrete upper bound.
+
+**Examples**
+```pure
+PureZero->hasUpperBound()   // true  -- bounded at 0
+ZeroOne->hasUpperBound()    // true
+PureOne->hasUpperBound()    // true
+ZeroMany->hasUpperBound()   // false -- [*]
+OneMany->hasUpperBound()    // false -- [1..*]
+```
+
+**See also** `getUpperBound(Multiplicity[1]):Integer[1]`,
+`hasToOneUpperBound(Multiplicity[1]):Boolean[1]`,
+`isToMany(Multiplicity[1]):Boolean[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::hasUpperBound(multiplicity:Multiplicity[1]):Boolean[1]
 {
     let upperBound = $multiplicity.upperBound;

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/isToMany.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/isToMany.pure
@@ -14,6 +14,33 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether a multiplicity can hold more than one value.
+
+True when the multiplicity is unbounded above, or bounded at more than one. This is the usual test for
+"is this a collection?" when reflecting over a property — a `[*]` or `[1..*]` property needs collection
+handling, while `[0..1]` and `[1]` do not.
+
+Not the negation of `isToOne(Multiplicity[1]):Boolean[1]`: `[0..1]` is neither to-one nor to-many.
+
+**Parameters**
+- `m` — the multiplicity to inspect.
+
+**Returns** `true` when more than one value is permitted.
+
+**Examples**
+```pure
+ZeroMany->isToMany()   // true  -- [*]
+OneMany->isToMany()    // true  -- [1..*]
+PureOne->isToMany()    // false
+ZeroOne->isToMany()    // false
+PureZero->isToMany()   // false
+```
+
+**See also** `isToOne(Multiplicity[1]):Boolean[1]`,
+`hasUpperBound(Multiplicity[1]):Boolean[1]`,
+`getUpperBound(Multiplicity[1]):Integer[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::isToMany(m:Multiplicity[1]):Boolean[1]
 {
    !$m->hasUpperBound() || ($m->getUpperBound() > 1);

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/isToOne.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/multiplicity/isToOne.pure
@@ -14,6 +14,31 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether a multiplicity requires exactly one value.
+
+True only for `[1]`. This is the strict test — a value is both required and single — so `[0..1]` is
+false because the value is optional. When you only care that at most one value is permitted, use
+`hasToOneUpperBound(Multiplicity[1]):Boolean[1]` instead.
+
+**Parameters**
+- `multiplicity` — the multiplicity to inspect.
+
+**Returns** `true` only for exactly-one.
+
+**Examples**
+```pure
+PureOne->isToOne()    // true
+ZeroOne->isToOne()    // false -- optional
+PureZero->isToOne()   // false
+ZeroMany->isToOne()   // false
+OneMany->isToOne()    // false
+```
+
+**See also** `isToMany(Multiplicity[1]):Boolean[1]`,
+`hasToOneUpperBound(Multiplicity[1]):Boolean[1]`,
+`getLowerBound(Multiplicity[1]):Integer[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::isToOne(multiplicity:Multiplicity[1]):Boolean[1]
 {
     hasToOneUpperBound($multiplicity) && eq($multiplicity->getLowerBound(), 1)

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/profile/stereotype.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/profile/stereotype.pure
@@ -14,4 +14,28 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Looks up a stereotype on a profile by name.
+
+Stereotypes are the `<<Profile.name>>` markers attached to model elements. This resolves the name to the
+`Stereotype` object itself, which is what you compare against when checking whether an element carries
+it — comparing strings would miss the profile it belongs to, since two profiles may define stereotypes
+of the same name.
+
+**A name the profile does not define is an error, not an empty result**, since the return multiplicity
+is `[1]`.
+
+**Parameters**
+- `profile` — the profile that defines the stereotype.
+- `str` — the stereotype's name.
+
+**Returns** the stereotype.
+
+**Examples**
+```pure
+$element.stereotypes->contains(PCT->stereotype('function'))
+```
+
+**See also** `tag(Profile[1], String[1]):Tag[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::stereotype(profile:Profile[1], str:String[1]):Stereotype[1];

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/profile/tag.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/profile/tag.pure
@@ -17,8 +17,7 @@ import meta::pure::test::pct::*;
 '''
 Looks up a tag on a profile by name.
 
-Tags are the `{Profile.name='value'}` annotations attached to model elements; where a stereotype is a
-bare marker, a tag carries a string value. This resolves the name to the `Tag` object, which is what you
+A TaggedValue annotation on a model element, `{Profile.name='value'}`, associates a Tag with a string value (unlike a stereotype, which is a bare marker). This resolves the name to the `Tag` object, which is what you
 match a `TaggedValue`'s `tag` against — comparing names alone would ignore which profile the tag belongs
 to, and two profiles may define tags of the same name.
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/profile/tag.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/profile/tag.pure
@@ -14,4 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Looks up a tag on a profile by name.
+
+Tags are the `{Profile.name='value'}` annotations attached to model elements; where a stereotype is a
+bare marker, a tag carries a string value. This resolves the name to the `Tag` object, which is what you
+match a `TaggedValue`'s `tag` against — comparing names alone would ignore which profile the tag belongs
+to, and two profiles may define tags of the same name.
+
+The `doc` tag of `meta::pure::profiles::doc` is the one behind documentation comments.
+
+**A name the profile does not define is an error, not an empty result**, since the return multiplicity is
+`[1]`.
+
+**Parameters**
+- `profile` — the profile that defines the tag.
+- `str` — the tag's name.
+
+**Returns** the tag.
+
+**Examples**
+```pure
+$element.taggedValues->filter(tv | $tv.tag == meta::pure::profiles::doc->tag('doc')).value
+```
+
+**See also** `stereotype(Profile[1], String[1]):Stereotype[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::tag(profile:Profile[1], str:String[1]):Tag[1];

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/reflect/canReactivateDynamically.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/reflect/canReactivateDynamically.pure
@@ -14,6 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether a syntax tree can be evaluated dynamically.
+
+Not every captured expression can be run back: a tree may refer to something the dynamic evaluator
+cannot resolve. This is the guard to call before
+`reactivate(ValueSpecification[1], Map<String, List<Any>>[1]):Any[*]` when the tree came from somewhere
+you do not control — user input, generated code, a stored query — so you can fail gracefully instead of
+erroring mid-evaluation.
+
+**Parameters**
+- `vs` — the syntax tree to test.
+
+**Returns** `true` when the tree can be evaluated dynamically.
+
+**Examples**
+```pure
+canReactivateDynamically({|1}->evaluateAndDeactivate().expressionSequence->toOne())   // true
+
+if($vs->canReactivateDynamically(), |$vs->reactivate(), |[])
+```
+
+**See also** `reactivate(ValueSpecification[1], Map<String, List<Any>>[1]):Any[*]`,
+`deactivate(Any[*]):ValueSpecification[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::canReactivateDynamically(vs:ValueSpecification[1]):Boolean[1];
 
 function <<test.Test>> meta::pure::functions::meta::tests::canReactivateDynamically::testBasicInstanceValue():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/reflect/deactivate.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/reflect/deactivate.pure
@@ -16,6 +16,33 @@ import meta::pure::functions::meta::tests::model::*;
 import meta::pure::functions::meta::tests::evaluateAndDeactivate::*;
 import meta::pure::test::pct::*;
 
+'''
+Turns an expression into its own syntax tree, instead of evaluating it.
+
+This is Pure's metaprogramming entry point. Normally an expression such as `$people->filter(p | …)` runs
+and yields a result; deactivating it yields the `ValueSpecification` describing *how* the result would be
+computed — the function being called, its arguments, and so on. So a call becomes a
+`SimpleFunctionExpression` whose `func` and `parametersValues` can be inspected or rewritten.
+
+That makes it the basis of query manipulation: read a query's structure, transform it, and run the
+transformed version with `reactivate(ValueSpecification[1], Map<String, List<Any>>[1]):Any[*]`.
+
+**Parameters**
+- `var` — the expression to capture rather than evaluate.
+
+**Returns** the syntax tree of the expression.
+
+**Examples**
+```pure
+let f = CC_Person.all()->filter(p | $p.lastName == 'Doe')->first()->deactivate();
+$f->cast(@SimpleFunctionExpression).func.functionName;         // 'first'
+$f->cast(@SimpleFunctionExpression).parametersValues->size();  // 1
+```
+
+**See also** `reactivate(ValueSpecification[1], Map<String, List<Any>>[1]):Any[*]`,
+`evaluateAndDeactivate(T[m]):T[m]`,
+`canReactivateDynamically(ValueSpecification[1]):Boolean[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::deactivate(var:Any[*]):ValueSpecification[1];
 
 function <<test.Test, test.ExcludeModular>> meta::pure::functions::meta::tests::deactivate::testDeactivateFunctionToOne():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/reflect/evaluateAndDeactivate.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/reflect/evaluateAndDeactivate.pure
@@ -14,6 +14,35 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Evaluates a value and then makes its internals inspectable, returning it unchanged.
+
+Where `deactivate(Any[*]):ValueSpecification[1]` captures an expression *instead of* running it, this
+runs it and then exposes the resulting object's structure for reflection. The value and its type come
+back unchanged — `T[m]` in, `T[m]` out — so it drops into an expression without altering its meaning.
+
+In practice it is what makes a lambda's or function type's internals readable: after this, an
+`expressionSequence` or a parameter list can be walked, where before the parts had not been realised.
+
+**Parameters**
+- `var` — the value to evaluate and open up.
+
+**Returns** the same value, with its structure reflectable.
+
+**Examples**
+```pure
+let f = {| true};
+$f->evaluateAndDeactivate().expressionSequence->cast(@InstanceValue).values;   // true
+
+let g = {a:String[1], b:Integer[1] | true};
+$g->genericType().typeArguments->at(0).rawType->toOne()->cast(@FunctionType)
+  .parameters->evaluateAndDeactivate()->map(v | $v.name);                      // ['a', 'b']
+```
+
+**See also** `deactivate(Any[*]):ValueSpecification[1]`,
+`reactivate(ValueSpecification[1], Map<String, List<Any>>[1]):Any[*]`,
+`functionType(Function<Any>[1]):FunctionType[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::evaluateAndDeactivate<T|m>(var:T[m]):T[m];
 
 function <<test.Test>> meta::pure::functions::meta::tests::evaluateAndDeactivate::testEvaluateAndDeactivate():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/reflect/openVariableValues.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/reflect/openVariableValues.pure
@@ -14,6 +14,37 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The values a function has captured from its surrounding scope, keyed by variable name.
+
+A lambda may refer to variables it does not declare — its *open* variables — which it captures from where
+it was written. `{|1 + $a->plus()}` has one open variable, `a`. This collects those captured values.
+
+The map it returns is exactly what
+`reactivate(ValueSpecification[1], Map<String, List<Any>>[1]):Any[*]` needs, so the pair is the reliable
+way to move a captured expression somewhere else and still run it: take the open variables from the
+original function, then reactivate the tree with them. Assembling that map by hand risks missing a
+variable, which surfaces only at evaluation time.
+
+Values are wrapped in `List` objects, so a captured collection survives intact; read them through
+`.values`.
+
+**Parameters**
+- `f` — the function whose captured variables should be collected.
+
+**Returns** a map from variable name to captured value.
+
+**Examples**
+```pure
+let a = [1, 2, 5];
+let f = {|1 + $a->plus()};
+$f->openVariableValues()->get('a').values;   // [1, 2, 5]
+```
+
+**See also** `reactivate(ValueSpecification[1], Map<String, List<Any>>[1]):Any[*]`,
+`deactivate(Any[*]):ValueSpecification[1]`,
+`meta::pure::functions::collection::list(U[*]):List<U>[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::openVariableValues(f:Function<Any>[1]):Map<String, List<Any>>[1];
 
 function <<test.Test>> meta::pure::functions::meta::tests::openVariableValues::testOpenVariableValuesForLambda():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/reflect/reactivate.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/reflect/reactivate.pure
@@ -33,7 +33,7 @@ The result is `Any[*]`, so callers normally cast it.
 - `vs` — the syntax tree to evaluate.
 - `vars` — values for the tree's open variables, keyed by name.
 
-**Returns** the value the expression produces.
+**Returns** the values the expression produces.
 
 **Examples**
 ```pure

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/reflect/reactivate.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/reflect/reactivate.pure
@@ -15,6 +15,36 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+Evaluates a syntax tree, supplying values for any variables it refers to but does not define.
+
+The counterpart of `deactivate(Any[*]):ValueSpecification[1]`: that captures an expression as structure,
+this runs the structure. Together they let a query be inspected or rewritten and then executed.
+
+A captured expression may mention variables from the scope it was written in — its *open* variables.
+Those are not part of the tree, so their values must be supplied here, keyed by name. Use
+`openVariableValues(Function<Any>[1]):Map<String, List<Any>>[1]` to collect them from the original
+function rather than assembling the map by hand. The single-argument overload in this package passes an
+empty map, which is enough when the tree has no open variables.
+
+The result is `Any[*]`, so callers normally cast it.
+
+**Parameters**
+- `vs` — the syntax tree to evaluate.
+- `vars` — values for the tree's open variables, keyed by name.
+
+**Returns** the value the expression produces.
+
+**Examples**
+```pure
+let f = [^CC_Person(firstName='ok', lastName='a')]->map(p | $p.lastName)->deactivate()->cast(@FunctionExpression);
+$f->reactivate();   // ['a']
+```
+
+**See also** `deactivate(Any[*]):ValueSpecification[1]`,
+`openVariableValues(Function<Any>[1]):Map<String, List<Any>>[1]`,
+`canReactivateDynamically(ValueSpecification[1]):Boolean[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::reactivate(vs:ValueSpecification[1], vars:Map<String, List<Any>>[1]):Any[*];
 
 function meta::pure::functions::meta::reactivate(vs:ValueSpecification[1]):Any[*]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/removeOverride.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/removeOverride.pure
@@ -14,4 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Returns an instance with any getter override stripped off.
+
+An instance built with getter overrides computes property values on access rather than reading stored
+state. This yields an equivalent instance without that behaviour, so subsequent reads see the stored
+values directly.
+
+Use it when an override has served its purpose — after materialising a lazily-loaded object, say — and
+you want a plain instance to pass on. To read past an override case by case instead, use
+`meta::pure::functions::lang::rawEvalProperty(Property<Nil, V|m>[1], Any[1]):V[m]`.
+
+The type is preserved, so no cast is needed afterwards.
+
+**Parameters**
+- `instance` — the instance to strip.
+
+**Returns** the same instance without its override.
+
+**Examples**
+```pure
+$lazyInstance->removeOverride()
+```
+
+**See also** `meta::pure::functions::lang::rawEvalProperty(Property<Nil, V|m>[1], Any[1]):V[m]`,
+`meta::pure::functions::meta::getHiddenPayload(Any[1]):Any[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::removeOverride<T>(instance:T[1]):T[1];

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/source/sourceInformation.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/source/sourceInformation.pure
@@ -26,17 +26,45 @@ Class meta::pure::functions::meta::SourceInformation
     <<equality.Key>> endColumn : Integer[1];
 }
 
+'''
+Where a model element was defined: its source file, and the span it occupies.
+
+Returns a `SourceInformation` carrying the file `source` plus two coordinate pairs — `startLine`/
+`startColumn` and `endLine`/`endColumn` delimit the element's whole span, while `line`/`column` point at
+its name. That distinction matters when reporting a diagnostic: the span is what to underline, the name
+is where to put the caret.
+
+**Values that were not written in a source file have no source information**, so the result is `[0..1]`
+and a primitive yields empty rather than an error.
+
+Note that these coordinates are line numbers in a file, so they move whenever anything above the element
+moves. Tests and tools that hard-code them need updating alongside any edit that shifts the file.
+
+**Parameters**
+- `node` — the element to locate.
+
+**Returns** its source information, or empty for a value that has none.
+
+**Examples**
+```pure
+XTestClass->sourceInformation()->toOne().source   // '/platform/pure/.../sourceInformation.pure'
+1->sourceInformation()                            // empty -- primitives have no source
+```
+
+**See also** `elementToPath(Function<Any>[1]):String[1]`,
+`meta::pure::functions::asserts::assertError(Function<{->Any[*]}>[1], String[1], Integer[0..1], Integer[0..1]):Boolean[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::sourceInformation(node:Any[1]):SourceInformation[0..1];
 
 function <<test.Test>> meta::pure::functions::meta::tests::sourceInformation::testClassSourceInformation():Boolean[1]
 {
     let sourceInfo = XTestClass->sourceInformation()->toOne();
     assertEq('/platform/pure/essential/meta/source/sourceInformation.pure', $sourceInfo.source);
-    assertEq(61, $sourceInfo.startLine);
+    assertEq(89, $sourceInfo.startLine);
     assertEq(1, $sourceInfo.startColumn);
-    assertEq(61, $sourceInfo.line);
+    assertEq(89, $sourceInfo.line);
     assertEq(62, $sourceInfo.column);
-    assertEq(64, $sourceInfo.endLine);
+    assertEq(92, $sourceInfo.endLine);
     assertEq(1, $sourceInfo.endColumn);
 }
 
@@ -44,11 +72,11 @@ function <<test.Test>> meta::pure::functions::meta::tests::sourceInformation::te
 {
     let sourceInfo = meta::pure::functions::meta::tests::sourceInformation::testFunctionSourceInformation__Boolean_1_->sourceInformation()->toOne();
     assertEq('/platform/pure/essential/meta/source/sourceInformation.pure', $sourceInfo.source);
-    assertEq(43, $sourceInfo.startLine);
+    assertEq(71, $sourceInfo.startLine);
     assertEq(1, $sourceInfo.startColumn);
-    assertEq(43, $sourceInfo.line);
+    assertEq(71, $sourceInfo.line);
     assertEq(79, $sourceInfo.column);
-    assertEq(53, $sourceInfo.endLine);
+    assertEq(81, $sourceInfo.endLine);
     assertEq(1, $sourceInfo.endColumn);
 }
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/_subTypeOf.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/_subTypeOf.pure
@@ -15,6 +15,29 @@
 import meta::pure::functions::meta::tests::subTypeOf::*;
 import meta::pure::test::pct::*;
 
+'''
+Whether one type is the same as, or a subtype of, another — computed in Pure rather than natively.
+
+Behaves as `subTypeOf(Type[1], Type[1]):Boolean[1]`: reflexive, with `Nil` a subtype of everything. It
+reaches the answer by walking the generalisation chain, so prefer the native `subTypeOf` in ordinary
+code and use this where a Pure-level implementation is specifically wanted.
+
+**Parameters**
+- `subType` — the candidate subtype.
+- `superType` — the candidate supertype.
+
+**Returns** `true` when `subType` is `superType` or descends from it.
+
+**Examples**
+```pure
+Any->_subTypeOf(Any)       // true  -- reflexive
+Any->_subTypeOf(Nil)       // false
+Any->_subTypeOf(Integer)   // false
+```
+
+**See also** `subTypeOf(Type[1], Type[1]):Boolean[1]`,
+`generalizations(Type[1]):Type[1..*]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::_subTypeOf(subType:Type[1], superType:Type[1]):Boolean[1]
 {
     if($subType == Nil,|true, |$subType->getAllTypeGeneralisations()->contains($superType));  

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/class/class.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/class/class.pure
@@ -15,6 +15,32 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+The `Class` of a value, for values that have one.
+
+Narrower than `type(Any[*]):Type[1]`: only class instances have a `Class`. **A primitive yields an empty
+result** even though the signature says `[1]` — `1->class()` is empty, not `Integer`. Guard with
+`isEmpty()`, or use `type(Any[*]):Type[1]` when the value may be a primitive.
+
+Returning a `Class` rather than a `Type` is what makes the class's own members reachable, such as
+`.properties`.
+
+**Parameters**
+- `any` — the value to inspect.
+
+**Returns** its class, or empty for a primitive.
+
+**Examples**
+```pure
+^CC_Person(firstName='Pierre', lastName='Doe')->class()   // CC_Person
+1->class()                                                // empty -- not Integer
+'abc'->class()                                            // empty
+```
+
+**See also** `type(Any[*]):Type[1]`,
+`genericTypeClass(GenericType[1]):Class<Any>[1]`,
+`properties(GenericType[1]):Property<Nil, Any|*>[*]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::class<T>(any:T[*]):Class<T>[1]
 {
     $any->genericType()->genericTypeClass()->cast(@Class<T>);

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/class/genericTypeClass.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/class/genericTypeClass.pure
@@ -15,6 +15,30 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+The `Class` underlying a generic type, for generic types that have one.
+
+Takes the `GenericType` rather than the value, so it composes after
+`genericType(Any[*]):GenericType[1]` when you already hold one. **A generic type whose raw type is a
+primitive yields an empty result** despite the `[1]` in the signature.
+
+`class(T[*]):Class<T>[1]` is the shorthand for going straight from a value to its class.
+
+**Parameters**
+- `g` — the generic type to unwrap.
+
+**Returns** its class, or empty when the raw type is not a class.
+
+**Examples**
+```pure
+^CC_Person(firstName='Pierre', lastName='Doe')->genericType()->genericTypeClass()   // CC_Person
+1->genericType()->genericTypeClass()                                               // empty
+```
+
+**See also** `class(T[*]):Class<T>[1]`,
+`genericType(Any[*]):GenericType[1]`,
+`properties(GenericType[1]):Property<Nil, Any|*>[*]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::genericTypeClass(g:GenericType[1]):Class<Any>[1];
 
 function <<test.Test>> meta::pure::functions::meta::tests::genericTypeClass::testGenericTypeClassPrimitive():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/class/properties.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/class/properties.pure
@@ -15,6 +15,33 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+Every property of a class, including inherited ones and those contributed by associations.
+
+Three sources are combined, which is what makes this more useful than reading `.properties` directly:
+the class's own properties, the properties it gains from `Association` declarations, and — walking the
+generalisation chain — everything inherited from its supertypes.
+
+Qualified properties are not included; those are a separate member list on the class.
+
+Each result is a `Property` metamodel object, so `.name` gives its name and
+`meta::pure::functions::lang::eval(Function<{T[n]->V[m]}>[1], T[n]):V[m]` reads it off an instance.
+
+**Parameters**
+- `genericType` — the generic type whose class should be inspected.
+
+**Returns** the properties, in no guaranteed order.
+
+**Examples**
+```pure
+$address->genericType()->properties()                      // own + association + inherited
+$address->genericType()->properties()->map(p | $p.name)
+```
+
+**See also** `genericType(Any[*]):GenericType[1]`,
+`genericTypeClass(GenericType[1]):Class<Any>[1]`,
+`generalizations(Type[1]):Type[1..*]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::properties(genericType:GenericType[1]):Property<Nil,Any|*>[*]
 {
     // TODO use this once problems with compiled execution are fixed

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/enum/enumName.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/enum/enumName.pure
@@ -15,6 +15,26 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+The simple name of an enumeration, without its package.
+
+Takes the enumeration itself, not one of its values, so it answers "what is this enum called" rather
+than "which value is this". The result is the bare name — use
+`elementToPath(Function<Any>[1]):String[1]` for the fully-qualified path.
+
+**Parameters**
+- `enum` — the enumeration to name.
+
+**Returns** its simple name.
+
+**Examples**
+```pure
+CC_GeographicEntityType->enumName()   // 'CC_GeographicEntityType'
+```
+
+**See also** `enumValues(Enumeration<T>[1]):T[*]`,
+`elementToPath(Function<Any>[1]):String[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::enumName<T>(enum:Enumeration<T>[1]):String[1];
 
 function <<test.Test>> meta::pure::functions::meta::tests::enumName::testEnumName():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/enum/enumName.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/enum/enumName.pure
@@ -18,9 +18,9 @@ import meta::pure::test::pct::*;
 '''
 The simple name of an enumeration, without its package.
 
-Takes the enumeration itself, not one of its values, so it answers "what is this enum called" rather
+Takes the enumeration itself, not one of its values, so it answers "what is this enumeration called" rather
 than "which value is this". The result is the bare name — use
-`elementToPath(Function<Any>[1]):String[1]` for the fully-qualified path.
+`elementToPath(PackageableElement[1]):String[1]` for the fully-qualified path.
 
 **Parameters**
 - `enum` — the enumeration to name.
@@ -33,7 +33,7 @@ CC_GeographicEntityType->enumName()   // 'CC_GeographicEntityType'
 ```
 
 **See also** `enumValues(Enumeration<T>[1]):T[*]`,
-`elementToPath(Function<Any>[1]):String[1]`
+`elementToPath(PackageableElement[1]):String[1]`
 '''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::enumName<T>(enum:Enumeration<T>[1]):String[1];
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/enum/enumValues.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/enum/enumValues.pure
@@ -15,6 +15,27 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+Every value of an enumeration, in declaration order.
+
+The way to enumerate an enum's members without naming them — for building a lookup, validating input,
+or iterating all cases. The enumeration may be held in a variable, so the enum need not be known when
+the code is written.
+
+**Parameters**
+- `enum` — the enumeration to expand.
+
+**Returns** its values, in declaration order.
+
+**Examples**
+```pure
+CC_GeographicEntityType->enumValues()              // [CITY, COUNTRY, REGION]
+CC_GeographicEntityType->enumValues()->map(v | $v->toString())
+```
+
+**See also** `enumName(Enumeration<T>[1]):String[1]`,
+`meta::pure::functions::collection::map(T[m], Function<{T[1]->V[1]}>[1]):V[m]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::enumValues<T>(enum:Enumeration<T>[1]):T[*];
 
 function <<test.Test>> meta::pure::functions::meta::tests::enumValues::testEnumValues():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/enum/enumValues.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/enum/enumValues.pure
@@ -18,8 +18,8 @@ import meta::pure::test::pct::*;
 '''
 Every value of an enumeration, in declaration order.
 
-The way to enumerate an enum's members without naming them — for building a lookup, validating input,
-or iterating all cases. The enumeration may be held in a variable, so the enum need not be known when
+The way to enumerate an enumeration's members without naming them — for building a lookup, validating input,
+or iterating all cases. The enumeration may be held in a variable, so it need not be known when
 the code is written.
 
 **Parameters**

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/function/functionType.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/function/functionType.pure
@@ -14,6 +14,33 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The signature of a function, as a `FunctionType` metamodel object.
+
+Gives programmatic access to what a function accepts and returns: the result's `parameters` are the
+declared parameters, each with its own name, type and multiplicity, and `returnType` and
+`returnMultiplicity` describe the result. This is how generic code inspects a function value before
+calling it.
+
+**Supported only for ordinary and native functions.** Passing any other kind of `Function` — a lambda
+that is not a `FunctionDefinition`, or a property — fails with an explicit error rather than returning
+empty.
+
+**Parameters**
+- `f` — the function to inspect.
+
+**Returns** its function type.
+
+**Examples**
+```pure
+$someFunction->functionType().parameters->map(p | $p.name)
+$someFunction->functionType().returnMultiplicity->isToMany()
+```
+
+**See also** `meta::pure::functions::lang::eval(Function<{T[n]->V[m]}>[1], T[n]):V[m]`,
+`isToMany(Multiplicity[1]):Boolean[1]`,
+`type(Any[*]):Type[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::functionType(f:Function<Any>[1]):FunctionType[1]
 {
    assert($f->instanceOf(FunctionDefinition) || $f->instanceOf(NativeFunction), | 'functionType is not supported yet for this subtype of function '+$f->type()->id());

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/generalizations.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/generalizations.pure
@@ -15,6 +15,31 @@
 import meta::pure::functions::meta::tests::generalizations::*;
 import meta::pure::test::pct::*;
 
+'''
+A type together with all of its supertypes, most specific first.
+
+**The type itself is the first element**, which is why the result is `[1..*]` and never empty — every
+type generalises to at least itself. The chain always ends at `Any`.
+
+Useful for walking an inheritance chain, or for a subtype test by membership; for the latter,
+`subTypeOf(Type[1], Type[1]):Boolean[1]` says the same thing more directly.
+
+**Parameters**
+- `class` — the type to inspect.
+
+**Returns** the type and its supertypes, most specific first.
+
+**Examples**
+```pure
+Integer->generalizations()   // [Integer, Number, Any]
+Boolean->generalizations()   // [Boolean, Any]
+Any->generalizations()       // [Any]
+```
+
+**See also** `subTypeOf(Type[1], Type[1]):Boolean[1]`,
+`type(Any[*]):Type[1]`,
+`instanceOf(Any[1], Type[1]):Boolean[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::generalizations(class:Type[1]):Type[1..*];
 
 Class meta::pure::functions::meta::tests::generalizations::G_A {}

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/generalizations.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/generalizations.pure
@@ -16,7 +16,7 @@ import meta::pure::functions::meta::tests::generalizations::*;
 import meta::pure::test::pct::*;
 
 '''
-A type together with all of its supertypes, most specific first.
+A type together with all of its supertypes, in inheritance order. That is, the order in which types are searched when trying to resolve something (such as a property) through inheritance.
 
 **The type itself is the first element**, which is why the result is `[1..*]` and never empty — every
 type generalises to at least itself. The chain always ends at `Any`.

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/genericType.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/genericType.pure
@@ -15,6 +15,31 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+The full generic type of a value, including its type arguments.
+
+Where `type(Any[*]):Type[1]` gives only the raw type, a `GenericType` keeps the type parameters too. Its
+`rawType` is the type itself and its `typeArguments` are the parameters, so a `List<String>` reports a
+raw type of `List` with `String` as its single argument.
+
+Note the metamodel is reflective: asking a *class* for its generic type describes the class object, so
+`CC_Person->genericType().rawType` is `Class`, and the argument is `CC_Person`.
+
+**Parameters**
+- `any` — the value to inspect.
+
+**Returns** its generic type.
+
+**Examples**
+```pure
+CC_Person->genericType().rawType->toOne()                    // Class
+CC_Person->genericType().typeArguments->at(0).rawType->toOne()   // CC_Person
+```
+
+**See also** `type(Any[*]):Type[1]`,
+`genericTypeClass(GenericType[1]):Class<Any>[1]`,
+`properties(GenericType[1]):Property<Nil, Any|*>[*]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::genericType(any:Any[*]):GenericType[1];
 
 function <<test.Test>> meta::pure::functions::meta::tests::genericType::testGenericType():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/instanceOf.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/instanceOf.pure
@@ -16,6 +16,34 @@ import meta::pure::functions::meta::tests::instanceOf::*;
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+Whether a value is an instance of a type, including through inheritance.
+
+The value-level counterpart of `subTypeOf(Type[1], Type[1]):Boolean[1]`: this tests a *value*, that one
+tests two *types*. A value of a subclass satisfies its superclass, so an `Integer` is an instance of
+`Number`.
+
+For dispatching on type, prefer `meta::pure::functions::lang::match(Any[*], Function<{Nil[n]->T[m]}>[1..*]):T[m]`
+— it selects a branch and hands you the value already typed, where this returns only a boolean and
+leaves you to cast.
+
+**Parameters**
+- `instance` — the value to test.
+- `type` — the type to test against.
+
+**Returns** `true` when the value is an instance of the type.
+
+**Examples**
+```pure
+1->instanceOf(Integer)   // true
+1->instanceOf(Number)    // true  -- through inheritance
+1->instanceOf(String)    // false
+```
+
+**See also** `subTypeOf(Type[1], Type[1]):Boolean[1]`,
+`type(Any[*]):Type[1]`,
+`meta::pure::functions::lang::cast(Any[m], T[1]):T[m]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::instanceOf(instance:Any[1], type:Type[1]):Boolean[1];
 
 Enum meta::pure::functions::meta::tests::instanceOf::InstanceOfEnumA { VALUE1, VALUE2 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/relation/addColumns.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/relation/addColumns.pure
@@ -15,6 +15,34 @@
 import meta::pure::test::pct::*;
 import meta::pure::metamodel::relation::*;
 
+'''
+Extends a relation type with additional columns.
+
+Operates on the *type*, not on data: it computes the `RelationType` you get by appending columns to an
+existing one. That is what lets a function that adds columns to a relation describe its own return type,
+so the extra columns are known statically rather than only at runtime.
+
+New columns are appended after the existing ones, and each keeps the multiplicity its column
+specification declares — a column written `ab:String[1]` stays `[1..1]`, while one written without a
+multiplicity, such as `z:Integer`, is `[0..1]`.
+
+Column specifications are written with the `~[…]` array syntax.
+
+**Parameters**
+- `source` — the relation type to extend.
+- `colSpec` — the columns to append.
+
+**Returns** the extended relation type.
+
+**Examples**
+```pure
+addColumns(@(x:String)->genericType().rawType->cast(@RelationType<Any>)->toOne(), ~[ab:String[1], z:Integer])
+// x:String[0..1], ab:String[1..1], z:Integer[0..1]
+```
+
+**See also** `genericType(Any[*]):GenericType[1]`,
+`type(Any[*]):Type[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::addColumns(source:RelationType<Any>[1], colSpec:ColSpecArray<Any>[1]):RelationType<Any>[1];
 
 function <<test.Test>> meta::pure::functions::meta::tests::addColumns():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/subtypeOf.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/subtypeOf.pure
@@ -15,6 +15,34 @@
 import meta::pure::functions::meta::tests::subTypeOf::*;
 import meta::pure::test::pct::*;
 
+'''
+Whether one type is the same as, or a subtype of, another.
+
+**Reflexive** — every type is a subtype of itself, so `Boolean->subTypeOf(Boolean)` is true. This is
+the type-level relation; use `instanceOf(Any[1], Type[1]):Boolean[1]` to test a *value* instead.
+
+`Nil` is the bottom type and is a subtype of everything, including primitives. Nothing but `Nil` is a
+subtype of `Nil`, so `Any->subTypeOf(Nil)` is false.
+
+**Parameters**
+- `subType` — the candidate subtype.
+- `superType` — the candidate supertype.
+
+**Returns** `true` when `subType` is `superType` or descends from it.
+
+**Examples**
+```pure
+Integer->subTypeOf(Number)   // true
+Boolean->subTypeOf(Boolean)  // true  -- reflexive
+Boolean->subTypeOf(Any)      // true
+Nil->subTypeOf(String)       // true  -- Nil is the bottom type
+Any->subTypeOf(Nil)          // false
+```
+
+**See also** `instanceOf(Any[1], Type[1]):Boolean[1]`,
+`generalizations(Type[1]):Type[1..*]`,
+`_subTypeOf(Type[1], Type[1]):Boolean[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::subTypeOf(subType:Type[1], superType:Type[1]):Boolean[1];
 
 Class meta::pure::functions::meta::tests::subTypeOf::SA {}

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/type.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/meta/type/type.pure
@@ -15,6 +15,32 @@
 import meta::pure::functions::meta::tests::model::*;
 import meta::pure::test::pct::*;
 
+'''
+The type of a value, as a metamodel `Type` object.
+
+The starting point for reflection: the result is the `Type` itself, so it can be compared with a class
+or primitive by name, or passed to `instanceOf(Any[1], Type[1]):Boolean[1]` and
+`subTypeOf(Type[1], Type[1]):Boolean[1]`.
+
+This discards type arguments — a `List<String>` reports `List`. Use
+`genericType(Any[*]):GenericType[1]` when the type parameters matter.
+
+**Parameters**
+- `any` — the value to inspect.
+
+**Returns** its type.
+
+**Examples**
+```pure
+1->type()        // Integer
+'abc'->type()    // String
+$person->type()  // Person
+```
+
+**See also** `genericType(Any[*]):GenericType[1]`,
+`instanceOf(Any[1], Type[1]):Boolean[1]`,
+`generalizations(Type[1]):Type[1..*]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::meta::type(any:Any[*]):Type[1]
 {
     $any->genericType().rawType->toOne()

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/boolean/contains.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/boolean/contains.pure
@@ -14,14 +14,42 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether `source` contains `val` anywhere within it.
+
+The match is literal and case-sensitive; `val` is not treated as a regular expression.
+Every string contains the empty string.
+
+**Parameters**
+- `source` — the string to search in.
+- `val` — the substring to look for.
+
+**Returns** `true` if `val` occurs anywhere in `source`.
+
+**Examples**
+```pure
+'the quick brown fox'->contains('brown')   // true
+'the quick brown fox'->contains('lazy')    // false
+```
+
+**See also** `startsWith(String[1], String[1]):Boolean[1]`,
+`endsWith(String[1], String[1]):Boolean[1]`,
+`indexOf(String[1], String[1]):Integer[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::contains(source:String[1], val:String[1]):Boolean[1];
 
+'''
+A substring occurring in the middle or at the end is found.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::contains::testTrueContains<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assert($f->eval(|contains('the quick brown fox jumps over the lazy dog', 'lazy dog')));
     assert($f->eval(|contains('the quick brown fox jumps over the lazy dog', 'brown fox')));
 }
 
+'''
+Words present separately but not as a contiguous substring do not match.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::contains::testFalseContains<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertFalse($f->eval(|contains('the quick brown fox jumps over the lazy dog', 'lazy fox')));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/boolean/endsWith.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/boolean/endsWith.pure
@@ -14,14 +14,40 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether `source` ends with `val`.
+
+The match is literal and case-sensitive. Every string ends with the empty string.
+
+**Parameters**
+- `source` — the string to test.
+- `val` — the suffix to look for.
+
+**Returns** `true` if `source` ends with `val`.
+
+**Examples**
+```pure
+'the quick brown fox'->endsWith('fox')     // true
+'the quick brown fox'->endsWith('brown')   // false
+```
+
+**See also** `startsWith(String[1], String[1]):Boolean[1]`,
+`contains(String[1], String[1]):Boolean[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::endsWith(source:String[1], val:String[1]):Boolean[1];
 
+'''
+Both a single trailing word and a longer trailing phrase match.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::endswith::testTrueEndsWith<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assert($f->eval(|endsWith('the quick brown fox jumps over the lazy dog', 'dog')));
     assert($f->eval(|endsWith('the quick brown fox jumps over the lazy dog', 'lazy dog')));
 }
 
+'''
+A substring that occurs earlier in the string is not a suffix.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::endswith::testFalseEndsWith<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertFalse($f->eval(|endsWith('the quick brown fox jumps over the lazy dog', 'brown fox')));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/boolean/startsWith.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/boolean/startsWith.pure
@@ -14,19 +14,42 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether `source` begins with `val`.
+
+The match is literal and case-sensitive. Every string starts with the empty string.
+
+**Parameters**
+- `source` — the string to test.
+- `val` — the prefix to look for.
+
+**Returns** `true` if `source` begins with `val`.
+
+**Examples**
+```pure
+'the quick brown fox'->startsWith('the')   // true
+'the quick brown fox'->startsWith('fox')   // false
+```
+
+**See also** `endsWith(String[1], String[1]):Boolean[1]`,
+`contains(String[1], String[1]):Boolean[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::string::startsWith(source:String[1], val:String[1]):Boolean[1];
 
+'''
+Both a single leading word and a longer leading phrase match.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::startswith::testTrueStartsWith<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assert($f->eval(|startsWith('the quick brown fox jumps over the lazy dog', 'the')));
     assert($f->eval(|startsWith('the quick brown fox jumps over the lazy dog', 'the quick brown fox')));
 }
 
+'''
+A substring that occurs later in the string is not a prefix.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::startswith::testFalseStartsWith<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertFalse($f->eval(|startsWith('the quick brown fox jumps over the lazy dog', 'the lazy dog')));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/index/indexOf.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/index/indexOf.pure
@@ -14,11 +14,40 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The zero-based position of the first occurrence of `toFind` in `str`, or `-1` if it does not occur.
+
+Because a miss returns `-1` rather than an empty value, test the result explicitly rather than
+relying on it being empty.
+
+**Parameters**
+- `str` — the string to search in.
+- `toFind` — the substring to locate.
+
+**Returns** the index of the first occurrence, or `-1` when there is none.
+
+**Examples**
+```pure
+'the quick brown fox'->indexOf('quick')   // 4
+'the quick brown fox'->indexOf('fox')     // 16
+'the quick brown fox'->indexOf('happy')   // -1
+```
+
+**See also** `contains(String[1], String[1]):Boolean[1]`,
+`substring(String[1], Integer[1], Integer[1]):String[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::indexOf(str:String[1], toFind:String[1]):Integer[1];
 
+'''
+As `indexOf(String[1], String[1]):Integer[1]`, but begins searching at `fromIndex` rather than at
+the start of the string. Still returns `-1` when there is no occurrence at or after that position.
+'''
 native function <<PCT.function>> meta::pure::functions::string::indexOf(str:String[1], toFind:String[1], fromIndex:Integer[1]):Integer[1];
 
 
+'''
+Positions are zero-based, and a substring that is absent gives -1.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::indexOf::testSimple<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let string = 'the quick brown fox jumps over the lazy dog';
@@ -29,6 +58,9 @@ function <<PCT.test>> meta::pure::functions::string::tests::indexOf::testSimple<
 }
 
 
+'''
+Raising `fromIndex` past the first occurrence finds the next one instead.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::indexOf::testFromIndex<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let string = 'the the';

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/length/length.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/length/length.pure
@@ -14,18 +14,38 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The number of characters in a string.
+
+**Parameters**
+- `str` — the string to measure.
+
+**Returns** the character count; `0` for the empty string.
+
+**Examples**
+```pure
+'hello'->length()   // 5
+''->length()        // 0
+```
+
+**See also** `substring(String[1], Integer[1]):String[1]`,
+`indexOf(String[1], String[1]):Integer[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::string::length(str:String[1]):Integer[1];
 
+'''
+Length counts every character, spaces included.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::length::testLength<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals(43, $f->eval(|length('the quick brown fox jumps over the lazy dog')));
 }
 
+'''
+The empty string has length zero rather than being an empty value.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::length::testEmptyLength<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals(0, $f->eval(|length('')));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/parse/parseBoolean.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/parse/parseBoolean.pure
@@ -14,8 +14,29 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Reads a boolean from its textual form.
+
+Matching is case-insensitive, so `'true'`, `'True'` and `'TRUE'` are all accepted.
+
+**Parameters**
+- `string` — the text to read.
+
+**Returns** the boolean the text denotes.
+
+**Examples**
+```pure
+'true'->parseBoolean()    // true
+'FALSE'->parseBoolean()   // false
+```
+
+**See also** `parseInteger(String[1]):Integer[1]`, `parseFloat(String[1]):Float[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::parseBoolean(string:String[1]):Boolean[1];
 
+'''
+Every capitalisation of 'true' parses to true.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::parseBoolean::testParseTrue<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assert($f->eval(|parseBoolean('true')));
@@ -26,6 +47,9 @@ function <<PCT.test>> meta::pure::functions::string::tests::parseBoolean::testPa
     assert($f->eval(|parseBoolean('TRUE')));
 }
 
+'''
+Every capitalisation of 'false' parses to false.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::parseBoolean::testParseFalse<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertFalse($f->eval(|parseBoolean('false')));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/parse/parseDate.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/parse/parseDate.pure
@@ -14,20 +14,52 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Reads a date, or a date and time, from its ISO-8601 textual form.
+
+Month and day may be written with or without a leading zero. A trailing `Z` denotes UTC, and an
+offset such as `-0500` is honoured — the resulting instant is the same moment in time, so comparing
+two dates written in different zones compares the instants, not the text.
+
+**Parameters**
+- `string` — the text to read.
+
+**Returns** the date the text denotes.
+
+**Examples**
+```pure
+parseDate('2014-02-27T10:01:35.231')        // %2014-02-27T10:01:35.231
+parseDate('2014-2-27T10:01:35.231')         // same; a leading zero is optional
+parseDate('2014-02-27T10:01:35.231Z')       // same, stated as UTC
+parseDate('2014-02-27T10:01:35.231-0500')   // %2014-02-27T15:01:35.231+0000
+```
+
+**See also** `parseInteger(String[1]):Integer[1]`,
+`meta::pure::functions::string::toString(Any[1]):String[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::parseDate(string:String[1]):Date[1];
 
+'''
+A leading zero in the month or day is optional.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::parseDate::testParseDate<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEq(%2014-02-27T10:01:35.231, $f->eval(|parseDate('2014-02-27T10:01:35.231')));
     assertEq(%2014-02-27T10:01:35.231, $f->eval(|parseDate('2014-2-27T10:01:35.231')));
 }
 
+'''
+An explicit trailing Z states UTC without changing the instant.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::parseDate::testParseDateWithZ<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEq(%2014-02-27T10:01:35.231, $f->eval(|parseDate('2014-02-27T10:01:35.231Z')));
     assertEq(%2014-02-27T10:01:35.231, $f->eval(|parseDate('2014-2-27T10:01:35.231Z')));
 }
 
+'''
+An offset is honoured: the same instant compares equal across zones.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::parseDate::testParseDateWithTimezone<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEq(%2014-02-27T10:01:35.231-0500, $f->eval(|parseDate('2014-02-27T10:01:35.231-0500')));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/parse/parseFloat.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/parse/parseFloat.pure
@@ -14,8 +14,32 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Reads a floating-point number from its textual form.
+
+An explicit `+` or `-` sign is accepted, as are leading and trailing zeros. Use
+`parseDecimal(String[1]):Decimal[1]` instead when exact decimal arithmetic matters, such as for
+monetary amounts.
+
+**Parameters**
+- `string` — the text to read.
+
+**Returns** the float the text denotes.
+
+**Examples**
+```pure
+'3.14159'->parseFloat()               // 3.14159
+'+0000003.1415900000'->parseFloat()   // 3.14159
+'-000.000'->parseFloat()              // 0.0
+```
+
+**See also** `parseDecimal(String[1]):Decimal[1]`, `parseInteger(String[1]):Integer[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::parseFloat(string:String[1]):Float[1];
 
+'''
+Signs, leading zeros and trailing zeros are all accepted.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::parseFloat::testParseFloat<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEq(3.14159, $f->eval(|parseFloat('3.14159')));
@@ -23,6 +47,9 @@ function <<PCT.test>> meta::pure::functions::string::tests::parseFloat::testPars
     assertEq(-3.14159, $f->eval(|parseFloat('-0000003.1415900000')));
 }
 
+'''
+Zero parses to zero however it is written, including a signed all-zeros form.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::parseFloat::testParseZero<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEq(0.0, $f->eval(|parseFloat('0.0')));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/parse/parseInteger.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/parse/parseInteger.pure
@@ -14,8 +14,32 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Reads an integer from its textual form.
+
+An explicit `+` or `-` sign is accepted, as are leading zeros.
+
+**Parameters**
+- `string` — the text to read.
+
+**Returns** the integer the text denotes.
+
+**Examples**
+```pure
+'17'->parseInteger()          // 17
+'+00000017'->parseInteger()   // 17
+'-17'->parseInteger()         // -17
+```
+
+**See also** `parseFloat(String[1]):Float[1]`,
+`parseDecimal(String[1]):Decimal[1]`,
+`meta::pure::functions::string::toString(Any[1]):String[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::parseInteger(string:String[1]):Integer[1];
 
+'''
+Signs and leading zeros are accepted, including at the top of the integer range.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::parseInteger::testParseInteger<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEq(17, $f->eval(|parseInteger('17')));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/slice/substring.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/slice/substring.pure
@@ -14,15 +14,47 @@
 
 import meta::pure::test::pct::*;
 
+'''
+The portion of a string from `start` to its end.
+
+Positions are zero-based, so `start` is the number of characters to drop from the front. A `start`
+of `0` returns the whole string.
+
+**Parameters**
+- `str` — the string to take from.
+- `start` — zero-based index of the first character to keep.
+
+**Returns** the remainder of the string from `start` onwards.
+
+**Examples**
+```pure
+'the quick brown'->substring(0)   // 'the quick brown'
+'the quick brown'->substring(4)   // 'quick brown'
+```
+
+**See also** `substring(String[1], Integer[1], Integer[1]):String[1]`,
+`indexOf(String[1], String[1]):Integer[1]`, `length(String[1]):Integer[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::string::substring(str:String[1], start:Integer[1]):String[1];
 
+'''
+The portion of a string between two positions: from `start` inclusive to `end` exclusive.
+
+Both indexes are zero-based, so the result has `end - start` characters, and passing `length()` as
+`end` is equivalent to `substring(String[1], Integer[1]):String[1]`.
+
+**Examples**
+```pure
+'the quick brown fox'->substring(4, 9)   // 'quick'
+```
+'''
 native function <<PCT.function>> meta::pure::functions::string::substring(str:String[1], start:Integer[1], end:Integer[1]):String[1];
 
+'''
+`start` counts characters dropped from the front, so 0 returns the whole string.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::substring::testStart<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let string = 'the quick brown fox jumps over the lazy dog';
@@ -33,6 +65,9 @@ function <<PCT.test>> meta::pure::functions::string::tests::substring::testStart
     assertEquals('quick brown fox jumps over the lazy dog', $f->eval(|substring($string, 4)));
 }
 
+'''
+`end` is exclusive, so the slice spans `end - start` characters.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::substring::testStartEnd<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     let string = 'the quick brown fox jumps over the lazy dog';

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/split/split.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/split/split.pure
@@ -14,18 +14,43 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Splits a string into a collection of pieces around each occurrence of a separator.
+
+The separator is matched literally, not as a regular expression, and is not itself included in the
+result. If the separator never occurs, the result is a single-element collection holding the
+original string — not an empty collection.
+
+**Parameters**
+- `str` — the string to split.
+- `token` — the literal separator to split on.
+
+**Returns** the pieces, in order.
+
+**Examples**
+```pure
+'Hello World'->split(' ')   // ['Hello', 'World']
+'Hello World'->split(';')   // ['Hello World']
+```
+
+**See also** `joinStrings(String[*], String[1]):String[1]`,
+`indexOf(String[1], String[1]):Integer[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::string::split(str:String[1], token:String[1]):String[*];
 
+'''
+The separator is consumed and the surrounding pieces are returned.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::split::testSplit<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals(['Hello', 'World'], $f->eval(|'Hello World'->split(' ')));
 }
 
+'''
+A separator that never occurs yields the whole string as a single element.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::split::testSplitWithNoSplit<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals(['Hello World'], $f->eval(|'Hello World'->split(';')));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/format.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/format.pure
@@ -15,11 +15,38 @@
 import meta::pure::test::pct::*;
 
 // Used by Pair
+'''
+Builds a string by substituting values into a format template.
+
+Each specifier in `format` consumes the next value from `args`, in order.
+
+**Specifiers**
+- `%s` — the value as a string.
+- `%d` — an integer; width and zero-padding may be given, as in `%05d`.
+- `%f` — a floating-point number; precision may be given, as in `%.2f`.
+- `%r` — the value's Pure representation, quoting strings as they would be written in source.
+- `%t` — a date. A pattern may follow in braces, as in `%t{yyyy-MM-dd}`, optionally opening with a
+  timezone, as in `%t{[CET]yyyy-MM-dd HH:mm:ss.SSSZ}`.
+
+**Parameters**
+- `format` — the template.
+- `args` — the values to substitute, in the order their specifiers appear.
+
+**Returns** the formatted string.
+
+**Examples**
+```pure
+format('Hello %s %s', ['John', 'Roe'])                  // 'Hello John Roe'
+format('%s scored %.2f', ['Pierre', 3.14159])           // 'Pierre scored 3.14'
+format('%s has %05d points', ['Pierre', 42])            // 'Pierre has 00042 points'
+format('on %t{yyyy-MM-dd}', %2014-02-27T10:01:35.231)   // 'on 2014-02-27'
+```
+
+**See also** `meta::pure::functions::string::toString(Any[1]):String[1]`,
+`joinStrings(String[*], String[1]):String[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::string::format(format:String[1], args:Any[*]):String[1];
 
 function <<PCT.test>> meta::pure::functions::string::tests::format::testFormatString<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/joinStrings.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/joinStrings.pure
@@ -14,22 +14,46 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Concatenates a collection of strings, placing a separator between consecutive elements.
+
+The separator appears only *between* elements, so a single-element collection comes back unchanged
+and an empty collection yields the empty string.
+
+**Parameters**
+- `strings` — the strings to join.
+- `separator` — placed between consecutive elements.
+
+**Returns** the joined string.
+
+**Examples**
+```pure
+['a', 'b', 'c']->joinStrings(',')   // 'a,b,c'
+['a']->joinStrings(',')             // 'a'
+```
+
+**See also** `split(String[1], String[1]):String[*]`,
+`meta::pure::functions::string::toString(Any[1]):String[1]`
+'''
 function
     <<PCT.function, functionType.ReducerFunction>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::string::joinStrings(strings:String[*], separator:String[1]):String[1]
 {
     $strings->joinStrings('', $separator, '')
 }
 
+'''
+The separator falls only between elements.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::joinStrings::testJoinStrings<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEq('a,b,c', $f->eval(|joinStrings(['a', 'b', 'c'], ',')));
     assertEq('[a,b,c]', $f->eval(|joinStrings(['a', 'b', 'c'], '[', ',', ']')));
 }
 
+'''
+The arrow form reads the same as the prefix form.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::joinStrings::testJoinStringsUsingGenericArrow<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEq('a,b,c', $f->eval(|['a', 'b', 'c']->joinStrings(',')));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/toRepresentation.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/toRepresentation.pure
@@ -15,6 +15,28 @@
 import meta::pure::functions::string::tests::toRepresentation::*;
 import meta::pure::test::pct::*;
 
+'''
+The Pure source representation of a value — the form you would write to produce it.
+
+This differs from `toString(Any[1]):String[1]`, which gives the plain human-readable rendering.
+Here strings are quoted and escaped, dates and times carry their `%` prefix, and decimals their `D`
+suffix, so the result can be read back as Pure. A value with no literal syntax is rendered as
+`<id instanceOf Type>`.
+
+**Parameters**
+- `any` — the value to represent.
+
+**Returns** the value as it would appear in Pure source.
+
+**Examples**
+```pure
+1->toRepresentation()        // 1
+true->toRepresentation()     // true
+'abc'->toRepresentation()    // 'abc'   -- includes the quote characters, unlike toString
+```
+
+**See also** `meta::pure::functions::string::toString(Any[1]):String[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::string::toRepresentation(any:Any[1]):String[1]
 {
     $any->match([

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/toString.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/toString.pure
@@ -16,11 +16,32 @@ import meta::pure::test::pct::*;
 import meta::pure::functions::string::tests::toString::*;
 
 // Used by List
+'''
+The plain textual form of any value.
+
+This is the human-readable rendering: strings come back as their own contents, with no surrounding
+quotes. Use `toRepresentation(Any[1]):String[1]` when you want the form a value would take in Pure
+source, with strings quoted and escaped.
+
+**Parameters**
+- `any` — the value to render.
+
+**Returns** the value as a string.
+
+**Examples**
+```pure
+1->toString()       // '1'
+3.14->toString()    // '3.14'
+true->toString()    // 'true'
+'abc'->toString()   // 'abc'   (no quotes; contrast toRepresentation)
+```
+
+**See also** `toRepresentation(Any[1]):String[1]`,
+`format(String[1], Any[*]):String[1]`,
+`parseInteger(String[1]):Integer[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::string::toString(any:Any[1]):String[1];
 
 function <<PCT.test>> meta::pure::functions::string::tests::toString::testIntegerToString<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/toString.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/toString.pure
@@ -20,8 +20,12 @@ import meta::pure::functions::string::tests::toString::*;
 The plain textual form of any value.
 
 This is the human-readable rendering: strings come back as their own contents, with no surrounding
-quotes. Use `toRepresentation(Any[1]):String[1]` when you want the form a value would take in Pure
-source, with strings quoted and escaped.
+quotes or escapes. This can yield ambiguous results; e.g., `1->toString()` and `'1'->toString()` both
+give the same result. Use `toRepresentation(Any[1]):String[1]` when you want the form a value would
+take in Pure source, with strings quoted and escaped.
+
+If a Class defines a qualified property `toString()` returning `String[1]`, it will be called by this
+function to generate string renderings for its instances.
 
 **Parameters**
 - `any` — the value to render.

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/replace.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/replace.pure
@@ -14,13 +14,36 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Replaces every occurrence of a substring within a string.
+
+Matching is literal, not a regular expression, and every occurrence is replaced.
+If `toReplace` does not occur in `source`, the source string is returned unchanged.
+
+**Parameters**
+- `source` — the string to search in.
+- `toReplace` — the literal substring to look for.
+- `replacement` — the string to substitute in its place.
+
+**Returns** a new string with the replacements applied.
+
+**Examples**
+```pure
+'abcde'->replace('ab', 'fg')      // 'fgcde'
+'a-b-c'->replace('-', '')         // 'abc'
+'hello'->replace('z', 'y')        // 'hello'
+```
+
+**See also** `split(String[1], String[1]):String[*]`,
+`substring(String[1], Integer[1], Integer[1]):String[1]`
+'''
 native function
     <<PCT.function>>
-    {
-        doc.doc=''
-    }
     meta::pure::functions::string::replace(source:String[1], toReplace:String[1], replacement:String[1]):String[1];
 
+'''
+Replacing a leading substring rewrites only that occurrence.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::replace::testReplace<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals('fgcde', $f->eval(|'abcde'->replace('ab', 'fg')));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/reverse.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/reverse.pure
@@ -14,8 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Reverses the order of the characters in a string.
+
+**Parameters**
+- `str` — the string to reverse.
+
+**Returns** the string with its characters in reverse order; the empty string reverses to itself.
+
+**Examples**
+```pure
+'cba'->reverseString()   // 'abc'
+''->reverseString()      // ''
+```
+
+**See also** `meta::pure::functions::collection::reverse(T[m]):T[m]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::reverseString(str:String[1]):String[1];
 
+'''
+Characters are reversed, and the empty string is returned unchanged.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::reverse::testReverseString<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals('', $f->eval(|''->reverseString()));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/toLower.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/toLower.pure
@@ -14,8 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Converts every character in a string to lower case.
+
+Characters that have no lower-case form, such as digits and punctuation, are left unchanged, so a
+string that is already lower case comes back identical.
+
+**Parameters**
+- `source` — the string to convert.
+
+**Returns** the lower-cased string.
+
+**Examples**
+```pure
+'TesT'->toLower()   // 'test'
+'test'->toLower()   // 'test'
+```
+
+**See also** `toUpper(String[1]):String[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::toLower(source:String[1]):String[1];
 
+'''
+Mixed case is lowered, and an already-lower-case string is unchanged.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::tolower::testToLower<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals('test', $f->eval(|'TesT'->toLower()));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/toUpper.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/toUpper.pure
@@ -14,8 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Converts every character in a string to upper case.
+
+Characters that have no upper-case form, such as digits and punctuation, are left unchanged, so a
+string that is already upper case comes back identical.
+
+**Parameters**
+- `source` — the string to convert.
+
+**Returns** the upper-cased string.
+
+**Examples**
+```pure
+'TesT'->toUpper()   // 'TEST'
+'TEST'->toUpper()   // 'TEST'
+```
+
+**See also** `toLower(String[1]):String[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::toUpper(source:String[1]):String[1];
 
+'''
+Mixed case is raised, and an already-upper-case string is unchanged.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::toupper::testToUpper<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals('TEST', $f->eval(|'TesT'->toUpper()));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/trim/lTrim.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/trim/lTrim.pure
@@ -14,8 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Removes whitespace from the start of a string, leaving the end untouched.
+
+**Parameters**
+- `str` — the string to trim.
+
+**Returns** the string without leading whitespace; any trailing whitespace is preserved.
+
+**Examples**
+```pure
+'  hello  '->ltrim()   // 'hello  '
+'hello  '->ltrim()     // 'hello  '
+```
+
+**See also** `rtrim(String[1]):String[1]`, `trim(String[1]):String[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::ltrim(str:String[1]):String[1];
 
+'''
+Only the leading whitespace goes; trailing whitespace survives.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::trim::testLTrim<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals('A Simple Text To Trim    ', $f->eval(|' A Simple Text To Trim    '->ltrim()));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/trim/rTrim.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/trim/rTrim.pure
@@ -14,8 +14,27 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Removes whitespace from the end of a string, leaving the start untouched.
+
+**Parameters**
+- `str` — the string to trim.
+
+**Returns** the string without trailing whitespace; any leading whitespace is preserved.
+
+**Examples**
+```pure
+'  hello  '->rtrim()   // '  hello'
+'  hello'->rtrim()     // '  hello'
+```
+
+**See also** `ltrim(String[1]):String[1]`, `trim(String[1]):String[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::rtrim(str:String[1]):String[1];
 
+'''
+Only the trailing whitespace goes; leading whitespace survives.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::trim::testRTrim<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals(' A Simple Text To Trim', $f->eval(|' A Simple Text To Trim    '->rtrim()));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/trim/trim.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/transformation/trim/trim.pure
@@ -14,8 +14,30 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Removes whitespace from both ends of a string.
+
+Whitespace inside the string is left alone — only the leading and trailing runs are removed.
+
+**Parameters**
+- `str` — the string to trim.
+
+**Returns** the string without leading or trailing whitespace.
+
+**Examples**
+```pure
+'  hello  '->trim()   // 'hello'
+'  hello'->trim()     // 'hello'
+'a b'->trim()         // 'a b'
+```
+
+**See also** `ltrim(String[1]):String[1]`, `rtrim(String[1]):String[1]`
+'''
 native function <<PCT.function>> meta::pure::functions::string::trim(str:String[1]):String[1];
 
+'''
+Whitespace is removed from both ends, whichever end actually has any.
+'''
 function <<PCT.test>> meta::pure::functions::string::tests::trim::testTrim<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
 {
     assertEquals('A Simple Text To Trim', $f->eval(|' A Simple Text To Trim    '->trim()));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/tests/assertError.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/tests/assertError.pure
@@ -15,9 +15,59 @@
 import meta::pure::functions::asserts::*;
 import meta::pure::test::pct::*;
 
+'''
+Asserts that evaluating a function raises an error, and inspects that error with a matcher.
+
+The code under test is passed as a zero-argument function, written `|expression`, so that the error
+happens inside the assertion rather than at the call site. The matcher receives the error message and
+its source information, and is free to assert whatever it needs — which is what makes this the most
+general of the three forms. The assertion fails if the function does *not* raise.
+
+Reach for the simpler `assertError(Function<{->Any[*]}>[1], String[1]):Boolean[1]` when you only need
+to check the message.
+
+**Parameters**
+- `f` — the code expected to fail, as `|expression`.
+- `errorMessageMatcher` — receives the message and source information, and asserts against them.
+
+**Returns** `true` when the expected error was raised and the matcher passed.
+
+**Examples**
+```pure
+assertError(|[1, 2]->at(3), {msg, si | assertEquals(42, $si.line->toOne())})
+```
+
+**See also** `assertError(Function<{->Any[*]}>[1], String[1]):Boolean[1]`,
+`assertError(Function<{->Any[*]}>[1], String[1], Integer[0..1], Integer[0..1]):Boolean[1]`
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::asserts::assertError(f:Function<{->Any[*]}>[1], errorMessageMatcher:Function<{String[1], SourceInformation[0..1]->Any[*]}>[1]):Boolean[1];
 
 
+'''
+Asserts that evaluating a function raises an error with a given message, at a given source location.
+
+`line` and `column` are both `[0..1]`, so pass `[]` for either to leave it unchecked — checking the
+message and line but not the column is the common case. The message must match exactly, not merely
+contain the expected text.
+
+Use this when the *location* of the error is part of what you are testing, such as for compiler
+diagnostics. Prefer `assertError(Function<{->Any[*]}>[1], String[1]):Boolean[1]` otherwise, since
+hard-coded line numbers must be updated whenever the source above them moves.
+
+**Parameters**
+- `f` — the code expected to fail, as `|expression`.
+- `message` — the exact expected error message.
+- `line` — the expected line, or `[]` to skip the check.
+- `column` — the expected column, or `[]` to skip the check.
+
+**Returns** `true` when the expected error was raised at the expected place.
+
+**Examples**
+```pure
+// checks the message and the line, leaving the column unchecked
+assertError(|[1, 2]->at(3), 'The system is trying to get an element at offset 3 where the collection is of size 2', 42, [])
+```
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::asserts::assertError(f:Function<{->Any[*]}>[1], message:String[1], line:Integer[0..1], column:Integer[0..1]):Boolean[1]
 {
     $f->assertError({msg, si |
@@ -27,6 +77,28 @@ function <<PCT.function, PCT.platformOnly>> meta::pure::functions::asserts::asse
     });
 }
 
+'''
+Asserts that evaluating a function raises an error with exactly the given message.
+
+The usual form. The code under test is passed as `|expression` so the error is raised inside the
+assertion, and the assertion fails if no error is raised at all. The source location is not checked,
+which keeps the test stable when surrounding code moves.
+
+The message must match exactly rather than being a substring.
+
+**Parameters**
+- `f` — the code expected to fail, as `|expression`.
+- `message` — the exact expected error message.
+
+**Returns** `true` when the expected error was raised.
+
+**Examples**
+```pure
+assertError(|[1, 2]->at(3), 'The system is trying to get an element at offset 3 where the collection is of size 2')
+```
+
+**See also** `assertError(Function<{->Any[*]}>[1], String[1], Integer[0..1], Integer[0..1]):Boolean[1]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::asserts::assertError(f:Function<{->Any[*]}>[1], message:String[1]):Boolean[1]
 {
     assertError($f, $message, [], []);
@@ -39,12 +111,12 @@ function <<test.Test>> meta::pure::functions::asserts::testSimpleAssertError():B
 
 function <<test.Test>> meta::pure::functions::asserts::testSimpleAssertErrorLine():Boolean[1]
 {
-    assertError(|[1,2]->at(3),'The system is trying to get an element at offset 3 where the collection is of size 2', 42, []);
+    assertError(|[1,2]->at(3),'The system is trying to get an element at offset 3 where the collection is of size 2', 114, []);
 }
 
 function <<test.Test>> meta::pure::functions::asserts::testSimpleAssertErrorLineColumn():Boolean[1]
 {
-    assertError(|[1,2]->at(3),'The system is trying to get an element at offset 3 where the collection is of size 2', 47, 25);
+    assertError(|[1,2]->at(3),'The system is trying to get an element at offset 3 where the collection is of size 2', 119, 25);
 }
 
 function <<test.Test>> meta::pure::functions::asserts::testSimpleAssertErrorColumn():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/greaterThan.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/greaterThan.pure
@@ -198,7 +198,9 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Strin
 }
 
 '''
-Compares two dates chronologically — true when `left` falls strictly after `right`.
+Compares two dates chronologically. For dates of the same granularity, this is true when `left` falls
+strictly after `right`. The general case is that it is true when `left` starts strictly after the start of
+`right`, or when they start at the same time but `left` ends strictly before `right`.
 
 As `greaterThan(Number[1], Number[1]):Boolean[1]`, the operator is written `>` — `$a > $b` — but the
 order is chronological rather than numeric.
@@ -208,6 +210,7 @@ order is chronological rather than numeric.
 %2012-10-02 > %2012-10-01   // true
 %2015-01-01 > %2016-01-01   // false
 %2012-10-02 > %2012-10-02   // false
+%2015-01-01 > %2015         // true, both start together but %2015-01-01 ends first
 ```
 
 **See also** `greaterThan(Number[1], Number[1]):Boolean[1]`

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/greaterThan.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/greaterThan.pure
@@ -15,15 +15,10 @@
 import meta::pure::test::pct::*;
 
 '''
-Whether the first operand succeeds the second, according to the type's natural order.
+Whether the first number succeeds the second, in numeric order.
 
-Written `>` in Pure: `$a > $b`. Overloads cover `Number`, `Date`, `String` and `Boolean`, so the
-same operator orders numerically, chronologically, lexicographically, or with `false` before `true`.
-
-An absent operand makes the result `false`, **not** empty — the comparison does not propagate
-emptiness the way arithmetic does. So a missing value never satisfies the comparison, and
-`$a > $b` is false whenever either side is empty. Test with `isEmpty()` first when you need to
-distinguish "absent" from "present but not greater than".
+Written `>` in Pure: `$a > $b`. Both operands are present, so the comparison is always decided; it is
+strict, so equal numbers give `false`.
 
 **Parameters**
 - `left` — the first operand.
@@ -33,13 +28,16 @@ distinguish "absent" from "present but not greater than".
 
 **Examples**
 ```pure
-1 > 2
-'a' > 'b'
-%2015-01-01 > %2016-01-01
-false > true
+4 > 3   // true
+1 > 2   // false
+3 > 3   // false, the comparison is strict
 ```
 
-**See also** `lessThan(Number[1], Number[1]):Boolean[1]`,
+**See also** `greaterThan(Date[1], Date[1]):Boolean[1]`,
+`greaterThan(String[1], String[1]):Boolean[1]`,
+`greaterThan(Boolean[1], Boolean[1]):Boolean[1]`,
+`greaterThan(Number[0..1], Number[0..1]):Boolean[1]`,
+`lessThan(Number[1], Number[1]):Boolean[1]`,
 `meta::pure::functions::collection::sort(T[m], Function<{T[1], T[1]->Integer[1]}>[0..1]):T[m]`
 '''
 function
@@ -56,7 +54,13 @@ function
 
 '''
 As `greaterThan(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent.
+
+An absent operand makes the result `false`, **not** empty — the comparison does not propagate
+emptiness the way arithmetic does. Each `[0..1]` operand is tested with `isNotEmpty()` before being
+compared, so a missing value never satisfies the comparison and `$a > $b` is false whenever either
+side is empty. Test with `isEmpty()` first when you need to distinguish "absent" from "present but
+not greater than". The other overloads taking `[0..1]` operands behave the same way.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Number[0..1], right:Number[0..1]):Boolean[1]
 {
@@ -65,7 +69,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Numbe
 
 '''
 As `greaterThan(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`greaterThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Number[1], right:Number[0..1]):Boolean[1]
 {
@@ -74,7 +79,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Numbe
 
 '''
 As `greaterThan(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`greaterThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Number[0..1], right:Number[1]):Boolean[1]
 {
@@ -83,7 +89,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Numbe
 
 '''
 As `greaterThan(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent; absent operands are treated as described in
+`greaterThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Date[0..1], right:Date[0..1]):Boolean[1]
 {
@@ -92,7 +99,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Date[
 
 '''
 As `greaterThan(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`greaterThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Date[1], right:Date[0..1]):Boolean[1]
 {
@@ -101,7 +109,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Date[
 
 '''
 As `greaterThan(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`greaterThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Date[0..1], right:Date[1]):Boolean[1]
 {
@@ -110,7 +119,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Date[
 
 '''
 As `greaterThan(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent; absent operands are treated as described in
+`greaterThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:String[0..1], right:String[0..1]):Boolean[1]
 {
@@ -119,7 +129,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Strin
 
 '''
 As `greaterThan(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`greaterThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:String[1], right:String[0..1]):Boolean[1]
 {
@@ -128,7 +139,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Strin
 
 '''
 As `greaterThan(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`greaterThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:String[0..1], right:String[1]):Boolean[1]
 {
@@ -137,7 +149,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Strin
 
 '''
 As `greaterThan(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent; absent operands are treated as described in
+`greaterThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Boolean[0..1], right:Boolean[0..1]):Boolean[1]
 {
@@ -146,7 +159,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Boole
 
 '''
 As `greaterThan(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`greaterThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Boolean[1], right:Boolean[0..1]):Boolean[1]
 {
@@ -155,7 +169,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Boole
 
 '''
 As `greaterThan(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`greaterThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Boolean[0..1], right:Boolean[1]):Boolean[1]
 {
@@ -164,6 +179,18 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Boole
 
 '''
 Compares two strings lexicographically, character by character.
+
+As `greaterThan(Number[1], Number[1]):Boolean[1]`, the operator is written `>` — `$a > $b` — but the
+order is lexicographic rather than numeric.
+
+**Examples**
+```pure
+'b' > 'a'   // true
+'a' > 'b'   // false
+'a' > 'a'   // false
+```
+
+**See also** `greaterThan(Number[1], Number[1]):Boolean[1]`
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:String[1], right:String[1]):Boolean[1]
 {
@@ -172,6 +199,18 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Strin
 
 '''
 Compares two dates chronologically — true when `left` falls strictly after `right`.
+
+As `greaterThan(Number[1], Number[1]):Boolean[1]`, the operator is written `>` — `$a > $b` — but the
+order is chronological rather than numeric.
+
+**Examples**
+```pure
+%2012-10-02 > %2012-10-01   // true
+%2015-01-01 > %2016-01-01   // false
+%2012-10-02 > %2012-10-02   // false
+```
+
+**See also** `greaterThan(Number[1], Number[1]):Boolean[1]`
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Date[1], right:Date[1]):Boolean[1]
 {
@@ -179,7 +218,20 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Date[
 }
 
 '''
-Orders booleans with `false` before `true`.
+Orders booleans with `false` before `true`, so `true > false` is the only case that holds.
+
+As `greaterThan(Number[1], Number[1]):Boolean[1]`, the operator is written `>` — `$a > $b` — but the
+order is over the two boolean values rather than numeric.
+
+**Examples**
+```pure
+true > false    // true
+false > true    // false
+true > true     // false
+false > false   // false
+```
+
+**See also** `greaterThan(Number[1], Number[1]):Boolean[1]`
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Boolean[1], right:Boolean[1]):Boolean[1]
 {

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/greaterThan.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/greaterThan.pure
@@ -14,10 +14,37 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether the first operand succeeds the second, according to the type's natural order.
+
+Written `>` in Pure: `$a > $b`. Overloads cover `Number`, `Date`, `String` and `Boolean`, so the
+same operator orders numerically, chronologically, lexicographically, or with `false` before `true`.
+
+An absent operand makes the result `false`, **not** empty — the comparison does not propagate
+emptiness the way arithmetic does. So a missing value never satisfies the comparison, and
+`$a > $b` is false whenever either side is empty. Test with `isEmpty()` first when you need to
+distinguish "absent" from "present but not greater than".
+
+**Parameters**
+- `left` — the first operand.
+- `right` — the second operand.
+
+**Returns** `true` when `left` is greater than `right`.
+
+**Examples**
+```pure
+1 > 2
+'a' > 'b'
+%2015-01-01 > %2016-01-01
+false > true
+```
+
+**See also** `lessThan(Number[1], Number[1]):Boolean[1]`,
+`meta::pure::functions::collection::sort(T[m], Function<{T[1], T[1]->Integer[1]}>[0..1]):T[m]`
+'''
 function
     <<PCT.function>>
     {
-        doc.doc='Returns true if, according to the type order, $left succeeds $right',
         PCT.grammarDoc='$first > $second',
         PCT.grammarCharacters='>'
     }
@@ -27,76 +54,133 @@ function
 }
 
 
+'''
+As `greaterThan(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Number[0..1], right:Number[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && greaterThan($left->toOne(), $right->toOne())
 }
 
+'''
+As `greaterThan(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Number[1], right:Number[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && greaterThan($left, $right->toOne())
 }
 
+'''
+As `greaterThan(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Number[0..1], right:Number[1]):Boolean[1]
 {
     $left->isNotEmpty() && greaterThan($left->toOne(), $right)
 }
 
+'''
+As `greaterThan(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Date[0..1], right:Date[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && greaterThan($left->toOne(), $right->toOne())
 }
 
+'''
+As `greaterThan(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Date[1], right:Date[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && greaterThan($left, $right->toOne())
 }
 
+'''
+As `greaterThan(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Date[0..1], right:Date[1]):Boolean[1]
 {
     $left->isNotEmpty() && greaterThan($left->toOne(), $right)
 }
 
+'''
+As `greaterThan(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:String[0..1], right:String[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && greaterThan($left->toOne(), $right->toOne())
 }
 
+'''
+As `greaterThan(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:String[1], right:String[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && greaterThan($left, $right->toOne())
 }
 
+'''
+As `greaterThan(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:String[0..1], right:String[1]):Boolean[1]
 {
     $left->isNotEmpty() && greaterThan($left->toOne(), $right)
 }
 
+'''
+As `greaterThan(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Boolean[0..1], right:Boolean[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && greaterThan($left->toOne(), $right->toOne())
 }
 
+'''
+As `greaterThan(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Boolean[1], right:Boolean[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && greaterThan($left, $right->toOne())
 }
 
+'''
+As `greaterThan(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Boolean[0..1], right:Boolean[1]):Boolean[1]
 {
     $left->isNotEmpty() && greaterThan($left->toOne(), $right)
 }
 
+'''
+Compares two strings lexicographically, character by character.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:String[1], right:String[1]):Boolean[1]
 {
     lessThan($right, $left)
 }
 
+'''
+Compares two dates chronologically — true when `left` falls strictly after `right`.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Date[1], right:Date[1]):Boolean[1]
 {
     lessThan($right, $left)
 }
 
+'''
+Orders booleans with `false` before `true`.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThan(left:Boolean[1], right:Boolean[1]):Boolean[1]
 {
     lessThan($right, $left)

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/greaterThanEqual.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/greaterThanEqual.pure
@@ -15,16 +15,10 @@
 import meta::pure::test::pct::*;
 
 '''
-Whether the first number succeeds or equals the second, in numeric order, where either operand may be
-absent.
+Whether the first number succeeds or equals the second, in numeric order.
 
-Written `>=` in Pure: `$a >= $b`. The comparison is not strict, so equal numbers give `true`.
-
-An absent operand makes the result `false`, **not** empty — the comparison does not propagate
-emptiness the way arithmetic does. Each `[0..1]` operand is tested with `isNotEmpty()` before being
-compared, so a missing value never satisfies the comparison and `$a >= $b` is false whenever either
-side is empty. Test with `isEmpty()` first when you need to distinguish "absent" from "present but
-not greater than or equal to". The other overloads taking `[0..1]` operands behave the same way.
+Written `>=` in Pure: `$a >= $b`. Both operands are present, so the comparison is always decided; it is
+not strict, so equal numbers give `true`.
 
 **Parameters**
 - `left` — the first operand.
@@ -34,16 +28,15 @@ not greater than or equal to". The other overloads taking `[0..1]` operands beha
 
 **Examples**
 ```pure
-4 >= 3     // true
-3 >= 3     // true, the comparison is not strict
-3 >= 4     // false
-$a >= $b   // false when either $a or $b is empty
+4 >= 3   // true
+3 >= 3   // true, the comparison is not strict
+3 >= 4   // false
 ```
 
-**See also** `greaterThanEqual(Number[1], Number[1]):Boolean[1]`,
-`greaterThanEqual(Date[1], Date[1]):Boolean[1]`,
+**See also** `greaterThanEqual(Date[1], Date[1]):Boolean[1]`,
 `greaterThanEqual(String[1], String[1]):Boolean[1]`,
 `greaterThanEqual(Boolean[1], Boolean[1]):Boolean[1]`,
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]`,
 `lessThanEqual(Number[1], Number[1]):Boolean[1]`,
 `meta::pure::functions::collection::sort(T[m], Function<{T[1], T[1]->Integer[1]}>[0..1]):T[m]`
 '''
@@ -53,7 +46,23 @@ function
         PCT.grammarDoc='$first >= $second',
         PCT.grammarCharacters='>='
     }
-    meta::pure::functions::boolean::greaterThanEqual(left:Number[0..1], right:Number[0..1]):Boolean[1]
+    meta::pure::functions::boolean::greaterThanEqual(left:Number[1], right:Number[1]):Boolean[1]
+{
+    lessThanEqual($right, $left)
+}
+
+
+'''
+As `greaterThanEqual(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
+Either operand may be absent.
+
+An absent operand makes the result `false`, **not** empty — the comparison does not propagate
+emptiness the way arithmetic does. Each `[0..1]` operand is tested with `isNotEmpty()` before being
+compared, so a missing value never satisfies the comparison and `$a >= $b` is false whenever either
+side is empty. Test with `isEmpty()` first when you need to distinguish "absent" from "present but
+not greater than or equal to". The other overloads taking `[0..1]` operands behave the same way.
+'''
+function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Number[0..1], right:Number[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && greaterThanEqual($left->toOne(), $right->toOne())
 }
@@ -169,17 +178,6 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 }
 
 '''
-Whether one number is greater than or equal to another, both operands being present.
-
-The `[1]` form, so there is no empty case to consider — see
-`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]` for how absent operands are treated.
-'''
-function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Number[1], right:Number[1]):Boolean[1]
-{
-    lessThanEqual($right, $left)
-}
-
-'''
 Compares two strings lexicographically, character by character.
 
 As `greaterThanEqual(Number[1], Number[1]):Boolean[1]`, the operator is written `>=` — `$a >= $b` —
@@ -200,7 +198,9 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 }
 
 '''
-Compares two dates chronologically — true when `left` falls at or after `right`.
+Compares two dates chronologically. For dates of the same granularity, this is true when `left` falls at
+or after `right`. The general case is that it is true when `left` starts strictly after the start of
+`right`, or when they start at the same time and `left` ends before or at the same time as `right`.
 
 As `greaterThanEqual(Number[1], Number[1]):Boolean[1]`, the operator is written `>=` — `$a >= $b` —
 but the order is chronological rather than numeric.
@@ -210,6 +210,7 @@ but the order is chronological rather than numeric.
 %2012-10-02 >= %2012-10-01   // true
 %2012-10-02 >= %2012-10-02   // true, the comparison is not strict
 %2015-01-01 >= %2016-01-01   // false
+%2015-01-01 >= %2015         // true, both start together but %2015-01-01 ends first
 ```
 
 **See also** `greaterThanEqual(Number[1], Number[1]):Boolean[1]`

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/greaterThanEqual.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/greaterThanEqual.pure
@@ -14,10 +14,37 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether the first operand succeeds or equals the second, according to the type's natural order.
+
+Written `>=` in Pure: `$a >= $b`. Overloads cover `Number`, `Date`, `String` and `Boolean`, so the
+same operator orders numerically, chronologically, lexicographically, or with `false` before `true`.
+
+An absent operand makes the result `false`, **not** empty — the comparison does not propagate
+emptiness the way arithmetic does. So a missing value never satisfies the comparison, and
+`$a >= $b` is false whenever either side is empty. Test with `isEmpty()` first when you need to
+distinguish "absent" from "present but not greater than or equal to".
+
+**Parameters**
+- `left` — the first operand.
+- `right` — the second operand.
+
+**Returns** `true` when `left` is greater than or equal to `right`.
+
+**Examples**
+```pure
+1 >= 2
+'a' >= 'b'
+%2015-01-01 >= %2016-01-01
+false >= true
+```
+
+**See also** `lessThanEqual(Number[1], Number[1]):Boolean[1]`,
+`meta::pure::functions::collection::sort(T[m], Function<{T[1], T[1]->Integer[1]}>[0..1]):T[m]`
+'''
 function
     <<PCT.function>>
     {
-        doc.doc='Returns true if, according to the type order, $left succeeds or is equal to $right',
         PCT.grammarDoc='$first >= $second',
         PCT.grammarCharacters='>='
     }
@@ -26,76 +53,135 @@ function
     $left->isNotEmpty() && $right->isNotEmpty() && greaterThanEqual($left->toOne(), $right->toOne())
 }
 
+'''
+As `greaterThanEqual(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Number[1], right:Number[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && greaterThanEqual($left, $right->toOne())
 }
 
+'''
+As `greaterThanEqual(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Number[0..1], right:Number[1]):Boolean[1]
 {
     $left->isNotEmpty() && greaterThanEqual($left->toOne(), $right)
 }
 
+'''
+As `greaterThanEqual(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Date[0..1], right:Date[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && greaterThanEqual($left->toOne(), $right->toOne())
 }
 
+'''
+As `greaterThanEqual(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Date[1], right:Date[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && greaterThanEqual($left, $right->toOne())
 }
 
+'''
+As `greaterThanEqual(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Date[0..1], right:Date[1]):Boolean[1]
 {
     $left->isNotEmpty() && greaterThanEqual($left->toOne(), $right)
 }
 
+'''
+As `greaterThanEqual(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:String[0..1], right:String[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && greaterThanEqual($left->toOne(), $right->toOne())
 }
 
+'''
+As `greaterThanEqual(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:String[1], right:String[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && greaterThanEqual($left, $right->toOne())
 }
 
+'''
+As `greaterThanEqual(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:String[0..1], right:String[1]):Boolean[1]
 {
     $left->isNotEmpty() && greaterThanEqual($left->toOne(), $right)
 }
 
+'''
+As `greaterThanEqual(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Boolean[0..1], right:Boolean[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && greaterThanEqual($left->toOne(), $right->toOne())
 }
 
+'''
+As `greaterThanEqual(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Boolean[1], right:Boolean[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && greaterThanEqual($left, $right->toOne())
 }
 
+'''
+As `greaterThanEqual(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Boolean[0..1], right:Boolean[1]):Boolean[1]
 {
     $left->isNotEmpty() && greaterThanEqual($left->toOne(), $right)
 }
 
+'''
+Whether one number is greater than or equal to another, both operands being present.
+
+The `[1]` form, so there is no empty case to consider — see
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]` for how absent operands are treated.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Number[1], right:Number[1]):Boolean[1]
 {
     lessThanEqual($right, $left)
 }
 
+'''
+Compares two strings lexicographically, character by character.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:String[1], right:String[1]):Boolean[1]
 {
     lessThanEqual($right, $left)
 }
 
+'''
+Compares two dates chronologically — true when `left` falls at or after `right`.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Date[1], right:Date[1]):Boolean[1]
 {
     lessThanEqual($right, $left)
 }
 
+'''
+Orders booleans with `false` before `true`.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Boolean[1], right:Boolean[1]):Boolean[1]
 {
     lessThanEqual($right, $left)

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/greaterThanEqual.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/greaterThanEqual.pure
@@ -15,15 +15,16 @@
 import meta::pure::test::pct::*;
 
 '''
-Whether the first operand succeeds or equals the second, according to the type's natural order.
+Whether the first number succeeds or equals the second, in numeric order, where either operand may be
+absent.
 
-Written `>=` in Pure: `$a >= $b`. Overloads cover `Number`, `Date`, `String` and `Boolean`, so the
-same operator orders numerically, chronologically, lexicographically, or with `false` before `true`.
+Written `>=` in Pure: `$a >= $b`. The comparison is not strict, so equal numbers give `true`.
 
 An absent operand makes the result `false`, **not** empty — the comparison does not propagate
-emptiness the way arithmetic does. So a missing value never satisfies the comparison, and
-`$a >= $b` is false whenever either side is empty. Test with `isEmpty()` first when you need to
-distinguish "absent" from "present but not greater than or equal to".
+emptiness the way arithmetic does. Each `[0..1]` operand is tested with `isNotEmpty()` before being
+compared, so a missing value never satisfies the comparison and `$a >= $b` is false whenever either
+side is empty. Test with `isEmpty()` first when you need to distinguish "absent" from "present but
+not greater than or equal to". The other overloads taking `[0..1]` operands behave the same way.
 
 **Parameters**
 - `left` — the first operand.
@@ -33,13 +34,17 @@ distinguish "absent" from "present but not greater than or equal to".
 
 **Examples**
 ```pure
-1 >= 2
-'a' >= 'b'
-%2015-01-01 >= %2016-01-01
-false >= true
+4 >= 3     // true
+3 >= 3     // true, the comparison is not strict
+3 >= 4     // false
+$a >= $b   // false when either $a or $b is empty
 ```
 
-**See also** `lessThanEqual(Number[1], Number[1]):Boolean[1]`,
+**See also** `greaterThanEqual(Number[1], Number[1]):Boolean[1]`,
+`greaterThanEqual(Date[1], Date[1]):Boolean[1]`,
+`greaterThanEqual(String[1], String[1]):Boolean[1]`,
+`greaterThanEqual(Boolean[1], Boolean[1]):Boolean[1]`,
+`lessThanEqual(Number[1], Number[1]):Boolean[1]`,
 `meta::pure::functions::collection::sort(T[m], Function<{T[1], T[1]->Integer[1]}>[0..1]):T[m]`
 '''
 function
@@ -55,7 +60,8 @@ function
 
 '''
 As `greaterThanEqual(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Number[1], right:Number[0..1]):Boolean[1]
 {
@@ -64,7 +70,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 
 '''
 As `greaterThanEqual(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Number[0..1], right:Number[1]):Boolean[1]
 {
@@ -73,7 +80,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 
 '''
 As `greaterThanEqual(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent; absent operands are treated as described in
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Date[0..1], right:Date[0..1]):Boolean[1]
 {
@@ -82,7 +90,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 
 '''
 As `greaterThanEqual(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Date[1], right:Date[0..1]):Boolean[1]
 {
@@ -91,7 +100,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 
 '''
 As `greaterThanEqual(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Date[0..1], right:Date[1]):Boolean[1]
 {
@@ -100,7 +110,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 
 '''
 As `greaterThanEqual(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent; absent operands are treated as described in
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:String[0..1], right:String[0..1]):Boolean[1]
 {
@@ -109,7 +120,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 
 '''
 As `greaterThanEqual(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:String[1], right:String[0..1]):Boolean[1]
 {
@@ -118,7 +130,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 
 '''
 As `greaterThanEqual(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:String[0..1], right:String[1]):Boolean[1]
 {
@@ -127,7 +140,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 
 '''
 As `greaterThanEqual(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent; absent operands are treated as described in
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Boolean[0..1], right:Boolean[0..1]):Boolean[1]
 {
@@ -136,7 +150,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 
 '''
 As `greaterThanEqual(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Boolean[1], right:Boolean[0..1]):Boolean[1]
 {
@@ -145,7 +160,8 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 
 '''
 As `greaterThanEqual(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`greaterThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Boolean[0..1], right:Boolean[1]):Boolean[1]
 {
@@ -165,6 +181,18 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 
 '''
 Compares two strings lexicographically, character by character.
+
+As `greaterThanEqual(Number[1], Number[1]):Boolean[1]`, the operator is written `>=` — `$a >= $b` —
+but the order is lexicographic rather than numeric.
+
+**Examples**
+```pure
+'b' >= 'a'   // true
+'a' >= 'a'   // true, the comparison is not strict
+'a' >= 'b'   // false
+```
+
+**See also** `greaterThanEqual(Number[1], Number[1]):Boolean[1]`
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:String[1], right:String[1]):Boolean[1]
 {
@@ -173,6 +201,18 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 
 '''
 Compares two dates chronologically — true when `left` falls at or after `right`.
+
+As `greaterThanEqual(Number[1], Number[1]):Boolean[1]`, the operator is written `>=` — `$a >= $b` —
+but the order is chronological rather than numeric.
+
+**Examples**
+```pure
+%2012-10-02 >= %2012-10-01   // true
+%2012-10-02 >= %2012-10-02   // true, the comparison is not strict
+%2015-01-01 >= %2016-01-01   // false
+```
+
+**See also** `greaterThanEqual(Number[1], Number[1]):Boolean[1]`
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Date[1], right:Date[1]):Boolean[1]
 {
@@ -180,7 +220,20 @@ function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:
 }
 
 '''
-Orders booleans with `false` before `true`.
+Orders booleans with `false` before `true`, so `false >= true` is the only case that does not hold.
+
+As `greaterThanEqual(Number[1], Number[1]):Boolean[1]`, the operator is written `>=` — `$a >= $b` —
+but the order is over the two boolean values rather than numeric.
+
+**Examples**
+```pure
+true >= false    // true
+true >= true     // true, the comparison is not strict
+false >= false   // true
+false >= true    // false
+```
+
+**See also** `greaterThanEqual(Number[1], Number[1]):Boolean[1]`
 '''
 function <<PCT.function>> meta::pure::functions::boolean::greaterThanEqual(left:Boolean[1], right:Boolean[1]):Boolean[1]
 {

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/lessThan.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/lessThan.pure
@@ -175,7 +175,9 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Boolean[
 }
 
 '''
-Compares two dates chronologically — true when `left` falls strictly before `right`.
+Compares two dates chronologically. For dates of the same granularity, this is true when `left` falls
+strictly before `right`. The general case is that it is true when `left` starts strictly before the start
+of `right`, or when they start at the same time and `left` ends strictly after the end of `right`.
 
 As `lessThan(Number[1], Number[1]):Boolean[1]`, the operator is written `<` — `$a < $b` — but the
 order is chronological rather than numeric.
@@ -185,6 +187,7 @@ order is chronological rather than numeric.
 %2012-10-01 < %2012-10-02   // true
 %2015-01-01 < %2016-01-01   // true
 %2012-10-02 < %2012-10-02   // false
+%2015 < %2015-01-01         // true, both start together but %2015 ends later
 ```
 
 **See also** `lessThan(Number[1], Number[1]):Boolean[1]`

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/lessThan.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/lessThan.pure
@@ -14,86 +14,170 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether the first operand precedes the second, according to the type's natural order.
+
+Written `<` in Pure: `$a < $b`. Overloads cover `Number`, `Date`, `String` and `Boolean`, so the
+same operator orders numerically, chronologically, lexicographically, or with `false` before `true`.
+
+An absent operand makes the result `false`, **not** empty — the comparison does not propagate
+emptiness the way arithmetic does. So a missing value never satisfies the comparison, and
+`$a < $b` is false whenever either side is empty. Test with `isEmpty()` first when you need to
+distinguish "absent" from "present but not less than".
+
+**Parameters**
+- `left` — the first operand.
+- `right` — the second operand.
+
+**Returns** `true` when `left` is less than `right`.
+
+**Examples**
+```pure
+1 < 2
+'a' < 'b'
+%2015-01-01 < %2016-01-01
+false < true
+```
+
+**See also** `greaterThan(Number[1], Number[1]):Boolean[1]`,
+`meta::pure::functions::collection::sort(T[m], Function<{T[1], T[1]->Integer[1]}>[0..1]):T[m]`
+'''
 native function
     <<PCT.function>>
     {
-        doc.doc='Returns true if, according to the type order, $left precedes $right',
         PCT.grammarDoc='$first < $second',
         PCT.grammarCharacters='<'
     }
     meta::pure::functions::boolean::lessThan(left:Number[1], right:Number[1]):Boolean[1];
 
 
+'''
+As `lessThan(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Number[0..1], right:Number[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && lessThan($left->toOne(), $right->toOne())
 }
 
+'''
+As `lessThan(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Number[1], right:Number[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && lessThan($left, $right->toOne())
 }
 
+'''
+As `lessThan(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Number[0..1], right:Number[1]):Boolean[1]
 {
     $left->isNotEmpty() && lessThan($left->toOne(), $right)
 }
 
+'''
+As `lessThan(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Date[0..1], right:Date[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && lessThan($left->toOne(), $right->toOne())
 }
 
+'''
+As `lessThan(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Date[1], right:Date[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && lessThan($left, $right->toOne())
 }
 
+'''
+As `lessThan(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Date[0..1], right:Date[1]):Boolean[1]
 {
     $left->isNotEmpty() && lessThan($left->toOne(), $right)
 }
 
+'''
+As `lessThan(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:String[0..1], right:String[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && lessThan($left->toOne(), $right->toOne())
 }
 
+'''
+As `lessThan(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:String[1], right:String[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && lessThan($left, $right->toOne())
 }
 
+'''
+As `lessThan(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:String[0..1], right:String[1]):Boolean[1]
 {
     $left->isNotEmpty() && lessThan($left->toOne(), $right)
 }
 
+'''
+As `lessThan(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Boolean[0..1], right:Boolean[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && lessThan($left->toOne(), $right->toOne())
 }
 
+'''
+As `lessThan(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Boolean[1], right:Boolean[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && lessThan($left, $right->toOne())
 }
 
+'''
+As `lessThan(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Boolean[0..1], right:Boolean[1]):Boolean[1]
 {
     $left->isNotEmpty() && lessThan($left->toOne(), $right)
 }
 
+'''
+Compares two dates chronologically — true when `left` falls strictly before `right`.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Date[1], right:Date[1]):Boolean[1]
 {
     compare($left, $right) < 0
 }
 
+'''
+Compares two strings lexicographically, character by character.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:String[1], right:String[1]):Boolean[1]
 {
     compare($left, $right) < 0
 }
 
+'''
+Orders booleans with `false` before `true`.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Boolean[1], right:Boolean[1]):Boolean[1]
 {
     !$left && $right

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/lessThan.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/lessThan.pure
@@ -15,15 +15,10 @@
 import meta::pure::test::pct::*;
 
 '''
-Whether the first operand precedes the second, according to the type's natural order.
+Whether the first number precedes the second, in numeric order.
 
-Written `<` in Pure: `$a < $b`. Overloads cover `Number`, `Date`, `String` and `Boolean`, so the
-same operator orders numerically, chronologically, lexicographically, or with `false` before `true`.
-
-An absent operand makes the result `false`, **not** empty — the comparison does not propagate
-emptiness the way arithmetic does. So a missing value never satisfies the comparison, and
-`$a < $b` is false whenever either side is empty. Test with `isEmpty()` first when you need to
-distinguish "absent" from "present but not less than".
+Written `<` in Pure: `$a < $b`. Both operands are present, so the comparison is always decided; it is
+strict, so equal numbers give `false`.
 
 **Parameters**
 - `left` — the first operand.
@@ -33,13 +28,16 @@ distinguish "absent" from "present but not less than".
 
 **Examples**
 ```pure
-1 < 2
-'a' < 'b'
-%2015-01-01 < %2016-01-01
-false < true
+1 < 2   // true
+4 < 3   // false
+3 < 3   // false, the comparison is strict
 ```
 
-**See also** `greaterThan(Number[1], Number[1]):Boolean[1]`,
+**See also** `lessThan(Date[1], Date[1]):Boolean[1]`,
+`lessThan(String[1], String[1]):Boolean[1]`,
+`lessThan(Boolean[1], Boolean[1]):Boolean[1]`,
+`lessThan(Number[0..1], Number[0..1]):Boolean[1]`,
+`greaterThan(Number[1], Number[1]):Boolean[1]`,
 `meta::pure::functions::collection::sort(T[m], Function<{T[1], T[1]->Integer[1]}>[0..1]):T[m]`
 '''
 native function
@@ -53,7 +51,13 @@ native function
 
 '''
 As `lessThan(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent.
+
+An absent operand makes the result `false`, **not** empty — the comparison does not propagate
+emptiness the way arithmetic does. Each `[0..1]` operand is tested with `isNotEmpty()` before being
+compared, so a missing value never satisfies the comparison and `$a < $b` is false whenever either
+side is empty. Test with `isEmpty()` first when you need to distinguish "absent" from "present but
+not less than". The other overloads taking `[0..1]` operands behave the same way.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Number[0..1], right:Number[0..1]):Boolean[1]
 {
@@ -62,7 +66,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Number[0
 
 '''
 As `lessThan(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`lessThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Number[1], right:Number[0..1]):Boolean[1]
 {
@@ -71,7 +76,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Number[1
 
 '''
 As `lessThan(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`lessThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Number[0..1], right:Number[1]):Boolean[1]
 {
@@ -80,7 +86,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Number[0
 
 '''
 As `lessThan(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent; absent operands are treated as described in
+`lessThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Date[0..1], right:Date[0..1]):Boolean[1]
 {
@@ -89,7 +96,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Date[0..
 
 '''
 As `lessThan(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`lessThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Date[1], right:Date[0..1]):Boolean[1]
 {
@@ -98,7 +106,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Date[1],
 
 '''
 As `lessThan(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`lessThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Date[0..1], right:Date[1]):Boolean[1]
 {
@@ -107,7 +116,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Date[0..
 
 '''
 As `lessThan(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent; absent operands are treated as described in
+`lessThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:String[0..1], right:String[0..1]):Boolean[1]
 {
@@ -116,7 +126,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:String[0
 
 '''
 As `lessThan(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`lessThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:String[1], right:String[0..1]):Boolean[1]
 {
@@ -125,7 +136,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:String[1
 
 '''
 As `lessThan(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`lessThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:String[0..1], right:String[1]):Boolean[1]
 {
@@ -134,7 +146,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:String[0
 
 '''
 As `lessThan(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent; absent operands are treated as described in
+`lessThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Boolean[0..1], right:Boolean[0..1]):Boolean[1]
 {
@@ -143,7 +156,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Boolean[
 
 '''
 As `lessThan(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`lessThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Boolean[1], right:Boolean[0..1]):Boolean[1]
 {
@@ -152,7 +166,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Boolean[
 
 '''
 As `lessThan(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`lessThan(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Boolean[0..1], right:Boolean[1]):Boolean[1]
 {
@@ -161,6 +176,18 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Boolean[
 
 '''
 Compares two dates chronologically — true when `left` falls strictly before `right`.
+
+As `lessThan(Number[1], Number[1]):Boolean[1]`, the operator is written `<` — `$a < $b` — but the
+order is chronological rather than numeric.
+
+**Examples**
+```pure
+%2012-10-01 < %2012-10-02   // true
+%2015-01-01 < %2016-01-01   // true
+%2012-10-02 < %2012-10-02   // false
+```
+
+**See also** `lessThan(Number[1], Number[1]):Boolean[1]`
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Date[1], right:Date[1]):Boolean[1]
 {
@@ -169,6 +196,18 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Date[1],
 
 '''
 Compares two strings lexicographically, character by character.
+
+As `lessThan(Number[1], Number[1]):Boolean[1]`, the operator is written `<` — `$a < $b` — but the
+order is lexicographic rather than numeric.
+
+**Examples**
+```pure
+'a' < 'b'   // true
+'b' < 'a'   // false
+'a' < 'a'   // false
+```
+
+**See also** `lessThan(Number[1], Number[1]):Boolean[1]`
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:String[1], right:String[1]):Boolean[1]
 {
@@ -176,7 +215,20 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:String[1
 }
 
 '''
-Orders booleans with `false` before `true`.
+Orders booleans with `false` before `true`, so `false < true` is the only case that holds.
+
+As `lessThan(Number[1], Number[1]):Boolean[1]`, the operator is written `<` — `$a < $b` — but the
+order is over the two boolean values rather than numeric.
+
+**Examples**
+```pure
+false < true    // true
+true < false    // false
+true < true     // false
+false < false   // false
+```
+
+**See also** `lessThan(Number[1], Number[1]):Boolean[1]`
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThan(left:Boolean[1], right:Boolean[1]):Boolean[1]
 {

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/lessThanEqual.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/lessThanEqual.pure
@@ -175,7 +175,10 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Boo
 }
 
 '''
-Compares two dates chronologically — true when `left` falls at or before `right`.
+Compares two dates chronologically. For dates of the same granularity, this is true when `left` falls at
+or before `right`. The general case is that it is true when `left` starts strictly before the start of
+`right`, or when they start at the same time and `left` ends at the same time as or after the end of
+`right`.
 
 As `lessThanEqual(Number[1], Number[1]):Boolean[1]`, the operator is written `<=` — `$a <= $b` — but
 the order is chronological rather than numeric.
@@ -186,6 +189,7 @@ the order is chronological rather than numeric.
 %2015-01-01 <= %2016-01-01   // true
 %2012-10-02 <= %2012-10-02   // true, the comparison is not strict
 %2012-10-03 <= %2012-10-02   // false
+%2015 <= %2015-01-01         // true, both start together but %2015 ends later
 ```
 
 **See also** `lessThanEqual(Number[1], Number[1]):Boolean[1]`

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/lessThanEqual.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/lessThanEqual.pure
@@ -15,15 +15,10 @@
 import meta::pure::test::pct::*;
 
 '''
-Whether the first operand precedes or equals the second, according to the type's natural order.
+Whether the first number precedes or equals the second, in numeric order.
 
-Written `<=` in Pure: `$a <= $b`. Overloads cover `Number`, `Date`, `String` and `Boolean`, so the
-same operator orders numerically, chronologically, lexicographically, or with `false` before `true`.
-
-An absent operand makes the result `false`, **not** empty — the comparison does not propagate
-emptiness the way arithmetic does. So a missing value never satisfies the comparison, and
-`$a <= $b` is false whenever either side is empty. Test with `isEmpty()` first when you need to
-distinguish "absent" from "present but not less than or equal to".
+Written `<=` in Pure: `$a <= $b`. Both operands are present, so the comparison is always decided; it
+is not strict, so equal numbers give `true`.
 
 **Parameters**
 - `left` — the first operand.
@@ -33,13 +28,16 @@ distinguish "absent" from "present but not less than or equal to".
 
 **Examples**
 ```pure
-1 <= 2
-'a' <= 'b'
-%2015-01-01 <= %2016-01-01
-false <= true
+1 <= 2   // true
+3 <= 3   // true, the comparison is not strict
+4 <= 3   // false
 ```
 
-**See also** `greaterThanEqual(Number[1], Number[1]):Boolean[1]`,
+**See also** `lessThanEqual(Date[1], Date[1]):Boolean[1]`,
+`lessThanEqual(String[1], String[1]):Boolean[1]`,
+`lessThanEqual(Boolean[1], Boolean[1]):Boolean[1]`,
+`lessThanEqual(Number[0..1], Number[0..1]):Boolean[1]`,
+`greaterThanEqual(Number[1], Number[1]):Boolean[1]`,
 `meta::pure::functions::collection::sort(T[m], Function<{T[1], T[1]->Integer[1]}>[0..1]):T[m]`
 '''
 native function
@@ -53,7 +51,13 @@ native function
 
 '''
 As `lessThanEqual(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent.
+
+An absent operand makes the result `false`, **not** empty — the comparison does not propagate
+emptiness the way arithmetic does. Each `[0..1]` operand is tested with `isNotEmpty()` before being
+compared, so a missing value never satisfies the comparison and `$a <= $b` is false whenever either
+side is empty. Test with `isEmpty()` first when you need to distinguish "absent" from "present but
+not less than or equal to". The other overloads taking `[0..1]` operands behave the same way.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Number[0..1], right:Number[0..1]):Boolean[1]
 {
@@ -62,7 +66,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Num
 
 '''
 As `lessThanEqual(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`lessThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Number[1], right:Number[0..1]):Boolean[1]
 {
@@ -71,7 +76,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Num
 
 '''
 As `lessThanEqual(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`lessThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Number[0..1], right:Number[1]):Boolean[1]
 {
@@ -80,7 +86,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Num
 
 '''
 As `lessThanEqual(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent; absent operands are treated as described in
+`lessThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Date[0..1], right:Date[0..1]):Boolean[1]
 {
@@ -89,7 +96,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Dat
 
 '''
 As `lessThanEqual(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`lessThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Date[1], right:Date[0..1]):Boolean[1]
 {
@@ -98,7 +106,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Dat
 
 '''
 As `lessThanEqual(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`lessThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Date[0..1], right:Date[1]):Boolean[1]
 {
@@ -107,7 +116,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Dat
 
 '''
 As `lessThanEqual(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent; absent operands are treated as described in
+`lessThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:String[0..1], right:String[0..1]):Boolean[1]
 {
@@ -116,7 +126,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Str
 
 '''
 As `lessThanEqual(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`lessThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:String[1], right:String[0..1]):Boolean[1]
 {
@@ -125,7 +136,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Str
 
 '''
 As `lessThanEqual(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`lessThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:String[0..1], right:String[1]):Boolean[1]
 {
@@ -134,7 +146,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Str
 
 '''
 As `lessThanEqual(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
-Either operand may be absent; an absent operand makes the result `false` rather than empty.
+Either operand may be absent; absent operands are treated as described in
+`lessThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Boolean[0..1], right:Boolean[0..1]):Boolean[1]
 {
@@ -143,7 +156,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Boo
 
 '''
 As `lessThanEqual(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
-The second operand may be absent; an absent operand makes the result `false` rather than empty.
+The second operand may be absent; absent operands are treated as described in
+`lessThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Boolean[1], right:Boolean[0..1]):Boolean[1]
 {
@@ -152,7 +166,8 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Boo
 
 '''
 As `lessThanEqual(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
-The first operand may be absent; an absent operand makes the result `false` rather than empty.
+The first operand may be absent; absent operands are treated as described in
+`lessThanEqual(Number[0..1], Number[0..1]):Boolean[1]`.
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Boolean[0..1], right:Boolean[1]):Boolean[1]
 {
@@ -161,6 +176,19 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Boo
 
 '''
 Compares two dates chronologically — true when `left` falls at or before `right`.
+
+As `lessThanEqual(Number[1], Number[1]):Boolean[1]`, the operator is written `<=` — `$a <= $b` — but
+the order is chronological rather than numeric.
+
+**Examples**
+```pure
+%2012-10-01 <= %2012-10-02   // true
+%2015-01-01 <= %2016-01-01   // true
+%2012-10-02 <= %2012-10-02   // true, the comparison is not strict
+%2012-10-03 <= %2012-10-02   // false
+```
+
+**See also** `lessThanEqual(Number[1], Number[1]):Boolean[1]`
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Date[1], right:Date[1]):Boolean[1]
 {
@@ -169,6 +197,18 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Dat
 
 '''
 Compares two strings lexicographically, character by character.
+
+As `lessThanEqual(Number[1], Number[1]):Boolean[1]`, the operator is written `<=` — `$a <= $b` — but
+the order is lexicographic rather than numeric.
+
+**Examples**
+```pure
+'a' <= 'b'   // true
+'a' <= 'a'   // true, the comparison is not strict
+'b' <= 'a'   // false
+```
+
+**See also** `lessThanEqual(Number[1], Number[1]):Boolean[1]`
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:String[1], right:String[1]):Boolean[1]
 {
@@ -176,7 +216,20 @@ function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Str
 }
 
 '''
-Orders booleans with `false` before `true`.
+Orders booleans with `false` before `true`, so `true <= false` is the only case that does not hold.
+
+As `lessThanEqual(Number[1], Number[1]):Boolean[1]`, the operator is written `<=` — `$a <= $b` — but
+the order is over the two boolean values rather than numeric.
+
+**Examples**
+```pure
+false <= true    // true
+false <= false   // true, the comparison is not strict
+true <= true     // true
+true <= false    // false
+```
+
+**See also** `lessThanEqual(Number[1], Number[1]):Boolean[1]`
 '''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Boolean[1], right:Boolean[1]):Boolean[1]
 {

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/lessThanEqual.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/boolean/inequality/lessThanEqual.pure
@@ -14,86 +14,170 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Whether the first operand precedes or equals the second, according to the type's natural order.
+
+Written `<=` in Pure: `$a <= $b`. Overloads cover `Number`, `Date`, `String` and `Boolean`, so the
+same operator orders numerically, chronologically, lexicographically, or with `false` before `true`.
+
+An absent operand makes the result `false`, **not** empty — the comparison does not propagate
+emptiness the way arithmetic does. So a missing value never satisfies the comparison, and
+`$a <= $b` is false whenever either side is empty. Test with `isEmpty()` first when you need to
+distinguish "absent" from "present but not less than or equal to".
+
+**Parameters**
+- `left` — the first operand.
+- `right` — the second operand.
+
+**Returns** `true` when `left` is less than or equal to `right`.
+
+**Examples**
+```pure
+1 <= 2
+'a' <= 'b'
+%2015-01-01 <= %2016-01-01
+false <= true
+```
+
+**See also** `greaterThanEqual(Number[1], Number[1]):Boolean[1]`,
+`meta::pure::functions::collection::sort(T[m], Function<{T[1], T[1]->Integer[1]}>[0..1]):T[m]`
+'''
 native function
     <<PCT.function>>
     {
-        doc.doc='Returns true if, according to the type order, $left precedes or is equal to $right',
         PCT.grammarDoc='$first <= $second',
         PCT.grammarCharacters='<='
     }
     meta::pure::functions::boolean::lessThanEqual(left:Number[1], right:Number[1]):Boolean[1];
 
 
+'''
+As `lessThanEqual(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Number[0..1], right:Number[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && lessThanEqual($left->toOne(), $right->toOne())
 }
 
+'''
+As `lessThanEqual(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Number[1], right:Number[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && lessThanEqual($left, $right->toOne())
 }
 
+'''
+As `lessThanEqual(Number[1], Number[1]):Boolean[1]`, for `Number` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Number[0..1], right:Number[1]):Boolean[1]
 {
     $left->isNotEmpty() && lessThanEqual($left->toOne(), $right)
 }
 
+'''
+As `lessThanEqual(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Date[0..1], right:Date[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && lessThanEqual($left->toOne(), $right->toOne())
 }
 
+'''
+As `lessThanEqual(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Date[1], right:Date[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && lessThanEqual($left, $right->toOne())
 }
 
+'''
+As `lessThanEqual(Date[1], Date[1]):Boolean[1]`, for `Date` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Date[0..1], right:Date[1]):Boolean[1]
 {
     $left->isNotEmpty() && lessThanEqual($left->toOne(), $right)
 }
 
+'''
+As `lessThanEqual(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:String[0..1], right:String[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && lessThanEqual($left->toOne(), $right->toOne())
 }
 
+'''
+As `lessThanEqual(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:String[1], right:String[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && lessThanEqual($left, $right->toOne())
 }
 
+'''
+As `lessThanEqual(String[1], String[1]):Boolean[1]`, for `String` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:String[0..1], right:String[1]):Boolean[1]
 {
     $left->isNotEmpty() && lessThanEqual($left->toOne(), $right)
 }
 
+'''
+As `lessThanEqual(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
+Either operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Boolean[0..1], right:Boolean[0..1]):Boolean[1]
 {
     $left->isNotEmpty() && $right->isNotEmpty() && lessThanEqual($left->toOne(), $right->toOne())
 }
 
+'''
+As `lessThanEqual(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
+The second operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Boolean[1], right:Boolean[0..1]):Boolean[1]
 {
     $right->isNotEmpty() && lessThanEqual($left, $right->toOne())
 }
 
+'''
+As `lessThanEqual(Boolean[1], Boolean[1]):Boolean[1]`, for `Boolean` operands where a value may be missing.
+The first operand may be absent; an absent operand makes the result `false` rather than empty.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Boolean[0..1], right:Boolean[1]):Boolean[1]
 {
     $left->isNotEmpty() && lessThanEqual($left->toOne(), $right)
 }
 
+'''
+Compares two dates chronologically — true when `left` falls at or before `right`.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Date[1], right:Date[1]):Boolean[1]
 {
     compare($left, $right) <= 0
 }
 
+'''
+Compares two strings lexicographically, character by character.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:String[1], right:String[1]):Boolean[1]
 {
     compare($left, $right) <= 0
 }
 
+'''
+Orders booleans with `false` before `true`.
+'''
 function <<PCT.function>> meta::pure::functions::boolean::lessThanEqual(left:Boolean[1], right:Boolean[1]):Boolean[1]
 {
     !$left || $right

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/collection/iteration/map.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/collection/iteration/map.pure
@@ -25,8 +25,21 @@ native function
     }
     meta::pure::functions::collection::map<T,V|m>(value:T[m], func:Function<{T[1]->V[1]}>[1]):V[m];
 
+'''
+Applies a function returning a collection to each element, flattening the results into one collection.
+
+**The results are flattened, not nested.** Mapping 3 elements to 2 values each gives 6 values, not 3
+collections — Pure collections do not nest. Wrap in `meta::pure::functions::collection::list(U[*]):List<U>[1]`
+if you need to keep the groups apart.
+'''
 native function <<PCT.function>> meta::pure::functions::collection::map<T,V>(value:T[*], func:Function<{T[1]->V[*]}>[1]):V[*];
 
+'''
+Applies a function to an optional value, giving an optional result.
+
+The multiplicity is carried through: an empty input yields empty without calling the function, so this is
+the safe way to transform a value that may be absent without an `isEmpty` check first.
+'''
 native function <<PCT.function>> meta::pure::functions::collection::map<T,V>(value:T[0..1], func:Function<{T[1]->V[0..1]}>[1]):V[0..1];
 //--------------------------------------
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/collection/size/isEmpty.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/collection/size/isEmpty.pure
@@ -22,6 +22,12 @@ native function
     }
     meta::pure::functions::collection::isEmpty(p:Any[*]):Boolean[1];
 
+'''
+Whether an optional value is absent.
+
+The `[0..1]` overload, for a value that may or may not be present. Note this asks whether there is *no
+value*: an empty `String` is still a present value, so `''->isEmpty()` is false.
+'''
 function <<PCT.function>> meta::pure::functions::collection::isEmpty(p:Any[0..1]):Boolean[1]
 {
     eq($p->size(), 0)

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/collection/size/isNotEmpty.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/collection/size/isNotEmpty.pure
@@ -25,6 +25,12 @@ function
     !isEmpty($p)
 }
 
+'''
+Whether an optional value is present.
+
+The `[0..1]` overload, and the negation of `isEmpty(Any[0..1]):Boolean[1]`. Commonly the guard before
+`meta::pure::functions::multiplicity::toOne(T[*]):T[1]`.
+'''
 function <<PCT.function>> meta::pure::functions::collection::isNotEmpty(p:Any[0..1]):Boolean[1]
 {
     !isEmpty($p)

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/cast/toOne.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/cast/toOne.pure
@@ -23,6 +23,19 @@ native function
     }
     meta::pure::functions::multiplicity::toOne<T>(values:T[*]):T[1];
 
+'''
+Asserts a collection holds exactly one value and returns it, failing with a given message otherwise.
+
+As `meta::pure::functions::multiplicity::toOne(T[*]):T[1]`, but you supply the error message. Worth using
+wherever the failure would otherwise be hard to trace back — the default message says only that the
+multiplicity was wrong, not which value was missing or why it mattered.
+
+**Parameters**
+- `values` — the collection expected to hold exactly one value.
+- `message` — the error to raise when it does not.
+
+**Returns** the single value.
+'''
 native function <<PCT.function>> meta::pure::functions::multiplicity::toOne<T>(values:T[*], message: String[1]): T[1];
 
 function <<test.Test>> meta::pure::functions::multiplicity::tests::toOne::testToOneMultiplicity():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/cast/toOne.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/cast/toOne.pure
@@ -15,20 +15,45 @@
 import meta::pure::test::pct::*;
 
 // For Milestoning generated properties & Support function for inequalities definition
+'''
+Asserts a collection holds exactly one value and returns it.
+
+The way to move from a collection to a single value where the surrounding code requires `[1]` — after
+`filter`, after `first`, or on a property whose declared multiplicity is wider than the use site needs.
+
+**It fails rather than yielding empty when the collection does not hold exactly one value**, so it is an
+assertion and not a conversion: both `[]->toOne()` and `['a', 'b', 'c']->toOne()` raise. Reach for
+`meta::pure::functions::collection::first(T[*]):T[0..1]` when an empty collection is an acceptable
+outcome, and for `toOne(T[*], String[1]):T[1]` when the failure deserves a message of its own.
+
+**Parameters**
+- `values` — the collection expected to hold exactly one value.
+
+**Returns** the single value.
+
+**Examples**
+```pure
+'a'->toOne()                  // 'a'
+[1, 2, 3]->first()->toOne()   // 1
+[]->toOne()                   // fails: Cannot cast a collection of size 0 to multiplicity [1]
+['a', 'b']->toOne()           // fails: Cannot cast a collection of size 2 to multiplicity [1]
+```
+
+**See also** `toOne(T[*], String[1]):T[1]`,
+`meta::pure::functions::multiplicity::toOneMany(T[*]):T[1..*]`,
+`meta::pure::functions::collection::first(T[*]):T[0..1]`
+'''
 native function
     <<PCT.function>>
     {
-        doc.doc='Cast the result of a function to [1]',
         PCT.grammarDoc='toOne is leveraged in milestoning generated derived properties'
     }
     meta::pure::functions::multiplicity::toOne<T>(values:T[*]):T[1];
 
 '''
-Asserts a collection holds exactly one value and returns it, failing with a given message otherwise.
-
-As `meta::pure::functions::multiplicity::toOne(T[*]):T[1]`, but you supply the error message. Worth using
-wherever the failure would otherwise be hard to trace back — the default message says only that the
-multiplicity was wrong, not which value was missing or why it mattered.
+As `toOne(T[*]):T[1]`, but you supply the error message. Worth using wherever the failure would otherwise
+be hard to trace back — the default message says only that the multiplicity was wrong, not which value
+was missing or why it mattered.
 
 **Parameters**
 - `values` — the collection expected to hold exactly one value.

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/cast/toOneMany.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/cast/toOneMany.pure
@@ -23,6 +23,13 @@ native function
     }
     meta::pure::functions::multiplicity::toOneMany<T>(values:T[*]):T[1..*];
 
+'''
+Asserts a collection is non-empty and returns it, failing with a given message otherwise.
+
+As `meta::pure::functions::multiplicity::toOneMany(T[*]):T[1..*]`, but you supply the error message. The
+result is `[1..*]`, so it narrows "possibly empty" to "at least one" without collapsing to a single value
+the way `toOne` does.
+'''
 native function <<PCT.function>> meta::pure::functions::multiplicity::toOneMany<T>(values:T[*], message: String[1]):T[1..*];
 
 function <<test.Test>> meta::pure::functions::multiplicity::tests::toOneMany::testToOneManyMultiplicity():Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/creation/copy.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/creation/copy.pure
@@ -24,6 +24,12 @@ native function
     }
     meta::pure::functions::lang::copy<T>(object:T[1], id:String[1], keyExpressions:KeyExpression[*]):T[1];
 
+'''
+Copies an instance, giving the copy a new identifier.
+
+The reflective form of `^$object(...)`. Property values are carried over from the original and the copy
+keeps its type, so no cast is needed. The `id` identifies the new instance rather than setting any property.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::copy<T>(object:T[1], id:String[1]):T[1];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/creation/new.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/creation/new.pure
@@ -16,6 +16,16 @@ import meta::pure::test::pct::*;
 import meta::pure::functions::lang::tests::model::*;
 import meta::pure::functions::lang::tests::new::*;
 
+'''
+Creates an instance of a class, giving it an identifier.
+
+The reflective form of `^Class(...)`, for when the class is chosen at runtime. The `id` names the instance
+so it can be referred to later — it is the identifier `meta::pure::functions::meta::id(Any[1]):String[1]`
+reports, not a property value.
+
+Properties are not set here; use the `KeyValue` form
+`meta::pure::functions::lang::dynamicNew(Class<Any>[1], KeyValue[*]):Any[1]` when you need to populate them.
+'''
 native function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::new<T>(class:Class<T>[1], id:String[1]):T[1];
 native function
     <<PCT.function, PCT.platformOnly>>

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/enum/extractEnumValue.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/enum/extractEnumValue.pure
@@ -15,29 +15,52 @@
 import meta::pure::test::pct::*;
 import meta::pure::functions::lang::tests::model::*;
 
+'''
+Looks up an enumeration value by name.
+
+The way to turn a string — from parsing, configuration, or user input — into an enum value, and the
+function the `Enum.value` syntax stands for: writing `LA_GeographicEntityType.COUNTRY` is the same lookup
+with the name written as a literal. Going through the function instead is what lets the name be decided
+at runtime.
+
+The name must be one of the enumeration's values; the return multiplicity is `[1]`, so there is no
+"not found" result to test for. Use `enumValues(Enumeration<T>[1]):T[*]` when you need to know which
+names are valid.
+
+**Parameters**
+- `enum` — the enumeration to search.
+- `value` — the name of the value to look up.
+
+**Returns** the matching enum value.
+
+**Examples**
+```pure
+extractEnumValue(LA_GeographicEntityType, 'COUNTRY')   // LA_GeographicEntityType.COUNTRY
+LA_GeographicEntityType.COUNTRY                        // the same lookup, name written as a literal
+$enumeration->extractEnumValue($name)                  // both decided at runtime
+```
+
+**See also** `extractEnumValue(Enumeration<T>[1], String[0..1]):T[0..1]`,
+`meta::pure::functions::meta::enumValues(Enumeration<T>[1]):T[*]`
+'''
 native function
     <<PCT.function, PCT.platformOnly>>
     {
-        doc.doc='Extract a value from the Enumeration',
         PCT.grammarDoc='Enum.value',
         PCT.grammarCharacters='.'
     }
     meta::pure::functions::lang::extractEnumValue<T>(enum:Enumeration<T>[1], value:String[1]):T[1];
 
 '''
-Looks up an enumeration value by name.
-
-The way to turn a string — from parsing, configuration, or user input — into an enum value. **An empty
-input gives an empty result** rather than failing, which is why both the parameter and the return are
-`[0..1]`: the optionality passes straight through.
+As `extractEnumValue(Enumeration<T>[1], String[1]):T[1]`, for a name that may be absent. **An empty input
+gives an empty result** rather than failing, which is why both the parameter and the return are `[0..1]`:
+the optionality passes straight through. A name that is present is looked up exactly as above.
 
 **Parameters**
 - `enum` — the enumeration to search.
 - `value` — the value's name, or empty.
 
 **Returns** the matching enum value, or empty.
-
-**See also** `meta::pure::functions::meta::enumValues(Enumeration<T>[1]):T[*]`
 '''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::extractEnumValue<T>(enum:Enumeration<T>[1], value:String[0..1]):T[0..1]
 {

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/enum/extractEnumValue.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/lang/enum/extractEnumValue.pure
@@ -24,6 +24,21 @@ native function
     }
     meta::pure::functions::lang::extractEnumValue<T>(enum:Enumeration<T>[1], value:String[1]):T[1];
 
+'''
+Looks up an enumeration value by name.
+
+The way to turn a string — from parsing, configuration, or user input — into an enum value. **An empty
+input gives an empty result** rather than failing, which is why both the parameter and the return are
+`[0..1]`: the optionality passes straight through.
+
+**Parameters**
+- `enum` — the enumeration to search.
+- `value` — the value's name, or empty.
+
+**Returns** the matching enum value, or empty.
+
+**See also** `meta::pure::functions::meta::enumValues(Enumeration<T>[1]):T[*]`
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::lang::extractEnumValue<T>(enum:Enumeration<T>[1], value:String[0..1]):T[0..1]
 {
     if ($value->isEmpty(), | [], | $enum->extractEnumValue($value->toOne()));

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/divide.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/divide.pure
@@ -14,10 +14,36 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Divides one number by another.
+
+Written `/` in Pure: `$left / $right`. Unlike the other arithmetic operators, this one does not preserve
+the type of its operands — the result is always a `Float`, even when both operands are `Integer`, so
+`4 / 2` is `2.0` rather than `2`. A quotient with no terminating expansion is carried at floating-point
+precision. When an exact result matters, use `divide(Decimal[1], Decimal[1], Integer[1]):Decimal[1]`,
+which takes a scale and returns a `Decimal`.
+
+**Parameters**
+- `left` — the dividend.
+- `right` — the divisor.
+
+**Returns** the quotient as a `Float`.
+
+**Examples**
+```pure
+4 / 2         // 2.0
+3 / 2         // 1.5
+4 / -2        // -2.0
+1 / 96        // 0.010416666666666666
+```
+
+**See also** `divide(Decimal[1], Decimal[1], Integer[1]):Decimal[1]`,
+`times(Integer[*]):Integer[1]`,
+`rem(Number[1], Number[1]):Number[1]`
+'''
 native function
     <<PCT.function>>
     {
-        doc.doc='Divides the first parameter by the second one.',
         PCT.grammarDoc='$left / $right',
         PCT.grammarCharacters='/'
     }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/divide.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/divide.pure
@@ -23,6 +23,20 @@ native function
     }
     meta::pure::functions::math::divide(left:Number[1], right:Number[1]):Float[1];
 
+'''
+Divides one decimal by another, rounding the result to a given number of decimal places.
+
+The `scale` is what makes this the right choice for exact arithmetic: decimal division can produce a
+non-terminating expansion, so a scale must be chosen somewhere. Fixing it here keeps the result an exact
+`Decimal` rather than falling back to floating point.
+
+**Parameters**
+- `left` — the dividend.
+- `right` — the divisor.
+- `scale` — decimal places to round the result to.
+
+**Returns** the quotient as a `Decimal`.
+'''
 native function <<PCT.function>> meta::pure::functions::math::divide(left:Decimal[1], right:Decimal[1], scale:Integer[1]):Decimal[1];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/minus.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/minus.pure
@@ -23,10 +23,28 @@ native function
     }
     meta::pure::functions::math::minus(ints:Integer[*]):Integer[1];
 
+'''
+Subtracting every element of a `Float` collection, left to right, returning a `Float`.
+
+The `-` operator desugars to this: `$a - $b` is `minus([$a, $b])`, which is why the parameter is a
+collection rather than two values. The result keeps the `Float` type.
+'''
 native function <<PCT.function>> meta::pure::functions::math::minus(float:Float[*]):Float[1];
 
+'''
+Subtracting every element of a `Decimal` collection, left to right, returning a `Decimal`.
+
+The `-` operator desugars to this: `$a - $b` is `minus([$a, $b])`, which is why the parameter is a
+collection rather than two values. The result keeps the `Decimal` type.
+'''
 native function <<PCT.function>> meta::pure::functions::math::minus(decimal:Decimal[*]):Decimal[1];
 
+'''
+Subtracting every element of a `Number` collection, left to right, returning a `Number`.
+
+The `-` operator desugars to this: `$a - $b` is `minus([$a, $b])`, which is why the parameter is a
+collection rather than two values. The result keeps the `Number` type.
+'''
 native function <<PCT.function>> meta::pure::functions::math::minus(numbers:Number[*]):Number[1];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/minus.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/minus.pure
@@ -14,10 +14,37 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Subtracts every element of an `Integer` collection from the first, left to right, returning a single
+`Integer`.
+
+Written `-` in Pure: `$a - $b` desugars to `minus([$a, $b])`, which is why the parameter is a collection
+rather than two values. A single value is the case worth knowing: unlike `plus`, it is *negated* rather
+than returned unchanged, so `minus(1)` is `-1` — this is what makes unary `-` work. An empty collection
+gives `0`.
+
+**Parameters**
+- `ints` — the values to subtract; the first is the starting value, the rest are taken off it in order.
+
+**Returns** the first value with all the others subtracted from it, or the negation of a lone value.
+
+**Examples**
+```pure
+3 - 2                // 1
+3 - -2               // 5
+6 - (4 - 5) - 7      // 0
+minus(1)             // -1
+```
+
+**See also** `plus(Integer[*]):Integer[1]`,
+`times(Integer[*]):Integer[1]`,
+`minus(Float[*]):Float[1]`,
+`minus(Decimal[*]):Decimal[1]`,
+`minus(Number[*]):Number[1]`
+'''
 native function
     <<PCT.function>>
     {
-        doc.doc='Subtracts all the provided values',
         PCT.grammarDoc='1 - 2',
         PCT.grammarCharacters='-'
     }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/plus.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/plus.pure
@@ -23,10 +23,28 @@ native function
     }
     meta::pure::functions::math::plus(ints:Integer[*]):Integer[1];
 
+'''
+Adding every element of a `Float` collection, returning a `Float`.
+
+The `+` operator desugars to this: `$a + $b` is `plus([$a, $b])`, which is why the parameter is a
+collection rather than two values. The result keeps the `Float` type.
+'''
 native function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::plus(float:Float[*]):Float[1];
 
+'''
+Adding every element of a `Decimal` collection, returning a `Decimal`.
+
+The `+` operator desugars to this: `$a + $b` is `plus([$a, $b])`, which is why the parameter is a
+collection rather than two values. The result keeps the `Decimal` type.
+'''
 native function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::plus(decimal:Decimal[*]):Decimal[1];
 
+'''
+Adding every element of a `Number` collection, returning a `Number`.
+
+The `+` operator desugars to this: `$a + $b` is `plus([$a, $b])`, which is why the parameter is a
+collection rather than two values. The result keeps the `Number` type.
+'''
 native function <<PCT.function, functionType.ReducerFunction>> meta::pure::functions::math::plus(numbers:Number[*]):Number[1];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/plus.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/plus.pure
@@ -14,10 +14,36 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Adds every element of an `Integer` collection, returning a single `Integer`.
+
+Written `+` in Pure: `$a + $b` desugars to `plus([$a, $b])`, which is why the parameter is a collection
+rather than two values. The collection parameter is also what shapes the edge cases: a single value is
+returned unchanged, so unary `+1` is just `1`, and an empty collection gives `0` — the additive
+identity, so that adding nothing changes nothing.
+
+**Parameters**
+- `ints` — the values to add.
+
+**Returns** the sum of the collection.
+
+**Examples**
+```pure
+1 + 2                        // 3
+3 + 4 + 5 + 7                // 19
+[15, 13, 2, 1, 1]->plus()    // 32
++1                           // 1
+```
+
+**See also** `minus(Integer[*]):Integer[1]`,
+`times(Integer[*]):Integer[1]`,
+`plus(Float[*]):Float[1]`,
+`plus(Decimal[*]):Decimal[1]`,
+`plus(Number[*]):Number[1]`
+'''
 native function
     <<PCT.function, functionType.ReducerFunction>>
     {
-        doc.doc='Adds all the provided values',
         PCT.grammarDoc='4 + 1',
         PCT.grammarCharacters='+'
     }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/times.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/times.pure
@@ -23,10 +23,28 @@ native function
     }
     meta::pure::functions::math::times(ints:Integer[*]):Integer[1];
 
+'''
+Multiplying every element of a `Float` collection, returning a `Float`.
+
+The `*` operator desugars to this: `$a * $b` is `times([$a, $b])`, which is why the parameter is a
+collection rather than two values. The result keeps the `Float` type.
+'''
 native function <<PCT.function>> meta::pure::functions::math::times(ints:Float[*]):Float[1];
 
+'''
+Multiplying every element of a `Decimal` collection, left to right, returning a `Decimal`.
+
+The `*` operator desugars to this: `$a * $b` is `times([$a, $b])`, which is why the parameter is a
+collection rather than two values. The result keeps the `Decimal` type.
+'''
 native function <<PCT.function>> meta::pure::functions::math::times(decimal:Decimal[*]):Decimal[1];
 
+'''
+Multiplying every element of a `Number` collection, left to right, returning a `Number`.
+
+The `*` operator desugars to this: `$a * $b` is `times([$a, $b])`, which is why the parameter is a
+collection rather than two values. The result keeps the `Number` type.
+'''
 native function <<PCT.function>> meta::pure::functions::math::times(numbers:Number[*]):Number[1];
 
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/times.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/math/operation/times.pure
@@ -14,10 +14,36 @@
 
 import meta::pure::test::pct::*;
 
+'''
+Multiplies every element of an `Integer` collection, returning a single `Integer`.
+
+Written `*` in Pure: `$a * $b` desugars to `times([$a, $b])`, which is why the parameter is a collection
+rather than two values. There is no unary `*`, so the short cases only arise when a collection is passed
+directly: a one-element collection returns that element unchanged, and an empty collection gives `1` —
+the multiplicative identity, so that multiplying nothing changes nothing.
+
+**Parameters**
+- `ints` — the values to multiply.
+
+**Returns** the product of the collection.
+
+**Examples**
+```pure
+3 * 2                 // 6
+3 * (4 * 5) * 7       // 420
+3 * -2                // -6
+[1, 2, 3]->times()    // 6
+```
+
+**See also** `plus(Integer[*]):Integer[1]`,
+`divide(Number[1], Number[1]):Float[1]`,
+`times(Float[*]):Float[1]`,
+`times(Decimal[*]):Decimal[1]`,
+`times(Number[*]):Number[1]`
+'''
 native function
     <<PCT.function>>
     {
-        doc.doc='Multiplies all the provided values',
         PCT.grammarDoc='5 * 2',
         PCT.grammarCharacters='*'
     }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/meta/type/relation/window/frame.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/meta/type/relation/window/frame.pure
@@ -45,6 +45,12 @@ Class meta::pure::functions::relation::UnboundedFrameValue extends meta::pure::f
 {
 }
 
+'''
+The unbounded boundary of a window frame.
+
+Used where a window frame has no limit in one direction — from the start of the partition, or through to
+its end — rather than a fixed offset. Pass it as a frame boundary instead of a row count.
+'''
 function <<PCT.function, PCT.platformOnly>> meta::pure::functions::relation::unbounded():meta::pure::functions::relation::UnboundedFrameValue[1]
 {
     ^meta::pure::functions::relation::UnboundedFrameValue();

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/classpath/TestClassLoaderCodeStorage.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/filesystem/usercodestorage/classpath/TestClassLoaderCodeStorage.java
@@ -103,7 +103,7 @@ public class TestClassLoaderCodeStorage
         Assert.assertEquals(
                 Lists.mutable.with("/test/codestorage/fake.pure", "/test/org/finos/legend/pure/m3/serialization/filesystem/test/level1/level1.pure", "/test/org/finos/legend/pure/m3/serialization/filesystem/test/level1/level2/level2.pure"),
                 this.testCodeStorage.getUserFiles().toSortedList());
-        Assert.assertEquals(241, this.combinedCodeStorage.getUserFiles().toSet().size());
+        Assert.assertEquals(243, this.combinedCodeStorage.getUserFiles().toSet().size());
     }
 
     @Test

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestSourceNavigation.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestSourceNavigation.java
@@ -273,12 +273,12 @@ public class TestSourceNavigation extends AbstractPureTestWithCoreCompiledPlatfo
         runtime.compile();
         CoreInstance found = source.navigate(4, 7, processorSupport);
         Assert.assertEquals("/platform/pure/essential/io/print.pure", found.getSourceInformation().getSourceId());
-        Assert.assertEquals(17, found.getSourceInformation().getLine());
+        Assert.assertEquals(47, found.getSourceInformation().getLine());
         Assert.assertEquals(79, found.getSourceInformation().getColumn());
 
         found = source.navigate(6, 7, processorSupport);
         Assert.assertEquals("/platform/pure/essential/io/print.pure", found.getSourceInformation().getSourceId());
-        Assert.assertEquals(17, found.getSourceInformation().getLine());
+        Assert.assertEquals(47, found.getSourceInformation().getLine());
         Assert.assertEquals(79, found.getSourceInformation().getColumn());
     }
 }


### PR DESCRIPTION
Builds on #1299, which added the `'''…'''` documentation form. That gave every
PCT function somewhere to put documentation; this fills it in.

## What changes

**Coverage goes from 83 of 309 signatures to all 309.** Much of the previous 83
was a single plain sentence, and 16 were an empty `doc.doc=''`. Every signature
now has a summary, parameters, returns, runnable examples and cross-references.
The 31 PCT tests in `essential/string` are documented too, so they publish as
worked examples.

**PCT test documentation now reaches the report.** `FunctionDefinition` tracked
tests as two counters and nothing else, so a documentation literal on a
`<<PCT.test>>` was parsed, attached, and then dropped. Tests become a single
list of `TestDefinition`; `testCount` and `pctTestCount` become getters over it,
so they cannot drift. They are `@JsonIgnore` because a derived value written to
JSON cannot be read back, and these files round-trip through
`PCTReportProviderLoader`.

**A standard for writing the documentation**, in `docs/standards/`.

## What the documentation says

Examples and behaviour are taken from the PCT assertions in each file rather
than from the signature. Signatures say what the types are; the tests say what
actually happens, and that is usually the part worth writing down:

- `round` is half-even — `17.5` gives `18`, `16.5` gives `16`
- `dateDiff` counts calendar boundaries, not elapsed time: `2016-02-01` to
  `2016-02-29` is **0** months, while `2015-12-31T23:59:59` to
  `2016-01-01T00:00:01` is **1** year
- the `[0..1]` comparison overloads return `false` when an operand is absent
  rather than propagating emptiness, so a missing value never compares
- `indexOf` returns `-1`, not empty, so an `isEmpty` guard silently never fires
- `at` returns `[1]` and errors out of range, unlike `first`/`last` at `[0..1]`
- the date extractors error rather than return empty when a component is
  absent — which is what the `has*` family exists for
- `pow` returns floating point even for integer arguments
- `getIfAbsentPutWithKey` mutates the map

Cross-references use full signatures, since `substring` has two overloads and
`contains` exists in both the string and collection packages. They were taken
from the generated `FUNCTIONS_*.json`, not written by hand, and all 464 resolve.

## Two things reviewers should know

**Documentation shifts line numbers, and some tests assert them.** They come in
three unrelated shapes — error-message strings, Java integer assertions, and
self-referential `assertError` calls that assert the line they sit on — so no
single grep finds them all. `TestSourceNavigation` moves with `print.pure`; the
affected files are listed in the standard.

**The tests that exercise this do not run in `legend-pure-m3-core`.** Both
`Test_*_PCT` and `TestCoreFunctions` live in the runtime engine modules, and
`TestCoreFunctions` does not match `*_PCT`, so a filtered run skips it. A green
m3-core build says nothing about the position assertions above.

## Verification

- `mvn clean install -pl legend-pure-core/legend-pure-m3-core -am`
- `mvn test -pl legend-pure-runtime/legend-pure-runtime-java-engine-interpreted`
  (whole module, not filtered)
- 309/309 signatures documented, 464/464 cross-references resolve, 0 checkstyle
  violations

Documentation is parse-time sugar over `doc.doc`, so no PCT result changes.

## Follow-up, not in this PR

Neither renderer in `legend-engine` handles Markdown. `PCT_to_SimpleHTML`
HTML-escapes into a `<td>` with no `<pre>`, so newlines collapse.
`DocumentationHelper` passes documentation through `WordUtils.wrap`, which does
not reset its column counter at existing newlines — so in any doc longer than
80 characters it breaks lines mid-token, including inside fenced code blocks.
Both are small fixes on the engine side and neither affects this repo.


---

# Review round 2 — accuracy audit and PCT index changes

## What prompted it

`fold` was documented as reducing "to a single value". The signature is
`fold<T,V|m>(value:T[*], func:…, accumulator:V[m]):V[m]`, so the result carries the
accumulator's multiplicity and may be a collection — `testFoldCollectionAccumulator`
asserts exactly that. Rather than patch the one case, every documented file was
audited against its declared signature, its body, and its own test assertions.

**Corrections found (6 files):**

| File | Was wrong |
|---|---|
| `fold` | "reduces to a single value" — result is `V[m]` |
| `replaceAll` | Documented *merge* semantics; it discards the original map's entries |
| `reactivate` | Singular prose on an `Any[*]` return |
| `getUpperBound` | Implied a value is returned where the tests assert the call fails |
| `hasSubsecond` | Claimed a predicate "fails" on a missing component |
| `dateDiff` | "negative when earlier" — `WEEKS` is not antisymmetric |

`replaceAll` is the significant one: `testReplaceAll` seeds a map with keys 1 and 2,
supplies keys 1 and 3, and asserts the result has size **2**, not 3. Following the old
documentation would silently drop entries.

## Reviewer feedback

All 21 review threads addressed. Beyond the direct wording fixes:

- **`cast` / `toMultiplicity`** — reworded per review: a cast need not narrow (it may
  widen, or move to an unrelated type, since Pure supports multiple inheritance) and
  **never changes the value**, only the declared type.
- **`plus` / `minus` / `times` / `divide`** — the "missing documentation" on the
  Integer/Number variants had a single cause: those declarations still carried a legacy
  `doc.doc=` tagged value, and a `'''` literal alongside an explicit `doc.doc` is a
  compile error. The tagged value is removed and `PCT.grammarDoc` retained. Empty and
  single-element behaviour is now documented, verified against **both** engines: empty
  gives `0` / `0` / `1`, and `minus` on a single value **negates** (`minus(1)` is `-1`).
- **Inequality operators** — the `>` / `<` / `<=` documentation blocks sat on the
  `(Number[1], Number[1])` overload while describing operator syntax, other operand
  types, and empty-operand behaviour. Empty-operand prose moved to the `[0..1]`
  overloads, cross-type framing and non-numeric examples to the per-type overloads.
  `greaterThanEqual` was already anchored on `[0..1]` and keeps its empty-operand
  paragraph.

## Scope note — this round changes the PCT function index

Reviewer feedback on `elementToPath` exposed a structural problem: the documentation
sat on the `Function<Any>[1]` variant, kept only for backward compatibility, while the
`PackageableElement` variants are fundamental. Those variants carried no
`<<PCT.function>>` stereotype, so documentation moved there would never have reached
`FUNCTIONS_*.json`.

Resolved by indexing them rather than leaving the documentation unpublished:

- All seven `elementToPath` overloads now carry `<<PCT.function, PCT.platformOnly>>`,
  and the file is ordered `PackageableElement[1]` → `Type[1]` → `Function<Any>[1]`.
- `elementPath` and `lenientPathToElement` moved to their own files and were
  stereotyped. Both had to move: `FunctionsGeneration` permits only **one PCT function
  name per source file**. Their tests moved with them, since tests are attributed to a
  function by source id.
- `pathToElement(String[1], String[1])` stereotyped.

**PCT index: 312 → 322 signatures.** All ten additions are `PCT.platformOnly`, so none
enters the cross-engine adapter matrix and no adapter results change. The affected
surface is `FUNCTIONS_*.json` and the published documentation. Two new files under
`platform/pure/**` required bumping the count in
`TestClassLoaderCodeStorage#testGetUserFiles` (241 → 243).

## Verification

- 302 documentation blocks, 0 structural defects
- 591 cross-references, **0 unresolved and 0 outside the PCT index**
- No file mixes `platformOnly` with regular PCT functions, declares more than one PCT
  function name, or places a `<<PCT.test>>` in a platform-only file
- No changed file carries a self-referential `assertError` position assertion

## Engine defects found, deliberately not addressed here

Two genuine cross-engine divergences surfaced while verifying documentation claims.
Both are undocumented because there is no single true behaviour to state, and both
share a root cause — no PCT test covers the case:

- **`monthNumber`** — compiled `CoreHelper.monthNumber()` has no `hasMonth()` guard and
  returns `-1` (`Year.getMonth()`), while `dayOfMonth()` and `hour()` in the same class
  do guard and throw. Interpreted `MonthNumber` throws `Cannot get month for …`. So
  `%2015->monthNumber()` errors on one engine and returns `-1` on the other.
  `monthNumber.pure` is the only date extractor with no `assertError` test.
- **Division by zero** — compiled `CompiledSupport.divide()` throws
  `Cannot divide X by zero`; interpreted `Divide` has no guard and reaches
  `NumericAccumulator.divide`, giving `Infinity`/`NaN` or a raw `ArithmeticException`.

Both are now tracked separately: #1309 (`monthNumber`) and #1310 (division by zero).
