### PR TITLE
Document and test DateFunctions, and fix the defects that surfaced

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -163,7 +163,7 @@ paths are always equivalent from a user's perspective.
 | [Documentation Maintenance](maintenance/maintenance.md) | Keeping docs up to date, ownership, and review cadence |
 | [Module README Template](templates/module-readme-template.md) | Standard template for per-module README files |
 | [Phased Documentation Plan](maintenance/documentation-plan.md) | The phased timeline that produced this documentation set |
-| [Architecture Decision Records](decisions/) | ADR-001 JUnit 4; ADR-002 Eclipse Collections; ADR-003 No mocking |
+| [Architecture Decision Records](decisions/) | ADR-001 JUnit 4; ADR-002 Eclipse Collections; ADR-003 No mocking; ADR-004 Date difference semantics (proposed) |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -163,7 +163,6 @@ paths are always equivalent from a user's perspective.
 | [Documentation Maintenance](maintenance/maintenance.md) | Keeping docs up to date, ownership, and review cadence |
 | [Module README Template](templates/module-readme-template.md) | Standard template for per-module README files |
 | [Phased Documentation Plan](maintenance/documentation-plan.md) | The phased timeline that produced this documentation set |
-| [Distributed Metadata Removal Plan](maintenance/remove-distributed-metadata-plan.md) | Retiring the pre-PELT compiled-mode metadata format — inventory, phased deletion, and decisions |
 | [Architecture Decision Records](decisions/) | ADR-001 JUnit 4; ADR-002 Eclipse Collections; ADR-003 No mocking |
 
 ---

