### PR TITLE
Add UnsignedBigInt, UnsignedInt, UnsignedTinyInt relational datatypes

### DIFF
--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/grammar/relational.pure
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/grammar/relational.pure
@@ -409,6 +409,18 @@ Class meta::relational::metamodel::datatype::Integer extends meta::relational::m
 {
 }
 
+Class meta::relational::metamodel::datatype::UnsignedBigInt extends meta::relational::metamodel::datatype::CoreDataType
+{
+}
+
+Class meta::relational::metamodel::datatype::UnsignedInt extends meta::relational::metamodel::datatype::CoreDataType
+{
+}
+
+Class meta::relational::metamodel::datatype::UnsignedTinyInt extends meta::relational::metamodel::datatype::CoreDataType
+{
+}
+
 Class meta::relational::metamodel::datatype::Float extends meta::relational::metamodel::datatype::CoreDataType
 {
 }


### PR DESCRIPTION
Adds three unsigned integer datatypes to the shared relational metamodel: UnsignedBigInt, UnsignedInt, UnsignedTinyInt