### PR TITLE
Add a shaded jar for the Pure LSP server

### DIFF
--- a/legend-pure-lsp/README.md
+++ b/legend-pure-lsp/README.md
@@ -35,6 +35,23 @@ java -cp "legend-pure-lsp-server/target/legend-pure-lsp-server-<version>.jar:leg
 
 `target/dependency/*` is produced during `package`; it keeps runtime dependencies separate from the server jar so host repositories can add language/store extensions dynamically.
 
+### Shaded Jar
+
+`package` also produces a self-contained jar at `legend-pure-lsp-server/target/legend-pure-lsp-server-<version>-shaded.jar`, with every runtime dependency and a `Main-Class` manifest entry:
+
+```bash
+java -jar legend-pure-lsp-server/target/legend-pure-lsp-server-<version>-shaded.jar
+```
+
+Use it where a single artifact is easier to distribute than a jar plus a dependency directory. To add host language or store extensions on top of it, put it on an explicit classpath instead of using `-jar`:
+
+```bash
+java -cp "legend-pure-lsp-server/target/legend-pure-lsp-server-<version>-shaded.jar:<extension jars/classes>" \
+  org.finos.legend.pure.lsp.LegendPureLspServer
+```
+
+The thin jar remains the default: the VS Code extension ignores `-shaded.jar` when it auto-discovers a server jar in `target`, so point `legendPure.server.jarPath` at the shaded jar explicitly if you want the extension to use it.
+
 Workspace repositories are discovered from `*.definition.json` files under the opened workspace. Runtime extensions and any classpath repositories not already represented by the workspace are discovered from the Java classpath.
 
 ## VS Code Packaging

--- a/legend-pure-lsp/legend-pure-lsp-server/pom.xml
+++ b/legend-pure-lsp/legend-pure-lsp-server/pom.xml
@@ -58,6 +58,46 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shaded-server-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/versions/*/module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.finos.legend.pure.lsp.LegendPureLspServer</mainClass>
+                                </transformer>
+                                <!-- Pure repositories are discovered via ServiceLoader; every DSL/store jar
+                                     contributes its own CodeRepositoryProvider entry, so these must be merged. -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <includes>

--- a/legend-pure-lsp/legend-pure-lsp-vscode/src/extension.ts
+++ b/legend-pure-lsp/legend-pure-lsp-vscode/src/extension.ts
@@ -389,7 +389,8 @@ function resolveServerJar(): string | undefined {
                 f.endsWith('.jar') &&
                 !f.endsWith('-sources.jar') &&
                 !f.endsWith('-javadoc.jar') &&
-                !f.endsWith('-tests.jar')
+                !f.endsWith('-tests.jar') &&
+                !f.endsWith('-shaded.jar')
         );
         if (mainJar) {
             return path.join(serverTargetDir, mainJar);
@@ -414,7 +415,8 @@ function resolveServerJar(): string | undefined {
                         f.endsWith('.jar') &&
                         !f.endsWith('-sources.jar') &&
                         !f.endsWith('-javadoc.jar') &&
-                        !f.endsWith('-tests.jar')
+                        !f.endsWith('-tests.jar') &&
+                        !f.endsWith('-shaded.jar')
                 );
                 if (mainJar) {
                     return path.join(targetDir, mainJar);

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
         <maven.plugin.plugin.version>3.10.2</maven.plugin.plugin.version>
         <maven.resources.plugin.version>3.3.0</maven.resources.plugin.version>
+        <maven.shade.plugin.version>3.6.0</maven.shade.plugin.version>
         <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
         <versions.maven.plugin.version>2.21.0</versions.maven.plugin.version>
     </properties>
@@ -172,6 +173,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>${maven.resources.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>${maven.shade.plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What

`mvn package` on `legend-pure-lsp-server` now also produces a self-contained `legend-pure-lsp-server-<version>-shaded.jar`, for cases where a single artifact is easier to distribute than a jar plus a dependency directory.

```bash
java -jar legend-pure-lsp-server/target/legend-pure-lsp-server-<version>-shaded.jar
```

## Approach

The shaded jar is an **attached classifier**, not a replacement for the main artifact. The thin jar and the `target/dependency/*` layout stay exactly as they are, because the README and the VS Code extension both rely on them so host repositories can add language and store extensions to the classpath dynamically. Nothing depends on this module as a Maven dependency, so `createDependencyReducedPom` is off.

Per repo convention, the plugin version lives in the root `pluginManagement` block behind a property.

## The part that isn't boilerplate

`LegendPureSession` discovers repositories via `CodeRepositoryProviderHelper.findCodeRepositories()`, which is `ServiceLoader`-based, and nine separate jars each ship their own `META-INF/services/...CodeRepositoryProvider` file. Without `ServicesResourceTransformer` those nine files overwrite each other during shading and the server comes up with a single repository instead of all nine — it still starts cleanly, it just has almost nothing loaded. The transformer is required here, not cosmetic.

The config also merges license/notice files and strips dependency signature files and `module-info.class`.

## VS Code extension

`resolveServerJar()` picks the server jar with a `find()` over `target/`, so a second jar there would have made the choice depend on directory-read order. `-shaded.jar` is now excluded alongside `-sources`/`-javadoc`/`-tests`, keeping the thin jar the deterministic default. Set `legendPure.server.jarPath` explicitly to use the shaded jar instead.

## Verification

- Reactor build succeeds; both jars produced (thin 219 KB, shaded 47 MB).
- The merged services file contains all 9 providers, checked against the 9 contributing dependency jars.
- Drove a full LSP `initialize` → `initialized` → `shutdown` → `exit` handshake against both jars. Identical results: same 10 capabilities, `state: ready`, same `symbolCount: 2267`, no errors on stderr, clean exit — so the platform Pure sources compile the same way out of the shaded jar.
- `mvn verify` on the module: 208 tests pass, checkstyle clean.
- Extension typechecks (`tsc --noEmit`).