--- a/docs/decisions/ADR-004-date-difference-semantics.md
+++ b/docs/decisions/ADR-004-date-difference-semantics.md
@@ -1,0 +1,1003 @@
+# ADR-004: Date Difference Semantics
+
+**Status:** Proposed. Options analysis; no decision taken.
+**Date:** 2026-08-06, revised 2026-08-07
+**Deciders:** Legend Pure core team
+
+## Goals
+
+Three, in priority order.
+
+1. **Well defined, usable, and internally coherent.** The rule should be statable in a sentence or
+   two, hold without exceptions, agree with the rest of the platform's date functions, and not
+   surprise a user who has read the documentation. **Conforming to a standard is the strongest form
+   of being well defined**, since it replaces a house convention with one the user may already know
+   and can look up independently. ISO 8601 carries particular weight: Pure's date literals, its
+   granularity model, and its lexical representation already follow it, so a date function that
+   departs from it departs from the platform's own foundation.
+2. **Sufficient in the platform.** Pure does not always push computation down. A great deal of work
+   runs in the platform's own engines, and that is a first-class execution mode rather than a
+   fallback, since the in-memory answer *is* the definition of the function. Users therefore have to
+   be able to compute what they actually need without leaving Pure. And where more than one reading
+   of "the difference between two dates" is legitimate, letting a user ask for the one they want is
+   a feature rather than a complication.
+3. **Translatable to external target systems.** Where computation is pushed down, Legend pushes it
+   into the data stores and query engines it runs against. Many are relational, but nothing about
+   the design requires that. A rule that no target can reproduce is a rule that silently gives
+   different answers depending on where a query runs.
+
+Where these conflict, the earlier wins. A function that is wrong in a well defined way is worse than
+one that is right and needs emulation, and a function users cannot get the answer they need out of
+is worse than one that needs a second call. Most of the options below trade against each other along
+these lines, so all three are weighed explicitly throughout.
+
+## Context
+
+`meta::pure::functions::date::dateDiff(d1, d2, unit)` and
+`meta::pure::functions::date::adjust(date, n, unit)` are `<<PCT.function>>` natives. Both are
+implemented once, in `legend-pure-m4`: `DateFunctions.dateDifference` (delegating to the
+package-private `DateDiff`) and the `PureDate.addX` family. Both engines call straight into them,
+`CoreHelper.dateDiff` in the compiled engine and the `DateDiff` and `AdjustDate` natives in the
+interpreted engine, so the two engines cannot disagree. Every other execution backend translates
+them into the target system's own functions, and there they can and do disagree. Most of the
+evidence below comes from the relational adapters, because that is where the manifests are, but the
+question is general: any store or query engine Legend pushes into has to be able to reproduce the
+rule.
+
+This ADR takes the platform as it stands today as its baseline and asks what to do next. It records
+what the current semantics are, what they cost us, and what the alternatives are. It does not choose
+between them.
+
+The platform is written in Java today, but Pure is a language rather than a Java library and should
+be reimplementable in C, Rust, or anything else with the same answers. So what a particular library
+does is evidence here, never justification, and "cheap to implement with the library we happen to
+use" is a cost, not a reason. Every candidate below is therefore stated as a formula over instants
+and calendar fields before any implementation is mentioned.
+
+### Terms
+
+- **Unit**: one of the `DurationUnit` values, YEARS through NANOSECONDS.
+- **Grid**: the set of instants at which a unit's counter ticks over. Midnights for DAYS, the first
+  of the month for MONTHS, and so on. A date is **aligned** to a unit when it sits exactly on that
+  unit's grid.
+- **Granularity**: how much of a date is written down. A Pure date stops at the year, the month, the
+  day, the hour, the minute, the second, or a subsecond of any precision, and stands for the whole
+  span it leaves unsaid. `dateDiff` reads a date as the first instant of that span.
+
+### What the platform does today
+
+| Unit | Rule | Family |
+|---|---|---|
+| YEARS, MONTHS, DAYS | Floor both operands onto the unit's grid, subtract the grid positions | Boundary counting (A below) |
+| WEEKS | Sunday-based grid going forward, Monday-based grid going backward | Boundary counting, inconsistently (B below) |
+| HOURS through NANOSECONDS | Elapsed time, truncated toward zero | Elapsed (C below) |
+
+The WEEKS row is usually described as "half open: a boundary landing on `d2` counts, one landing on
+`d1` does not." That is true, but there is a sharper way to say it. `weeksBetween` counts
+`weekNumber(to) - weekNumber(from)` going forward and `weekNumber(to - 1) - weekNumber(from - 1)`
+going backward, and shifting both operands back one day is exactly the same as shifting the grid
+origin forward one day. So:
+
+> **`dateDiff(a, b, WEEKS)` counts boundaries on a Sunday-based week grid when `b >= a`, and on a
+> Monday-based week grid when `b < a`.**
+
+That is the defect, stated plainly. It is not a half-open convention that happens to be visible for
+one unit; it is two different week grids depending on the direction of travel. It is also why the
+asymmetry exists: `2015-07-04 -> 2015-07-05` is 1 but `2015-07-05 -> 2015-07-04` is 0.
+
+Four further properties of the function as it stands, which the options below have to preserve or
+deliberately change:
+
+- **A coarse operand is read as the start of its span**, so `%2014` behaves as `%2014-01-01T00:00:00`
+  and `%2014->dateDiff(%2014-06, MONTHS)` is 5. See axis 4.
+- **Subsecond digits count down to the nanosecond** and anything finer is ignored.
+- **A span too large for the unit raises an error** rather than wrapping, which NANOSECONDS reaches
+  at about 292 years.
+- **The calendar is proleptic ISO**, matching `adjust`, so there is no Julian cutover and years at or
+  below zero are ordinary years. Most SQL targets support neither, which is a translation limit
+  rather than a semantic one.
+
+One gap is worth naming here rather than leaving to the evidence section: **MICROSECONDS and
+NANOSECONDS are accepted in memory and translatable nowhere.** `adjust` accepts them, so `dateDiff`
+does too, but every dialect's unit list stops at MILLISECONDS and neither unit has a
+`<<PCT.test>>`. Whatever is decided below, that pair is currently outside the contract that PCT is
+supposed to enforce.
+
+## The design space
+
+Choosing "the semantics of `dateDiff`" is really six independent choices. The literature and the
+existing discussion collapse them, which is why the WEEKS question keeps reappearing. The letters
+A through E below label positions on the first axis only.
+
+### Axis 1: what is being counted
+
+Let `g_U(t)` be the **grid index** of instant `t` for unit `U`:
+
+```
+g_YEARS(t)   = year(t)
+g_MONTHS(t)  = 12 * year(t) + month(t)
+g_U(t)       = floor((t - origin_U) / length_U)      for WEEKS and every finer unit
+```
+
+For DAYS and finer, `origin_U` and `length_U` are fixed by the calendar and the definition of the
+second. For WEEKS, `length_U` is seven days but `origin_U` is a free parameter: see axis 3.
+
+| | Name | Definition | `2015-12-31 -> 2016-01-01` in YEARS |
+|---|---|---|---|
+| **A** | Boundary counting | `g_U(b) - g_U(a)` | 1 |
+| **B** | Half-open boundary counting | Grid points in `(a, b]` going forward, minus grid points in `[b, a)` going backward. Equals A plus `[a aligned]` minus `[b aligned]` when `b < a`, and equals A exactly when `b >= a` | 1 |
+| **C** | Complete elapsed units | `trunc((b - a) / length_U)` for fixed-length units; for YEARS and MONTHS, the largest `n` such that `a` advanced by `n` units does not pass `b`, mirrored going backward | 0 |
+| **D** | Exact fractional | `(b - a) / length_U` exactly for fixed-length units; **undefined for YEARS and MONTHS without a named convention**, see axis 5 | 0.0027... |
+| **E** | Compound period | The record of years, months, and days (and optionally a time part) `P` such that `a` advanced by `P` is exactly `b`, computed field by field with borrowing | 0 years, 0 months, 1 day |
+
+Their algebraic properties, which is what "internally coherent" cashes out to:
+
+| | Antisymmetric | Additive | `d(a,b) = 0` means | Derivable from |
+|---|---|---|---|---|
+| **A** | Yes | **Yes** | `a` and `b` fall in the same grid cell (an equivalence relation) | C, after truncating both operands to the unit; on the fixed-length units, D as well |
+| **B** | **No** | No | Nothing uniform | Nothing |
+| **C** | Yes | No | `a` and `b` are less than one unit apart | On the fixed-length units, `trunc` of D, or of C in a finer unit. **On YEARS and MONTHS, nothing** |
+| **D** | Yes | Yes | `a` and `b` begin at the same instant, which is not the same as being equal: see axis 4 | On the fixed-length units, C in the finest unit, divided. **On YEARS and MONTHS, nothing** |
+| **E** | Yes by construction | No | as D | Nothing |
+
+Five of these deserve comment, because they are easy to get wrong.
+
+**A is additive.** `d(a,c) = d(a,b) + d(b,c)` for every `a`, `b`, and `c`, because A is the
+difference of a rank function and therefore telescopes. Antisymmetry, additivity, and the fact that
+a zero result is an equivalence relation all fall out of that single structural fact rather than
+being separate properties that have to be checked. A is the only integer candidate with this
+property, and it is the strongest formal argument available for boundary counting. It is easy to
+mistake additivity for something only a fractional result can offer; it is not.
+
+**A is derivable, given truncation.** A is not recoverable from a C or D *result*: `HOURS(12:59,
+13:01)` is 1 under A while the exact distance is 0.033, and no rounding of 0.033 yields 1. But it is
+recoverable by truncating the *operands* first, and the platform already ships those truncations:
+`firstDayOfYear`, `firstDayOfMonth`, `firstDayOfWeek`, `firstHourOfDay`, `firstMinuteOfHour`, and
+`firstSecondOfMinute`, all in legend-engine's `core/pure/corefunctions/dateExtension.pure`.
+
+**On the fixed-length units, everything reduces to the finest one.** Given an elapsed count in
+NANOSECONDS a user can build C in any coarser fixed-length unit by dividing, D by dividing without
+truncating, and A by truncating the operands first. So for WEEKS and below the platform needs to
+offer only one primitive, and it already does. The one caveat is range: NANOSECONDS overflows at
+about 292 years, so long spans have to start from MICROSECONDS or MILLISECONDS instead.
+
+**On YEARS and MONTHS, nothing reduces to anything.** Complete months cannot be built out of
+boundary-counted months, because the correction term is anniversary arithmetic with month-end
+clamping, which is precisely where hand-written code goes wrong: see the `2015-01-31 -> 2015-02-28`
+row below, where boundary counting says one month, complete units say zero, and `adjust` by one
+month lands exactly on the target date. Fractional months cannot be built either, since they need
+complete months first, plus a convention. **So `dateDiff` is one primitive short: complete years and
+months are the only reading a user cannot assemble from what the platform provides.** That is a
+goal 2 gap, and it is the same gap under both the complete and the fractional reading.
+
+**C is `trunc` of D, not `floor` of D.** C as defined and as implemented truncates toward zero,
+which is what makes it antisymmetric. `floor(-0.5)` is -1 where C gives 0, so deriving C with
+`floor` breaks antisymmetry on every backward pair. Anywhere this document or the code says "floor
+the fractional result," read "truncate toward zero."
+
+**E is the only candidate that inverts `adjust` off the diagonal.** `a` advanced by `E(a, b)` is `b`
+for all `a` and `b`, by construction, which is the property `java.time.Period.between` guarantees. No
+scalar candidate can do this, because a scalar in a single unit cannot carry the remainder. E is
+listed for completeness and is not proposed: it would require a new Pure type and a new arithmetic,
+and no target we push into returns it. But it should be rejected explicitly rather than left out,
+because it is the answer to "what is the difference between two dates" that most calendar libraries
+actually give.
+
+### What the candidates actually give you
+
+Every candidate produces an answer somebody will call obviously wrong. Stating the rules abstractly
+hides that; putting the numbers side by side does not. A uses the Sunday grid, which is what the
+platform counts forward on today. D needs a convention for YEARS and MONTHS, so where the Oracle
+convention (a flat 31-day month) and the anniversary convention (the fraction of the way to the next
+anniversary, measured against the real length of that span) disagree, both are given as
+`Oracle / anniversary`. That they disagree at all is the argument of axis 5.
+
+| From | To | Unit | A | B | C | D | The uncomfortable reading |
+|---|---|---|---|---|---|---|---|
+| `%2015-12-31` | `%2016-01-01` | YEARS | **1** | **1** | 0 | 0.0027 | One day apart is a whole year |
+| `%2015-01-01` | `%2015-12-31` | YEARS | 0 | 0 | 0 | 0.9973 | 364 days apart is no years at all |
+| `%2016-01-31` | `%2016-03-01` | MONTHS | **2** | **2** | 1 | 1.03 | Thirty days is two months |
+| `%2016-02-01` | `%2016-02-29` | MONTHS | 0 | 0 | 0 | 0.90 / 0.97 | Almost all of February is no months, and the two D conventions disagree about how much of it, because February is not 31 days long |
+| `%2015-01-31` | `%2015-02-28` | MONTHS | 1 | 1 | **0** | 1 | C says zero months even though `adjust(%2015-01-31, 1, MONTHS)` lands exactly on `%2015-02-28` |
+| `%2015-07-04` | `%2015-07-05` | WEEKS | 1 | 1 | 0 | 0.14 | Saturday to Sunday is a whole week. On a Monday grid A gives 0 |
+| `%2015-07-05` | `%2015-07-04` | WEEKS | -1 | **0** | 0 | -0.14 | The same pair reversed. B is the only candidate whose magnitude changes with direction |
+| `%2015-07-06` | `%2015-07-11` | WEEKS | 0 | 0 | 0 | 0.71 | Monday to Saturday is no weeks, on either grid |
+| `%2015-07-07T23:59` | `%2015-07-08T00:01` | DAYS | **1** | **1** | 0 | 0.0014 | Two minutes is a day |
+| `%2015-07-07T12:59` | `%2015-07-07T13:01` | HOURS | **1** | **1** | 0 | 0.033 | Two minutes is an hour |
+| `%2015-07-07T12:00` | `%2015-07-07T12:59` | HOURS | 0 | 0 | 0 | 0.983 | Fifty-nine minutes is no hours |
+| `%2015-07-07T12:59` | `%2015-07-07T13:01` | MINUTES | 2 | 2 | 2 | 2 | All four agree, which is the usual case and the reason the disagreements are easy to miss |
+
+Read down the A column and the complaint is "tiny gaps become whole units." Read down the C column
+and it is "large gaps vanish." Neither is a defect to be fixed; they are answers to different
+questions, and the last row is why the difference so rarely surfaces.
+
+Three structural consequences follow, each of which the table makes concrete:
+
+- **C is not additive.** From `%2015-01-01T00:00` to `00:59` is zero HOURS, and `00:59` to `01:58` is
+  zero HOURS, but `00:00` to `01:58` is one. Two zeroes that sum to one. A gives 0, 1, and 1, which
+  do add up.
+- **Under A, units do not convert.** The `12:59 -> 13:01` pair is one HOUR and two MINUTES, and two
+  minutes divided by sixty is zero, not one. Only D converts exactly.
+- **A zero answer never means the dates are equal.** Every candidate returns 0 for `%2014` against
+  `%2014-01`, which are different dates that begin at the same instant. See axis 4.
+
+### Axis 2: rounding
+
+Independent of what is being counted, a non-integral result has to be resolved. The options are
+truncation toward zero, floor, ceiling, and round to nearest. The trade-off is exact:
+
+- **Truncation toward zero gives antisymmetry** and a plateau of width two units around zero, since
+  everything strictly between -1 and 1 maps to 0.
+- **Floor gives monotonicity** in both arguments and a uniform plateau of width one, and gives up
+  antisymmetry.
+
+You cannot have both. A escapes the choice entirely by flooring both *operands* onto the grid, which
+is why it is antisymmetric and monotone at once. C and D must choose, and the platform has chosen
+truncation.
+
+Round to nearest is a real user-facing semantics, not only a bug: "about three months" is a sensible
+answer to a sensible question. Databricks and Oracle currently produce it by accident, and that is a
+translation defect, but a rounding mode is the sort of thing an options record would expose
+deliberately. See Option 6.
+
+### Axis 3: the grid origin for WEEKS
+
+Every other unit's grid is fixed by the calendar. WEEKS is not: days are not aligned to weeks, so
+the origin is a free parameter, and it is the only reason A and B ever differ in practice.
+
+**The platform currently holds three different answers at once.**
+
+| Function | Week convention | Where |
+|---|---|---|
+| `dateDiff(..., WEEKS)` | Sunday-based grid forward, Monday-based grid backward | `legend-pure-m4` `DateDiff.weeksBetween` |
+| `firstDayOfWeek` | Monday | legend-engine `dateExtension.pure`, `mostRecentDayOfWeek(DayOfWeek.Monday)` |
+| `weekOfYear` | `GregorianCalendar.get(WEEK_OF_YEAR)`, so it depends on the **JVM default locale** and uses the Julian cutover calendar | legend-engine `FunctionsHelper.weekOfYear` |
+
+Any decision about WEEKS in `dateDiff` that does not also settle `firstDayOfWeek` and `weekOfYear`
+leaves the platform incoherent, which is goal 1. The `weekOfYear` locale dependence is a defect in
+its own right and should be fixed regardless.
+
+Mainstream systems treat the origin as a parameter rather than a constant: BigQuery takes it in the
+call (`DATE_DIFF(d2, d1, WEEK(MONDAY))`), Snowflake takes it from the `WEEK_START` session
+parameter, Tableau takes it as a fourth argument to `DATEDIFF`, and SAS encodes it in the interval
+name (`WEEK.2`). SQL Server is the outlier that hard-codes Sunday and documents that `SET DATEFIRST`
+deliberately does not affect `DATEDIFF`.
+
+### Axis 4: mixed granularity
+
+`dateDiff` reads a coarse date as the first instant of its span, so `%2014` behaves as
+`%2014-01-01T00:00:00`. Alternatives are to reject a unit finer than either operand's granularity,
+or to return a range. Three observations:
+
+- **`adjust` already rejects it.** `%2014->adjust(1, DAYS)` throws, while
+  `%2014->dateDiff(%2015, DAYS)` cheerfully answers 365. The two halves of the same arithmetic
+  disagree about whether a coarse date has a day.
+- **`compare` treats a date as a span; `dateDiff` treats it as a point.** `compare(%2014, %2014-01)`
+  is -1, because a date that runs out of components sorts before one that carries on, yet
+  `dateDiff(%2014, %2014-01, U)` is 0 for every `U`. So a zero difference does not imply equality,
+  under any of A through D. This is worth knowing before claiming that a fractional result would
+  make zero mean "equal": it would not, because granularity, not precision, is what separates those
+  two dates.
+- Mixed granularity is almost entirely an in-memory concern, because year and year-month granularity
+  do not survive pushdown at all. See the translation evidence below.
+- **`%latest` is deliberately handled differently by the two functions.** `LatestDate` has neither
+  components nor a fixed position on the time line: what it stands for is decided by the context it
+  appears in, so it means different things in different places despite being a singleton. Sorting
+  has to be total, so `compare` orders it after every other date, which is a sorting convention
+  rather than a claim about when it falls. Differencing does not have to be total, so `dateDiff`
+  rejects it in either position, including against itself. Inventing an answer to a question that
+  has no meaning would be worse than refusing it.
+
+### Axis 5: conventions for variable-length units
+
+WEEKS and below have a constant length, so C and D need no convention. YEARS and MONTHS do not, and
+this is where a fractional answer has to invent something.
+
+The claim that every such convention is arbitrary is too strong. Finance has standardized several,
+and they are the reason `YEARFRAC` in Excel takes a `basis` argument: 30/360 bond basis, 30E/360,
+ACT/360, ACT/365F, and ACT/ACT in the ISDA and ICMA variants. Oracle's `MONTHS_BETWEEN` picks a
+different one, a flat 31-day month for the fractional part, so
+`MONTHS_BETWEEN('2016-02-29', '2016-02-01')` is 28/31 even though that February had 29 days. DB2
+documents its `TIMESTAMPDIFF` as an approximation using 30-day months and 365-day years.
+
+There is also a convention that needs no arbitrary denominator: complete units by anniversary
+arithmetic, plus the fraction of the way to the next anniversary, measured against the actual length
+of that partial month or year. TC39 Temporal appears to implement exactly this in
+`Duration.prototype.total({ unit, relativeTo })`, where the anchor is what makes the fraction well
+defined. That should be confirmed against the specification before being relied on, but the
+statement "no system implements it" should not stand unchecked.
+
+The design consequence: **a fractional variant should take the convention as an argument rather than
+pin one.** For a platform whose users compute accruals and day counts, one hard-coded denominator is
+the wrong answer no matter which one is chosen.
+
+### Axis 6: time zones
+
+Pure dates carry no zone today; every date is understood as UTC. The choice made here constrains
+what zone support can look like later:
+
+- **Elapsed time is zone independent. Calendar boundaries are not.** A boundary count needs a zone
+  to locate the boundary.
+- Under a hybrid (calendar units count boundaries, time units measure elapsed time), only the
+  calendar units would need a zone. Under A uniformly, **every** unit would, including HOURS: zones
+  with :30 and :45 offsets put the top of the hour in a different place.
+- The classic pitfall is DAYS against HOURS across a DST transition: a civil day is 23 or 25 hours
+  long, so `DAYS * 24` is not `HOURS`. The current split already gets this right, since DAYS counts
+  civil midnights while HOURS measures elapsed time. Temporal makes the same choice deliberately:
+  `ZonedDateTime.until` with `largestUnit: 'day'` counts calendar days, not 86,400-second blocks.
+
+### Out of scope
+
+Business-day and holiday-calendar counting (`NETWORKDAYS` and friends), fiscal calendars, and leap
+seconds. The first is a real and probably imminent requirement given the
+`meta::pure::functions::date::calendar::*` family already in legend-engine, which carries NY and
+London calendars and fiscal-day semantics, but it is a different function rather than a different
+reading of this one.
+
+## Why the calendar/time split is principled
+
+A calendar unit names a position in a civil calendar. A date has a year, a month, and a day of
+month, and those positions are defined by rules people agreed on, not by any quantity of elapsed
+time. A time unit names an offset within a day and is a fixed quantity of elapsed time. Counting
+boundaries is the natural question to ask of the first kind, and measuring duration is the natural
+question to ask of the second, so a rule that treats them differently is following a real
+distinction rather than an arbitrary one.
+
+The strongest corroboration is not a library but a standard: **ANSI SQL has two interval families,
+year-month and day-time, and forbids mixing them**, for exactly this reason. Four unrelated language
+designs land on the same line: Java separates date-based from time-based `ChronoUnit`s and
+`Period` from `Duration`, Temporal separates plain dates from instants and gives durations separate
+date and time fields, .NET added `DateOnly` and `TimeOnly` alongside its tick-based `TimeSpan`, and
+Julia separates calendar periods from fixed-length time periods.
+
+What is not principled is that the boundary-counting family is implemented two different ways. For
+YEARS, MONTHS, and DAYS the distinction is invisible, because truncating to the unit already puts
+both operands on the unit's grid. WEEKS is the only unit where the grid origin is a choice, and it
+is the only unit that got a second implementation.
+
+## How other systems choose
+
+Evidence, not authority. The point of the table is that the two goals pull in opposite directions.
+
+| System | What differencing two dates gives | Semantics |
+|---|---|---|
+| Python, stdlib `datetime` | Subtraction yields a `timedelta` of days, seconds, and microseconds | D; no calendar-aware difference at all |
+| JavaScript `Date` | Subtraction yields milliseconds | D |
+| JavaScript Temporal | `until` yields a `Duration` in whichever largest unit the caller asks for; `total` yields a fraction; `roundingMode` is explicit | E and C, with D on demand |
+| C# / .NET | Subtraction yields a `TimeSpan` of ticks; NodaTime adds `Period.Between(start, end, units)` | D, with E in NodaTime |
+| Go | `Sub` yields a `Duration` of nanoseconds | D |
+| Rust `chrono` | Subtraction yields a `TimeDelta`; `years_since` yields complete years | D, with C for years |
+| Java | `ChronoUnit.between` yields complete units; `Period.between` yields a compound period | C and E |
+| Common Lisp | Universal time is a second count | D |
+| SAS | `INTCK(interval, a, b, method)` takes `DISCRETE` or `CONTINUOUS`; intervals are shiftable, as in `WEEK.2` | **A and C, selected by an argument** |
+| Excel and Sheets | `DATEDIF`; `DAYS360`; `YEARFRAC(..., basis)` | C, plus D under named conventions |
+| SQL Server, Snowflake, BigQuery, DuckDB, Trino, ClickHouse | `DATEDIFF` / `DATE_DIFF` count boundaries | A |
+| MySQL and SingleStore | `TIMESTAMPDIFF` counts complete units; `DATEDIFF` is days only | C |
+| Oracle | `MONTHS_BETWEEN` is fractional; date subtraction is fractional days | D |
+| PostgreSQL | No `DATEDIFF` at all: subtraction yields a day-time interval, `age()` yields a compound interval | D and E |
+| SQLite | `julianday()` difference | D |
+
+Two patterns matter.
+
+**Essentially no general-purpose language offers boundary counting.** A is a database idea. Languages
+give you an exact duration, whole units, or a compound period, and the ones that offer only exact
+durations do not provide a calendar-aware difference at all. That cuts across our goals rather than
+along them: choosing A aligns Pure with the databases it pushes down to and away from how languages
+think about dates, and choosing C or D does the reverse.
+
+**SAS is the closest existing precedent for this whole document.** `INTCK` has taken a method
+argument selecting between boundary counting and complete units for decades, in a language whose
+users are doing exactly the kind of work Legend's users do. It is the strongest evidence that
+Option 6 is a viable shape rather than a hedge, and that a mode argument can be made to work if it
+is named well.
+
+**`adjust` is not universally agreed either.** Java clamps month overflow, so 31 January plus one
+month is 28 February; Go normalizes, so the same addition yields 3 March. Pure clamps, and
+`adjust.pure` now says so. Note also that clamping costs two algebraic laws that users assume:
+`(d + 1 month) + 1 month` is not `d + 2 months`, and `(d + 1 month) - 1 month` is not `d`. NodaTime
+documents this loudly; Pure should too.
+
+*Confidence: the relational rows for PostgreSQL, SingleStore, Oracle, and Databricks are verified
+below against Legend's own generated SQL. High confidence on Python, JavaScript's `Date`, Go, .NET,
+Java, and SQL Server. Moderate on the Temporal, `chrono`, Julia, SAS, and DuckDB/Trino/ClickHouse
+specifics, which should be checked against current documentation before being relied on.*
+
+## Evaluation criteria
+
+1. **Internal coherence.** Can the rule be stated briefly and completely; is it antisymmetric and
+   additive; does it need special cases; does it agree with `adjust`, `compare`, `firstDayOfWeek`,
+   and `weekOfYear`.
+2. **Translatability.** How cheaply and reliably it maps onto the systems we target, and whether
+   emulation has a uniform shape.
+3. **Cost.** Implementation work, plus the downstream cost of changing behavior that already ships.
+
+The third splits into two costs that are easy to conflate and that pull in different directions.
+
+**Retracting a declared expectation.** The `<<PCT.test>>` functions in `dateDiff.pure` are not a
+regression net that happens to be checked in. They are the platform's published statement of what
+`dateDiff` does: users read them to find out what Legend supports, and adapter authors implement
+against them. Changing an assertion is therefore not a test edit, it is a retraction of something
+the platform has told people is true, and the cost includes every expectation built on it. That cost
+is high, and it depends on **what** is retracted as much as on how many: withdrawing an assertion
+that contradicts its own mirror image costs far less than withdrawing one that was defensible on its
+own terms, even though both count as one line.
+
+**Changing behavior silently.** An option can move a large share of real answers while changing few
+assertions or none. That is not cheap because the declaration held still; it is arguably worse,
+because the published statement stays true and stops being a description of the function. Users have
+no signal that anything moved. Each option below reports a measured share of ordered pairs whose
+answer changes, alongside the assertions it retracts.
+
+The two are reported separately, and neither substitutes for the other.
+
+## Evidence
+
+### The `adjust` relationship
+
+`adjust(a, dateDiff(a, b, U), U) == b` holds for all `a` and `b` exactly when `a` and `b` share a
+granularity and `U` names that granularity: the "diagonal." Verified over **46,496** ordered pairs
+in `TestDateDifference.testAdjustInvertsDateDifferenceAtMatchingGranularity`.
+
+**This criterion barely discriminates between A, B, C, and D.** On the diagonal both operands are
+aligned to the unit's grid, which is precisely the condition under which all four coincide. Every
+one of them satisfies it. Off the diagonal none of them do, for reasons fixed by design: `adjust`
+refuses units finer than the date's granularity, and a coarser unit loses information through
+truncation or month-end clamping.
+
+It does discriminate in two places.
+
+**It penalizes D.** `adjust` takes an `Integer`, so `adjust(a, dateDiff(a, b, U), U)` does not
+typecheck under fractional results; the invariant has to be written with an explicit truncation. It
+still holds on the diagonal, since a fractional difference between aligned operands is a whole
+number, but the relationship stops being expressible without a conversion.
+
+**It rewards E**, which inverts `adjust` for all pairs by construction rather than by coincidence.
+
+C has a *potential* off-diagonal relationship: it can be **defined** as "the largest `n` such that
+advancing `a` by `n` units does not overshoot `b`," which would make the two functions inverse where
+the granularity permits. That definition has to be built deliberately, because a library's
+complete-units function will not give it to you:
+
+```
+2015-01-31 plus 1 month                        = 2015-02-28    (adjust clamps to the short month)
+complete months from 2015-01-31 to 2015-02-28  = 0             (yet the adjustment landed exactly there)
+```
+
+Anyone adopting C should implement it against `adjust` directly and test the pair, in whatever
+language the platform is written in.
+
+### What the declared expectations say, and what they leave unsaid
+
+Scoring all 70 `assertEquals` in `dateDiff.pure` against each candidate, after first confirming that
+the current implementation reproduces all 70. These counts are what each option would have to
+**retract from the platform's published statement of what `dateDiff` does**, not a sample of usage:
+
+| Unit | Cases | A differs | B differs | C differs |
+|---|---|---|---|---|
+| YEARS | 7 | 0 | 0 | 1 |
+| MONTHS | 11 | 0 | 0 | 0 |
+| WEEKS | 14 | 3 | 0 | 2 |
+| DAYS | 10 | 0 | 0 | 0 |
+| HOURS through MILLISECONDS | 28 | 0 | 0 | 0 |
+| **Total** | **70** | **3** | **0** | **3** |
+
+**Which three assertions matters more than the number three.** Under A they are:
+
+```
+2015-07-05 -> 2015-07-04     0  ->  -1
+2015-07-12 -> 2015-07-06     0  ->  -1
+2015-08-02 -> 2015-07-06    -3  ->  -4
+```
+
+All three are backward pairs whose declared answer disagrees in magnitude with its own forward
+counterpart. Retracting them withdraws statements that are self-contradictory. Under C the three are
+`%2015-12-31T23:59:59 -> %2016-01-01T00:00:01 = 1 year`, which is the headline example in the
+published documentation of `dateDiff`, plus two coherent WEEKS statements. Retracting those
+withdraws things the platform is entitled to have said. Same count, very different cost.
+
+What the declarations say is also narrower than it looks, which matters for what these numbers can
+and cannot settle:
+
+- **Every `d1` in `dateDiff.pure` is aligned to the unit under test.** That is exactly the condition
+  under which A, B, and C agree. All 28 time-unit assertions hold under all three candidates, so the
+  platform has never actually declared that the time units measure elapsed time rather than count
+  boundaries, and no PCT run can detect a change there.
+- **B uniformly would retract nothing**, because forward B is A and the declared backward cases are
+  aligned at both ends. Nothing retracted plus a changed function is the worst combination, not the
+  best.
+- The same gap reaches the adapter manifests below: **they record only the divergence the
+  declarations happen to probe.** Oracle's MONTHS is generated as `floor(months_between(d2, d1))`,
+  so `dateDiff(%2016-01-31, %2016-02-01, MONTHS)` is -1 on Oracle and 1 in Pure. Nothing declares
+  it, so nothing excludes it, and `testDateDiffMonths` is not on Oracle's exclusion list.
+
+That is an argument for **declaring more**, not for discounting what is already declared. Adding
+assertions over unaligned operands states the calendar-versus-time split the platform already
+implements, which is worth doing on its own terms: an addition costs a user nothing to accept, and
+it is the precondition for any PCT run being able to confirm a decision taken here.
+
+### Current translatability
+
+Taken from the PCT manifests in legend-engine
+(`**/src/main/resources/pct-manifests/*/EssentialFunctions_manifest.json`), which record the tests
+each adapter is known to fail, cross-checked against the generators that produce the target
+expression. Twelve adapters carry manifests: eleven relational (ClickHouse, Databricks, DuckDB, H2,
+MemSQL, Oracle, PostgreSQL, Snowflake, Spanner, SQL Server, and Trino) and Deephaven, which is not.
+
+**WEEKS does not work on a single target.** `testDateDiffWeeks` is excluded on all ten adapters that
+support `dateDiff` at all:
+
+| Signature | Adapters | Cause |
+|---|---|---|
+| `expected 0, actual -1` | H2, Oracle, SQL Server | Target counts boundaries on a Sunday grid in both directions. Verified for Oracle: `(next_day(d2, 'SUNDAY') - next_day(d1, 'SUNDAY')) / 7` groups days into Sunday-to-Saturday blocks, which is our forward grid. This divergence is exactly our backward Monday grid |
+| `expected 1, actual 0` | ClickHouse, DuckDB, MemSQL, PostgreSQL, Snowflake, Trino | **Not one cause.** PostgreSQL generates `TRUNC((d2 - d1) / 7)` and MemSQL generates `timestampdiff(WEEK, d1, d2)`, both of which are semantics C, not a week-start difference. For ClickHouse, DuckDB, Snowflake, and Trino the call goes straight to the native `datediff`, and a Monday-based grid would produce the same signature; that reading is inferred and unverified |
+| Not supported | Databricks | The generator has no WEEK branch and fails explicitly |
+
+The distinction matters: **pinning a Sunday week start in the generated SQL cannot fix PostgreSQL or
+MemSQL, because week start is not what they are doing.** It would, however, fix them under Option 4.
+
+**Year and year-month granularity do not survive pushdown at all.** `testDateDiffYears`,
+`testAdjustByYears`, and `testAdjustByMonths` are excluded on all eleven relational adapters, with
+errors like "Ensure the target system understands Year or Year-month semantic" and "Date has no day:
+2012-03." No SQL type represents `%2015` or `%2012-03`, and this is one place where the limitation is
+genuinely about SQL rather than about targets in general. The mixed-granularity semantics of axis 4
+therefore matters almost entirely for in-memory execution.
+
+**Some targets round where we truncate.** Oracle fails `testDateDiffHours` (`expected 2, actual 3`)
+and `testDateDiffMinutes` (`expected 0, actual 1`) because its generator produces fractional days
+and multiplies, for example `(CAST(d2 AS DATE) - CAST(d1 AS DATE)) * 24`, which is then rounded on
+the way to an integer. Databricks fails the same two plus `testDateDiffMonths` because its generator
+literally emits `cast(round(months_between(d2, d1)) AS INT)`. This is a translation defect rather
+than a semantics choice, but it is the same class of problem.
+
+**Other gaps.** Oracle does not support `dateDiff` in MILLISECONDS (ORA-30081). SQL Server returns
+the wrong answer for `adjust` by milliseconds, its legacy `datetime` having about 3.33 ms
+resolution. Deephaven and Spanner support neither function. **No generator handles MICROSECONDS or
+NANOSECONDS**: every dialect's unit list stops at MILLISECONDS, so those two units are in-memory
+only, silently.
+
+**How translation is done.** Dialects with a native `DATEDIFF` map directly to it; SQL Server emits
+`datediff(%s, %s, %s)`. Dialects without one use a hand-written generator, such as
+`generateDateDiffExpressionForPostgres` and `generateDateDiffExpressionForOracle`. The direct
+mappings inherit whatever semantics the target has, without checking that it matches Pure's. That is
+the root cause of most of the divergences above.
+
+**The practical consequence:** since WEEKS is already broken on every backend, *changing WEEKS
+semantics carries no pushdown regression risk.* It can only reduce the number of exclusions.
+
+### Measured impact
+
+The second cost: how many answers move, over every ordered pair in a dense sweep. None of this is
+visible in the declarations, which is exactly why it is reported separately.
+
+| Change | Ordered pairs affected |
+|---|---|
+| WEEKS from today's rule to A on the Sunday grid | 12.2% of ordered day pairs in 2015 and 2016 |
+| WEEKS from today's rule to A on the Monday grid | 12.2% of the same pairs |
+| WEEKS from today's rule to complete 7-day spans (C) | 42.7% |
+| HOURS from elapsed (C) to boundary counting (A) | 47.1% of ordered minute pairs within a day |
+
+The first two being equal is not a coincidence: today's rule already *is* A on the Sunday grid going
+forward and A on the Monday grid going backward, so picking either one keeps half the answers and
+changes the other half. Sunday keeps the forward answers; Monday keeps the backward ones.
+
+The last row is the number to keep in view for Option 2. `HOURS(12:59, 13:01) = 1` is not a corner
+case; boundary counting and elapsed time disagree for nearly half of all unaligned pairs, and not
+one of those pairs is covered by anything the platform currently declares.
+
+## Options
+
+Option to semantics, at a glance: 0 is A + B + C, 1 is A + C, 2 is A, 3 is B, 4 is C, 5 is D, and 6
+is more than one of them exposed to the user.
+
+### Option 0: status quo
+
+- **Coherence:** three rules for two families. The calendar and time split is principled; the WEEKS
+  variant is not, and is best described as using two different week grids depending on direction.
+  WEEKS is not antisymmetric, needs its own paragraph of documentation, and can never invert
+  `adjust`. The platform also disagrees with itself about week start across three functions.
+- **Translatability:** as measured above. WEEKS broken on all ten adapters that support `dateDiff`;
+  time units diverge from boundary-counting targets whenever operands are not aligned; MICROSECONDS
+  and NANOSECONDS untranslatable everywhere.
+- **Cost:** nothing retracted and nothing moved. This is the only option with zero cost on both
+  measures, which is the whole of its case.
+
+### Option 1: hybrid, with the WEEKS fix (A for all calendar units, C for time)
+
+Make WEEKS use a single grid in both directions, so that `dateDiff(a, b, WEEKS)` is
+`weekNumber(b) - weekNumber(a)` unconditionally. **Which grid is a real sub-decision, not a detail.**
+
+| | Grid | Declarations retracted | What they said | Answers moved | Fixes | Notes |
+|---|---|---|---|---|---|---|
+| **1a** | Sunday | 3 | All three self-contradictory: each disagrees in magnitude with its own forward counterpart | 12.2% | H2, Oracle, SQL Server | Keeps today's forward answers; contradicts `firstDayOfWeek` and ISO 8601 |
+| **1b** | Monday (ISO 8601) | 2 | Both defensible: `2015-07-04 -> 2015-07-05 = 1` and `2016-01-01 -> 2017-01-01 = 53` | 12.2% | Plausibly ClickHouse, DuckDB, Snowflake, Trino; needs verification | Keeps today's backward answers; agrees with `firstDayOfWeek` and ISO 8601; SQL Server hard-codes Sunday and would need emulation |
+| **1c** | Caller supplies it | As its default | As its default | As its default | Whichever matches the default | Signature change to a `<<PCT.function>>`, or a sibling function; matches BigQuery, Snowflake, Tableau, and SAS |
+
+- **Coherence:** two rules, both one sentence, split on the calendar and time line argued for above.
+  Antisymmetric everywhere. The calendar units become additive; the time units do not, which is
+  inherent to C and is the one structural property this option gives up relative to Option 2. No
+  special cases. Preserves the graceful path to zone support: calendar units would take a zone, time
+  units would not. 1b additionally makes the platform agree with itself, which is goal 1; 1a leaves
+  `dateDiff` and `firstDayOfWeek` disagreeing.
+- **Translatability:** strictly better than today under any of the three. Emulation is cheap and
+  uniform either way, since a fixed seven-day grid count is
+  `floor((epochday(b) - k) / 7) - floor((epochday(a) - k) / 7)` on any target that can produce a day
+  number. That is an argument for settling the grid on coherence grounds rather than on adapter
+  counts, which are close to a wash.
+- **Cost:** the implementation is a deletion under 1a, `weeksBetween` losing its backward branch, and
+  the same deletion plus a one-line change to the grid origin constant under 1b. The retractions
+  differ in kind, which matters more than the counts. Under 1a:
+
+  ```
+  2015-07-05 -> 2015-07-04     0  ->  -1
+  2015-07-12 -> 2015-07-06     0  ->  -1
+  2015-08-02 -> 2015-07-06    -3  ->  -4
+  ```
+
+  Every one of those is a backward pair whose declared answer contradicts its own forward
+  counterpart, so what is being withdrawn is an anomaly rather than a commitment. Under 1b the two
+  are `2015-07-04 -> 2015-07-05` (1 to 0) and `2016-01-01 -> 2017-01-01` (53 to 52), both of which
+  are perfectly coherent things for the platform to have said and which a user could reasonably have
+  built on. Either way, 12.2% of ordered day pairs move, and no backend reproduces today's answers,
+  so nothing regresses under pushdown. Requires an engine rebuild to re-run PCT.
+
+### Option 2: semantics A uniformly
+
+- **Coherence:** one rule, *floor both dates onto the unit's grid and subtract*. Antisymmetric and
+  additive everywhere. No special cases. Simplest of all the options to state, and the only one that
+  makes the whole function a single sentence.
+- **Translatability:** best. Maps 1:1 onto `DATEDIFF` for SQL Server, Snowflake, BigQuery, and other
+  boundary-counting targets, for every unit. Where emulation is needed the shape is uniform, a
+  truncation and a subtraction, so one generator template serves all units. Caveat: fine units over
+  long spans overflow 32-bit `DATEDIFF` on SQL Server, which is why `DATEDIFF_BIG` exists.
+- **Cost:** the worst shape of any integer option. It retracts only the same three anomalous WEEKS
+  assertions, so the declared expectations barely move, and then **47.1% of ordered minute pairs
+  within a day get a different HOURS answer**. Every published statement about the time units
+  survives untouched while ceasing to describe the function, so a user reading `dateDiff.pure` sees
+  no change at all and gets different numbers. It also discards the elapsed-time reading entirely,
+  which shipped Pure code relies on: `toEpochValue`, `firstMillisecondOfSecond`, the router's timing
+  instrumentation, and `tdsEquivalent`'s tolerance comparison all call `dateDiff` in a time unit.
+  Under future zone support every unit becomes zone dependent, including HOURS, which the hybrid
+  avoids. If this option is taken, the time-unit assertions must be rewritten to state the new rule
+  even where they would still pass.
+
+### Option 3: semantics B uniformly
+
+- **Coherence:** one rule, but the wrong one. The half-open convention makes every unit asymmetric
+  whenever exactly one endpoint sits on a boundary: `HOURS(13:00:00, 13:30:00)` would be 0 while
+  `HOURS(13:30:00, 13:00:00)` would be -1. Operands on a boundary are extremely common. This spreads
+  the WEEKS anomaly across the whole function rather than removing it.
+- **Translatability:** poor. No target implements B. Every unit on every dialect would need
+  hand-written emulation to reproduce the asymmetry.
+- **Cost:** it retracts nothing and changes the function everywhere, which is the worst combination
+  on offer rather than a point in its favor: the platform's declarations would keep saying exactly
+  what they say now, about a function that no longer behaves that way. **Not recommended under any
+  weighting.** Listed for completeness.
+
+### Option 4: semantics C uniformly
+
+- **Coherence:** one rule, *how many whole units fit between them*. Antisymmetric but not additive.
+  Its headline advantage, being definable in terms of `adjust`, has to be built deliberately. Its
+  headline disadvantage is that it abandons the calendar and time distinction argued for above:
+  under C, `%2015-12-31T23:59:59 -> %2016-01-01T00:00:01` is zero years, which is defensible as
+  duration and indefensible as calendar arithmetic.
+- **Translatability:** mixed, and better for WEEKS than previously recorded. Maps 1:1 onto MySQL and
+  SingleStore `TIMESTAMPDIFF` and onto `floor(MONTHS_BETWEEN(...))`. **PostgreSQL and MemSQL would
+  pass `testDateDiffWeeks` with no change to the generated SQL at all**, since both already emit
+  exactly C. But YEARS, MONTHS, and DAYS would then need emulation on SQL Server, Snowflake,
+  BigQuery, and every other boundary-counting target, and emulating complete months and years
+  requires anniversary logic, the fiddliest of the integer generators.
+- **Cost:** three retractions, the same count as Option 1, but far more expensive ones. The first is
+  `%2015-12-31T23:59:59 -> %2016-01-01T00:00:01 = 1` in YEARS, which is not an incidental assertion:
+  it is the worked example the published documentation of `dateDiff` leads with, and it is the
+  clearest statement the platform makes about what the function is for. Withdrawing it is
+  withdrawing the function's advertised character. Behaviorally, 42.7% of ordered day pairs change in
+  WEEKS, and DAYS, MONTHS, and YEARS all change for any operand carrying a time of day, which the
+  declarations do not currently cover.
+
+### Option 5: semantics D, fractional results
+
+Change `dateDiff` to return the exact real-valued distance, `Float[1]` or `Decimal[1]` instead of
+`Integer[1]`.
+
+- **Coherence:** the best of any option on the constant-duration units, and the worst on the others.
+
+  For WEEKS and below it is the only option that is *lossless*. It is exactly antisymmetric and
+  additive, and unit conversion becomes exact, so `dateDiff(a, b, HOURS)` is
+  `dateDiff(a, b, MINUTES) / 60`, which is false under every other option. Note that additivity is
+  **not** unique to D: A has it too, for a different reason.
+
+  For YEARS and MONTHS it is the weakest option, because the denominator is a convention. See
+  axis 5: the right response is to take the convention as an argument, which a single fixed-arity
+  `dateDiff` cannot do.
+
+  A zero result does **not** recover the meaning "the two dates are equal," because Pure dates carry
+  granularity: `%2014`, `%2014-01`, and `%2014-01-01` are pairwise unequal and every difference
+  between them is exactly zero.
+
+  It also weakens the `adjust` relationship, which no longer typechecks without an explicit
+  truncation.
+
+- **Precision:** a real hazard, and a silent one. `Float` in Pure is a floating point number without
+  a mandated representation, so the exact limit is implementation defined, but every floating point
+  format has finite precision, so for any of them there is a span beyond which
+  `dateDiff(a, b, NANOSECONDS)` stops being able to represent whole nanoseconds and quietly loses
+  resolution. On the current platform, which uses a Java `double`, that happens at 2^53 nanoseconds,
+  about 104 days. Wherever the limit falls, this is worse than the status quo, which now raises an
+  overflow error rather than returning a plausible wrong answer. `Decimal[1]` pushes the limit far
+  enough out to stop mattering but is slower and translates less cleanly, since decimal arithmetic
+  and precision rules differ by dialect.
+- **Translatability:** genuinely good on some targets, poor on others, and split along a different
+  line than the integer options. Oracle is a natural fit, and Databricks and Spark `months_between`
+  also returns a double following Oracle's convention. PostgreSQL, DuckDB, Trino, and ClickHouse can
+  all divide an epoch difference to get any constant-duration unit exactly. But SQL Server,
+  Snowflake, and BigQuery return integers from `DATEDIFF`, so fractional has to be built from a
+  fine-grained integer difference and a division, which runs into exactly the overflow that forced
+  SQL Server to add `DATEDIFF_BIG`. And no system has a `YEARS_BETWEEN`, so fractional years need
+  emulating everywhere, against whichever convention is picked.
+- **Cost:** the highest of any option, and different in kind. This is a **signature change** to a
+  `<<PCT.function>>`, not a semantics change. Every Pure query that assigns the result to an
+  `Integer` or uses it in integer arithmetic fails to compile, every Java caller changes from `long`
+  to `double`, and every generator is rewritten. On the declaration side it is total: all 70
+  assertions change shape and need a tolerance, so the platform retracts and restates everything it
+  has ever said about this function at once. **Not recommended standalone**, but see Option 6, where
+  the same semantics costs far less.
+
+### Option 6: expose more than one reading
+
+Either sibling functions or an options record:
+
+```
+dateDiff(d1, d2, unit)                                      -- Integer, unchanged
+dateDiffBoundaries(d1, d2, unit)                            -- Integer, A
+dateDiffElapsed(d1, d2, unit)                               -- Integer, C
+dateDiffExact(d1, d2, unit, convention)                     -- Float or Decimal, D
+```
+
+or, following Temporal and SAS,
+
+```
+dateDiff(d1, d2, unit, ^DateDiffOptions(mode=..., rounding=..., weekStart=..., dayCount=...))
+```
+
+**Which variants are needed is a much smaller question than it looks**, because the readings are not
+independent, and the derivability analysis of axis 1 narrows it to one:
+
+- On WEEKS and below, a single elapsed count in the finest unit gives all of A, C, and D by
+  truncating operands or dividing. The platform already provides that, so nothing needs adding.
+- On YEARS and MONTHS, **complete units are the only primitive missing**. Boundary counting is
+  already there; fractional needs complete units plus a convention; and complete units cannot be
+  assembled from boundary counting without hand-written anniversary arithmetic.
+- B is not derivable from anything and is not wanted.
+
+So the smallest thing that closes the goal 2 gap is **one function, giving complete years and
+months**, rather than a menu. A fractional variant is worth more than a boundary-counting one if a
+second is ever added, because it is the one that can carry a day-count convention, but it is not
+what users are currently unable to express.
+
+- **Coherence:** each function is individually coherent, nothing is retracted, and no existing
+  behavior moves. It is the only option that scores zero on both cost measures, which is a real
+  argument in its favor rather than a technicality, and **the only one that serves goal 2 directly**:
+  it is the difference between a user being able to compute complete months in the platform and
+  having to hand-roll anniversary arithmetic. But the incoherence of the default does not go away;
+  it acquires companions. Users must now understand a
+  distinction that took this team a lengthy investigation to characterize, and must pick correctly.
+  Separate names make the choice visible at the call site; an options record makes it invisible but
+  extensible, and is the only shape that can carry the week start of axis 3, the rounding mode of
+  axis 2, and the day-count convention of axis 5 without a combinatorial explosion of function
+  names. Note that a fractional sibling sidesteps Option 5's fatal objection entirely: the signature
+  change stops being a change, because the new signature belongs to a new function.
+- **Translatability:** genuinely good, and the fractional variant improves it rather than adding
+  load. Each variant maps cleanly onto the dialects that implement it natively: boundary counting to
+  `DATEDIFF` on SQL Server and Snowflake, elapsed to `TIMESTAMPDIFF` on MySQL and SingleStore and to
+  `TRUNC((d2 - d1) / 7)` on PostgreSQL, and fractional to date subtraction and `MONTHS_BETWEEN` on
+  Oracle and Databricks. Oracle and Databricks are currently among the worst-served adapters,
+  precisely because they are fractional underneath and we force an integer through them.
+- **Cost:** highest ongoing cost. Every new function multiplies across the whole PCT surface: a full
+  set of `<<PCT.test>>` functions, plus a `dynaFnToSql` mapping and manifest maintenance for each of
+  the twelve adapters. Roughly doubles the date-function translation surface permanently. An options
+  record is cheaper per reading but harder to translate, since each combination has to be lowered
+  separately or rejected.
+- **`adjust` does not need variants**, only documentation: add N units, clamping at month end, with
+  the two algebraic laws that clamping costs spelled out. Whether clamping should be configurable is
+  a separate and much smaller question.
+- **A cheaper middle path:** land the second reading as `<<PCT.platformOnly>>` first, in-memory
+  engines only with `<<test.Test>>` tests, and add translation per target only where there is
+  demand. That also keeps the new reading out of the declared contract until it has settled.
+
+## Comparison
+
+Coherence and translatability rated best (++) to worst (--). The two cost columns are the ones from
+the evaluation criteria: what the platform would have to withdraw from its published statement of
+what `dateDiff` does, and how much behavior moves without any statement changing.
+
+| | Rules | Antisymmetric | Additive | Translatability | Declarations retracted | Answers moved | Cost |
+|---|---|---|---|---|---|---|---|
+| **0** Status quo (A + B + C) | 3 | No (WEEKS) | No (WEEKS) | - (WEEKS broken on 10 of 10) | none | none | none |
+| **1a** Hybrid, Sunday grid | 2 | Yes | Calendar units only | + | 3, all self-contradictory | 12.2% of day pairs, WEEKS only | low |
+| **1b** Hybrid, Monday grid | 2 | Yes | Calendar units only | + | 2, both defensible | 12.2% of day pairs, WEEKS only | low; also agrees with ISO 8601 and `firstDayOfWeek` |
+| **1c** Hybrid, week start supplied | 2 | Yes | Calendar units only | ++ | as its default | as its default | medium; signature change |
+| **2** Semantics A uniformly | 1 | Yes | Yes | ++ | 3, all self-contradictory | 47.1% of minute pairs, HOURS | medium to high; almost all of it silent |
+| **3** Semantics B uniformly | 1 | **No (all units)** | No | -- | none | large | worst shape on offer |
+| **4** Semantics C uniformly | 1 | Yes | No | - overall, + for WEEKS | 3, including the documented headline example | 42.7% of day pairs, plus every unaligned operand | high |
+| **5** Semantics D (fractional) | 1 | Yes | Yes | mixed: ++ Oracle and Spark, -- SQL Server and Snowflake | all 70 (**signature change**) | all | highest |
+| **6** More than one reading | per variant | per variant | per variant | ++ | none | none | high, ongoing |
+
+**Goal 2 cuts across this table in a way the columns do not show.** What a user can compute in the
+platform depends only on which readings are primitive, and on the calendar units complete years and
+months are the one reading nothing else yields:
+
+- **Options 0, 1, and 2** all leave the gap exactly where it is today. Boundary counting is provided,
+  complete units are not, and no amount of truncation recovers them.
+- **Option 4** is the only single-reading option that closes it. With complete units provided,
+  boundary counting comes back by truncating the operands, so a user can express both. That is a
+  real argument for C that has nothing to do with which answer is more natural, and it is worth
+  weighing against the objections above.
+- **Option 5** closes it only under the anniversary convention, where truncating the fractional
+  result gives complete units by construction. Under Oracle's convention it does not:
+  `%2015-01-31 -> %2015-02-28` is exactly 1.0, which truncates to 1, while complete months is 0.
+- **Option 6** closes it by design, with one function.
+
+## Recommendation
+
+**Take Option 1b: keep the hybrid, and put WEEKS on a single Monday-based ISO 8601 grid in both
+directions.** Option 1 removes the only genuinely indefensible part of the current design, is a code
+deletion rather than an addition, improves pushdown, and preserves the calendar and time split that
+the future zone story depends on. The grid is the whole of the sub-decision, and it turns on
+goal 1.
+
+**ISO 8601 defines the week, and Pure already runs on ISO 8601.** Date literals, the granularity
+model, and the lexical representation all follow it. A `dateDiff` that counts weeks from Sunday is a
+house convention sitting inside a function whose every other aspect is standardized, and a user who
+looks up what a week is will get the wrong answer about Legend. Legend's own `firstDayOfWeek` is
+already Monday, so ISO is also the convention that makes the platform agree with itself.
+
+The cost is real and runs the other way:
+
+- **1a (Sunday)** retracts three assertions, every one of which declares an answer that contradicts
+  its own forward counterpart. What is withdrawn is an anomaly.
+- **1b (Monday)** retracts two, but they are `2015-07-04 -> 2015-07-05 = 1` and
+  `2016-01-01 -> 2017-01-01 = 53`, both coherent statements a user could reasonably have built on.
+
+Withdrawing a commitment costs more than withdrawing a mistake, so on that measure alone 1a wins.
+Three things outweigh it. First, standards conformance is a goal 1 property and transition cost is
+not; the end state should decide a semantics meant to last. Second, **1a probably retracts twice.**
+The platform's week convention has to be reconciled across `dateDiff`, `firstDayOfWeek`, and
+`weekOfYear` regardless, and the only defensible place for that to land is ISO 8601; taking Sunday
+now means changing `dateDiff` again when it does. Third, a retraction is easier to accept when it
+has a reason a user can look up, and "weeks now follow ISO 8601, like the rest of Pure's date
+handling" is the most explicable reason available. Translatability does not break the tie: a fixed
+seven-day grid count is trivially emulatable on any target that can produce a day number, and the
+adapter split is close to even either way.
+
+**1a remains an acceptable fallback** if the team judges the two retractions too expensive right
+now, but only as part of moving `firstDayOfWeek` to Sunday as well. What should not happen is
+settling `dateDiff` in isolation and leaving three week conventions standing. `weekOfYear`'s
+dependence on the JVM default locale should be fixed whichever way the decision goes.
+
+**Option 2** remains the strongest choice if translatability is weighted above coherence, and is the
+only option that makes the whole function a single sentence with an additive, antisymmetric rule.
+But note its cost shape: it retracts the same three anomalies as 1a and then changes 47.1% of HOURS
+answers with no declaration moving at all. If it is taken, the time-unit assertions should be
+rewritten to state the new rule even where they would still pass, so that the change is visible to
+anyone reading what the platform says about the function.
+
+**Option 4** is stronger than it first appears and should still not be taken. Its WEEKS story is much
+better than the failure signatures alone suggest, and it is the only single-reading option that
+leaves nothing a user cannot compute in the platform, which is goal 2. Against that: it abandons the
+calendar and time distinction, it retracts the worked example the published documentation leads with,
+and `%2015-12-31T23:59:59 -> %2016-01-01T00:00:01 = 0 years` is a worse answer to give a user than
+any of the alternatives. Option 6 gets the same goal 2 benefit without any of that, which is the
+better trade.
+
+**Option 5** should not be taken standalone. Its properties on the constant-duration units are
+attractive, but it needs a convention for months and years, hides a silent precision cliff at about
+104 days for nanosecond differences, and above all changes the signature of a shipped
+`<<PCT.function>>`. The same semantics is available at a fraction of the cost as a sibling.
+
+**Option 6 should be taken next, and it is smaller than it looks.** Goal 2 says users must be able to
+compute what they need in the platform, and there is exactly one thing they currently cannot:
+complete years and months. Everything else, on every other unit, is already reachable by truncating
+operands or by dividing an elapsed count in a finer unit. So the whole of the gap closes with **one
+function, giving complete calendar units**, not a menu. Order it after the default is coherent,
+since a companion to an incoherent default compounds the problem, but do not treat it as
+speculative: it is the only option here that adds a capability rather than moving one.
+
+If a third reading is ever wanted, make it the fractional one, which is the natural fit for Oracle
+and Databricks and the only one that can carry a day-count convention. Prefer an options record over
+a family of names at that point, since the week start of axis 3, the rounding mode of axis 2, and
+the day-count convention of axis 5 multiply.
+
+## Consequences
+
+**Positive, under Option 1 or 2:**
+
+- `dateDiff` becomes statable without exceptions, and is antisymmetric everywhere. It becomes
+  additive on the calendar units under Option 1, and on every unit under Option 2.
+- WEEKS gains a chance of ever working under pushdown, and the `//TODO - fix this, still not right`
+  in the Oracle generator can be retired.
+- The WEEKS special case disappears from the javadoc, the Pure documentation, and the declarations.
+- Under 1b, weeks follow ISO 8601, the standard Pure already uses for dates, and `dateDiff` and
+  `firstDayOfWeek` stop disagreeing about when a week starts.
+
+**Negative:**
+
+- Any change to `dateDiff` is a change to a `<<PCT.function>>`, so it must be coordinated with
+  legend-engine: `dateDiff.pure` assertions, adapter manifests, and a full PCT run per adapter, some
+  of which need live database credentials.
+- Published assertions are withdrawn: two under 1b, three under 1a. Users read those to find out
+  what Legend supports, so the change needs release notes that say what was retracted and why, not
+  just a version bump. Under 1b the two are defensible statements rather than anomalies, which makes
+  the standards rationale part of the announcement rather than a footnote to it.
+- Users relying on the current WEEKS answers would see a change in 12.2% of ordered day pairs.
+  In-memory execution is the only place they could be getting those answers today.
+- Shipped Pure functions defined in terms of `dateDiff` move with it and must be re-checked:
+  `toEpochValue`, `firstMillisecondOfSecond`, `tdsEquivalent`, and the router's timing
+  instrumentation.
+
+## Work to do regardless of which option is chosen
+
+1. **Fix the `dateDiff.pure` documentation.** It currently states, without qualification, that the
+   function "counts calendar boundaries crossed, not elapsed time," and advises computing in a finer
+   unit and converting if elapsed duration is wanted. Both are wrong for HOURS and below, which
+   already measure elapsed time, and the advice does not work under boundary counting either. This is
+   the documentation users actually read, and it contradicts the implementation for six of the ten
+   units.
+2. **Declare the calendar and time split explicitly, with unaligned operands.** As measured above,
+   nothing in `dateDiff.pure` distinguishes boundary counting from elapsed time for any time unit,
+   so the platform has never actually stated the rule it implements, no PCT run can validate a
+   decision taken here, and real adapter divergence goes unrecorded. This is worth doing on its own
+   terms: additions cost nothing to accept, and they are what makes the rest of this document
+   checkable.
+3. **Fix the rounding in the Oracle and Databricks generators** so they truncate as Pure does.
+4. **Decide what MICROSECONDS and NANOSECONDS mean under pushdown.** They are accepted in memory and
+   translatable nowhere; either add them to the generators or exclude them explicitly.
+5. **Fix `weekOfYear`.** Depending on the JVM default locale for a query result is a defect
+   independent of everything else in this document, as is its use of the Julian cutover calendar
+   while `dateDiff` and `adjust` use proleptic ISO.
+6. **Document `adjust`'s algebra**, not only its clamping rule: `(d + 1 month) + 1 month` is not
+   `d + 2 months`, and `(d + 1 month) - 1 month` is not `d`.
+
+## Verifying the evidence
+
+- Unit semantics and the diagonal invariant:
+  `mvn test -pl legend-pure-core/legend-pure-m4 -Dtest=TestDateDifference -DfailIfNoTests=false`
+- Cross-engine contract, both engines:
+  `mvn test -pl legend-pure-runtime/legend-pure-runtime-java-engine-interpreted -Dtest=Test_Interpreted_EssentialFunctions_PCT -DfailIfNoTests=false`
+  and
+  `mvn test -pl legend-pure-runtime/legend-pure-runtime-java-engine-compiled -Dtest=Test_Compiled_EssentialFunctions_PCT -DfailIfNoTests=false`
+- Per-adapter support: parse the `exclusions` array of each `EssentialFunctions_manifest.json` under
+  `legend-engine/**/src/main/resources/pct-manifests/`, filtering for test names matching
+  `test(DateDiff|Adjust)`. Cross-check each exclusion against the generator that produces the SQL,
+  since the failure signature alone does not identify the cause.
+- Generated SQL per dialect: the `dynaFnToSql('dateDiff', ...)` entry and any
+  `generateDateDiffExpressionFor*` function in each `*Extension.pure`.
+
+## References
+
+Legend:
+
+- `legend-pure-m4`: `DateFunctions.dateDifference`, `DateDiff`, `TestDateDifference`
+- `legend-pure-m3-core`: `platform/pure/essential/date/operation/dateDiff.pure`, `adjust.pure`,
+  `_structures.pure`
+- legend-engine: `core/pure/corefunctions/dateExtension.pure` for the truncation helpers,
+  `firstDayOfWeek`, and `toEpochValue`; `FunctionsHelper.weekOfYear`;
+  `relational/sqlQueryToString/dbExtension.pure` and the per-dialect `*Extension.pure` files
+- ADR-003 for the house style of these documents
+
+External:
+
+- ANSI SQL year-month and day-time interval types, and the prohibition on mixing them
+- ISO 8601-1:2019 for week dates (Monday-based) and durations
+- TC39 Temporal: `until`, `since`, `Duration.total({ unit, relativeTo })`, `largestUnit`,
+  `smallestUnit`, and `roundingMode`
+- NodaTime `Period.Between(start, end, PeriodUnits)`, and its documentation of the
+  non-associativity of period arithmetic
+- SAS `INTCK` and `INTNX`: the `DISCRETE` and `CONTINUOUS` methods, and shifted intervals
+- BigQuery `DATE_DIFF(..., WEEK(MONDAY))`; Snowflake `WEEK_START`; Tableau `DATEDIFF` with
+  `start_of_week`; SQL Server's documented decision that `SET DATEFIRST` does not affect `DATEDIFF`
+- Oracle `MONTHS_BETWEEN`; PostgreSQL `age()`; MySQL and SingleStore `TIMESTAMPDIFF`; DB2
+  `TIMESTAMPDIFF` and its documented approximation
+- Excel `DATEDIF`, `DAYS360`, and `YEARFRAC(..., basis)`; the ISDA and ICMA day count fractions
+  (30/360, 30E/360, ACT/360, ACT/365F, ACT/ACT)
+- Reingold and Dershowitz, *Calendrical Calculations*, for fixed-day (rank) arithmetic, which is the
+  formal basis of semantics A

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractPureDate.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractPureDate.java
@@ -40,7 +40,15 @@ abstract class AbstractPureDate implements PureDate, Serializable
             return false;
         }
 
