### PR TITLE
refactor $src accessor to $row for row-based property access in relation mappings

### DIFF
--- a/docs/reference/mapping-grammar-reference.md
+++ b/docs/reference/mapping-grammar-reference.md
@@ -1225,7 +1225,7 @@ Mapping my::mappings::PersonMapping
     {
         ~func my::personRelation__Relation_1_   // zero-argument function returning Relation
         firstName : FIRSTNAME,                  // property : COLUMN_NAME (bare-column form)
-        age       : $src.AGE                    // property : Pure expression over $src
+        age       : $row.AGE                    // property : Pure expression over $row
     }
 )
 ```
@@ -1240,9 +1240,16 @@ Mapping my::mappings::PersonMapping
   returns are rejected at validation with:
   *"Relation mapping function should return a Relation! Found a &lt;Type&gt; instead."*
 - Each property RHS is either a **bare column name** (§15.4) or a **Pure
-  expression over the row variable `$src`** (§15.5). Both forms compile to the
+  expression over the row variable `$row`** (§15.5). Both forms compile to the
   same underlying lambda shape (`valueFn: LambdaFunction<{Nil[1]->Any[*]}>[1]`),
-  so bare-column is simply parser sugar for `$src.<column>`.
+  so bare-column is simply parser sugar for `$row.<column>`.
+- `$row` is bound only within the property-mapping `valueFn` and gives access to
+  the columns of the source relation's row type. It is unrelated to `~src`
+  (§15.3), which is the source-declaration keyword. `$src` itself is **not**
+  bound inside a `Relation` mapping's property expressions — a reference to it
+  fails with *"The variable 'src' is unknown!"*. `$src` is reserved for a
+  separate, relation-level access pattern (e.g. `$src->modelJoin(...)`) intended
+  for cross-relation joins
 
 ### 15.2 `~func` — reference a named Pure function
 
@@ -1369,16 +1376,16 @@ Person[person]: Relation
 }
 ```
 
-- Bare column names are lowered at parse time to `{| $src.<col> }`, so §15.5
+- Bare column names are lowered at parse time to `{| $row.<col> }`, so §15.5
   applies to the resulting lambda body.
 - Quoted column names — for columns whose name contains spaces or special
   characters — use single quotes: `firstName: 'FIRST NAME'`. Both unquoted and
   quoted forms are supported.
 
-### 15.5 Property RHS — Pure expression over `$src`
+### 15.5 Property RHS — Pure expression over `$row`
 
 The RHS of a property mapping can also be **any Pure expression over an