-        PureDate that = (PureDate)other;
+        PureDate that = (PureDate) other;
+        if (LatestDate.isLatestDate(that))
+        {
+            // LatestDate has no components to compare, and is a singleton equal only to itself,
+            // which the identity check above has already handled. Asking it for a component would
+            // throw, and equals must not.
+            return false;
+        }
+
         return (this.getYear() == that.getYear()) &&
                 (this.getMonth() == that.getMonth()) &&
                 (this.getDay() == that.getDay()) &&

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateDiff.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateDiff.java
@@ -14,109 +14,157 @@
 
 package org.finos.legend.pure.m4.coreinstance.primitive.date;
 
-import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.tuple.Tuples;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.util.concurrent.TimeUnit;
-
+/**
+ * Implementation of {@link DateFunctions#dateDifference(PureDate, PureDate, String)}. See that
+ * method for what each unit means.
+ */
 class DateDiff
 {
+    /**
+     * Epoch day of 1970-01-04, a Sunday, used as the origin for counting weeks.
+     */
+    private static final long SUNDAY_EPOCH_DAY = 3L;
+
     private DateDiff()
     {
     }
 
-    static long getDiffYears(PureDate from, PureDate to)
+    static long dateDifference(PureDate from, PureDate to, String unit)
     {
-        return Math.abs(from.getYear() - to.getYear());
-    }
-
-    static long getDiffMonths(PureDate from, PureDate to)
-    {
-        int thisMonthTotal = (from.getYear() * 12) + from.getMonth();
-        int otherMonthTotal = (to.getYear() * 12) + to.getMonth();
-        return Math.abs(thisMonthTotal - otherMonthTotal);
-    }
-
-    static long getDateDiffWeeks(PureDate from, PureDate to)
-    {
-        long absDateDiffDays = Math.abs(getDiffDays(from, to));
-        int noDaysTillSunday = daysUntilSunday(from.getCalendar(), to.getCalendar());
-
-        if (noDaysTillSunday > absDateDiffDays)
+        switch (unit)
         {
-            return 0;
-        }
-        else
-        {
-            long fullWeeks = (absDateDiffDays - noDaysTillSunday) / 7;
-            boolean partialWeek = noDaysTillSunday > 0;
-            return fullWeeks + (partialWeek ? 1 : 0);
-        }
-    }
-
-    static long getDiffDays(PureDate first, PureDate second)
-    {
-        Pair<GregorianCalendar, PureDate> thisCalPair = Tuples.pair(first.getCalendar(), first);
-        Pair<GregorianCalendar, PureDate> otherCalPair = Tuples.pair(second.getCalendar(), second);
-        Pair<Pair<GregorianCalendar, PureDate>, Pair<GregorianCalendar, PureDate>> earlierLaterPair = thisCalPair.getOne().before(otherCalPair.getOne()) ? Tuples.pair(thisCalPair, otherCalPair) : Tuples.pair(otherCalPair, thisCalPair);
-        long result = 0;
-        if (first.getYear() != second.getYear())
-        {
-            int fromYear = earlierLaterPair.getOne().getTwo().getYear();
-            int toYear = earlierLaterPair.getTwo().getTwo().getYear();
-            result += DateFunctions.getYearDays(fromYear) - earlierLaterPair.getOne().getOne().get(Calendar.DAY_OF_YEAR);
-            int nextYear = fromYear + 1;
-            for (; nextYear != toYear; nextYear++)
+            case "YEARS":
             {
-                result += DateFunctions.getYearDays(nextYear);
+                return (long) to.getYear() - (long) from.getYear();
             }
-            result += earlierLaterPair.getTwo().getOne().get(Calendar.DAY_OF_YEAR);
+            case "MONTHS":
+            {
+                return monthNumber(to) - monthNumber(from);
+            }
+            case "WEEKS":
+            {
+                return weeksBetween(toLocalDate(from), toLocalDate(to));
+            }
+            case "DAYS":
+            {
+                return toLocalDate(to).toEpochDay() - toLocalDate(from).toEpochDay();
+            }
+            case "HOURS":
+            {
+                return elapsed(from, to, ChronoUnit.HOURS);
+            }
+            case "MINUTES":
+            {
+                return elapsed(from, to, ChronoUnit.MINUTES);
+            }
+            case "SECONDS":
+            {
+                return elapsed(from, to, ChronoUnit.SECONDS);
+            }
+            case "MILLISECONDS":
+            {
+                return elapsed(from, to, ChronoUnit.MILLIS);
+            }
+            case "MICROSECONDS":
+            {
+                return elapsed(from, to, ChronoUnit.MICROS);
+            }
+            case "NANOSECONDS":
+            {
+                return elapsed(from, to, ChronoUnit.NANOS);
+            }
+            default:
+            {
+                throw new IllegalArgumentException("Unsupported duration unit: " + unit);
+            }
         }
-        else
+    }
+
+    /**
+     * The month of the given date counted from year zero, so that subtracting two of these gives the
+     * number of month boundaries between them. A date with no month starts in January.
+     */
+    private static long monthNumber(PureDate date)
+    {
+        return (12L * date.getYear()) + (date.hasMonth() ? date.getMonth() : 1);
+    }
+
+    /**
+     * The number of Sundays passed going from one date to the other. Counting forwards, a Sunday
+     * counts if it falls after the first date and on or before the second; counting backwards, if it
+     * falls on or after the second date and before the first. The two directions are therefore not
+     * always mirror images, which is longstanding behavior pinned by the PCT tests for
+     * {@code dateDiff}.
+     */
+    private static long weeksBetween(LocalDate from, LocalDate to)
+    {
+        long fromDay = from.toEpochDay();
+        long toDay = to.toEpochDay();
+        return (toDay >= fromDay) ?
+               (weekNumber(toDay) - weekNumber(fromDay)) :
+               (weekNumber(toDay - 1) - weekNumber(fromDay - 1));
+    }
+
+    /**
+     * The Sunday-to-Saturday week the given day falls in, counted from the week of
+     * {@link #SUNDAY_EPOCH_DAY}.
+     */
+    private static long weekNumber(long epochDay)
+    {
+        return Math.floorDiv(epochDay - SUNDAY_EPOCH_DAY, 7L);
+    }
+
+    /**
+     * The time elapsed between the two dates in whole units, with any remainder dropped. Since
+     * {@link ChronoUnit#between} counts only complete units, the remainder is always dropped toward
+     * zero, which keeps the result the same size in either direction.
+     */
+    private static long elapsed(PureDate from, PureDate to, ChronoUnit unit)
+    {
+        return unit.between(toLocalDateTime(from), toLocalDateTime(to));
+    }
+
+    /**
+     * The first instant of the span the given date covers: a date with no month starts in January,
+     * one with no day starts on the first, and one with no time starts at midnight. Subsecond digits
+     * beyond the nanosecond are dropped, since that is as fine as {@link LocalDateTime} goes.
+     */
+    private static LocalDateTime toLocalDateTime(PureDate date)
+    {
+        return LocalDateTime.of(toLocalDate(date), toLocalTime(date));
+    }
+
+    private static LocalDate toLocalDate(PureDate date)
+    {
+        return LocalDate.of(date.getYear(), date.hasMonth() ? date.getMonth() : 1, date.hasDay() ? date.getDay() : 1);
+    }
+
+    private static LocalTime toLocalTime(PureDate date)
+    {
+        return LocalTime.of(
+                date.hasHour() ? date.getHour() : 0,
+                date.hasMinute() ? date.getMinute() : 0,
+                date.hasSecond() ? date.getSecond() : 0,
+                date.hasSubsecond() ? nanosecond(date.getSubsecond()) : 0);
+    }
+
+    /**
+     * Read a subsecond as a whole number of nanoseconds, padding it with zeros if it is shorter than
+     * nine digits and ignoring anything past the ninth.
+     */
+    private static int nanosecond(String subsecond)
+    {
+        int digits = subsecond.length();
+        int nanoseconds = 0;
+        for (int i = 0; i < 9; i++)
         {
-            result = (long)earlierLaterPair.getTwo().getOne().get(Calendar.DAY_OF_YEAR) - earlierLaterPair.getOne().getOne().get(Calendar.DAY_OF_YEAR);
+            nanoseconds = (nanoseconds * 10) + ((i < digits) ? (subsecond.charAt(i) - '0') : 0);
         }
-        return result;
-    }
-
-    static long getDiffHours(PureDate first, PureDate second)
-    {
-        long msDiff = getDiffInMilliseconds(first, second);
-        return TimeUnit.MILLISECONDS.toHours(msDiff);
-    }
-
-    static long getDiffMinutes(PureDate first, PureDate second)
-    {
-        long msDiff = getDiffInMilliseconds(first, second);
-        return TimeUnit.MILLISECONDS.toMinutes(msDiff);
-    }
-
-    static long getDiffSeconds(PureDate first, PureDate second)
-    {
-        long msDiff = getDiffInMilliseconds(first, second);
-        return TimeUnit.MILLISECONDS.toSeconds(msDiff);
-    }
-
-    static long getDiffInMilliseconds(PureDate date1, PureDate date2)
-    {
-        long time1 = date1.getCalendar().getTimeInMillis();
-        long time2 = date2.getCalendar().getTimeInMillis();
-        return Math.abs(time1 - time2);
-    }
-
-    private static int daysUntilSunday(Calendar start, Calendar end)
-    {
-        if (start.before(end))
-        {
-            int dayOfWeek = start.get(Calendar.DAY_OF_WEEK);
-            return 7 - (dayOfWeek - 1);
-        }
-        else
-        {
-            int dayOfWeek = start.get(Calendar.DAY_OF_WEEK);
-            return dayOfWeek - 1;
-        }
+        return nanoseconds;
     }
 }

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
@@ -689,6 +689,12 @@ public class DateFunctions extends TimeFunctions
      * <p>This is a total order, it never returns anything but -1, 0, or 1, and it agrees with equals:
      * it returns 0 exactly when the two dates are equal.
      *
+     * <p><b>{@link LatestDate} sorts after every other date.</b> It has no components to compare and
+     * no fixed position on the time line: what {@code %latest} stands for is decided by the context
+     * it appears in. Ordering it last is a sorting convention rather than a claim about when it
+     * falls, chosen so that any two dates can be sorted. It is a singleton, so it is equal only to
+     * itself.
+     *
      * @param date1 first date
      * @param date2 second date
      * @return -1, 0, or 1 as date1 sorts before, equal to, or after date2
@@ -698,6 +704,17 @@ public class DateFunctions extends TimeFunctions
         if (date1 == date2)
         {
             return 0;
+        }
+
+        // LatestDate sorts last. It is a singleton, so the check above has already dealt with it
+        // against itself, and at most one of the two can be it here.
+        if (LatestDate.isLatestDate(date1))
+        {
+            return 1;
+        }
+        if (LatestDate.isLatestDate(date2))
+        {
+            return -1;
         }
 
         // Compare year

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
@@ -19,6 +19,10 @@ import org.finos.legend.pure.m4.ModelRepository;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.chrono.IsoChronology;
 import java.util.Calendar;
 import java.util.Date;
@@ -178,7 +182,124 @@ public class DateFunctions extends TimeFunctions
 
     public static DateTime fromInstant(Instant instant, int subsecondPrecision)
     {
-        return DateWithSubsecond.fromInstant(instant, subsecondPrecision);
+        return fromLocalDateTime(LocalDateTime.ofInstant(instant, ZoneOffset.UTC), subsecondPrecision);
+    }
+
+    /**
+     * Convert a {@link java.time.Year} to a Pure date of year granularity.
+     *
+     * @param year year
+     * @return Pure date
+     */
+    public static PureDate fromYear(java.time.Year year)
+    {
+        return Year.fromYear(year);
+    }
+
+    /**
+     * Convert a {@link java.time.YearMonth} to a Pure date of month granularity.
+     *
+     * @param yearMonth year and month
+     * @return Pure date
+     */
+    public static PureDate fromYearMonth(java.time.YearMonth yearMonth)
+    {
+        return YearMonth.fromYearMonth(yearMonth);
+    }
+
+    /**
+     * Convert a {@link LocalDate} to a Pure date of day granularity.
+     *
+     * @param date local date
+     * @return Pure date
+     */
+    public static StrictDate fromLocalDate(LocalDate date)
+    {
+        return StrictDate.fromLocalDate(date);
+    }
+
+    /**
+     * Convert a {@link LocalDateTime} to a Pure date, keeping all nine subsecond digits. Pure dates
+     * carry no time zone and are always understood as UTC, and a {@link LocalDateTime} carries no
+     * zone either, so its fields are taken as they stand.
+     *
+     * @param dateTime local date and time
+     * @return Pure date
+     */
+    public static DateTime fromLocalDateTime(LocalDateTime dateTime)
+    {
+        return fromLocalDateTime(dateTime, 9);
+    }
+
+    /**
+     * Convert a {@link LocalDateTime} to a Pure date, keeping the given number of subsecond digits.
+     * Digits beyond that number are dropped, not rounded. A precision of 0 gives a date of second
+     * granularity. Pure dates carry no time zone and are always understood as UTC, and a
+     * {@link LocalDateTime} carries no zone either, so its fields are taken as they stand.
+     *
+     * @param dateTime           local date and time
+     * @param subsecondPrecision number of subsecond digits to keep (0-9)
+     * @return Pure date
+     */
+    public static DateTime fromLocalDateTime(LocalDateTime dateTime, int subsecondPrecision)
+    {
+        return (subsecondPrecision == 0) ? DateWithSecond.fromLocalDateTime(dateTime) : DateWithSubsecond.fromLocalDateTime(dateTime, subsecondPrecision);
+    }
+
+    /**
+     * Convert an {@link OffsetDateTime} to a Pure date, keeping all nine subsecond digits. Since
+     * Pure dates are always understood as UTC, the instant is shifted to UTC first: the offset is
+     * applied, not discarded.
+     *
+     * @param dateTime date and time with a UTC offset
+     * @return Pure date
+     */
+    public static DateTime fromOffsetDateTime(OffsetDateTime dateTime)
+    {
+        return fromOffsetDateTime(dateTime, 9);
+    }
+
+    /**
+     * Convert an {@link OffsetDateTime} to a Pure date, keeping the given number of subsecond
+     * digits. Digits beyond that number are dropped, not rounded. A precision of 0 gives a date of
+     * second granularity. Since Pure dates are always understood as UTC, the instant is shifted to
+     * UTC first: the offset is applied, not discarded.
+     *
+     * @param dateTime           date and time with a UTC offset
+     * @param subsecondPrecision number of subsecond digits to keep (0-9)
+     * @return Pure date
+     */
+    public static DateTime fromOffsetDateTime(OffsetDateTime dateTime, int subsecondPrecision)
+    {
+        return fromInstant(dateTime.toInstant(), subsecondPrecision);
+    }
+
+    /**
+     * Convert a {@link ZonedDateTime} to a Pure date, keeping all nine subsecond digits. Since Pure
+     * dates are always understood as UTC, the instant is shifted to UTC first, using the offset the
+     * zone was in at that instant.
+     *
+     * @param dateTime date and time in a time zone
+     * @return Pure date
+     */
+    public static DateTime fromZonedDateTime(ZonedDateTime dateTime)
+    {
+        return fromZonedDateTime(dateTime, 9);
+    }
+
+    /**
+     * Convert a {@link ZonedDateTime} to a Pure date, keeping the given number of subsecond digits.
+     * Digits beyond that number are dropped, not rounded. A precision of 0 gives a date of second
+     * granularity. Since Pure dates are always understood as UTC, the instant is shifted to UTC
+     * first, using the offset the zone was in at that instant.
+     *
+     * @param dateTime           date and time in a time zone
+     * @param subsecondPrecision number of subsecond digits to keep (0-9)
+     * @return Pure date
+     */
+    public static DateTime fromZonedDateTime(ZonedDateTime dateTime, int subsecondPrecision)
+    {
+        return fromInstant(dateTime.toInstant(), subsecondPrecision);
     }
 
     /**
@@ -188,7 +309,7 @@ public class DateFunctions extends TimeFunctions
      */
     public static StrictDate today()
     {
-        return StrictDate.fromLocalDate(LocalDate.now(Clock.systemUTC()));
+        return fromLocalDate(LocalDate.now(Clock.systemUTC()));
     }
 
     static int getYearDays(int year)

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
@@ -625,6 +625,74 @@ public class DateFunctions extends TimeFunctions
         }
     }
 
+    /**
+     * Compare two Pure dates, returning -1 if date1 sorts first, 1 if date2 sorts first, and 0 if
+     * they are the same date. This is the ordering used by {@link PureDate#compareTo(PureDate)}.
+     *
+     * <p><b>A Pure date is a span of time, not an instant.</b> A date stops at whatever granularity
+     * it was written with, and stands for everything it leaves unsaid: {@code 2014} is the whole of
+     * that year, {@code 2014-06} the whole of that month, {@code 2014-06-15T12} the whole of that
+     * hour. So every date covers a span running from the first instant it includes up to (but not
+     * including) the first instant after it. Below, s(x) is the start of x's span and e(x) is its
+     * end.
+     *
+     * <p>When two dates have the same granularity their spans are the same width, and the ordering
+     * is the obvious one: whichever span comes first on the time line sorts first. Dates of
+     * different granularities are what make this ordering surprising, because then one span can
+     * contain the other.
+     *
+     * <p><b>The rule.</b>
+     *
+     * <pre>{@code
+     * compare(a, b) <  0   iff   s(a) < s(b),   or   (s(a) == s(b) and e(a) > e(b))
+     * compare(a, b) == 0   iff   s(a) == s(b)   and   e(a) == e(b)
+     * compare(a, b) >  0   iff   s(a) > s(b),   or   (s(a) == s(b) and e(a) < e(b))
+     * }</pre>
+     *
+     * <p>In words: <b>the date that starts earlier sorts first; if both start at the same instant,
+     * the wider one sorts first.</b> Equivalently, a sorts before b if a starts before the start of
+     * b, or if a contains b without being equal to it.
+     *
+     * <p>The second half of the rule is what catches people out. Whenever one date contains
+     * another, <b>the container sorts first</b>, even though it ends after the end of the date it
+     * contains. That falls out of reading the components left to right - year, then month, then day,
+     * and so on - because a date that runs out of components sorts before one that carries on, the
+     * way "car" sorts before "cart" in a dictionary. Note that a coarse date does not sit in the
+     * middle of the finer dates inside it; it sorts before all of them, so {@code 2014} sorts before
+     * {@code 2014-12-31} just as it sorts before {@code 2014-01-01}.
+     *
+     * <p>Two tempting but wrong readings:
+     *
+     * <ul>
+     *     <li>It is <em>not</em> "a ends before the end of b". {@code compare(2014, 2014-06)} is -1,
+     *     yet 2014 ends six months after 2014-06 ends.</li>
+     *     <li>It is <em>not</em> "a starts before the start of b" on its own. {@code 2014} and
+     *     {@code 2014-01} start at the very same instant, and {@code 2014} still sorts first.</li>
+     * </ul>
+     *
+     * <p><b>Examples.</b>
+     *
+     * <pre>{@code
+     * compare(2013,       2014)                    == -1  // 2013 ends before 2014 starts
+     * compare(2014-06,    2014-07)                 == -1  // June ends before July starts
+     * compare(2014-06-15, 2014-07)                 == -1  // a day in June is before all of July
+     * compare(2014,       2014-06)                 == -1  // the year contains the month
+     * compare(2014-06,    2014)                    ==  1
+     * compare(2014,       2014-01)                 == -1  // same start, and the year is wider
+     * compare(2014,       2014-12)                 == -1  // same end, but the year starts earlier
+     * compare(2014-01-01, 2014-01-01T00)           == -1  // same start, and the day is wider
+     * compare(2014-01-01T00:00:00.1,
+     *         2014-01-01T00:00:00.10)              == -1  // same start: .1 is a tenth of a second,
+     *                                                     // .10 a hundredth, so .1 is wider
+     * }</pre>
+     *
+     * <p>This is a total order, it never returns anything but -1, 0, or 1, and it agrees with equals:
+     * it returns 0 exactly when the two dates are equal.
+     *
+     * @param date1 first date
+     * @param date2 second date
+     * @return -1, 0, or 1 as date1 sorts before, equal to, or after date2
+     */
     public static int compare(PureDate date1, PureDate date2)
     {
         if (date1 == date2)

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
@@ -78,18 +78,12 @@ public class DateFunctions extends TimeFunctions
 
     public static PureDate fromCalendar(GregorianCalendar calendar, int precision)
     {
-        TimeZone timeZone = calendar.getTimeZone();
-        if (!GMT_TIME_ZONE.equals(timeZone))
+        if ((calendar.get(Calendar.ZONE_OFFSET) != 0) || (calendar.get(Calendar.DST_OFFSET) != 0))
         {
             // Possibly adjust to UTC
-            long time = calendar.getTimeInMillis();
-            int offset = timeZone.getOffset(time);
-            if (offset != 0)
-            {
-                // Adjust to UTC
-                calendar = new GregorianCalendar(GMT_TIME_ZONE);
-                calendar.setTimeInMillis(time - offset);
-            }
+            GregorianCalendar newCalendar = new GregorianCalendar(GMT_TIME_ZONE);
+            newCalendar.setTimeInMillis(calendar.getTimeInMillis());
+            calendar = newCalendar;
         }
 
         switch (precision)

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
@@ -453,62 +453,59 @@ public class DateFunctions extends TimeFunctions
         return isLeapYear(year) ? 366 : 365;
     }
 
+    /**
+     * Get the difference between two Pure dates in the given unit. The result is positive when
+     * otherDate is the later of the two, negative when it is the earlier, and zero when neither is.
+     *
+     * <p>Each date is read as the first instant of the span it covers, so a date with no month
+     * starts in January, one with no day starts on the first, and one with no time starts at
+     * midnight. What is measured from there depends on which family the unit belongs to: YEARS
+     * through DAYS name positions in the civil calendar, while HOURS and below name a fixed quantity
+     * of elapsed time. (This is the same division {@link java.time.temporal.ChronoUnit} makes between
+     * date-based and time-based units, and {@link java.time.Period} between calendar periods and
+     * {@link java.time.Duration}, but the division is a property of the units rather than of any one
+     * library.)
+     *
+     * <p><b>The calendar units - YEARS, MONTHS, WEEKS, and DAYS - count boundaries crossed</b>,
+     * ignoring everything finer than the unit. YEARS counts new years begun, MONTHS new months, DAYS
+     * midnights passed, WEEKS Sundays reached. So 2015-12-31T23:59:59 to 2016-01-01T00:00:01 is one
+     * YEAR, though only two seconds passed, and 2016-02-01 to 2016-02-29 is zero MONTHS, though
+     * nearly a month did.
+     *
+     * <p>The counted range is half open: a boundary landing on otherDate counts, one landing on
+     * thisDate does not. For YEARS, MONTHS, and DAYS that makes no difference, because dropping the
+     * finer components already puts both dates on the unit's own boundaries, so the count is the same
+     * in either direction. <b>WEEKS is the exception</b>, since days are not aligned to weeks: a
+     * Saturday to the following Sunday is 1, while that Sunday back to the Saturday is 0 rather than
+     * -1. That asymmetry is the one place the half-open convention becomes visible.
+     *
+     * <p><b>The time units - HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, and NANOSECONDS -
+     * measure elapsed time</b>, dropping any remainder. <b>This is not the same as counting
+     * boundaries.</b> 12:59:00 to 13:01:00 crosses the 13:00 boundary yet is zero HOURS, and 12:00:00
+     * to 12:59:00 crosses none and is also zero. The two readings agree whenever thisDate falls on a
+     * boundary of the unit, which is the usual case, but they are different rules: the same two
+     * minutes from 23:59:00 to 00:01:00 the next day are one DAY and zero HOURS.
+     *
+     * <p>Subsecond digits count down to the nanosecond and anything finer is ignored. A span too
+     * large to express in the requested unit throws {@link ArithmeticException} rather than wrapping,
+     * which NANOSECONDS reaches at about 292 years.
+     *
+     * <p>This is the inverse of {@code meta::pure::functions::date::adjust} when the unit matches the
+     * granularity of both dates: for dates of day granularity,
+     * {@code adjust(a, dateDifference(a, b, "DAYS"), DAYS)} is b, and likewise for the other units
+     * that name a granularity. It is not an inverse otherwise, since a coarser unit drops the finer
+     * components and adjusting by a finer unit than the date carries is not supported at all. WEEKS
+     * is never an inverse, as adjusting by weeks adds seven days rather than moving to a Sunday.
+     *
+     * @param thisDate  date to measure from
+     * @param otherDate date to measure to
+     * @param unit      one of YEARS, MONTHS, WEEKS, DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS,
+     *                  MICROSECONDS, NANOSECONDS
+     * @return difference in the given unit
+     */
     public static long dateDifference(PureDate thisDate, PureDate otherDate, String unit)
     {
-        if (thisDate.equals(otherDate))
-        {
-            return 0;
-        }
-        long result;
-        switch (unit)
-        {
-            case "YEARS":
-            {
-                result = DateDiff.getDiffYears(thisDate, otherDate);
-                break;
-            }
-            case "MONTHS":
-            {
-                result = DateDiff.getDiffMonths(thisDate, otherDate);
-                break;
-            }
-            case "WEEKS":
-            {
-                result = DateDiff.getDateDiffWeeks(thisDate, otherDate);
-                break;
-            }
-            case "DAYS":
-            {
-                result = DateDiff.getDiffDays(thisDate, otherDate);
-                break;
-            }
-            case "HOURS":
-            {
-                result = DateDiff.getDiffHours(thisDate, otherDate);
-                break;
-            }
-            case "MINUTES":
-            {
-                result = DateDiff.getDiffMinutes(thisDate, otherDate);
-                break;
-            }
-            case "SECONDS":
-            {
-                result = DateDiff.getDiffSeconds(thisDate, otherDate);
-                break;
-            }
-            case "MILLISECONDS":
-            {
-                result = DateDiff.getDiffInMilliseconds(thisDate, otherDate);
-                break;
-            }
-            default:
-            {
-                throw new IllegalArgumentException("Unsupported duration unit: " + unit);
-            }
-        }
-        int sign = otherDate.compareTo(thisDate);
-        return sign * result;
+        return DateDiff.dateDifference(thisDate, otherDate, unit);
     }
 
     /**

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
@@ -29,6 +29,16 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
+/**
+ * Functions for creating, converting, and comparing Pure dates.
+ *
+ * <p>A Pure date carries a granularity: it may stop at the year, the month, the day, the hour, the
+ * minute, the second, or a subsecond with any number of digits, and it stands for everything it
+ * leaves unsaid. It carries no time zone; every Pure date is understood as UTC, so the conversions
+ * here shift an incoming value to UTC rather than discarding its zone or offset.
+ *
+ * <p>See {@link #compare(PureDate, PureDate)} for how dates of differing granularity are ordered.
+ */
 public class DateFunctions extends TimeFunctions
 {
     private static final int MAX_YEAR = java.time.Year.MAX_VALUE;
@@ -36,46 +46,128 @@ public class DateFunctions extends TimeFunctions
 
     static final TimeZone GMT_TIME_ZONE = TimeZone.getTimeZone("GMT");
 
+    /**
+     * Create a Pure date of year granularity, standing for the whole of the given year.
+     *
+     * @param year year
+     * @return Pure date
+     */
     public static PureDate newPureDate(int year)
     {
         return Year.newYear(year);
     }
 
+    /**
+     * Create a Pure date of month granularity, standing for the whole of the given month.
+     *
+     * @param year  year
+     * @param month month (1-12)
+     * @return Pure date
+     */
     public static PureDate newPureDate(int year, int month)
     {
         return YearMonth.newYearMonth(year, month);
     }
 
+    /**
+     * Create a Pure date of day granularity, standing for the whole of the given day.
+     *
+     * @param year  year
+     * @param month month (1-12)
+     * @param day   day of the month
+     * @return Pure date
+     */
     public static StrictDate newPureDate(int year, int month, int day)
     {
         return StrictDate.newStrictDate(year, month, day);
     }
 
+    /**
+     * Create a Pure date of hour granularity, standing for the whole of the given hour UTC.
+     *
+     * @param year  year
+     * @param month month (1-12)
+     * @param day   day of the month
+     * @param hour  hour (0-23)
+     * @return Pure date
+     */
     public static DateTime newPureDate(int year, int month, int day, int hour)
     {
         return DateWithHour.newDateWithHour(year, month, day, hour);
     }
 
+    /**
+     * Create a Pure date of minute granularity, standing for the whole of the given minute UTC.
+     *
+     * @param year   year
+     * @param month  month (1-12)
+     * @param day    day of the month
+     * @param hour   hour (0-23)
+     * @param minute minute (0-59)
+     * @return Pure date
+     */
     public static DateTime newPureDate(int year, int month, int day, int hour, int minute)
     {
         return DateWithMinute.newDateWithMinute(year, month, day, hour, minute);
     }
 
+    /**
+     * Create a Pure date of second granularity, standing for the whole of the given second UTC.
+     *
+     * @param year   year
+     * @param month  month (1-12)
+     * @param day    day of the month
+     * @param hour   hour (0-23)
+     * @param minute minute (0-59)
+     * @param second second (0-59)
+     * @return Pure date
+     */
     public static DateTime newPureDate(int year, int month, int day, int hour, int minute, int second)
     {
         return DateWithSecond.newDateWithSecond(year, month, day, hour, minute, second);
     }
 
+    /**
+     * Create a Pure date of subsecond granularity UTC. The subsecond is the digits after the decimal
+     * point, so its length is the precision: "07" is a hundredth of a second and "070" a thousandth.
+     * It must be a non-empty string of digits.
+     *
+     * @param year      year
+     * @param month     month (1-12)
+     * @param day       day of the month
+     * @param hour      hour (0-23)
+     * @param minute    minute (0-59)
+     * @param second    second (0-59)
+     * @param subsecond digits after the decimal point
+     * @return Pure date
+     */
     public static DateTime newPureDate(int year, int month, int day, int hour, int minute, int second, String subsecond)
     {
         return DateWithSubsecond.newDateWithSubsecond(year, month, day, hour, minute, second, subsecond);
     }
 
+    /**
+     * Convert a calendar to a Pure date of millisecond precision, reading the instant it holds as
+     * UTC.
+     *
+     * @param calendar calendar
+     * @return Pure date
+     */
     public static PureDate fromCalendar(GregorianCalendar calendar)
     {
         return fromCalendar(calendar, Calendar.MILLISECOND);
     }
 
+    /**
+     * Convert a calendar to a Pure date of the given precision, reading the instant it holds as UTC.
+     * The calendar's time zone decides only whether its fields can be read as they stand or have to
+     * be recomputed in GMT first; it never shifts the instant.
+     *
+     * @param calendar  calendar
+     * @param precision one of the {@link Calendar} field constants from {@link Calendar#YEAR} down
+     *                  to {@link Calendar#MILLISECOND}, naming the granularity of the result
+     * @return Pure date
+     */
     public static PureDate fromCalendar(GregorianCalendar calendar, int precision)
     {
         if ((calendar.get(Calendar.ZONE_OFFSET) != 0) || (calendar.get(Calendar.DST_OFFSET) != 0))
@@ -127,6 +219,14 @@ public class DateFunctions extends TimeFunctions
         }
     }
 
+    /**
+     * Get the name of the Pure primitive type the given date belongs to, which follows from its
+     * granularity: Date for year and month granularity, StrictDate for day granularity, DateTime for
+     * anything finer, and LatestDate for {@link LatestDate}.
+     *
+     * @param pureDate Pure date
+     * @return Pure primitive type name
+     */
     public static String datePrimitiveType(PureDate pureDate)
     {
         if (LatestDate.isLatestDate(pureDate))
@@ -144,6 +244,14 @@ public class DateFunctions extends TimeFunctions
         return ModelRepository.DATE_TYPE_NAME;
     }
 
+    /**
+     * Convert a Java date to a Pure date, reading the instant it holds as UTC. A
+     * {@link java.sql.Date} yields day granularity and a {@link java.sql.Timestamp} nanosecond
+     * granularity; any other {@link Date} yields millisecond granularity.
+     *
+     * @param date Java date
+     * @return Pure date
+     */
     public static PureDate fromDate(Date date)
     {
         if (date instanceof java.sql.Date)
@@ -159,21 +267,49 @@ public class DateFunctions extends TimeFunctions
         return fromCalendar(calendar, Calendar.MILLISECOND);
     }
 
+    /**
+     * Convert a SQL date to a Pure date of day granularity, reading the instant it holds as UTC.
+     *
+     * @param date SQL date
+     * @return Pure date
+     */
     public static StrictDate fromSQLDate(java.sql.Date date)
     {
         return StrictDate.fromSQLDate(date);
     }
 
+    /**
+     * Convert a SQL timestamp to a Pure date, reading the instant it holds as UTC and keeping all
+     * nine subsecond digits.
+     *
+     * @param timestamp SQL timestamp
+     * @return Pure date
+     */
     public static DateTime fromSQLTimestamp(java.sql.Timestamp timestamp)
     {
         return DateWithSubsecond.fromSQLTimestamp(timestamp);
     }
 
+    /**
+     * Convert an {@link Instant} to a Pure date in UTC, keeping all nine subsecond digits.
+     *
+     * @param instant instant
+     * @return Pure date
+     */
     public static DateTime fromInstant(Instant instant)
     {
         return fromInstant(instant, 9);
     }
 
+    /**
+     * Convert an {@link Instant} to a Pure date in UTC, keeping the given number of subsecond
+     * digits. Digits beyond that number are dropped, not rounded. A precision of 0 gives a date of
+     * second granularity.
+     *
+     * @param instant            instant
+     * @param subsecondPrecision number of subsecond digits to keep (0-9)
+     * @return Pure date
+     */
     public static DateTime fromInstant(Instant instant, int subsecondPrecision)
     {
         return fromLocalDateTime(LocalDateTime.ofInstant(instant, ZoneOffset.UTC), subsecondPrecision);
@@ -306,6 +442,12 @@ public class DateFunctions extends TimeFunctions
         return fromLocalDate(LocalDate.now(Clock.systemUTC()));
     }
 
+    /**
+     * Get the number of days in the given year according to the Gregorian calendar.
+     *
+     * @param year Gregorian calendar year
+     * @return number of days in the year
+     */
     static int getYearDays(int year)
     {
         return isLeapYear(year) ? 366 : 365;
@@ -438,6 +580,11 @@ public class DateFunctions extends TimeFunctions
         return DateFormat.parsePureDate(string, 0, string.length());
     }
 
+    /**
+     * Throw if the given year is outside the supported range.
+     *
+     * @param year year
+     */
     static void validateYear(int year)
     {
         if ((year < MIN_YEAR) || (year > MAX_YEAR))
@@ -446,6 +593,11 @@ public class DateFunctions extends TimeFunctions
         }
     }
 
+    /**
+     * Throw if the given month is not in the range 1-12.
+     *
+     * @param month month
+     */
     static void validateMonth(int month)
     {
         if ((month < 1) || (month > 12))
@@ -454,6 +606,13 @@ public class DateFunctions extends TimeFunctions
         }
     }
 
+    /**
+     * Throw if the given day does not exist in the given month of the given year.
+     *
+     * @param year  year
+     * @param month month (1-12)
+     * @param day   day of the month
+     */
     static void validateDay(int year, int month, int day)
     {
         if (day < 1)

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithSecond.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithSecond.java
@@ -15,6 +15,7 @@
 package org.finos.legend.pure.m4.coreinstance.primitive.date;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class DateWithSecond extends AbstractDateWithSecond
 {
@@ -84,5 +85,10 @@ public class DateWithSecond extends AbstractDateWithSecond
         DateFunctions.validateMinute(minute);
         DateFunctions.validateSecond(second);
         return new DateWithSecond(year, month, day, hour, minute, second);
+    }
+
+    static DateTime fromLocalDateTime(LocalDateTime time)
+    {
+        return new DateWithSecond(time.getYear(), time.getMonthValue(), time.getDayOfMonth(), time.getHour(), time.getMinute(), time.getSecond());
     }
 }

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithSubsecond.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithSubsecond.java
@@ -70,13 +70,10 @@ public class DateWithSubsecond extends AbstractDateWithSubsecond
 
     private static String getSubsecond(LocalDateTime time, int subsecondPrecision)
     {
-        if ((subsecondPrecision < 0) || (subsecondPrecision > 9))
+        // 0 is not valid here: a date with no subsecond is a DateWithSecond, not a DateWithSubsecond
+        if ((subsecondPrecision < 1) || (subsecondPrecision > 9))
         {
             throw new IllegalArgumentException("Invalid subsecond precision: " + subsecondPrecision);
-        }
-        if (subsecondPrecision == 0)
-        {
-            return null;
         }
         String string = String.format("%09d", time.getNano());
         return (subsecondPrecision == 9) ? string : string.substring(0, subsecondPrecision);

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/LatestDate.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/LatestDate.java
@@ -200,12 +200,6 @@ public class LatestDate implements PureDate
     }
 
     @Override
-    public int compareTo(PureDate pureDate)
-    {
-        throw new UnsupportedOperationException("Invalid operation for LatestDate");
-    }
-
-    @Override
     public String toString()
     {
         return latestDateConstant;

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/Year.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/Year.java
@@ -178,4 +178,9 @@ public final class Year extends AbstractPureDate
         DateFunctions.validateYear(year);
         return new Year(java.time.Year.of(year));
     }
+
+    static Year fromYear(java.time.Year year)
+    {
+        return new Year(year);
+    }
 }

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/YearMonth.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/YearMonth.java
@@ -184,4 +184,9 @@ public final class YearMonth extends AbstractPureDate
         DateFunctions.validateMonth(month);
         return new YearMonth(year, month);
     }
+
+    static YearMonth fromYearMonth(java.time.YearMonth yearMonth)
+    {
+        return new YearMonth(yearMonth);
+    }
 }

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateCompare.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateCompare.java
@@ -535,6 +535,67 @@ public class TestDateCompare
                 sorted.collect(PureDate::toString));
     }
 