-implicit row variable `$src`**. `$src` is bound to the row type of the relation
+implicit row variable `$row`**. `$row` is bound to the row type of the relation
 (the `T` in `Relation<T>[1]` on the source's last expression), so its
 properties are the columns of the row.
 
@@ -1386,18 +1393,18 @@ properties are the columns of the row.
 *Person[person]: Relation
 {
     ~func my::personRelation__Relation_1_
-    firstName : $src.FIRSTNAME,                                        // explicit column accessor
-    fullName  : $src.FIRSTNAME + ' ' + $src.LASTNAME,                  // concat
-    ageBucket : if($src.AGE > 65, |'senior', |'other'),                // conditional
-    aliases   : $src.LEGALNAME->split(','),                            // to-many result
-    country   : EnumerationMapping CountryEnum : $src.COUNTRY_CODE     // transformer over expression
+    firstName : $row.FIRSTNAME,                                        // explicit column accessor
+    fullName  : $row.FIRSTNAME + ' ' + $row.LASTNAME,                  // concat
+    ageBucket : if($row.AGE > 65, |'senior', |'other'),                // conditional
+    aliases   : $row.LEGALNAME->split(','),                            // to-many result
+    country   : EnumerationMapping CountryEnum : $row.COUNTRY_CODE     // transformer over expression
 }
 ```
 
-- The bare-column form (§15.4) is exactly equivalent to `$src.<col>` — writing
-  `firstName: FIRSTNAME` and `firstName: $src.FIRSTNAME` produces the same
+- The bare-column form (§15.4) is exactly equivalent to `$row.<col>` — writing
+  `firstName: FIRSTNAME` and `firstName: $row.FIRSTNAME` produces the same
   compiled graph.
-- Quoted columns work in the expression form too: `$src.'FIRST NAME'`.
+- Quoted columns work in the expression form too: `$row.'FIRST NAME'`.
 - Any function from the Pure standard library is fair game inside the
   expression, provided the result's generic type is compatible with the
   property (see §15.6).
@@ -1462,14 +1469,14 @@ Database my::mainDb
 Local properties work in `Relation` mappings exactly as in `Relational` mappings
 — see [§16 Local properties](#16-local-properties-) for the full description.
 The RHS follows §15.4 / §15.5: bare column name **or** Pure expression over
-`$src`.
+`$row`.
 
 ```pure
 Firm[f1] : Relation
 {
     ~func my::firmRelation__Relation_1_
     +id        : String[1] : ID,                          // bare-column form
-    +greeting  : String[1] : 'Hi, ' + $src.LEGALNAME,     // expression form
+    +greeting  : String[1] : 'Hi, ' + $row.LEGALNAME,     // expression form
     legalName  : LEGALNAME
 }
 ```
@@ -1479,7 +1486,7 @@ Firm[f1] : Relation
 Embedded class mappings (see [§9](#9-embedded-mapping)) work identically inside
 a `Relation` class mapping. The embedded block inherits the parent's
 `relationFunction` and its sub-property RHS follows the same bare-column /
-`$src`-expression rules:
+`$row`-expression rules:
 
 ```pure
 *Person[person]: Relation
@@ -1488,7 +1495,7 @@ a `Relation` class mapping. The embedded block inherits the parent's
     firstName : FIRSTNAME,
     address                                // embedded — inherits parent's relation function
     (
-        city : $src.CITY
+        city : $row.CITY
     )
 }
 ```
@@ -1500,7 +1507,7 @@ a `Relation` class mapping. The embedded block inherits the parent's
 | Data source | `###Relational` database table / view / join | Any Pure expression returning `Relation<Any>[1]` |
 | Source declaration | `~mainTable [db]Table` | `~func <fnRef>` **or** `~src <expression>` |
 | Store dependency | Requires a `Database` definition | None — store-agnostic (the source expression *may* reference a store, but the mapping itself does not require one) |
-| Property mapping | Column expression `[db]Table.column`, join traversal, operations | Bare column name **or** any Pure expression over `$src` |
+| Property mapping | Column expression `[db]Table.column`, join traversal, operations | Bare column name **or** any Pure expression over `$row` |
 | Non-primitive properties | Supported via joins | Supported when a Pure expression evaluates to a compatible non-primitive |
 
 ---
@@ -1520,7 +1527,7 @@ Syntax: `+<propertyName> : <Type>[<multiplicity>] : <columnExpression>`
 
 - The `+` prefix distinguishes a local property from a regular mapped property.
 - `<columnExpression>` is a full column reference for `Relational` mappings, or
-  either a bare column name or a Pure expression over `$src` for `Relation`
+  either a bare column name or a Pure expression over `$row` for `Relation`
   mappings (see below).
 - Local properties are available via `$this` and `$that` in XStore association
   expressions.
@@ -1558,7 +1565,7 @@ Mapping my::FirmMapping
 ### In a `Relation` mapping
 
 The column expression is either a bare column name from the relation returned