+    // LatestDate
+
+    /**
+     * {@link LatestDate} has no components to compare and no fixed position on the time line, so it
+     * is ordered after every other date. That is a sorting convention, adopted so that any two dates
+     * can be ordered, rather than a claim about when {@code %latest} falls.
+     */
+    @Test
+    public void testLatestDateSortsAfterEveryOtherDate()
+    {
+        Assert.assertEquals(0, DateFunctions.compare(LatestDate.instance, LatestDate.instance));
+        Assert.assertEquals(0, LatestDate.instance.compareTo(LatestDate.instance));
+
+        for (PureDate date : DATES)
+        {
+            String message = date.toString();
+            Assert.assertEquals(message, 1, DateFunctions.compare(LatestDate.instance, date));
+            Assert.assertEquals(message, -1, DateFunctions.compare(date, LatestDate.instance));
+            Assert.assertEquals(message, 1, LatestDate.instance.compareTo(date));
+            Assert.assertEquals(message, -1, date.compareTo(LatestDate.instance));
+        }
+
+        // including the latest date the platform can represent
+        PureDate maxDate = DateFunctions.newPureDate(java.time.Year.MAX_VALUE);
+        Assert.assertEquals(1, DateFunctions.compare(LatestDate.instance, maxDate));
+        Assert.assertEquals(-1, DateFunctions.compare(maxDate, LatestDate.instance));
+    }
+
+    /**
+     * {@link LatestDate} is equal only to itself, and answers from either side rather than throwing.
+     * Ordering it after every other date is only useful if {@code equals} agrees that it is not any
+     * of them, and {@code equals} has to be symmetric even where {@code %latest} has no components
+     * to offer.
+     */
+    @Test
+    public void testLatestDateEqualsOnlyItself()
+    {
+        Assert.assertEquals(LatestDate.instance, LatestDate.instance);
+
+        for (PureDate date : DATES)
+        {
+            String message = date.toString();
+            Assert.assertNotEquals(message, date, LatestDate.instance);
+            Assert.assertNotEquals(message, LatestDate.instance, date);
+            Assert.assertNotEquals(message, 0, DateFunctions.compare(date, LatestDate.instance));
+        }
+    }
+
+    @Test
+    public void testSortingWithLatestDate()
+    {
+        MutableList<PureDate> sorted = Lists.mutable.<PureDate>with(
+                parse("2015"),
+                LatestDate.instance,
+                parse("2014-06-15"),
+                parse("2013-12-31")).sortThis();
+        Assert.assertEquals(
+                Lists.mutable.with("2013-12-31", "2014-06-15", "2015", "%latest"),
+                sorted.collect(PureDate::toString));
+    }
+
     // Helpers
 
     private static PureDate parse(String string)

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateCompare.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateCompare.java
@@ -1,0 +1,733 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m4.coreinstance.primitive.date;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.EnumSet;
+import java.util.function.BiConsumer;
+
+/**
+ * Tests for {@link DateFunctions#compare(PureDate, PureDate)}, which also backs
+ * {@link PureDate#compareTo(PureDate)}.
+ *
+ * <p><b>The rule under test, in one sentence:</b> the date that starts earlier sorts first, and if
+ * both start at the same instant the wider one sorts first. {@link DateFunctions#compare} explains
+ * why, and is the place to look first; this class checks it.
+ *
+ * <p>The reason width comes into it is that a Pure date is a span of time, not an instant: it stops
+ * at whatever granularity it was written with and stands for everything it leaves unsaid, so
+ * {@code 2014} covers the whole year and {@code 2014-06} the whole month. Comparing dates of
+ * different granularities means comparing spans of different widths, and that is where the
+ * surprises live.
+ *
+ * <p>The tests come in three layers.
+ *
+ * <ol>
+ *     <li><b>Worked examples</b>, one granularity at a time and then across granularities, which
+ *     say in concrete terms what the ordering does.</li>
+ *     <li><b>Three equivalent characterizations</b>, each checked over every ordered pair of
+ *     {@link #DATES}: against the Allen interval relation between the two spans
+ *     ({@link #testCompareMatchesAllenCharacterization()}), against "start ascending, end
+ *     descending" ({@link #testCompareIsStartAscendingThenEndDescending()}), and against "starts
+ *     earlier, or properly contains"
+ *     ({@link #testCompareIsNegativeIffStartsEarlierOrProperlyContains()}). Two tempting but wrong
+ *     readings are pinned as counterexamples.</li>
+ *     <li><b>Order properties</b>: antisymmetry, reflexivity, transitivity, consistency with
+ *     {@code equals}, and that only -1, 0 and 1 are ever returned.</li>
+ * </ol>
+ *
+ * <p>Layer 2 uses Allen's interval algebra as its machinery, via {@link AllenRelation} and
+ * {@link #allenRelation(PureDate, PureDate)}, which derive the relation from the two spans'
+ * endpoints independently of {@code compare}. Only eleven of the thirteen relations can arise:
+ * granularity boundaries always subdivide the boundaries above them, so two Pure date spans are
+ * either disjoint or nested, never partially overlapping. That is what makes the ordering
+ * well defined, and {@link #testDateIntervalsNeverPartiallyOverlap()} asserts it.
+ */
+public class TestDateCompare
+{
+    /**
+     * A corpus spanning every granularity, chosen so that all eleven realizable Allen relations occur
+     * between some pair (see {@link #testAllRealizableAllenRelationsAreCovered()}).
+     */
+    private static final ListIterable<String> DATE_STRINGS = Lists.immutable.with(
+            // years
+            "-1", "0", "1", "2013", "2014", "2015", "2016",
+            // year-months
+            "2013-12", "2014-01", "2014-03", "2014-12", "2015-01", "2016-02",
+            // strict dates
+            "2013-12-31", "2014-01-01", "2014-03-01", "2014-03-10", "2014-03-11", "2014-03-31", "2014-12-31", "2016-02-29",
+            // dates with hour
+            "2013-12-31T23", "2014-03-10T00", "2014-03-10T16", "2014-03-10T23",
+            // dates with minute
+            "2014-03-10T16:00", "2014-03-10T16:12", "2014-03-10T16:13", "2014-03-10T16:59",
+            // dates with second
+            "2014-03-10T16:12:00", "2014-03-10T16:12:35", "2014-03-10T16:12:36", "2014-03-10T16:12:59",
+            // dates with subsecond, including nested subsecond precisions
+            "2014-03-10T16:12:35.0", "2014-03-10T16:12:35.07", "2014-03-10T16:12:35.070",
+            "2014-03-10T16:12:35.0700", "2014-03-10T16:12:35.070004235",
+            "2014-03-10T16:12:35.08", "2014-03-10T16:12:35.9", "2014-03-10T16:12:35.999999999");
+
+    private static final ListIterable<PureDate> DATES = DATE_STRINGS.collect(DateFunctions::parsePureDate);
+
+    /**
+     * Allen relations that {@code compare} maps to -1: everything where a starts first, plus the
+     * cases where a and b start together and a is the wider (containing) interval.
+     */
+    private static final EnumSet<AllenRelation> LESS_THAN_RELATIONS =
+            EnumSet.of(AllenRelation.BEFORE, AllenRelation.MEETS, AllenRelation.CONTAINS, AllenRelation.FINISHED_BY, AllenRelation.STARTED_BY);
+
+    /**
+     * Allen relations that {@code compare} maps to 1: the converses of {@link #LESS_THAN_RELATIONS}.
+     */
+    private static final EnumSet<AllenRelation> GREATER_THAN_RELATIONS =
+            EnumSet.of(AllenRelation.AFTER, AllenRelation.MET_BY, AllenRelation.DURING, AllenRelation.FINISHES, AllenRelation.STARTS);
+
+    // Worked examples, one granularity at a time
+
+    @Test
+    public void testCompareYears()
+    {
+        assertCompare(0, "2014", "2014");
+        assertCompare(-1, "2013", "2014");
+
+        // negative and zero years
+        assertCompare(-1, "-1", "0");
+        assertCompare(-1, "0", "1");
+
+        // an arbitrarily large gap still yields exactly -1 / 1
+        assertCompare(-1, "-999999999", "999999999");
+    }
+
+    @Test
+    public void testCompareYearMonths()
+    {
+        assertCompare(0, "2014-03", "2014-03");
+        assertCompare(-1, "2014-02", "2014-03");
+
+        // year dominates month
+        assertCompare(-1, "2013-12", "2014-01");
+    }
+
+    @Test
+    public void testCompareStrictDates()
+    {
+        assertCompare(0, "2014-03-10", "2014-03-10");
+        assertCompare(-1, "2014-03-09", "2014-03-10");
+
+        // month dominates day
+        assertCompare(-1, "2014-02-28", "2014-03-01");
+        // year dominates month and day
+        assertCompare(-1, "2013-12-31", "2014-01-01");
+    }
+
+    @Test
+    public void testCompareDatesWithHour()
+    {
+        assertCompare(0, "2014-03-10T16", "2014-03-10T16");
+        assertCompare(-1, "2014-03-10T15", "2014-03-10T16");
+
+        // day dominates hour
+        assertCompare(-1, "2014-03-10T23", "2014-03-11T00");
+    }
+
+    @Test
+    public void testCompareDatesWithMinute()
+    {
+        assertCompare(0, "2014-03-10T16:12", "2014-03-10T16:12");
+        assertCompare(-1, "2014-03-10T16:11", "2014-03-10T16:12");
+
+        // hour dominates minute
+        assertCompare(-1, "2014-03-10T15:59", "2014-03-10T16:00");
+    }
+
+    @Test
+    public void testCompareDatesWithSecond()
+    {
+        assertCompare(0, "2014-03-10T16:12:35", "2014-03-10T16:12:35");
+        assertCompare(-1, "2014-03-10T16:12:34", "2014-03-10T16:12:35");
+
+        // minute dominates second
+        assertCompare(-1, "2014-03-10T16:11:59", "2014-03-10T16:12:00");
+    }
+
+    @Test
+    public void testCompareSubsecondsOfEqualPrecision()
+    {
+        assertCompare(0, "2014-03-10T16:12:35.070004235", "2014-03-10T16:12:35.070004235");
+        assertCompare(-1, "2014-03-10T16:12:35.070004234", "2014-03-10T16:12:35.070004235");
+
+        // second dominates subsecond
+        assertCompare(-1, "2014-03-10T16:12:34.999", "2014-03-10T16:12:35.000");
+    }
+
+    // Worked examples across granularities
+
+    /**
+     * Subseconds of different digit counts are different granularities: ".07" is a ten millisecond
+     * span, ".070" a one millisecond span nested inside it. The comparison is a decimal expansion
+     * comparison, not a string or numeric comparison of the digits.
+     */
+    @Test
+    public void testCompareSubsecondsOfDifferentPrecision()
+    {
+        // ".0" = [.0, .1) contains ".070" = [.070, .071), so the wider value sorts first
+        assertCompare(-1, "2014-03-10T16:12:35.0", "2014-03-10T16:12:35.070");
+
+        // ".07" = [.07, .08) is inside ".0" = [.0, .1) but starts later, so it sorts after
+        assertCompare(1, "2014-03-10T16:12:35.07", "2014-03-10T16:12:35.0");
+
+        // a trailing zero narrows the span without moving its start, so the wider one sorts first
+        assertCompare(-1, "2014-03-10T16:12:35.070", "2014-03-10T16:12:35.0700");
+
+        // digit counts do not decide disjoint cases: ".07" is entirely before ".9"
+        assertCompare(-1, "2014-03-10T16:12:35.07", "2014-03-10T16:12:35.9");
+
+        // ".9" = [.9, 1.0) contains ".999999999"
+        assertCompare(-1, "2014-03-10T16:12:35.9", "2014-03-10T16:12:35.999999999");
+    }
+
+    /**
+     * Along a chain of ever finer granularities all starting at the same instant, each value sorts
+     * before every finer value below it: the container always precedes the contained.
+     */
+    @Test
+    public void testCompareGranularityLadderSharingAStart()
+    {
+        ListIterable<PureDate> ladder = Lists.immutable.with(
+                parse("2014"),
+                parse("2014-01"),
+                parse("2014-01-01"),
+                parse("2014-01-01T00"),
+                parse("2014-01-01T00:00"),
+                parse("2014-01-01T00:00:00"),
+                parse("2014-01-01T00:00:00.0"),
+                parse("2014-01-01T00:00:00.00"),
+                parse("2014-01-01T00:00:00.000000000"));
+        for (int i = 0; i < ladder.size(); i++)
+        {
+            PureDate coarser = ladder.get(i);
+            Assert.assertEquals(coarser.toString(), intervalStart(ladder.get(0)), intervalStart(coarser));
+            for (int j = i + 1; j < ladder.size(); j++)
+            {
+                PureDate finer = ladder.get(j);
+                String message = coarser + " vs " + finer;
+                Assert.assertEquals(message, -1, DateFunctions.compare(coarser, finer));
+                Assert.assertEquals(message, 1, DateFunctions.compare(finer, coarser));
+                Assert.assertEquals(message, AllenRelation.STARTED_BY, allenRelation(coarser, finer));
+            }
+        }
+    }
+
+    /**
+     * The mirror image of {@link #testCompareGranularityLadderSharingAStart()}: a chain of ever
+     * finer granularities all ending at the same instant. The container still precedes the
+     * contained, even though here it is the container that starts earlier.
+     */
+    @Test
+    public void testCompareGranularityLadderSharingAnEnd()
+    {
+        ListIterable<PureDate> ladder = Lists.immutable.with(
+                parse("2014"),
+                parse("2014-12"),
+                parse("2014-12-31"),
+                parse("2014-12-31T23"),
+                parse("2014-12-31T23:59"),
+                parse("2014-12-31T23:59:59"),
+                parse("2014-12-31T23:59:59.9"),
+                parse("2014-12-31T23:59:59.999999999"));
+        for (int i = 0; i < ladder.size(); i++)
+        {
+            PureDate coarser = ladder.get(i);
+            Assert.assertEquals(coarser.toString(), intervalEnd(ladder.get(0)), intervalEnd(coarser));
+            for (int j = i + 1; j < ladder.size(); j++)
+            {
+                PureDate finer = ladder.get(j);
+                String message = coarser + " vs " + finer;
+                Assert.assertEquals(message, -1, DateFunctions.compare(coarser, finer));
+                Assert.assertEquals(message, 1, DateFunctions.compare(finer, coarser));
+                Assert.assertEquals(message, AllenRelation.FINISHED_BY, allenRelation(coarser, finer));
+            }
+        }
+    }
+
+    /**
+     * A coarse date that properly contains a finer one sorts before it, wherever inside it the
+     * finer one falls.
+     */
+    @Test
+    public void testCompareContainingIntervalSortsFirst()
+    {
+        PureDate year = parse("2014");
+        ListIterable<PureDate> contained = Lists.immutable.with(
+                parse("2014-06"),
+                parse("2014-06-15"),
+                parse("2014-06-15T12"),
+                parse("2014-06-15T12:30"),
+                parse("2014-06-15T12:30:45"),
+                parse("2014-06-15T12:30:45.070004235"));
+        for (PureDate date : contained)
+        {
+            String message = year + " vs " + date;
+            Assert.assertEquals(message, AllenRelation.CONTAINS, allenRelation(year, date));
+            Assert.assertEquals(message, -1, DateFunctions.compare(year, date));
+            Assert.assertEquals(message, 1, DateFunctions.compare(date, year));
+        }
+
+        // and one level down: the month contains everything below it too
+        PureDate month = parse("2014-06");
+        Assert.assertEquals(-1, DateFunctions.compare(month, parse("2014-06-15T12:30")));
+        Assert.assertEquals(1, DateFunctions.compare(parse("2014-06-15T12:30"), month));
+    }
+
+    /**
+     * When the intervals are disjoint, granularity is irrelevant: whichever comes first on the time
+     * line sorts first.
+     */
+    @Test
+    public void testCompareDisjointIntervalsAcrossGranularities()
+    {
+        assertStrictlyIncreasing(Lists.immutable.with(
+                parse("2013-12-31T23:59:59.999"),
+                parse("2014"),
+                parse("2015-01-01T00"),
+                parse("2015-01-01T00:00:00.5"),
+                parse("2016-02"),
+                parse("2016-03-01")));
+
+        assertStrictlyIncreasing(Lists.immutable.with(
+                parse("2014-03"),
+                parse("2014-04-01T00:00"),
+                parse("2014-05"),
+                parse("2014-06-15T12:30:45.070004235"),
+                parse("2014-07")));
+    }
+
+    // The characterization itself
+
+    /**
+     * The full pairwise check: {@code compare} agrees with the Allen relation between the two
+     * intervals, for every ordered pair of the corpus, mixing granularities freely.
+     */
+    @Test
+    public void testCompareMatchesAllenCharacterization()
+    {
+        forEachPair((date1, date2) ->
+        {
+            AllenRelation relation = allenRelation(date1, date2);
+            int expected = LESS_THAN_RELATIONS.contains(relation) ? -1 : (GREATER_THAN_RELATIONS.contains(relation) ? 1 : 0);
+            Assert.assertEquals(date1 + " vs " + date2 + " (" + relation + ")", expected, DateFunctions.compare(date1, date2));
+            Assert.assertEquals(date1 + " vs " + date2, relation == AllenRelation.EQUALS, DateFunctions.compare(date1, date2) == 0);
+        });
+    }
+
+    /**
+     * Equivalent phrasing: {@code compare} sorts by interval start ascending, tie-broken by
+     * interval end <em>descending</em>. That is, it is the lexicographic comparison of
+     * {@code (start(a), -end(a))} against {@code (start(b), -end(b))}.
+     */
+    @Test
+    public void testCompareIsStartAscendingThenEndDescending()
+    {
+        forEachPair((date1, date2) ->
+        {
+            int startComparison = intervalStart(date1).compareTo(intervalStart(date2));
+            int endComparison = intervalEnd(date1).compareTo(intervalEnd(date2));
+            int expected = (startComparison != 0) ? Integer.signum(startComparison) : -Integer.signum(endComparison);
+            Assert.assertEquals(date1 + " vs " + date2, expected, DateFunctions.compare(date1, date2));
+        });
+    }
+
+    /**
+     * Equivalent phrasing: a sorts before b exactly when a starts before the starting of b, or a
+     * properly contains b.
+     */
+    @Test
+    public void testCompareIsNegativeIffStartsEarlierOrProperlyContains()
+    {
+        forEachPair((date1, date2) ->
+        {
+            boolean startsEarlier = intervalStart(date1).isBefore(intervalStart(date2));
+            boolean properlyContains = !intervalStart(date1).isAfter(intervalStart(date2)) &&
+                    !intervalEnd(date1).isBefore(intervalEnd(date2)) &&
+                    !date1.equals(date2);
+            Assert.assertEquals(date1 + " vs " + date2, startsEarlier || properlyContains, DateFunctions.compare(date1, date2) < 0);
+        });
+    }
+
+    /**
+     * {@code compare(a, b) == -1} is <em>not</em> "a ends before the ending of b". The year 2014
+     * contains June 2014 and sorts first, yet it ends six months later. Ordering by interval end
+     * would reverse this pair.
+     */
+    @Test
+    public void testCompareIsNotOrderingByIntervalEnd()
+    {
+        PureDate year = parse("2014");
+        PureDate month = parse("2014-06");
+
+        assertCompare(-1, "2014", "2014-06");
+        Assert.assertEquals(AllenRelation.CONTAINS, allenRelation(year, month));
+        Assert.assertTrue("the containing year ends after the contained month", intervalEnd(year).isAfter(intervalEnd(month)));
+    }
+
+    /**
+     * Neither is {@code compare(a, b) == -1} simply "a starts before the starting of b": the year
+     * 2014 and January 2014 start at the same instant, and the year still sorts first.
+     */
+    @Test
+    public void testCompareIsNotOrderingByIntervalStartAlone()
+    {
+        PureDate year = parse("2014");
+        PureDate january = parse("2014-01");
+
+        assertCompare(-1, "2014", "2014-01");
+        Assert.assertEquals(AllenRelation.STARTED_BY, allenRelation(year, january));
+        Assert.assertEquals("the year and January start together", intervalStart(year), intervalStart(january));
+    }
+
+    /**
+     * Pure date intervals are nested: any two are disjoint or one contains the other, so Allen's
+     * {@code overlaps} and {@code overlapped by} never arise. This is what keeps the ordering above
+     * well defined; a partially overlapping pair would have no consistent answer.
+     */
+    @Test
+    public void testDateIntervalsNeverPartiallyOverlap()
+    {
+        forEachPair((date1, date2) ->
+        {
+            AllenRelation relation = allenRelation(date1, date2);
+            Assert.assertNotEquals(date1 + " vs " + date2, AllenRelation.OVERLAPS, relation);
+            Assert.assertNotEquals(date1 + " vs " + date2, AllenRelation.OVERLAPPED_BY, relation);
+        });
+    }
+
+    /**
+     * Guards the corpus: every Allen relation other than the two impossible ones must actually be
+     * exercised by {@link #testCompareMatchesAllenCharacterization()}.
+     */
+    @Test
+    public void testAllRealizableAllenRelationsAreCovered()
+    {
+        EnumSet<AllenRelation> observed = EnumSet.noneOf(AllenRelation.class);
+        forEachPair((date1, date2) -> observed.add(allenRelation(date1, date2)));
+
+        EnumSet<AllenRelation> expected = EnumSet.allOf(AllenRelation.class);
+        expected.remove(AllenRelation.OVERLAPS);
+        expected.remove(AllenRelation.OVERLAPPED_BY);
+        Assert.assertEquals(expected, observed);
+    }
+
+    // General properties of the ordering
+
+    @Test
+    public void testCompareReturnsOnlyMinusOneZeroOrOne()
+    {
+        forEachPair((date1, date2) ->
+        {
+            int result = DateFunctions.compare(date1, date2);
+            Assert.assertTrue(date1 + " vs " + date2 + ": " + result, (result == -1) || (result == 0) || (result == 1));
+        });
+    }
+
+    @Test
+    public void testCompareIsAntisymmetric()
+    {
+        forEachPair((date1, date2) -> Assert.assertEquals(date1 + " vs " + date2, -DateFunctions.compare(date1, date2), DateFunctions.compare(date2, date1)));
+    }
+
+    @Test
+    public void testCompareIsReflexive()
+    {
+        for (PureDate date : DATES)
+        {
+            Assert.assertEquals(date.toString(), 0, DateFunctions.compare(date, date));
+            // not just the identity short circuit
+            PureDate copy = DateFunctions.parsePureDate(date.toString());
+            Assert.assertEquals(date.toString(), 0, DateFunctions.compare(date, copy));
+        }
+    }
+
+    @Test
+    public void testCompareIsTransitive()
+    {
+        for (PureDate date1 : DATES)
+        {
+            for (PureDate date2 : DATES)
+            {
+                if (DateFunctions.compare(date1, date2) < 0)
+                {
+                    for (PureDate date3 : DATES)
+                    {
+                        if (DateFunctions.compare(date2, date3) < 0)
+                        {
+                            Assert.assertTrue(date1 + " < " + date2 + " < " + date3, DateFunctions.compare(date1, date3) < 0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testCompareIsConsistentWithEquals()
+    {
+        forEachPair((date1, date2) ->
+        {
+            boolean equal = DateFunctions.compare(date1, date2) == 0;
+            Assert.assertEquals(date1 + " vs " + date2, equal, date1.equals(date2));
+            if (equal)
+            {
+                Assert.assertEquals(date1 + " vs " + date2, date1.hashCode(), date2.hashCode());
+            }
+        });
+    }
+
+    @Test
+    public void testCompareToDelegatesToCompare()
+    {
+        forEachPair((date1, date2) -> Assert.assertEquals(date1 + " vs " + date2, DateFunctions.compare(date1, date2), date1.compareTo(date2)));
+    }
+
+    @Test
+    public void testSortingMixedGranularities()
+    {
+        MutableList<PureDate> sorted = Lists.mutable.with(
+                parse("2014-06-15T12:30:45.070004235"),
+                parse("2014"),
+                parse("2015"),
+                parse("2014-06-15"),
+                parse("2013-12-31"),
+                parse("2014-06"),
+                parse("2014-06-15T12:30:45"),
+                parse("2014-06-15T12:30"),
+                parse("2014-07"),
+                parse("2014-06-15T12")).sortThis();
+        Assert.assertEquals(
+                Lists.mutable.with(
+                        "2013-12-31",
+                        "2014",
+                        "2014-06",
+                        "2014-06-15",
+                        "2014-06-15T12",
+                        "2014-06-15T12:30+0000",
+                        "2014-06-15T12:30:45+0000",
+                        "2014-06-15T12:30:45.070004235+0000",
+                        "2014-07",
+                        "2015"),
+                sorted.collect(PureDate::toString));
+    }
+
+    // Helpers
+
+    private static PureDate parse(String string)
+    {
+        return DateFunctions.parsePureDate(string);
+    }
+
+    /**
+     * Assert how the two dates compare, in both directions: comparing the second with the first must
+     * give the negation. Since {@code compare} is antisymmetric everywhere (see
+     * {@link #testCompareIsAntisymmetric()}), checking the mirror costs nothing and halves what each
+     * case has to spell out.
+     */
+    private static void assertCompare(int expected, String date1, String date2)
+    {
+        PureDate first = parse(date1);
+        PureDate second = parse(date2);
+        Assert.assertEquals(date1 + " vs " + date2, expected, DateFunctions.compare(first, second));
+        Assert.assertEquals(date2 + " vs " + date1, -expected, DateFunctions.compare(second, first));
+    }
+
+    private static void assertStrictlyIncreasing(ListIterable<PureDate> dates)
+    {
+        for (int i = 0; i < dates.size(); i++)
+        {
+            for (int j = i + 1; j < dates.size(); j++)
+            {
+                String message = dates.get(i) + " vs " + dates.get(j);
+                Assert.assertEquals(message, -1, DateFunctions.compare(dates.get(i), dates.get(j)));
+                Assert.assertEquals(message, 1, DateFunctions.compare(dates.get(j), dates.get(i)));
+            }
+        }
+    }
+
+    private static void forEachPair(BiConsumer<PureDate, PureDate> consumer)
+    {
+        for (PureDate date1 : DATES)
+        {
+            for (PureDate date2 : DATES)
+            {
+                consumer.accept(date1, date2);
+            }
+        }
+    }
+
+    /**
+     * The inclusive start of the interval denoted by the given date: every unspecified component
+     * takes its minimum value.
+     */
+    private static LocalDateTime intervalStart(PureDate date)
+    {
+        return LocalDateTime.of(
+                date.getYear(),
+                date.hasMonth() ? date.getMonth() : 1,
+                date.hasDay() ? date.getDay() : 1,
+                date.hasHour() ? date.getHour() : 0,
+                date.hasMinute() ? date.getMinute() : 0,
+                date.hasSecond() ? date.getSecond() : 0,
+                date.hasSubsecond() ? subsecondNanos(date.getSubsecond()) : 0);
+    }
+
+    /**
+     * The exclusive end of the interval denoted by the given date: its start advanced by one unit
+     * of its granularity.
+     */
+    private static LocalDateTime intervalEnd(PureDate date)
+    {
+        LocalDateTime start = intervalStart(date);
+        if (date.hasSubsecond())
+        {
+            return start.plusNanos(subsecondWidthInNanos(date.getSubsecond()));
+        }
+        if (date.hasSecond())
+        {
+            return start.plusSeconds(1);
+        }
+        if (date.hasMinute())
+        {
+            return start.plusMinutes(1);
+        }
+        if (date.hasHour())
+        {
+            return start.plusHours(1);
+        }
+        if (date.hasDay())
+        {
+            return start.plusDays(1);
+        }
+        if (date.hasMonth())
+        {
+            return start.plusMonths(1);
+        }
+        return start.plusYears(1);
+    }
+
+    private static int subsecondNanos(String subsecond)
+    {
+        Assert.assertTrue("this test models subseconds with LocalDateTime, so at most 9 digits: " + subsecond, subsecond.length() <= 9);
+        StringBuilder builder = new StringBuilder(subsecond);
+        while (builder.length() < 9)
+        {
+            builder.append('0');
+        }
+        return Integer.parseInt(builder.toString());
+    }
+
+    private static long subsecondWidthInNanos(String subsecond)
+    {
+        Assert.assertTrue("this test models subseconds with LocalDateTime, so at most 9 digits: " + subsecond, subsecond.length() <= 9);
+        long width = 1_000_000_000L;
+        for (int i = 0; i < subsecond.length(); i++)
+        {
+            width /= 10L;
+        }
+        return width;
+    }
+
+    /**
+     * The Allen relation from the first interval to the second, computed from the interval
+     * endpoints alone (with half-open intervals, so {@code meets} means that one ends exactly where
+     * the next begins).
+     */
+    private static AllenRelation allenRelation(PureDate date1, PureDate date2)
+    {
+        LocalDateTime start1 = intervalStart(date1);
+        LocalDateTime end1 = intervalEnd(date1);
+        LocalDateTime start2 = intervalStart(date2);
+        LocalDateTime end2 = intervalEnd(date2);
+
+        int startComparison = start1.compareTo(start2);
+        int endComparison = end1.compareTo(end2);
+
+        if (startComparison == 0)
+        {
+            if (endComparison == 0)
+            {
+                return AllenRelation.EQUALS;
+            }
+            return (endComparison < 0) ? AllenRelation.STARTS : AllenRelation.STARTED_BY;
+        }
+
+        if (startComparison < 0)
+        {
+            int comparison = end1.compareTo(start2);
+            if (comparison < 0)
+            {
+                return AllenRelation.BEFORE;
+            }
+            if (comparison == 0)
+            {
+                return AllenRelation.MEETS;
+            }
+            if (endComparison < 0)
+            {
+                return AllenRelation.OVERLAPS;
+            }
+            return (endComparison == 0) ? AllenRelation.FINISHED_BY : AllenRelation.CONTAINS;
+        }
+
+        int comparison = end2.compareTo(start1);
+        if (comparison < 0)
+        {
+            return AllenRelation.AFTER;
+        }
+        if (comparison == 0)
+        {
+            return AllenRelation.MET_BY;
+        }
+        if (endComparison > 0)
+        {
+            return AllenRelation.OVERLAPPED_BY;
+        }
+        return (endComparison == 0) ? AllenRelation.FINISHES : AllenRelation.DURING;
+    }
+
+    /**
+     * The thirteen relations of Allen's interval algebra. {@code OVERLAPS} and {@code OVERLAPPED_BY}
+     * cannot arise between Pure dates.
+     */
+    private enum AllenRelation
+    {
+        BEFORE,
+        MEETS,
+        OVERLAPS,
+        FINISHED_BY,
+        CONTAINS,
+        STARTS,
+        EQUALS,
+        STARTED_BY,
+        DURING,
+        FINISHES,
+        OVERLAPPED_BY,
+        MET_BY,
+        AFTER
+    }
+}

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateDifference.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateDifference.java
@@ -1,0 +1,673 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m4.coreinstance.primitive.date;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link DateFunctions#dateDifference(PureDate, PureDate, String)}, which backs the Pure
+ * function {@code meta::pure::functions::date::dateDiff} on both engines.
+ *
+ * <h2>What the units mean</h2>
+ *
+ * <p>A Pure date covers a span of time rather than naming an instant, so it is read here as the
+ * first instant of that span: a date with no month starts in January, one with no day starts on the
+ * first, and one with no time starts at midnight. The units then fall into two groups.
+ *
+ * <p><b>Calendar units count boundaries crossed, ignoring everything finer.</b> YEARS is the
+ * difference of the two year numbers, MONTHS the difference of the two months counted from year
+ * zero, and DAYS the difference of the two calendar days. So 2015-12-31T23:59:59 to
+ * 2016-01-01T00:00:01 is one YEAR even though only two seconds passed, and 2016-02-01 to 2016-02-29
+ * is zero MONTHS even though almost a month passed.
+ *
+ * <p><b>Time units count elapsed time, truncated toward zero.</b> HOURS, MINUTES, SECONDS,
+ * MILLISECONDS, MICROSECONDS, and NANOSECONDS all measure how much time actually passed and drop
+ * the remainder, so 13:00:00 to 13:01:01 is one MINUTE and 23:00:00 to 01:59:59 the next day is two
+ * HOURS.
+ *
+ * <p><b>WEEKS counts Sundays passed</b>, and is the one unit that is not symmetric. Counting
+ * forwards, a Sunday is counted if it falls after the first date and on or before the second.
+ * Counting backwards, it is counted if it falls on or after the second date and before the first.
+ * So Saturday to the following Sunday is 1, while that Sunday back to the Saturday is 0 rather than
+ * -1. This is longstanding behavior pinned by the PCT tests.
+ *
+ * <p>The sign follows the direction: the result is positive when the second date is the later of
+ * the two, negative when it is the earlier, and zero when neither is.
+ *
+ * <h2>Relationship to the PCT tests</h2>
+ *
+ * <p>{@link #testContractYears()} through {@link #testContractDifferentTimeZones()} mirror, case for
+ * case, the {@code <<PCT.test>>} functions in
+ * {@code platform/pure/essential/date/operation/dateDiff.pure}. Those run against both engines and
+ * are the real contract; these run in milliseconds and fail here first. Keep the two in step.
+ */
+public class TestDateDifference
+{
+    private static final ListIterable<String> UNITS = Lists.immutable.with(
+            "YEARS", "MONTHS", "WEEKS", "DAYS", "HOURS", "MINUTES", "SECONDS", "MILLISECONDS", "MICROSECONDS", "NANOSECONDS");
+
+    // The contract, mirroring dateDiff.pure
+
+    @Test
+    public void testContractYears()
+    {
+        assertDateDifference(1, "2015", "2016", "YEARS");
+        assertDateDifference(-1, "2016", "2015", "YEARS");
+        assertDateDifference(20, "2000", "2020", "YEARS");
+        assertDateDifference(-20, "2020", "2000", "YEARS");
+        assertDateDifference(0, "2015", "2015", "YEARS");
+        assertDateDifference(0, "2015-01-01T00:00:00", "2015-12-31T23:59:59", "YEARS");
+        assertDateDifference(1, "2015-12-31T23:59:59", "2016-01-01T00:00:01", "YEARS");
+    }
+
+    @Test
+    public void testContractMonths()
+    {
+        assertDateDifference(0, "2016-02-01", "2016-02-01", "MONTHS");
+        assertDateDifference(0, "2016-02-01", "2016-02-29", "MONTHS");
+        assertDateDifference(1, "2016-02-01", "2016-03-01", "MONTHS");
+        assertDateDifference(-1, "2016-03-01", "2016-02-01", "MONTHS");
+        assertDateDifference(12, "2015-01-29", "2016-01-29", "MONTHS");
+        assertDateDifference(14, "2015-01-29", "2016-03-29", "MONTHS");
+        assertDateDifference(-14, "2016-03-29", "2015-01-29", "MONTHS");
+        assertDateDifference(0, "2014-12-01T00:00:00", "2014-12-01T23:59:59", "MONTHS");
+        assertDateDifference(11, "2016-01-01", "2016-12-31", "MONTHS");
+        assertDateDifference(11, "2016-01-31", "2016-12-31", "MONTHS");
+        assertDateDifference(12, "2016-01-01", "2017-01-01", "MONTHS");
+    }
+
+    @Test
+    public void testContractWeeks()
+    {
+        assertDateDifference(0, "2015-07-05", "2015-07-05", "WEEKS");
+        assertDateDifference(0, "2015-07-03", "2015-07-04", "WEEKS");
+        assertDateDifference(1, "2015-07-04", "2015-07-05", "WEEKS");
+        assertDateDifference(0, "2015-07-05", "2015-07-04", "WEEKS");
+        assertDateDifference(1, "2015-07-05", "2015-07-12", "WEEKS");
+        assertDateDifference(-1, "2015-07-12", "2015-07-05", "WEEKS");
+        assertDateDifference(0, "2015-07-12", "2015-07-06", "WEEKS");
+        assertDateDifference(4, "2015-07-05", "2015-08-02", "WEEKS");
+        assertDateDifference(-4, "2015-08-02", "2015-07-05", "WEEKS");
+        assertDateDifference(-3, "2015-08-02", "2015-07-06", "WEEKS");
+        assertDateDifference(1, "2014-12-28", "2015-01-04", "WEEKS");
+        assertDateDifference(52, "2015-01-01", "2016-01-01", "WEEKS");
+        assertDateDifference(52, "2016-01-01", "2016-12-31", "WEEKS");
+        assertDateDifference(53, "2016-01-01", "2017-01-01", "WEEKS");
+    }
+
+    @Test
+    public void testContractDays()
+    {
+        assertDateDifference(0, "2015-07-07", "2015-07-07", "DAYS");
+        assertDateDifference(1, "2015-07-07", "2015-07-08", "DAYS");
+        assertDateDifference(-1, "2015-07-08", "2015-07-07", "DAYS");
+        assertDateDifference(365, "2015-01-1", "2016-01-01", "DAYS");
+        assertDateDifference(366, "2016-01-1", "2017-01-01", "DAYS");
+        assertDateDifference(394, "2014-01-31", "2015-03-01", "DAYS");
+        assertDateDifference(395, "2016-01-31", "2017-03-01", "DAYS");
+        assertDateDifference(-395, "2017-03-01", "2016-01-31", "DAYS");
+        assertDateDifference(7, "2014-12-28", "2015-01-04", "DAYS");
+        assertDateDifference(-7, "2015-01-04", "2014-12-28", "DAYS");
+    }
+
+    @Test
+    public void testContractHours()
+    {
+        assertDateDifference(0, "2015-07-07T13:00:00", "2015-07-07T13:00:00", "HOURS");
+        assertDateDifference(1, "2015-07-07T13:00:00", "2015-07-07T14:00:00", "HOURS");
+        assertDateDifference(-1, "2015-07-07T14:00:00", "2015-07-07T13:00:00", "HOURS");
+        assertDateDifference(2, "2015-07-07T23:00:00", "2015-07-08T01:00:00", "HOURS");
+        assertDateDifference(2, "2015-07-07T23:00:00", "2015-07-08T01:59:59", "HOURS");
+        assertDateDifference(24, "2014-12-31T23:00:00", "2015-01-01T23:00:00", "HOURS");
+        assertDateDifference(0, "2014-12-01T00:00:00", "2014-12-01T00:59:59", "HOURS");
+    }
+
+    @Test
+    public void testContractMinutes()
+    {
+        assertDateDifference(0, "2015-07-07T13:00:00", "2015-07-07T13:00:00", "MINUTES");
+        assertDateDifference(1, "2015-07-07T13:00:00", "2015-07-07T13:01:00", "MINUTES");
+        assertDateDifference(-1, "2015-07-07T13:01:00", "2015-07-07T13:00:00", "MINUTES");
+        assertDateDifference(1, "2015-07-07T13:00:00", "2015-07-07T13:01:01", "MINUTES");
+        assertDateDifference(61, "2015-07-07T13:00:00", "2015-07-07T14:01:00", "MINUTES");
+        assertDateDifference(120, "2015-07-07T23:00:00", "2015-07-08T01:00:00", "MINUTES");
+        assertDateDifference(0, "2014-12-01T00:00:00", "2014-12-01T00:00:59", "MINUTES");
+    }
+
+    @Test
+    public void testContractSeconds()
+    {
+        assertDateDifference(0, "2015-07-07T13:00:00", "2015-07-07T13:00:00", "SECONDS");
+        assertDateDifference(1, "2015-07-07T13:00:00", "2015-07-07T13:00:01", "SECONDS");
+        assertDateDifference(-1, "2015-07-07T13:00:01", "2015-07-07T13:00:00", "SECONDS");
+        assertDateDifference(60, "2015-07-07T13:00:00", "2015-07-07T13:01:00", "SECONDS");
+        assertDateDifference(61, "2015-07-07T13:00:00", "2015-07-07T13:01:01", "SECONDS");
+        assertDateDifference(3661, "2015-07-07T13:00:00", "2015-07-07T14:01:01", "SECONDS");
+        assertDateDifference(7200, "2015-07-07T23:00:00", "2015-07-08T01:00:00", "SECONDS");
+    }
+
+    @Test
+    public void testContractMilliseconds()
+    {
+        assertDateDifference(0, "2015-07-07T13:00:00", "2015-07-07T13:00:00", "MILLISECONDS");
+        assertDateDifference(1000, "2015-07-07T13:00:00", "2015-07-07T13:00:01", "MILLISECONDS");
+        assertDateDifference(-1000, "2015-07-07T13:00:01", "2015-07-07T13:00:00", "MILLISECONDS");
+        assertDateDifference(60000, "2015-07-07T13:00:00", "2015-07-07T13:01:00", "MILLISECONDS");
+        assertDateDifference(61000, "2015-07-07T13:00:00", "2015-07-07T13:01:01", "MILLISECONDS");
+        assertDateDifference(3661000, "2015-07-07T13:00:00", "2015-07-07T14:01:01", "MILLISECONDS");
+        assertDateDifference(7200000, "2015-07-07T23:00:00", "2015-07-08T01:00:00", "MILLISECONDS");
+    }
+
+    /**
+     * MICROSECONDS and NANOSECONDS have no {@code <<PCT.test>>} of their own, since {@code dateDiff}
+     * did not accept them until they were added alongside the {@code adjust} units of the same names.
+     * They behave as the other time units do.
+     */
+    @Test
+    public void testMicrosecondsAndNanoseconds()
+    {
+        assertDateDifference(0, "2015-07-07T13:00:00.000000", "2015-07-07T13:00:00.000000", "MICROSECONDS");
+        assertDateDifference(1, "2015-07-07T13:00:00.000000", "2015-07-07T13:00:00.000001", "MICROSECONDS");
+        assertDateDifference(-1, "2015-07-07T13:00:00.000001", "2015-07-07T13:00:00.000000", "MICROSECONDS");
+        assertDateDifference(1000, "2015-07-07T13:00:00.000", "2015-07-07T13:00:00.001", "MICROSECONDS");
+        assertDateDifference(1000000, "2015-07-07T13:00:00", "2015-07-07T13:00:01", "MICROSECONDS");
+
+        assertDateDifference(0, "2015-07-07T13:00:00.000000000", "2015-07-07T13:00:00.000000000", "NANOSECONDS");
+        assertDateDifference(1, "2015-07-07T13:00:00.000000000", "2015-07-07T13:00:00.000000001", "NANOSECONDS");
+        assertDateDifference(-1, "2015-07-07T13:00:00.000000001", "2015-07-07T13:00:00.000000000", "NANOSECONDS");
+        assertDateDifference(1000, "2015-07-07T13:00:00.000000", "2015-07-07T13:00:00.000001", "NANOSECONDS");
+        assertDateDifference(1000000000, "2015-07-07T13:00:00", "2015-07-07T13:00:01", "NANOSECONDS");
+
+        // remainders finer than the unit are still dropped
+        assertDateDifference(0, "2015-07-07T13:00:00.0000000001", "2015-07-07T13:00:00.0000009999", "MICROSECONDS");
+        assertDateDifference(999, "2015-07-07T13:00:00.000000000", "2015-07-07T13:00:00.0000009999", "NANOSECONDS");
+    }
+
+    /**
+     * Offsets are folded into UTC when the date is parsed, so two spellings of the same instant are
+     * the same date and every difference between them is zero.
+     */
+    @Test
+    public void testContractDifferentTimeZones()
+    {
+        PureDate newYork = DateFunctions.parsePureDate("2014-12-31T23:00:00.000-0500");
+        PureDate paris = DateFunctions.parsePureDate("2015-1-1T5:00:00.000+0100");
+        Assert.assertEquals(newYork, paris);
+
+        Assert.assertEquals(0, DateFunctions.dateDifference(newYork, paris, "YEARS"));
+        Assert.assertEquals(0, DateFunctions.dateDifference(newYork, paris, "MONTHS"));
+        Assert.assertEquals(0, DateFunctions.dateDifference(newYork, paris, "HOURS"));
+        Assert.assertEquals(0, DateFunctions.dateDifference(newYork, paris, "MINUTES"));
+        Assert.assertEquals(0, DateFunctions.dateDifference(newYork, paris, "SECONDS"));
+    }
+
+    // Sign and symmetry
+
+    /**
+     * The sign says which way round the two dates are, for every unit.
+     */
+    @Test
+    public void testSignFollowsTheDirection()
+    {
+        PureDate earlier = DateFunctions.parsePureDate("2015-07-07T13:00:00");
+        PureDate later = DateFunctions.parsePureDate("2016-09-11T17:30:45");
+        for (String unit : UNITS)
+        {
+            Assert.assertTrue(unit, DateFunctions.dateDifference(earlier, later, unit) > 0);
+            Assert.assertTrue(unit, DateFunctions.dateDifference(later, earlier, unit) < 0);
+            Assert.assertEquals(unit, 0, DateFunctions.dateDifference(earlier, earlier, unit));
+            Assert.assertEquals(unit, 0, DateFunctions.dateDifference(later, later, unit));
+        }
+    }
+
+    /**
+     * Every unit but WEEKS gives the same magnitude in both directions.
+     */
+    @Test
+    public void testAntisymmetry()
+    {
+        ListIterable<String> dates = Lists.immutable.with(
+                "2014", "2014-03", "2014-03-10", "2015-07-05", "2015-07-06", "2015-08-02",
+                "2016-02-29", "2015-07-07T13:00:00", "2015-07-07T13:00:00.123456789", "2017-03-01");
+        for (String from : dates)
+        {
+            for (String to : dates)
+            {
+                for (String unit : UNITS)
+                {
+                    if (!"WEEKS".equals(unit))
+                    {
+                        String message = from + " <-> " + to + " in " + unit;
+                        long forward = DateFunctions.dateDifference(parse(from), parse(to), unit);
+                        long backward = DateFunctions.dateDifference(parse(to), parse(from), unit);
+                        Assert.assertEquals(message, forward, -backward);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * WEEKS is deliberately not antisymmetric: a Sunday is counted when it is the date being counted
+     * to, but not when it is the date being counted from. The magnitudes differ by one exactly when
+     * a Sunday sits on one of the two endpoints.
+     */
+    @Test
+    public void testWeeksIsNotAntisymmetric()
+    {
+        // 2015-07-05 and 2015-07-12 are Sundays, 2015-07-04 a Saturday, 2015-07-06 a Monday
+        assertDateDifference(1, "2015-07-04", "2015-07-05", "WEEKS");
+        assertDateDifference(0, "2015-07-05", "2015-07-04", "WEEKS");
+
+        assertDateDifference(1, "2015-07-06", "2015-07-12", "WEEKS");
+        assertDateDifference(0, "2015-07-12", "2015-07-06", "WEEKS");
+
+        // when neither endpoint is a Sunday the two directions do mirror
+        assertDateDifference(1, "2015-07-04", "2015-07-06", "WEEKS");
+        assertDateDifference(-1, "2015-07-06", "2015-07-04", "WEEKS");
+    }
+
+    /**
+     * Sunday is the day the week count turns over, so a whole Monday to Saturday stretch counts as
+     * no weeks at all while a single step across a Sunday counts as one.
+     */
+    @Test
+    public void testWeeksCountsSundaysPassed()
+    {
+        // 2015-07-06 is a Monday, 2015-07-11 the Saturday of the same week
+        assertDateDifference(0, "2015-07-06", "2015-07-11", "WEEKS");
+        assertDateDifference(1, "2015-07-11", "2015-07-12", "WEEKS");
+
+        // and one Sunday per week thereafter
+        assertDateDifference(1, "2015-07-06", "2015-07-12", "WEEKS");
+        assertDateDifference(2, "2015-07-06", "2015-07-19", "WEEKS");
+        assertDateDifference(3, "2015-07-06", "2015-07-26", "WEEKS");
+
+        // time of day is not consulted
+        assertDateDifference(1, "2015-07-11T23:59:59", "2015-07-12T00:00:00", "WEEKS");
+        assertDateDifference(0, "2015-07-12T00:00:00", "2015-07-12T23:59:59", "WEEKS");
+    }
+
+    // Which family a unit belongs to
+
+    /**
+     * The calendar units count boundaries crossed and ignore everything finer than the unit, while
+     * the time units measure elapsed time. Nothing else pins this apart: the two readings agree
+     * whenever the first date sits on a boundary of the unit, which every case in
+     * {@code dateDiff.pure} does, so only operands offset from the boundary tell them apart.
+     */
+    @Test
+    public void testTimeUnitsMeasureElapsedTimeNotBoundariesCrossed()
+    {
+        // the same two minutes: one DAY crossed, but zero HOURS, though an hour boundary was crossed too
+        assertDateDifference(1, "2015-07-07T23:59:00", "2015-07-08T00:01:00", "DAYS");
+        assertDateDifference(0, "2015-07-07T23:59:00", "2015-07-08T00:01:00", "HOURS");
+
+        // two minutes across an hour boundary, and fifty-nine minutes within one, are both zero HOURS
+        assertDateDifference(0, "2015-07-07T12:59:00", "2015-07-07T13:01:00", "HOURS");
+        assertDateDifference(0, "2015-07-07T12:00:00", "2015-07-07T12:59:00", "HOURS");
+
+        // likewise 200ms across a second boundary is zero SECONDS
+        assertDateDifference(0, "2015-07-07T13:00:00.900", "2015-07-07T13:00:01.100", "SECONDS");
+
+        // measured from a boundary, the two readings coincide again
+        assertDateDifference(1, "2015-07-07T23:00:00", "2015-07-08T00:01:00", "HOURS");
+        assertDateDifference(1, "2015-07-07T13:00:00.000", "2015-07-07T13:00:01.100", "SECONDS");
+
+        // the calendar units ignore the time entirely, so any part of the later day counts
+        assertDateDifference(1, "2015-07-07T00:00:00", "2015-07-08T00:00:01", "DAYS");
+        assertDateDifference(1, "2015-07-31T23:59:59", "2015-08-01T00:00:00", "MONTHS");
+        assertDateDifference(1, "2015-12-31T23:59:59", "2016-01-01T00:00:00", "YEARS");
+    }
+
+    // Granularity
+
+    /**
+     * A date coarser than the unit being measured is read as the first instant of the span it
+     * covers, so a year starts in January on the first at midnight.
+     */
+    @Test
+    public void testCoarseDatesAreReadAsTheStartOfTheirSpan()
+    {
+        // a year behaves as its first day
+        assertDateDifference(0, "2014", "2014-01-01", "DAYS");
+        assertDateDifference(0, "2014", "2014-01", "MONTHS");
+        assertDateDifference(0, "2014", "2014-01-01T00:00:00", "SECONDS");
+        assertDateDifference(365, "2014", "2015", "DAYS");
+        assertDateDifference(12, "2014", "2015", "MONTHS");
+
+        // a month behaves as its first day
+        assertDateDifference(0, "2014-03", "2014-03-01", "DAYS");
+        assertDateDifference(14, "2014-03", "2014-03-15", "DAYS");
+        assertDateDifference(31, "2014-03", "2014-04", "DAYS");
+
+        // a day behaves as midnight
+        assertDateDifference(0, "2014-03-10", "2014-03-10T00:00:00", "SECONDS");
+        assertDateDifference(3600, "2014-03-10", "2014-03-10T01:00:00", "SECONDS");
+    }
+
+    /**
+     * Mixed granularities work in every unit. A month-granularity date has a month, so measuring
+     * months against it is meaningful; a year-granularity date is taken to be January.
+     */
+    @Test
+    public void testMixedGranularities()
+    {
+        assertDateDifference(5, "2014", "2014-06", "MONTHS");
+        assertDateDifference(-5, "2014-06", "2014", "MONTHS");
+        assertDateDifference(17, "2014", "2015-06", "MONTHS");
+        assertDateDifference(5, "2014", "2014-06-15", "MONTHS");
+        assertDateDifference(5, "2014", "2014-06-15T12:30:45", "MONTHS");
+
+        assertDateDifference(2, "2014", "2016-06-15", "YEARS");
+        assertDateDifference(-2, "2016-06-15", "2014", "YEARS");
+
+        assertDateDifference(165, "2014", "2014-06-15", "DAYS");
+        // 2014-06-15 is itself a Sunday, and is counted
+        assertDateDifference(24, "2014", "2014-06-15", "WEEKS");
+    }
+
+    // Precision
+
+    /**
+     * Subsecond digits are honored down to the nanosecond, so a difference smaller than the unit
+     * being measured truncates to zero instead of being rounded up by a coarser intermediate.
+     */
+    @Test
+    public void testSubsecondPrecision()
+    {
+        // just under a millisecond short of a full second
+        assertDateDifference(999, "2015-07-07T13:00:00.0009", "2015-07-07T13:00:01.0000", "MILLISECONDS");
+        assertDateDifference(-999, "2015-07-07T13:00:01.0000", "2015-07-07T13:00:00.0009", "MILLISECONDS");
+
+        // one nanosecond short of a full second
+        assertDateDifference(999, "2015-07-07T13:00:00.000000001", "2015-07-07T13:00:01.000000000", "MILLISECONDS");
+
+        // differences finer than the unit truncate toward zero
+        assertDateDifference(0, "2015-07-07T13:00:00.000000001", "2015-07-07T13:00:00.000000002", "MILLISECONDS");
+        assertDateDifference(0, "2015-07-07T13:00:00.999", "2015-07-07T13:00:01.000", "SECONDS");
+        assertDateDifference(1, "2015-07-07T13:00:00.000", "2015-07-07T13:00:01.000", "SECONDS");
+
+        // exact millisecond boundaries are not lost
+        assertDateDifference(1, "2015-07-07T13:00:00.000", "2015-07-07T13:00:00.001", "MILLISECONDS");
+        assertDateDifference(1500, "2015-07-07T13:00:00.000", "2015-07-07T13:00:01.500", "MILLISECONDS");
+
+        // digits beyond the nanosecond do not contribute
+        assertDateDifference(0, "2015-07-07T13:00:00.0000000001", "2015-07-07T13:00:00.0000000009", "MILLISECONDS");
+    }
+
+    /**
+     * Spans crossing a day, a month, and a leap day, in units finer than the span itself.
+     */
+    @Test
+    public void testSpansCrossingBoundaries()
+    {
+        assertDateDifference(3, "2014", "2017", "YEARS");
+        assertDateDifference(14, "2014-03", "2015-05", "MONTHS");
+        assertDateDifference(2, "2014-03-10", "2014-03-24", "WEEKS");
+        assertDateDifference(365, "2014-03-10", "2015-03-10", "DAYS");
+        assertDateDifference(366, "2015-03-10", "2016-03-10", "DAYS");
+        assertDateDifference(29, "2016-02-01", "2016-03-01", "DAYS");
+        assertDateDifference(28, "2015-02-01", "2015-03-01", "DAYS");
+
+        assertDateDifference(25, "2014-03-10T16:12:35.000", "2014-03-11T17:12:35.000", "HOURS");
+        assertDateDifference(90, "2014-03-10T16:12:35.000", "2014-03-10T17:42:35.000", "MINUTES");
+        assertDateDifference(65, "2014-03-10T16:12:35.000", "2014-03-10T16:13:40.000", "SECONDS");
+        assertDateDifference(1070, "2014-03-10T16:12:35.000", "2014-03-10T16:12:36.070", "MILLISECONDS");
+    }
+
+    // The relationship to adjust
+
+    /**
+     * {@code dateDiff} and {@code meta::pure::functions::date::adjust} are inverse when the unit
+     * names the granularity that both dates have: measure the gap between two days in DAYS and
+     * adjusting the first date by that many days lands exactly on the second.
+     *
+     * <p>Each unit that names a granularity is checked over every ordered pair of a run of dates at
+     * that granularity, chosen to cross the boundary above it. {@code adjust} dispatches to the
+     * {@code PureDate.addX} methods driven here, so this is the same arithmetic the Pure function
+     * performs.
+     *
+     * <p>The invariant holds only on this diagonal, and the two ways off it both fail for reasons
+     * fixed by design rather than by accident, so they are pinned in
+     * {@link #testAdjustDoesNotInvertDateDifferenceOffTheDiagonal()}.
+     */
+    @Test
+    public void testAdjustInvertsDateDifferenceAtMatchingGranularity()
+    {
+        assertAdjustInverts("YEARS", PureDate::addYears, yearDates());
+        assertAdjustInverts("MONTHS", PureDate::addMonths, runOf(DateFunctions.newPureDate(2015, 11), 30, PureDate::addMonths));
+        assertAdjustInverts("DAYS", PureDate::addDays, runOf(DateFunctions.newPureDate(2015, 11, 1), 200, PureDate::addDays));
+        assertAdjustInverts("HOURS", PureDate::addHours, runOf(DateFunctions.newPureDate(2015, 12, 31, 20), 30, PureDate::addHours));
+        assertAdjustInverts("MINUTES", PureDate::addMinutes, runOf(DateFunctions.newPureDate(2015, 12, 31, 23, 45), 30, PureDate::addMinutes));
+        assertAdjustInverts("SECONDS", PureDate::addSeconds, runOf(DateFunctions.newPureDate(2015, 12, 31, 23, 59, 45), 30, PureDate::addSeconds));
+        assertAdjustInverts("MILLISECONDS", PureDate::addMilliseconds, runOf(DateFunctions.newPureDate(2015, 12, 31, 23, 59, 59, "985"), 30, PureDate::addMilliseconds));
+        assertAdjustInverts("MICROSECONDS", PureDate::addMicroseconds, runOf(DateFunctions.newPureDate(2015, 12, 31, 23, 59, 59, "999985"), 30, PureDate::addMicroseconds));
+        assertAdjustInverts("NANOSECONDS", PureDate::addNanoseconds, runOf(DateFunctions.newPureDate(2015, 12, 31, 23, 59, 59, "999999985"), 30, PureDate::addNanoseconds));
+    }
+
+    /**
+     * Off the diagonal the two functions are not inverse, in two distinct ways.
+     *
+     * <p>A unit finer than the date's granularity cannot be adjusted by at all, so {@code dateDiff}
+     * returns a number {@code adjust} will not accept. A unit coarser than the granularity loses the
+     * finer components, either because {@code dateDiff} truncates or because {@code adjust} clamps to
+     * the end of a short month. WEEKS is never an inverse at any granularity, because adjusting by
+     * weeks adds seven days while measuring in weeks counts Sundays.
+     */
+    @Test
+    public void testAdjustDoesNotInvertDateDifferenceOffTheDiagonal()
+    {
+        // a unit finer than the granularity: dateDiff answers, adjust refuses
+        PureDate year = DateFunctions.parsePureDate("2014");
+        Assert.assertEquals(365, DateFunctions.dateDifference(year, DateFunctions.parsePureDate("2015"), "DAYS"));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> year.addDays(365));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> year.addMonths(1));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> DateFunctions.parsePureDate("2015-01").addDays(1));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> DateFunctions.parsePureDate("2015-01-31").addHours(1));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> DateFunctions.parsePureDate("2015-01-31T13:11:11").addMilliseconds(1));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> DateFunctions.parsePureDate("2015-01-31T13:11:11.338").addMicroseconds(1));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> DateFunctions.parsePureDate("2015-01-31T13:11:11.338000").addNanoseconds(1));
+
+        // a unit coarser than the granularity: dateDiff truncates
+        PureDate midnight = DateFunctions.parsePureDate("2015-04-15T00");
+        PureDate midday = DateFunctions.parsePureDate("2015-04-15T12");
+        Assert.assertEquals(0, DateFunctions.dateDifference(midnight, midday, "DAYS"));
+        Assert.assertEquals(midnight, midnight.addDays(0));
+
+        // a unit coarser than the granularity: adjust clamps to the end of a short month
+        PureDate endOfJanuary = DateFunctions.parsePureDate("2015-01-31");
+        PureDate firstOfMarch = DateFunctions.parsePureDate("2015-03-01");
+        Assert.assertEquals(2, DateFunctions.dateDifference(endOfJanuary, firstOfMarch, "MONTHS"));
+        Assert.assertEquals(DateFunctions.parsePureDate("2015-03-31"), endOfJanuary.addMonths(2));
+
+        // WEEKS measures Sundays but adjusts by seven days
+        PureDate saturday = DateFunctions.parsePureDate("2015-07-04");
+        PureDate sunday = DateFunctions.parsePureDate("2015-07-05");
+        Assert.assertEquals(1, DateFunctions.dateDifference(saturday, sunday, "WEEKS"));
+        Assert.assertEquals(DateFunctions.parsePureDate("2015-07-11"), saturday.addWeeks(1));
+    }
+
+    /**
+     * Dates of different granularity can never satisfy the invariant, whatever the unit or the
+     * values: {@code adjust} returns a date of the granularity it was given, and a date is never
+     * equal to one of a different granularity.
+     */
+    @Test
+    public void testAdjustPreservesGranularitySoMixedGranularitiesCannotInvert()
+    {
+        PureDate year = DateFunctions.parsePureDate("2014");
+        Assert.assertEquals(DateFunctions.parsePureDate("2015"), year.addYears(1));
+
+        PureDate month = DateFunctions.parsePureDate("2014-06");
+        Assert.assertEquals(DateFunctions.parsePureDate("2014-07"), month.addMonths(1));
+
+        PureDate second = DateFunctions.parsePureDate("2015-01-31T13:55:21");
+        Assert.assertEquals(DateFunctions.parsePureDate("2015-02-28T13:55:21"), second.addMonths(1));
+
+        // so no amount of adjustment turns a year into a month, whatever the difference says
+        long difference = DateFunctions.dateDifference(year, month, "MONTHS");
+        Assert.assertEquals(5, difference);
+        Assert.assertThrows(UnsupportedOperationException.class, () -> year.addMonths(difference));
+    }
+
+    // Units
+
+    @Test
+    public void testUnsupportedUnit()
+    {
+        PureDate from = DateFunctions.parsePureDate("2015-07-07");
+        PureDate to = DateFunctions.parsePureDate("2015-07-08");
+
+        Assert.assertEquals(
+                "Unsupported duration unit: FORTNIGHTS",
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.dateDifference(from, to, "FORTNIGHTS")).getMessage());
+        Assert.assertEquals(
+                "Unsupported duration unit: years",
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.dateDifference(from, to, "years")).getMessage());
+
+        // the unit is checked even when the two dates are the same
+        Assert.assertEquals(
+                "Unsupported duration unit: FORTNIGHTS",
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.dateDifference(from, from, "FORTNIGHTS")).getMessage());
+    }
+
+    @Test
+    public void testEveryDurationUnitIsSupported()
+    {
+        PureDate from = DateFunctions.parsePureDate("2015-07-07T13:00:00");
+        PureDate to = DateFunctions.parsePureDate("2015-07-08T13:00:00");
+        for (String unit : UNITS)
+        {
+            DateFunctions.dateDifference(from, to, unit);
+        }
+    }
+
+    /**
+     * The subsecond units can run out of room, and say so rather than wrapping. NANOSECONDS is the
+     * one to watch: a long holds only about 292 years of them, which is a span real data can reach.
+     */
+    @Test
+    public void testFineUnitsOverflowOnLargeSpans()
+    {
+        PureDate min = DateFunctions.newPureDate(java.time.Year.MIN_VALUE);
+        PureDate max = DateFunctions.newPureDate(java.time.Year.MAX_VALUE);
+
+        // over the full supported range every unit down to the second still fits
+        Assert.assertEquals(1999999998L, DateFunctions.dateDifference(min, max, "YEARS"));
+        Assert.assertEquals(23999999976L, DateFunctions.dateDifference(min, max, "MONTHS"));
+        Assert.assertEquals(730484999269L, DateFunctions.dateDifference(min, max, "DAYS"));
+        Assert.assertEquals(63113903936841600L, DateFunctions.dateDifference(min, max, "SECONDS"));
+
+        Assert.assertThrows(ArithmeticException.class, () -> DateFunctions.dateDifference(min, max, "MILLISECONDS"));
+        Assert.assertThrows(ArithmeticException.class, () -> DateFunctions.dateDifference(min, max, "MICROSECONDS"));
+        Assert.assertThrows(ArithmeticException.class, () -> DateFunctions.dateDifference(min, max, "NANOSECONDS"));
+
+        // NANOSECONDS gives out at 292 years
+        PureDate start = parse("2000-01-01T00:00:00");
+        Assert.assertEquals(9214646400000000000L, DateFunctions.dateDifference(start, parse("2292-01-01T00:00:00"), "NANOSECONDS"));
+        Assert.assertThrows(ArithmeticException.class, () -> DateFunctions.dateDifference(start, parse("2293-01-01T00:00:00"), "NANOSECONDS"));
+    }
+
+    /**
+     * {@link LatestDate} has no components to measure, in either position. Note that comparing it
+     * with itself throws as well: there is no longer an equality short circuit ahead of the
+     * measurement.
+     */
+    @Test
+    public void testLatestDateIsNotSupported()
+    {
+        PureDate date = DateFunctions.parsePureDate("2015-07-07");
+        Assert.assertThrows(UnsupportedOperationException.class, () -> LatestDate.instance.dateDifference(date, "DAYS"));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> DateFunctions.dateDifference(LatestDate.instance, date, "DAYS"));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> DateFunctions.dateDifference(date, LatestDate.instance, "DAYS"));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> DateFunctions.dateDifference(LatestDate.instance, LatestDate.instance, "DAYS"));
+    }
+
+    // Helpers
+
+    private static PureDate parse(String string)
+    {
+        return DateFunctions.parsePureDate(string);
+    }
+
+    /**
+     * Assert that adjusting the first date of each ordered pair by the measured difference lands on
+     * the second.
+     */
+    private static void assertAdjustInverts(String unit, DateAdjuster adjuster, ListIterable<PureDate> dates)
+    {
+        for (PureDate from : dates)
+        {
+            for (PureDate to : dates)
+            {
+                long difference = DateFunctions.dateDifference(from, to, unit);
+                Assert.assertEquals(
+                        from + " adjusted by " + difference + " " + unit + " should be " + to,
+                        to,
+                        adjuster.adjust(from, difference));
+            }
+        }
+    }
+
+    /**
+     * A run of consecutive dates at one granularity, starting from the given date.
+     */
+    private static ListIterable<PureDate> runOf(PureDate start, int count, DateAdjuster step)
+    {
+        MutableList<PureDate> dates = Lists.mutable.ofInitialCapacity(count);
+        for (int i = 0; i < count; i++)
+        {
+            dates.add(step.adjust(start, i));
+        }
+        return dates;
+    }
+
+    private static ListIterable<PureDate> yearDates()
+    {
+        MutableList<PureDate> dates = Lists.mutable.empty();
+        for (int year = -3; year <= 3; year++)
+        {
+            dates.add(DateFunctions.newPureDate(year));
+        }
+        for (int year : new int[]{1900, 1999, 2000, 2015, 2016, 2017, 2100})
+        {
+            dates.add(DateFunctions.newPureDate(year));
+        }
+        return dates;
+    }
+
+    private static void assertDateDifference(long expected, String from, String to, String unit)
+    {
+        PureDate fromDate = parse(from);
+        PureDate toDate = parse(to);
+        String message = from + " -> " + to + " in " + unit;
+        Assert.assertEquals(message, expected, DateFunctions.dateDifference(fromDate, toDate, unit));
+        Assert.assertEquals(message, expected, fromDate.dateDifference(toDate, unit));
+    }
+
+    /**
+     * One of the {@code PureDate.addX} methods, which is what
+     * {@code meta::pure::functions::date::adjust} dispatches to for a given duration unit.
+     */
+    private interface DateAdjuster
+    {
+        PureDate adjust(PureDate date, long amount);
+    }
+}

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFunctions.java
@@ -1,0 +1,573 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m4.coreinstance.primitive.date;
+
+import org.finos.legend.pure.m4.ModelRepository;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+/**
+ * Tests for {@link DateFunctions}, other than
+ * {@link DateFunctions#compare(PureDate, PureDate)} and
+ * {@link DateFunctions#dateDifference(PureDate, PureDate, String)}, which are covered by
+ * {@link TestDateCompare} and {@link TestDateDifference}.
+ */
+public class TestDateFunctions
+{
+    private static final long MILLIS_2014_03_10T16_12_35 = LocalDateTime.of(2014, 3, 10, 16, 12, 35).toInstant(ZoneOffset.UTC).toEpochMilli();
+    private static final long MILLIS_2014_07_10T16_12_35 = LocalDateTime.of(2014, 7, 10, 16, 12, 35).toInstant(ZoneOffset.UTC).toEpochMilli();
+
+    // Factories
+
+    @Test
+    public void testNewPureDateGranularities()
+    {
+        PureDate year = DateFunctions.newPureDate(2014);
+        assertGranularity(year, false, false, false, false, false, false);
+        Assert.assertEquals("2014", year.toString());
+        Assert.assertEquals(2014, year.getYear());
+
+        PureDate yearMonth = DateFunctions.newPureDate(2014, 3);
+        assertGranularity(yearMonth, true, false, false, false, false, false);
+        Assert.assertEquals("2014-03", yearMonth.toString());
+        Assert.assertEquals(3, yearMonth.getMonth());
+
+        PureDate strictDate = DateFunctions.newPureDate(2014, 3, 10);
+        assertGranularity(strictDate, true, true, false, false, false, false);
+        Assert.assertEquals("2014-03-10", strictDate.toString());
+        Assert.assertEquals(10, strictDate.getDay());
+
+        PureDate withHour = DateFunctions.newPureDate(2014, 3, 10, 16);
+        assertGranularity(withHour, true, true, true, false, false, false);
+        Assert.assertEquals("2014-03-10T16", withHour.toString());
+        Assert.assertEquals(16, withHour.getHour());
+
+        PureDate withMinute = DateFunctions.newPureDate(2014, 3, 10, 16, 12);
+        assertGranularity(withMinute, true, true, true, true, false, false);
+        Assert.assertEquals("2014-03-10T16:12+0000", withMinute.toString());
+        Assert.assertEquals(12, withMinute.getMinute());
+
+        PureDate withSecond = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35);
+        assertGranularity(withSecond, true, true, true, true, true, false);
+        Assert.assertEquals("2014-03-10T16:12:35+0000", withSecond.toString());
+        Assert.assertEquals(35, withSecond.getSecond());
+
+        PureDate withSubsecond = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070004235");
+        assertGranularity(withSubsecond, true, true, true, true, true, true);
+        Assert.assertEquals("2014-03-10T16:12:35.070004235+0000", withSubsecond.toString());
+        Assert.assertEquals("070004235", withSubsecond.getSubsecond());
+    }
+
+    /**
+     * Components a date does not have read back as -1 (or null for the subsecond), which is what
+     * keeps {@link AbstractPureDate#equals} consistent with
+     * {@link DateFunctions#compare(PureDate, PureDate)}.
+     */
+    @Test
+    public void testAbsentComponentsReadBackAsMinusOne()
+    {
+        PureDate year = DateFunctions.newPureDate(2014);
+        Assert.assertEquals(-1, year.getMonth());
+        Assert.assertEquals(-1, year.getDay());
+        Assert.assertEquals(-1, year.getHour());
+        Assert.assertEquals(-1, year.getMinute());
+        Assert.assertEquals(-1, year.getSecond());
+        Assert.assertNull(year.getSubsecond());
+
+        Assert.assertNotEquals(DateFunctions.newPureDate(2014), DateFunctions.newPureDate(2014, 1));
+        Assert.assertNotEquals(DateFunctions.newPureDate(2014, 1, 1), DateFunctions.newPureDate(2014, 1, 1, 0));
+    }
+
+    @Test
+    public void testNewPureDateValidation()
+    {
+        Assert.assertEquals(
+                String.format("Invalid year (valid [%,d, %,d]): %,d", java.time.Year.MIN_VALUE, java.time.Year.MAX_VALUE, java.time.Year.MAX_VALUE + 1L),
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(java.time.Year.MAX_VALUE + 1)).getMessage());
+        Assert.assertEquals("Invalid month: 13", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(2014, 13)).getMessage());
+        Assert.assertEquals("Invalid month: 0", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(2014, 0)).getMessage());
+        Assert.assertEquals("Invalid day: 0", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(2014, 3, 0)).getMessage());
+        Assert.assertEquals("Invalid day: 2014-2-29", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(2014, 2, 29)).getMessage());
+        Assert.assertEquals("Invalid hour: 24", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(2014, 3, 10, 24)).getMessage());
+        Assert.assertEquals("Invalid minute: 60", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(2014, 3, 10, 16, 60)).getMessage());
+        Assert.assertEquals("Invalid second: 60", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(2014, 3, 10, 16, 12, 60)).getMessage());
+        Assert.assertEquals("Invalid subsecond value: \"\"", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "")).getMessage());
+        Assert.assertEquals("Invalid subsecond value: null", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, null)).getMessage());
+
+        // February 29 is fine in a leap year
+        Assert.assertEquals("2016-02-29", DateFunctions.newPureDate(2016, 2, 29).toString());
+    }
+
+    // Calendar and Gregorian utilities
+
+    @Test
+    public void testIsLeapYear()
+    {
+        Assert.assertTrue(DateFunctions.isLeapYear(2016));
+        Assert.assertTrue(DateFunctions.isLeapYear(2000));
+        Assert.assertTrue(DateFunctions.isLeapYear(1600));
+        Assert.assertFalse(DateFunctions.isLeapYear(2014));
+        Assert.assertFalse(DateFunctions.isLeapYear(1900));
+        Assert.assertFalse(DateFunctions.isLeapYear(2100));
+    }
+
+    @Test
+    public void testGetDaysInMonth()
+    {
+        int[] nonLeapYearDays = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+        for (int month = 1; month <= 12; month++)
+        {
+            Assert.assertEquals("2014-" + month, nonLeapYearDays[month - 1], DateFunctions.getDaysInMonth(2014, month));
+        }
+        Assert.assertEquals(29, DateFunctions.getDaysInMonth(2016, 2));
+        Assert.assertEquals(28, DateFunctions.getDaysInMonth(1900, 2));
+
+        Assert.assertEquals("Invalid month: 13", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.getDaysInMonth(2014, 13)).getMessage());
+        Assert.assertEquals("Invalid month: 0", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.getDaysInMonth(2014, 0)).getMessage());
+    }
+
+    @Test
+    public void testGetYearDays()
+    {
+        Assert.assertEquals(365, DateFunctions.getYearDays(2014));
+        Assert.assertEquals(366, DateFunctions.getYearDays(2016));
+        Assert.assertEquals(365, DateFunctions.getYearDays(1900));
+        Assert.assertEquals(366, DateFunctions.getYearDays(2000));
+    }
+
+    @Test
+    public void testFromCalendarWithEachPrecision()
+    {
+        GregorianCalendar calendar = new GregorianCalendar(DateFunctions.GMT_TIME_ZONE);
+        calendar.setTimeInMillis(MILLIS_2014_03_10T16_12_35 + 70L);
+
+        Assert.assertEquals("2014", DateFunctions.fromCalendar(calendar, Calendar.YEAR).toString());
+        Assert.assertEquals("2014-03", DateFunctions.fromCalendar(calendar, Calendar.MONTH).toString());
+        Assert.assertEquals("2014-03-10", DateFunctions.fromCalendar(calendar, Calendar.DAY_OF_MONTH).toString());
+        Assert.assertEquals("2014-03-10", DateFunctions.fromCalendar(calendar, Calendar.DAY_OF_YEAR).toString());
+        Assert.assertEquals("2014-03-10T16", DateFunctions.fromCalendar(calendar, Calendar.HOUR_OF_DAY).toString());
+        Assert.assertEquals("2014-03-10T16:12+0000", DateFunctions.fromCalendar(calendar, Calendar.MINUTE).toString());
+        Assert.assertEquals("2014-03-10T16:12:35+0000", DateFunctions.fromCalendar(calendar, Calendar.SECOND).toString());
+        Assert.assertEquals("2014-03-10T16:12:35.070+0000", DateFunctions.fromCalendar(calendar, Calendar.MILLISECOND).toString());
+
+        // millisecond precision is the default
+        Assert.assertEquals("2014-03-10T16:12:35.070+0000", DateFunctions.fromCalendar(calendar).toString());
+
+        Assert.assertEquals(
+                "Unsupported calendar precision: " + Calendar.ERA,
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.fromCalendar(calendar, Calendar.ERA)).getMessage());
+    }
+
+    /**
+     * {@code fromCalendar} reads the instant the calendar holds, in UTC, whatever zone the calendar
+     * is in. The zone only decides whether the fields can be read as they stand or the calendar has
+     * to be rebuilt in GMT first; it never shifts the instant.
+     */
+    @Test
+    public void testFromCalendarIsIndependentOfTheCalendarTimeZone()
+    {
+        String[] zoneIds = {
+                "GMT",              // read as is
+                "UTC",              // zero offset, but not equal to the GMT TimeZone
+                "Etc/GMT-5",        // fixed positive offset
+                "Etc/GMT+7",        // fixed negative offset
+                "America/New_York"  // negative raw offset, and on daylight saving time in July
+        };
+        for (String zoneId : zoneIds)
+        {
+            GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone(zoneId));
+            calendar.setTimeInMillis(MILLIS_2014_07_10T16_12_35);
+            Assert.assertEquals(zoneId, "2014-07-10T16:12:35+0000", DateFunctions.fromCalendar(calendar, Calendar.SECOND).toString());
+
+            // the argument is left untouched
+            Assert.assertEquals(zoneId, MILLIS_2014_07_10T16_12_35, calendar.getTimeInMillis());
+            Assert.assertEquals(zoneId, TimeZone.getTimeZone(zoneId), calendar.getTimeZone());
+        }
+    }
+
+    /**
+     * A zone whose raw offset is zero can still be an hour off UTC while daylight saving time is in
+     * force, so the decision cannot be made from the raw offset (or from the zone's identity) alone.
+     * Europe/London is UTC+01:00 in July and UTC+00:00 in January.
+     */
+    @Test
+    public void testFromCalendarWithDaylightSavingOnAZeroRawOffsetZone()
+    {
+        TimeZone london = TimeZone.getTimeZone("Europe/London");
+        Assert.assertEquals(0, london.getRawOffset());
+
+        GregorianCalendar summer = new GregorianCalendar(london);
+        summer.setTimeInMillis(MILLIS_2014_07_10T16_12_35);
+        Assert.assertEquals(0, summer.get(Calendar.ZONE_OFFSET));
+        Assert.assertEquals(60 * 60 * 1000, summer.get(Calendar.DST_OFFSET));
+        Assert.assertEquals("2014-07-10T16:12:35+0000", DateFunctions.fromCalendar(summer, Calendar.SECOND).toString());
+
+        GregorianCalendar winter = new GregorianCalendar(london);
+        winter.setTimeInMillis(MILLIS_2014_03_10T16_12_35);
+        Assert.assertEquals(0, winter.get(Calendar.ZONE_OFFSET));
+        Assert.assertEquals(0, winter.get(Calendar.DST_OFFSET));
+        Assert.assertEquals("2014-03-10T16:12:35+0000", DateFunctions.fromCalendar(winter, Calendar.SECOND).toString());
+    }
+
+    /**
+     * {@link PureDate#getCalendar()} and {@code fromCalendar} are inverse at every granularity, down
+     * to the millisecond precision a {@link GregorianCalendar} can carry.
+     */
+    @Test
+    public void testFromCalendarRoundTripsGetCalendar()
+    {
+        assertRoundTripsThroughCalendar(DateFunctions.newPureDate(2014), Calendar.YEAR);
+        assertRoundTripsThroughCalendar(DateFunctions.newPureDate(2014, 3), Calendar.MONTH);
+        assertRoundTripsThroughCalendar(DateFunctions.newPureDate(2014, 3, 10), Calendar.DAY_OF_MONTH);
+        assertRoundTripsThroughCalendar(DateFunctions.newPureDate(2014, 3, 10, 16), Calendar.HOUR_OF_DAY);
+        assertRoundTripsThroughCalendar(DateFunctions.newPureDate(2014, 3, 10, 16, 12), Calendar.MINUTE);
+        assertRoundTripsThroughCalendar(DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35), Calendar.SECOND);
+        assertRoundTripsThroughCalendar(DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070"), Calendar.MILLISECOND);
+
+        // a date coarser than its target precision expands to the start of the span it covers
+        Assert.assertEquals("2014-01-01T00:00:00.000+0000", DateFunctions.fromCalendar(DateFunctions.newPureDate(2014).getCalendar()).toString());
+        Assert.assertEquals("2014-03-01", DateFunctions.fromCalendar(DateFunctions.newPureDate(2014, 3).getCalendar(), Calendar.DAY_OF_MONTH).toString());
+    }
+
+    // Conversions
+
+    @Test
+    public void testFromDate()
+    {
+        Date date = new Date(MILLIS_2014_03_10T16_12_35 + 70L);
+        Assert.assertEquals("2014-03-10T16:12:35.070+0000", DateFunctions.fromDate(date).toString());
+        Assert.assertEquals("2014-03-10T16:12:35.070+0000", DateFunctions.formatDate(date));
+    }
+
+    @Test
+    public void testFromSQLDate()
+    {
+        java.sql.Date sqlDate = new java.sql.Date(MILLIS_2014_03_10T16_12_35);
+        StrictDate date = DateFunctions.fromSQLDate(sqlDate);
+        Assert.assertEquals("2014-03-10", date.toString());
+        Assert.assertEquals(date, DateFunctions.fromDate(sqlDate));
+
+        // formatDate delegates to java.sql.Date.toString for SQL dates
+        Assert.assertEquals(sqlDate.toString(), DateFunctions.formatDate(sqlDate));
+    }
+
+    @Test
+    public void testFromSQLTimestamp()
+    {
+        java.sql.Timestamp timestamp = new java.sql.Timestamp(MILLIS_2014_03_10T16_12_35);
+        timestamp.setNanos(70004235);
+        DateTime date = DateFunctions.fromSQLTimestamp(timestamp);
+        Assert.assertEquals("2014-03-10T16:12:35.070004235+0000", date.toString());
+        Assert.assertEquals(date, DateFunctions.fromDate(timestamp));
+    }
+
+    @Test
+    public void testFromInstant()
+    {
+        Instant instant = LocalDateTime.of(2014, 3, 10, 16, 12, 35, 70004235).toInstant(ZoneOffset.UTC);
+        Assert.assertEquals("2014-03-10T16:12:35.070004235+0000", DateFunctions.fromInstant(instant).toString());
+        Assert.assertEquals("2014-03-10T16:12:35.0+0000", DateFunctions.fromInstant(instant, 1).toString());
+        Assert.assertEquals("2014-03-10T16:12:35.070+0000", DateFunctions.fromInstant(instant, 3).toString());
+        Assert.assertEquals("2014-03-10T16:12:35.070004235+0000", DateFunctions.fromInstant(instant, 9).toString());
+
+        // a precision of 0 drops to second granularity
+        Assert.assertEquals("2014-03-10T16:12:35+0000", DateFunctions.fromInstant(instant, 0).toString());
+
+        Assert.assertEquals(
+                "Invalid subsecond precision: 10",
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.fromInstant(instant, 10)).getMessage());
+        Assert.assertEquals(
+                "Invalid subsecond precision: -1",
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.fromInstant(instant, -1)).getMessage());
+    }
+
+    // java.time conversions
+
+    @Test
+    public void testFromYear()
+    {
+        PureDate date = DateFunctions.fromYear(java.time.Year.of(2014));
+        assertGranularity(date, false, false, false, false, false, false);
+        Assert.assertEquals(2014, date.getYear());
+        Assert.assertEquals("2014", date.toString());
+        Assert.assertEquals(ModelRepository.DATE_TYPE_NAME, DateFunctions.datePrimitiveType(date));
+        Assert.assertEquals(DateFunctions.newPureDate(2014), date);
+
+        // the whole supported range, including year zero and negative years
+        Assert.assertEquals(DateFunctions.newPureDate(-1), DateFunctions.fromYear(java.time.Year.of(-1)));
+        Assert.assertEquals(DateFunctions.newPureDate(0), DateFunctions.fromYear(java.time.Year.of(0)));
+        Assert.assertEquals(DateFunctions.newPureDate(java.time.Year.MIN_VALUE), DateFunctions.fromYear(java.time.Year.of(java.time.Year.MIN_VALUE)));
+        Assert.assertEquals(DateFunctions.newPureDate(java.time.Year.MAX_VALUE), DateFunctions.fromYear(java.time.Year.of(java.time.Year.MAX_VALUE)));
+    }
+
+    @Test
+    public void testFromYearMonth()
+    {
+        PureDate date = DateFunctions.fromYearMonth(java.time.YearMonth.of(2014, 3));
+        assertGranularity(date, true, false, false, false, false, false);
+        Assert.assertEquals(2014, date.getYear());
+        Assert.assertEquals(3, date.getMonth());
+        Assert.assertEquals("2014-03", date.toString());
+        Assert.assertEquals(ModelRepository.DATE_TYPE_NAME, DateFunctions.datePrimitiveType(date));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3), date);
+
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 1), DateFunctions.fromYearMonth(java.time.YearMonth.of(2014, 1)));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 12), DateFunctions.fromYearMonth(java.time.YearMonth.of(2014, 12)));
+    }
+
+    @Test
+    public void testFromLocalDate()
+    {
+        StrictDate date = DateFunctions.fromLocalDate(LocalDate.of(2014, 3, 10));
+        assertGranularity(date, true, true, false, false, false, false);
+        Assert.assertEquals("2014-03-10", date.toString());
+        Assert.assertEquals(ModelRepository.STRICT_DATE_TYPE_NAME, DateFunctions.datePrimitiveType(date));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10), date);
+
+        // leap day
+        Assert.assertEquals(DateFunctions.newPureDate(2016, 2, 29), DateFunctions.fromLocalDate(LocalDate.of(2016, 2, 29)));
+    }
+
+    @Test
+    public void testFromLocalDateTime()
+    {
+        LocalDateTime dateTime = LocalDateTime.of(2014, 3, 10, 16, 12, 35, 70004235);
+
+        DateTime date = DateFunctions.fromLocalDateTime(dateTime);
+        assertGranularity(date, true, true, true, true, true, true);
+        Assert.assertEquals("2014-03-10T16:12:35.070004235+0000", date.toString());
+        Assert.assertEquals(ModelRepository.DATETIME_TYPE_NAME, DateFunctions.datePrimitiveType(date));
+
+        // a LocalDateTime carries no zone, so its fields are taken as they stand
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070004235"), date);
+        Assert.assertEquals(date, DateFunctions.fromInstant(dateTime.toInstant(ZoneOffset.UTC)));
+
+        Assert.assertEquals("2014-03-10T16:12:35.0+0000", DateFunctions.fromLocalDateTime(dateTime, 1).toString());
+        Assert.assertEquals("2014-03-10T16:12:35.070+0000", DateFunctions.fromLocalDateTime(dateTime, 3).toString());
+        Assert.assertEquals("2014-03-10T16:12:35.070004235+0000", DateFunctions.fromLocalDateTime(dateTime, 9).toString());
+
+        // a whole number of seconds still gets a subsecond, zero padded to the requested precision
+        Assert.assertEquals("2014-03-10T16:12:35.000000000+0000", DateFunctions.fromLocalDateTime(LocalDateTime.of(2014, 3, 10, 16, 12, 35)).toString());
+        Assert.assertEquals("2014-03-10T16:12:35.000+0000", DateFunctions.fromLocalDateTime(LocalDateTime.of(2014, 3, 10, 16, 12, 35), 3).toString());
+
+        // digits beyond the requested precision are dropped, not rounded
+        Assert.assertEquals("2014-03-10T16:12:35.9+0000", DateFunctions.fromLocalDateTime(LocalDateTime.of(2014, 3, 10, 16, 12, 35, 999999999), 1).toString());
+
+        // a precision of 0 drops to second granularity
+        Assert.assertEquals("2014-03-10T16:12:35+0000", DateFunctions.fromLocalDateTime(dateTime, 0).toString());
+
+        Assert.assertEquals(
+                "Invalid subsecond precision: 10",
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.fromLocalDateTime(dateTime, 10)).getMessage());
+        Assert.assertEquals(
+                "Invalid subsecond precision: -1",
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.fromLocalDateTime(dateTime, -1)).getMessage());
+    }
+
+    /**
+     * Pure dates are always understood as UTC, so an offset is applied rather than discarded.
+     */
+    @Test
+    public void testFromOffsetDateTime()
+    {
+        DateTime expected = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070004235");
+
+        Assert.assertEquals(expected, DateFunctions.fromOffsetDateTime(OffsetDateTime.of(2014, 3, 10, 16, 12, 35, 70004235, ZoneOffset.UTC)));
+        Assert.assertEquals(expected, DateFunctions.fromOffsetDateTime(OffsetDateTime.of(2014, 3, 10, 11, 12, 35, 70004235, ZoneOffset.ofHours(-5))));
+        Assert.assertEquals(expected, DateFunctions.fromOffsetDateTime(OffsetDateTime.of(2014, 3, 10, 17, 12, 35, 70004235, ZoneOffset.ofHours(1))));
+        Assert.assertEquals(expected, DateFunctions.fromOffsetDateTime(OffsetDateTime.of(2014, 3, 10, 16, 42, 35, 70004235, ZoneOffset.ofHoursMinutes(0, 30))));
+
+        // an offset can carry the instant into the previous or next day
+        Assert.assertEquals(
+                DateFunctions.newPureDate(2014, 3, 10, 23, 30, 0, "000"),
+                DateFunctions.fromOffsetDateTime(OffsetDateTime.of(2014, 3, 11, 4, 30, 0, 0, ZoneOffset.ofHours(5)), 3));
+
+        Assert.assertEquals("2014-03-10T16:12:35.070+0000", DateFunctions.fromOffsetDateTime(OffsetDateTime.of(2014, 3, 10, 11, 12, 35, 70004235, ZoneOffset.ofHours(-5)), 3).toString());
+    }
+
+    /**
+     * As for offsets, but the offset comes from what the zone was doing at that instant, so daylight
+     * saving time is taken into account.
+     */
+    @Test
+    public void testFromZonedDateTime()
+    {
+        DateTime expected = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070004235");
+        ZoneId newYork = ZoneId.of("America/New_York");
+
+        // 2014-03-10 is after that year's daylight saving change, so New York is UTC-04:00
+        Assert.assertEquals(expected, DateFunctions.fromZonedDateTime(ZonedDateTime.of(LocalDateTime.of(2014, 3, 10, 12, 12, 35, 70004235), newYork)));
+        // in January it is UTC-05:00
+        Assert.assertEquals(
+                DateFunctions.newPureDate(2014, 1, 10, 16, 12, 35, "070004235"),
+                DateFunctions.fromZonedDateTime(ZonedDateTime.of(LocalDateTime.of(2014, 1, 10, 11, 12, 35, 70004235), newYork)));
+
+        Assert.assertEquals(expected, DateFunctions.fromZonedDateTime(ZonedDateTime.of(LocalDateTime.of(2014, 3, 10, 16, 12, 35, 70004235), ZoneId.of("UTC"))));
+        Assert.assertEquals("2014-03-10T16:12:35.070+0000", DateFunctions.fromZonedDateTime(ZonedDateTime.of(LocalDateTime.of(2014, 3, 10, 12, 12, 35, 70004235), newYork), 3).toString());
+    }
+
+    /**
+     * A subsecond precision of 0 means no subsecond at all, so the result is a date of second
+     * granularity. {@link DateWithSubsecond} does not accept 0 itself, since a date with no
+     * subsecond is not a {@link DateWithSubsecond}.
+     */
+    @Test
+    public void testSubsecondPrecisionZeroGivesSecondGranularity()
+    {
+        LocalDateTime dateTime = LocalDateTime.of(2014, 3, 10, 16, 12, 35, 70004235);
+        Instant instant = dateTime.toInstant(ZoneOffset.UTC);
+        DateTime expected = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35);
+
+        Assert.assertEquals(expected, DateFunctions.fromLocalDateTime(dateTime, 0));
+        Assert.assertEquals(expected, DateFunctions.fromInstant(instant, 0));
+        Assert.assertEquals(expected, DateFunctions.fromOffsetDateTime(OffsetDateTime.of(2014, 3, 10, 11, 12, 35, 70004235, ZoneOffset.ofHours(-5)), 0));
+        Assert.assertEquals(expected, DateFunctions.fromZonedDateTime(ZonedDateTime.of(dateTime, ZoneId.of("UTC")), 0));
+
+        // equality alone would not catch a subsecond date carrying a null subsecond, so check the
+        // granularity and the rendering too
+        DateTime date = DateFunctions.fromInstant(instant, 0);
+        Assert.assertTrue(date.getClass().getName(), date instanceof DateWithSecond);
+        assertGranularity(date, true, true, true, true, true, false);
+        Assert.assertNull(date.getSubsecond());
+        Assert.assertEquals("2014-03-10T16:12:35+0000", date.toString());
+        Assert.assertEquals(ModelRepository.DATETIME_TYPE_NAME, DateFunctions.datePrimitiveType(date));
+        Assert.assertEquals(0, DateFunctions.compare(date, expected));
+
+        // DateWithSubsecond rejects a precision of 0, as it does any other precision outside 1-9
+        Assert.assertEquals(
+                "Invalid subsecond precision: 0",
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateWithSubsecond.fromInstant(instant, 0)).getMessage());
+        Assert.assertEquals(
+                "Invalid subsecond precision: -1",
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateWithSubsecond.fromInstant(instant, -1)).getMessage());
+        Assert.assertEquals(
+                "Invalid subsecond precision: 10",
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateWithSubsecond.fromInstant(instant, 10)).getMessage());
+    }
+
+    /**
+     * Every route into a Pure date must agree on the same instant, whichever Java type it starts
+     * from and whatever zone or offset that type expresses the instant in.
+     */
+    @Test
+    public void testJavaTimeConversionsAgreeWithEachOther()
+    {
+        Instant instant = LocalDateTime.of(2014, 3, 10, 16, 12, 35, 70004235).toInstant(ZoneOffset.UTC);
+        DateTime expected = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070004235");
+
+        Assert.assertEquals(expected, DateFunctions.fromInstant(instant));
+        Assert.assertEquals(expected, DateFunctions.fromLocalDateTime(LocalDateTime.ofInstant(instant, ZoneOffset.UTC)));
+        Assert.assertEquals(expected, DateFunctions.fromOffsetDateTime(OffsetDateTime.ofInstant(instant, ZoneOffset.ofHours(-5))));
+        Assert.assertEquals(expected, DateFunctions.fromZonedDateTime(ZonedDateTime.ofInstant(instant, ZoneId.of("Asia/Tokyo"))));
+        Assert.assertEquals(expected, DateFunctions.parsePureDate("2014-03-10T16:12:35.070004235"));
+
+        // and the coarser granularities line up with the components of that instant
+        Assert.assertEquals(DateFunctions.fromYear(java.time.Year.of(2014)), DateFunctions.parsePureDate("2014"));
+        Assert.assertEquals(DateFunctions.fromYearMonth(java.time.YearMonth.of(2014, 3)), DateFunctions.parsePureDate("2014-03"));
+        Assert.assertEquals(DateFunctions.fromLocalDate(LocalDateTime.ofInstant(instant, ZoneOffset.UTC).toLocalDate()), DateFunctions.parsePureDate("2014-03-10"));
+    }
+
+    @Test
+    public void testToday()
+    {
+        StrictDate today = DateFunctions.today();
+        Assert.assertTrue(today.hasDay());
+        Assert.assertFalse(today.hasHour());
+        Assert.assertEquals(ModelRepository.STRICT_DATE_TYPE_NAME, DateFunctions.datePrimitiveType(today));
+
+        // allow a day either side so that the test cannot fail if the UTC date rolls over mid-test
+        LocalDate now = LocalDate.now(java.time.Clock.systemUTC());
+        Assert.assertTrue(
+                today.toString(),
+                today.equals(DateFunctions.newPureDate(now.getYear(), now.getMonthValue(), now.getDayOfMonth())) ||
+                        today.equals(DateFunctions.newPureDate(now.minusDays(1).getYear(), now.minusDays(1).getMonthValue(), now.minusDays(1).getDayOfMonth())) ||
+                        today.equals(DateFunctions.newPureDate(now.plusDays(1).getYear(), now.plusDays(1).getMonthValue(), now.plusDays(1).getDayOfMonth())));
+    }
+
+    @Test
+    public void testDatePrimitiveType()
+    {
+        Assert.assertEquals(ModelRepository.DATE_TYPE_NAME, DateFunctions.datePrimitiveType(DateFunctions.newPureDate(2014)));
+        Assert.assertEquals(ModelRepository.DATE_TYPE_NAME, DateFunctions.datePrimitiveType(DateFunctions.newPureDate(2014, 3)));
+        Assert.assertEquals(ModelRepository.STRICT_DATE_TYPE_NAME, DateFunctions.datePrimitiveType(DateFunctions.newPureDate(2014, 3, 10)));
+        Assert.assertEquals(ModelRepository.DATETIME_TYPE_NAME, DateFunctions.datePrimitiveType(DateFunctions.newPureDate(2014, 3, 10, 16)));
+        Assert.assertEquals(ModelRepository.DATETIME_TYPE_NAME, DateFunctions.datePrimitiveType(DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070")));
+        Assert.assertEquals(ModelRepository.LATEST_DATE_TYPE_NAME, DateFunctions.datePrimitiveType(LatestDate.instance));
+    }
+
+    // Parsing
+
+    @Test
+    public void testParsePureDate()
+    {
+        Assert.assertEquals(DateFunctions.newPureDate(2014), DateFunctions.parsePureDate("2014"));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3), DateFunctions.parsePureDate("2014-03"));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10), DateFunctions.parsePureDate("2014-03-10"));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10, 16), DateFunctions.parsePureDate("2014-03-10T16"));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10, 16, 12), DateFunctions.parsePureDate("2014-03-10T16:12"));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35), DateFunctions.parsePureDate("2014-03-10T16:12:35"));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070004235"), DateFunctions.parsePureDate("2014-03-10T16:12:35.070004235"));
+
+        // the Pure date prefix and surrounding whitespace are tolerated
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10), DateFunctions.parsePureDate("%2014-03-10"));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10), DateFunctions.parsePureDate("  2014-03-10  "));
+
+        // negative years
+        Assert.assertEquals(DateFunctions.newPureDate(-1), DateFunctions.parsePureDate("-1"));
+
+        // time zone offsets are normalized to UTC
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35), DateFunctions.parsePureDate("2014-03-10T11:12:35-0500"));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10, 16, 12), DateFunctions.parsePureDate("2014-03-10T17:12+0100"));
+    }
+
+    @Test
+    public void testParsePureDateRoundTrip()
+    {
+        String[] strings = {"2014", "2014-03", "2014-03-10", "2014-03-10T16", "2014-03-10T16:12+0000", "2014-03-10T16:12:35+0000", "2014-03-10T16:12:35.070004235+0000"};
+        for (String string : strings)
+        {
+            Assert.assertEquals(string, string, DateFunctions.parsePureDate(string).toString());
+        }
+    }
+
+    // Helpers
+
+    private static void assertRoundTripsThroughCalendar(PureDate date, int precision)
+    {
+        Assert.assertEquals(date, DateFunctions.fromCalendar(date.getCalendar(), precision));
+    }
+
+    private static void assertGranularity(PureDate date, boolean month, boolean day, boolean hour, boolean minute, boolean second, boolean subsecond)
+    {
+        Assert.assertEquals(date + " month", month, date.hasMonth());
+        Assert.assertEquals(date + " day", day, date.hasDay());
+        Assert.assertEquals(date + " hour", hour, date.hasHour());
+        Assert.assertEquals(date + " minute", minute, date.hasMinute());
+        Assert.assertEquals(date + " second", second, date.hasSecond());
+        Assert.assertEquals(date + " subsecond", subsecond, date.hasSubsecond());
+    }
+}


### PR DESCRIPTION
`DateFunctions` had no documentation and almost no direct tests. This adds both, and fixes the defects that writing them turned up. The intent was not to change behavior; where behavior did change it is because the old behavior was wrong, and each case is listed below.

Best read commit by commit — there are eight, each one thing, each with its own tests.

### What's here

- **Conversions from the `java.time` types.** `DateFunctions` could convert from `Calendar`, `java.util.Date`, the SQL types, and `Instant`, but not from `Year`, `YearMonth`, `LocalDate`, `LocalDateTime`, `OffsetDateTime`, or `ZonedDateTime`. Added, each with a subsecond-precision overload. The zoned ones shift the instant to UTC rather than dropping the offset, since a Pure date is always understood as UTC.
- **A rewrite of `dateDifference`.** The old implementation computed a magnitude and multiplied by the sign of a comparison, which is only right where the two directions are mirror images, and it went through `GregorianCalendar`, which applies the Julian cutover before 1582 and truncates to the millisecond. It now computes each unit directly: `YEARS`, `MONTHS`, `WEEKS`, and `DAYS` count calendar boundaries crossed, `HOURS` and below measure elapsed time via `ChronoUnit`, dropping the remainder toward zero.
- **Documentation of what the ordering and the difference actually mean** — including that a Pure date is a span rather than an instant, so a year sorts before every date inside it, and that `23:59` to `00:01` is one `DAY` and zero `HOURS`.
- **ADR-004**, proposed, on date difference semantics.
- Two fixes to `fromCalendar` and `LatestDate` ordering, below.