-by `~func` / `~src`, or a Pure expression over `$src` (see [§15.5](#155-property-rhs--pure-expression-over-src)):
+by `~func` / `~src`, or a Pure expression over `$row` (see [§15.5](#155-property-rhs--pure-expression-over-row)):
 
 ```pure
 ###Mapping
@@ -1568,7 +1575,7 @@ Mapping my::FirmMapping
     {
         ~func my::firmRelation__Relation_1_
         +id       : String[1] : ID,                              // bare-column form
-        +greeting : String[1] : 'Hi, ' + $src.LEGALNAME,         // expression form
+        +greeting : String[1] : 'Hi, ' + $row.LEGALNAME,         // expression form
         legalName : LEGALNAME
     }
 

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/antlr/RelationMappingGraphBuilder.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/antlr/RelationMappingGraphBuilder.java
@@ -99,7 +99,7 @@ public class RelationMappingGraphBuilder extends RelationMappingParserBaseVisito
         // zero-arg lambda so the rest of the pipeline can treat both forms
         // uniformly with the `~func` ImportStub flow. The user writes a single
         // expression (`~src my::personFunction()`) and the resulting lambda's
-        // last-expression generic type drives `$src` binding for property
+        // last-expression generic type drives `$row` binding for property
         // mappings exactly as if it had come from an explicit Pure function.
         String srcLambdaText = "{| " + extractText(ctx.combinedExpression()) + "}";
         return parseLambdaTextToM4(srcLambdaText, lambdaContextId(id, classPath, "src"));
@@ -137,13 +137,13 @@ public class RelationMappingGraphBuilder extends RelationMappingParserBaseVisito
         String lambdaText;
         if (ctx.columnName() != null)
         {
-            // Bare-column lowering: `prop: COL` -> `{| $src.COL}`.  Keep the
+            // Bare-column lowering: `prop: COL` -> `{| $row.COL}`.  Keep the
             // original (possibly quoted) column text so columns with spaces
             // (`'LEGAL NAME'`) still parse correctly as quoted property
             // accessors.  The M3 expression post-processor resolves the
-            // accessor once `src`'s generic type is bound to the relation's
+            // accessor once `row`'s generic type is bound to the relation's
             // last-expression type.
-            lambdaText = "{| $src." + ctx.columnName().getText() + "}";
+            lambdaText = "{| $row." + ctx.columnName().getText() + "}";
         }
         else
         {
@@ -214,7 +214,7 @@ public class RelationMappingGraphBuilder extends RelationMappingParserBaseVisito
 
     /**
      * Re-enter the M3 parser to convert a Pure lambda literal text (e.g.
-     * {@code "{| $src.X + $src.Y}"}) into its M4 string form, suitable for
+     * {@code "{| $row.X + $row.Y}"}) into its M4 string form, suitable for
      * embedding back into the M4 string this graph builder is assembling.
      * <p>
      * We deliberately do NOT serialize the parsed {@code LambdaFunction} via
@@ -224,7 +224,7 @@ public class RelationMappingGraphBuilder extends RelationMappingParserBaseVisito
      * {@code expressionSequence}, serialize just that, and hand-roll an empty
      * {@code FunctionType} wrapper around it — same shape the existing
      * {@code PureInstanceSetImplementation.parseMapping} produces.  The
-     * post-processor injects the {@code src} parameter and runs full type
+     * post-processor injects the {@code row} parameter and runs full type
      * inference at processing time.
      */
     private String parseLambdaTextToM4(String lambdaText, String lambdaContextSuffix)

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/processor/RelationFunctionInstanceSetImplementationProcessor.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/main/java/org/finos/legend/pure/m2/dsl/mapping/serialization/grammar/v1/processor/RelationFunctionInstanceSetImplementationProcessor.java
@@ -57,7 +57,7 @@ public class RelationFunctionInstanceSetImplementationProcessor extends Processo
 
         // The relation function's last expression has generic type Relation<T>
         // where T is the structural row type (a RelationType<...>).  We bind
-        // the valueFn `src` parameter to T so `$src.<col>` resolves against
+        // the valueFn `row` parameter to T so `$row.<col>` resolves against
         // the columns of the row, mirroring how `extend`/`filter` lambdas
         // type their row parameter.
         GenericType lastExprType = (GenericType) relationFunction
@@ -67,20 +67,20 @@ public class RelationFunctionInstanceSetImplementationProcessor extends Processo
         org.eclipse.collections.api.list.ListIterable<? extends GenericType> typeArgs = lastExprType._typeArguments().toList();
         if (typeArgs.isEmpty())
         {
-            throw new org.finos.legend.pure.m4.exception.PureCompilationException(instance.getSourceInformation(), "Relation function's last expression has no Relation type argument; cannot bind property mapping `$src` parameter.");
+            throw new org.finos.legend.pure.m4.exception.PureCompilationException(instance.getSourceInformation(), "Relation function's last expression has no Relation type argument; cannot bind property mapping `$row` parameter.");
         }
-        GenericType srcType = typeArgs.getFirst();
+        GenericType rowType = typeArgs.getFirst();
 
-        processPropertyMappings(instance._propertyMappings(), instance, srcType, matcher, state, processorSupport);
+        processPropertyMappings(instance._propertyMappings(), instance, rowType, matcher, state, processorSupport);
     }
 
-    private void processPropertyMappings(Iterable<? extends PropertyMapping> propertyMappings, RelationFunctionInstanceSetImplementation owner, GenericType srcType, Matcher matcher, ProcessorState state, ProcessorSupport processorSupport)
+    private void processPropertyMappings(Iterable<? extends PropertyMapping> propertyMappings, RelationFunctionInstanceSetImplementation owner, GenericType rowType, Matcher matcher, ProcessorState state, ProcessorSupport processorSupport)
     {
         for (PropertyMapping propertyMapping : propertyMappings)
         {
             if (propertyMapping instanceof RelationFunctionPropertyMapping)
             {
-                processRelationFunctionPropertyMapping((RelationFunctionPropertyMapping) propertyMapping, srcType, matcher, state, processorSupport);
+                processRelationFunctionPropertyMapping((RelationFunctionPropertyMapping) propertyMapping, rowType, matcher, state, processorSupport);
             }
             else if (propertyMapping instanceof EmbeddedRelationFunctionSetImplementation)
             {
@@ -93,12 +93,12 @@ public class RelationFunctionInstanceSetImplementationProcessor extends Processo
                 embeddedSet._classCoreInstance(targetClass);
                 embeddedSet._relationFunctionCoreInstance(owner._relationFunctionCoreInstance());
 
-                processPropertyMappings(embeddedSet._propertyMappings(), embeddedSet, srcType, matcher, state, processorSupport);
+                processPropertyMappings(embeddedSet._propertyMappings(), embeddedSet, rowType, matcher, state, processorSupport);
             }
         }
     }
 
-    private void processRelationFunctionPropertyMapping(RelationFunctionPropertyMapping pm, GenericType srcType, Matcher matcher, ProcessorState state, ProcessorSupport processorSupport)
+    private void processRelationFunctionPropertyMapping(RelationFunctionPropertyMapping pm, GenericType rowType, Matcher matcher, ProcessorState state, ProcessorSupport processorSupport)
     {
         if (pm._transformerCoreInstance() != null)
         {
@@ -114,21 +114,21 @@ public class RelationFunctionInstanceSetImplementationProcessor extends Processo
 
         try (ProcessorState.VariableContextScope ignore = state.withNewVariableContext())
         {
-            // Inject `src` parameter typed at the relation function's last-expression
-            // generic type (mirrors PureInstanceSetImplementationProcessor's pattern
-            // for `transform` lambdas).
+            // Inject the `row` parameter typed at the relation function's
+            // last-expression row type (the first type-arg of Relation<T>) so
+            // `$row.<col>` resolves against the columns of the row.
             FunctionType ft = getFunctionType(valueFn, processorSupport);
-            ft._parametersAdd(createSrcParameter(srcType, ft.getSourceInformation(), pm.getSourceInformation(), processorSupport));
+            ft._parametersAdd(createRowParameter(rowType, ft.getSourceInformation(), pm.getSourceInformation(), processorSupport));
 
             matcher.fullMatch(valueFn, state);
         }
     }
 
-    private VariableExpression createSrcParameter(GenericType srcType, SourceInformation genericTypeSourceInfo, SourceInformation parameterSourceInformation, ProcessorSupport processorSupport)
+    private VariableExpression createRowParameter(GenericType rowType, SourceInformation genericTypeSourceInfo, SourceInformation parameterSourceInformation, ProcessorSupport processorSupport)
     {
-        GenericType copy = (GenericType) org.finos.legend.pure.m3.navigation.generictype.GenericType.copyGenericType(srcType, processorSupport);
-        VariableExpression srcParam = (VariableExpression) processorSupport.newAnonymousCoreInstance(parameterSourceInformation, M3Paths.VariableExpression);
-        return srcParam._name("src")
+        GenericType copy = (GenericType) org.finos.legend.pure.m3.navigation.generictype.GenericType.copyGenericType(rowType, processorSupport);
+        VariableExpression rowParam = (VariableExpression) processorSupport.newAnonymousCoreInstance(parameterSourceInformation, M3Paths.VariableExpression);
+        return rowParam._name("row")
                 ._genericType(copy)
                 ._multiplicity((Multiplicity) processorSupport.package_getByUserPath(M3Paths.PureOne));
     }

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/test/java/org/finos/legend/pure/m2/dsl/mapping/test/TestRelationMapping.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/test/java/org/finos/legend/pure/m2/dsl/mapping/test/TestRelationMapping.java
@@ -27,7 +27,9 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.relation.Relation
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.FunctionDefinition;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.RelationType;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.FunctionType;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Type;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.VariableExpression;
 import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiled;
 import org.finos.legend.pure.m3.tests.RuntimeVerifier;
 import org.finos.legend.pure.m4.exception.PureCompilationException;
@@ -229,7 +231,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
                 "  {\n" +
                 "    ~func my::personFunction__Relation_1_\n" +
                 "    firstName: FIRSTNAME,\n" +
-                "    +concatenated: String[1]: $src.FIRSTNAME + ' ' + $src.FIRSTNAME\n" +
+                "    +concatenated: String[1]: $row.FIRSTNAME + ' ' + $row.FIRSTNAME\n" +
                 "  }\n" +
                 ")\n";
 
@@ -241,6 +243,34 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
                 ((Mapping) runtime.getCoreInstance("my::testMapping"))._classMappings().getOnly();
         RelationFunctionPropertyMapping concat = (RelationFunctionPropertyMapping) relSet._propertyMappings().toList().get(1);
         Assert.assertEquals("String", concat._valueFn()._expressionSequence().getOnly()._genericType()._rawType()._name());
+    }
+
+    @Test
+    public void testRelationMappingRejectsLegacySrcRowAccess()
+    {
+        // no `$src.<col>` syntax for relation mappings
+        // Authored sources must migrate to `$row.<col>`
+        String mappingSource = "###Mapping\n" +
+                "Mapping my::testMapping\n" +
+                "(\n" +
+                "  *my::Person[person]: Relation\n" +
+                "  {\n" +
+                "    ~func my::personFunction__Relation_1_\n" +
+                "    firstName: $src.FIRSTNAME\n" +
+                "  }\n" +
+                ")\n";
+
+        compileTestSource("class.pure", RELATION_MAPPING_CLASS_SOURCE);
+        compileTestSource("func.pure", RELATION_MAPPING_FUNCTION_SOURCE);
+        try
+        {
+            compileTestSource("mapping.pure", mappingSource);
+            Assert.fail("Expected compilation exception ($src is no longer bound in relation mappings)");
+        }
+        catch (PureCompilationException e)
+        {
+            Assert.assertTrue("Got: " + e.getMessage(), e.getMessage().contains("The variable 'src' is unknown!"));
+        }
     }
 
     @Test
@@ -285,7 +315,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
                 "  {\n" +
                 "    ~func my::personFunction__Relation_1_\n" +
                 "    firstName: FIRSTNAME,\n" +
-                "    +ageBucket: String[1]: if($src.AGE > 65, |'senior', |'other')\n" +
+                "    +ageBucket: String[1]: if($row.AGE > 65, |'senior', |'other')\n" +
                 "  }\n" +
                 ")\n";
 
@@ -309,7 +339,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
                 "  *my::Person[person]: Relation\n" +
                 "  {\n" +
                 "    ~func my::personFunction__Relation_1_\n" +
-                "    age: $src.FIRSTNAME\n" +
+                "    age: $row.FIRSTNAME\n" +
                 "  }\n" +
                 ")\n";
 
@@ -335,7 +365,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
                 "  *my::Person[person]: Relation\n" +
                 "  {\n" +
                 "    ~func my::personFunction__Relation_1_\n" +
-                "    firstName: $src.MISSING\n" +
+                "    firstName: $row.MISSING\n" +
                 "  }\n" +
                 ")\n";
 
@@ -366,7 +396,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
                 "  *my::Person[person]: Relation\n" +
                 "  {\n" +
                 "    ~func my::personFunction__Relation_1_\n" +
-                "    firstName: [$src.FIRSTNAME, $src.FIRSTNAME]\n" +
+                "    firstName: [$row.FIRSTNAME, $row.FIRSTNAME]\n" +
                 "  }\n" +
                 ")\n";
 
@@ -401,8 +431,8 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
                 "  *my::PersonWithGender[person]: Relation\n" +
                 "  {\n" +
                 "    ~func my::personWithGenderFunction__Relation_1_\n" +
-                "    firstName: $src.FIRSTNAME,\n" +
-                "    gender: EnumerationMapping GenderMapping: $src.GENDER\n" +
+                "    firstName: $row.FIRSTNAME,\n" +
+                "    gender: EnumerationMapping GenderMapping: $row.GENDER\n" +
                 "  }\n" +
                 ")\n";
 
@@ -429,7 +459,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
                 "    firstName: FIRSTNAME,\n" +
                 "    address\n" +
                 "    (\n" +
-                "      city: $src.CITY\n" +
+                "      city: $row.CITY\n" +
                 "    )\n" +
                 "  }\n" +
                 ")\n";
@@ -494,7 +524,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
         Assert.assertTrue(funcRf._expressionSequence().getLast()._genericType()._typeArguments().getOnly()._rawType() instanceof RelationType);
         Assert.assertTrue(srcRf._expressionSequence().getLast()._genericType()._typeArguments().getOnly()._rawType() instanceof RelationType);
 
-        // Property mapping under ~src resolves $src.FIRSTNAME the same way.
+        // Property mapping under ~src resolves $row.FIRSTNAME the same way.
         RelationFunctionPropertyMapping pm = (RelationFunctionPropertyMapping) srcSet._propertyMappings().getOnly();
         Assert.assertEquals("String", pm._valueFn()._expressionSequence().getOnly()._genericType()._rawType()._name());
     }
@@ -592,7 +622,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
     public void testRelationMappingInlineSrcWithEmbeddedSubMapping()
     {
         // Embedded mapping inherits relationFunction from the ~src parent;
-        // sub-property $src.<col> must resolve against the same row type.
+        // sub-property $row.<col> must resolve against the same row type.
         String mappingSource = "###Mapping\n" +
                 "Mapping my::testMapping\n" +
                 "(\n" +
@@ -602,7 +632,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
                 "    firstName: FIRSTNAME,\n" +
                 "    address\n" +
                 "    (\n" +
-                "      city: $src.CITY\n" +
+                "      city: $row.CITY\n" +
                 "    )\n" +
                 "  }\n" +
                 ")\n";
@@ -630,7 +660,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
     @Test
     public void testIncrementalIntegrityForExpressionRhsAndInlineSrc()
     {
-        // Mixes bare-column, $src expression, ~src inline source, embedded
+        // Mixes bare-column, $row expression, ~src inline source, embedded
         // mapping, and an enumeration transformer in a single mapping. Each
         // dependency source is deleted, recompiled, and reloaded; the
         // resulting graph must remain structurally identical.
@@ -641,10 +671,10 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
                 "  {\n" +
                 "    ~src my::personFunctionTyped()\n" +
                 "    firstName: FIRSTNAME,\n" +
-                "    +concatenated: String[1]: $src.FIRSTNAME + ' ' + $src.FIRSTNAME,\n" +
+                "    +concatenated: String[1]: $row.FIRSTNAME + ' ' + $row.FIRSTNAME,\n" +
                 "    address\n" +
                 "    (\n" +
-                "      city: $src.CITY\n" +
+                "      city: $row.CITY\n" +
                 "    )\n" +
                 "  }\n" +
                 ")\n";
@@ -673,7 +703,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
 
     // ------------------------------------------------------------------
     // Quoted column names (spaces in identifiers) — both bare-column and
-    // explicit `$src.'…'` expression forms must lower to a property
+    // explicit `$row.'…'` expression forms must lower to a property
     // accessor whose name preserves the space.
     // ------------------------------------------------------------------
 
@@ -693,7 +723,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
     public void testRelationMappingWithQuotedColumnBareForm()
     {
         // Bare-column form: `firstName: 'FIRST NAME'` must lower to
-        // `{| $src.'FIRST NAME'}` and resolve to the column whose name
+        // `{| $row.'FIRST NAME'}` and resolve to the column whose name
         // contains a space.
         String mappingSource = "###Mapping\n" +
                 "Mapping my::testMapping\n" +
@@ -724,9 +754,9 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
     }
 
     @Test
-    public void testRelationMappingWithQuotedColumnExplicitSrcForm()
+    public void testRelationMappingWithQuotedColumnExplicitRowForm()
     {
-        // Explicit `$src.'FIRST NAME'` expression form must resolve the
+        // Explicit `$row.'FIRST NAME'` expression form must resolve the
         // quoted column against the row type and produce a String-typed
         // value, exactly like the bare-column form.
         String mappingSource = "###Mapping\n" +
@@ -735,7 +765,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
                 "  *my::Person[person]: Relation\n" +
                 "  {\n" +
                 "    ~func my::personFunctionQuoted__Relation_1_\n" +
-                "    firstName: $src.'FIRST NAME'\n" +
+                "    firstName: $row.'FIRST NAME'\n" +
                 "  }\n" +
                 ")\n";
 
@@ -752,7 +782,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
     @Test
     public void testRelationMappingWithQuotedColumnInArithmeticExpression()
     {
-        // `$src.'FIRST NAME'` participating in a multi-step expression: the
+        // `$row.'FIRST NAME'` participating in a multi-step expression: the
         // quoted column accessor inside the body must still resolve and the
         // overall expression's result type must match the property type.
         String mappingSource = "###Mapping\n" +
@@ -761,7 +791,7 @@ public class TestRelationMapping extends AbstractPureTestWithCoreCompiled
                 "  *my::Person[person]: Relation\n" +
                 "  {\n" +
                 "    ~func my::personFunctionQuoted__Relation_1_\n" +
-                "    +greeted: String[1]: 'Hi ' + $src.'FIRST NAME'\n" +
+                "    +greeted: String[1]: 'Hi ' + $row.'FIRST NAME'\n" +
                 "  }\n" +
                 ")\n";
 

--- a/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/test/java/org/finos/legend/pure/m2/dsl/mapping/test/incremental/TestPureRuntimeRelationFunctionMapping.java
+++ b/legend-pure-dsl/legend-pure-dsl-mapping/legend-pure-m2-dsl-mapping-grammar/src/test/java/org/finos/legend/pure/m2/dsl/mapping/test/incremental/TestPureRuntimeRelationFunctionMapping.java
@@ -229,7 +229,7 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
     {
         // The relaxation still requires the valueFn's multiplicity to be subsumed by
         // the property's. Mapping a [1] property to an expression that returns [*]
-        // (here `$src.LEGALNAME->split(',')`) must be rejected with a multiplicity
+        // (here `$row.LEGALNAME->split(',')`) must be rejected with a multiplicity
         // error.
         try
         {
@@ -239,7 +239,7 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
                     "  *my::Firm[firm]: Relation\n" +
                     "  {\n" +
                     "    ~func my::firmFunction__Relation_1_\n" +
-                    "    legalName: $src.LEGALNAME->split(',')\n" +
+                    "    legalName: $row.LEGALNAME->split(',')\n" +
                     "  }\n" +
                     ")\n";
 
@@ -437,7 +437,7 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
                 "  *my::FirmWithAliases[firm]: Relation\n" +
                 "  {\n" +
                 "    ~func my::firmFunction__Relation_1_\n" +
-                "    aliases: $src.LEGALNAME->split(',')\n" +
+                "    aliases: $row.LEGALNAME->split(',')\n" +
                 "  }\n" +
                 ")\n";
         try
@@ -468,7 +468,7 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
                 "  *my::Firm[firm]: Relation\n" +
                 "  {\n" +
                 "    ~func my::firmFunction__Relation_1_\n" +
-                "    clientNames: $src.LEGALNAME->split(',')\n" +
+                "    clientNames: $row.LEGALNAME->split(',')\n" +
                 "  }\n" +
                 ")\n";
 
@@ -590,7 +590,7 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
     public void testRelationMappingRejectsZeroToOneExpressionForToOnePropertyWithExpressionRhs()
     {
         // Same multiplicity rejection as the bare-column form, but expressed
-        // through `$src.<col>->first()` which yields [0..1] from a [1] column.
+        // through `$row.<col>->first()` which yields [0..1] from a [1] column.
         // Demonstrates that the multiplicity check operates on the *result* of
         // the lambda, not on the column type alone.
         String mappingSource = "###Mapping\n" +
@@ -599,7 +599,7 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
                 "  *my::Firm[firm]: Relation\n" +
                 "  {\n" +
                 "    ~func my::firmFunction__Relation_1_\n" +
-                "    legalName: $src.LEGALNAME->toOneMany()->first()\n" +
+                "    legalName: $row.LEGALNAME->toOneMany()->first()\n" +
                 "  }\n" +
                 ")\n";
         try
@@ -874,7 +874,7 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
     }
 
     // ------------------------------------------------------------------
-    // Incremental coverage for the new $src.<col> and ~src forms.
+    // Incremental coverage for the new $row.<col> and ~src forms.
     //
     // Each test here exercises delete-and-reload-stable across the new
     // expression-RHS / inline-source code paths, mirroring the existing
@@ -884,7 +884,7 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
     @Test
     public void testDeleteAndReloadEachSourceWithExpressionRhs()
     {
-        // Mixes bare-column lowering, explicit `$src.X`, and a multi-step
+        // Mixes bare-column lowering, explicit `$row.X`, and a multi-step
         // arithmetic expression in a single mapping.
         String mappingSource = "###Mapping\n" +
                 "Mapping my::testMapping\n" +
@@ -893,8 +893,8 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
                 "  {\n" +
                 "    ~func my::personFunction__Relation_1_\n" +
                 "    firstName: FIRSTNAME,\n" +
-                "    age: $src.AGE,\n" +
-                "    +concatenated: String[1]: $src.FIRSTNAME + ' ' + $src.FIRSTNAME\n" +
+                "    age: $row.AGE,\n" +
+                "    +concatenated: String[1]: $row.FIRSTNAME + ' ' + $row.FIRSTNAME\n" +
                 "  }\n" +
                 ")\n";
 
@@ -942,7 +942,7 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
     @Test
     public void testDeleteAndReloadEachSourceWithInlineSrcAndEmbedded()
     {
-        // Inline ~src parent + embedded sub-mapping with $src.<col> RHS.
+        // Inline ~src parent + embedded sub-mapping with $row.<col> RHS.
         // Same caveat as testDeleteAndReloadEachSourceWithInlineSrc above.
         String mappingSource = "###Mapping\n" +
                 "Mapping my::testMapping\n" +
@@ -953,7 +953,7 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
                 "    firstName: FIRSTNAME,\n" +
                 "    address\n" +
                 "    (\n" +
-                "      city: $src.CITY\n" +
+                "      city: $row.CITY\n" +
                 "    )\n" +
                 "  }\n" +
                 ")\n";
@@ -1041,7 +1041,7 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
     {
         // Quoted-column lowering (`'LEGAL NAME'`) must survive delete-reload.
         // The bare-column branch in the graph builder must preserve quotes
-        // when synthesizing `{| $src.'LEGAL NAME'}` so the M3 parser still
+        // when synthesizing `{| $row.'LEGAL NAME'}` so the M3 parser still
         // accepts it as a quoted property accessor on the row.
         String functionSource = "###Pure\n" +
                 "import meta::pure::metamodel::relation::*;\n" +
@@ -1070,7 +1070,7 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
     @Test
     public void testDeleteAndReloadEachSourceWithEnumerationTransformerOverExpression()
     {
-        // Enumeration transformer + explicit `$src.<col>` expression RHS must
+        // Enumeration transformer + explicit `$row.<col>` expression RHS must
         // also be stable across delete-reload cycles.
         String mappingSource = "###Mapping\n" +
                 "Mapping my::testMapping\n" +
@@ -1083,8 +1083,8 @@ public class TestPureRuntimeRelationFunctionMapping extends AbstractPureMappingT
                 "  *my::PersonWithGender[person]: Relation\n" +
                 "  {\n" +
                 "    ~func my::personWithGenderFunction__Relation_1_\n" +
-                "    firstName: $src.FIRSTNAME,\n" +
-                "    gender: EnumerationMapping GenderMapping: $src.GENDER\n" +
+                "    firstName: $row.FIRSTNAME,\n" +
+                "    gender: EnumerationMapping GenderMapping: $row.GENDER\n" +
                 "  }\n" +
                 ")\n";
 


### PR DESCRIPTION
This change is not backwards compatible and updates relation mappings to use $row for property access instead of $src. $src is used for complex property access