### Behavior changes

| Case | Was | Now |
|---|---|---|
| `dateDiff(%2014, %2014-06, MONTHS)` | 7 | 5 |
| `dateDiff(%1582-10-01, %1582-11-01, DAYS)` | 21 | 31 |
| `dateDiff(%1500-01-01, %1500-12-31, DAYS)` | 365 | 364 |
| `dateDiff(%2015-07-07T12:00:00.0009, %2015-07-07T12:00:00.0011, MILLISECONDS)` | 1 | 0 |
| `dateDiff(a, b, MICROSECONDS)` and `NANOSECONDS` | rejected | computed |
| `dateDiff(d, d, <invalid unit>)` | 0 | `IllegalArgumentException` |
| `compare(d, %latest)`, `%latest.compareTo(d)`, `d.equals(%latest)` | throws | -1, 1, false |
| sorting a collection containing `%latest` | throws | `%latest` sorts last among dates |
| `fromCalendar` on a calendar at a non-zero offset | wrong instant | the instant, read as UTC |

Taking those in turn:

- **Year-granularity operands in `MONTHS`.** The old code read the month component of a date that has none, which reads back as the `-1` sentinel, so `%2014` was treated as month -1 of 2014 rather than January. Every mixed-granularity `MONTHS` difference was off by two.
- **Dates at or before the 1582 cutover.** `GregorianCalendar` switches to the Julian calendar, so October 1582 was ten days short and 1500 was a leap year. `java.time` is proleptic ISO throughout, which is also what the date literals mean.
- **Sub-millisecond operands.** The old path truncated each operand to whole milliseconds before subtracting; the difference is now measured and then truncated.
- **`MICROSECONDS` and `NANOSECONDS`** were already in `DurationUnit` and already accepted by `adjust`; `dateDiff` rejected them. It now takes the same units `adjust` does.
- **Invalid units with two equal dates** returned 0, because the equality short-circuit came before the unit was looked at. An invalid unit now always fails.
- **`%latest`** threw on comparison from `DateFunctions.compare`, which reached for a component it does not have, and unconditionally from `LatestDate.compareTo`, so sorting any collection that happened to contain one failed. `equals` threw from one side and answered false from the other. Comparison has to be total, so `%latest` now orders after every other date. That is a sorting convention, not a claim about when it falls: what it stands for is decided by where it is used, which is why `dateDifference` still rejects it.
- **`fromCalendar`** shifted the instant by the zone offset in the wrong direction. A calendar in `America/New_York` holding 16:12 UTC came out at 20:12 — neither the instant it held nor the wall clock it showed.

### API notes for legend-engine

Additive apart from one case: `DateWithSubsecond.fromInstant(instant, 0)` used to return a `DateWithSubsecond` carrying a null subsecond and now throws, because a precision of 0 means second granularity. `DateFunctions.fromInstant(instant, 0)` returns a proper second-granularity date instead. Nothing was removed; `LatestDate.compareTo` loses its override but keeps its inherited implementation.

### ADR-004

Proposed, and deliberately not implemented here. `dateDiff`'s semantics were inherited rather than chosen, and two are hard to defend: the calendar units count boundaries, so one day apart can be a whole year while 364 days apart is none, and `WEEKS` counts on a Sunday grid going forward and a Monday grid going back. The ADR sets out the four readings a date difference can have, the six axes they vary on, what each gives a user computing in the platform rather than pushing down, how other systems choose, and what each option would cost in translation and in changed PCT assertions. It recommends moving `WEEKS` to the ISO 8601 Monday grid and leaving the rest, but the alternatives are set out well enough to be picked instead. Discussion belongs there, not in this PR.

### Testing

Three new test classes in `legend-pure-m4`, 81 tests: the conversions in both directions, the ordering (worked examples, three equivalent characterizations checked over every ordered pair of a fixed corpus, and the order properties), and the difference (each unit, mixed granularities, sign and direction, the boundaries the calendar units count, overflow, and the relationship with `adjust`).