### PR TITLE
DateFormat improvements

### DIFF
--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -252,14 +252,7 @@ public class DateFormat
                 case 'z':
                 {
                     int count = getCharCountFrom(character, formatString, i);
-                    if (calendar == null)
-                    {
-                        safeAppendable.append("GMT");
-                    }
-                    else
-                    {
-                        safeAppendable.append(timeZoneId);
-                    }
+                    safeAppendable.append((calendar == null) ? "GMT" : timeZoneId);
                     i += count;
                     break;
                 }

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -115,7 +115,10 @@ public class DateFormat
                     int count = getCharCountFrom(character, formatString, i);
                     if (count < 3)
                     {
-                        appendNonNegTwoDigitInt(safeAppendable, displayYear % 100);
+                        // The two digit form is the last two digits of the year, which a year
+                        // before the era has as much as one after it: it drops the sign along with
+                        // the century, as it already drops the difference between 1914 and 2014.
+                        appendNonNegTwoDigitInt(safeAppendable, Math.abs(displayYear % 100));
                     }
                     else
                     {

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -100,9 +100,10 @@ public class DateFormat
                     {
                         if (calendar == null)
                         {
-                            calendar = date.getCalendar();
-                            calendar.setTimeZone(timeZone);
-                            calendar.add(Calendar.MILLISECOND, timeZone.getOffset(calendar.getTimeInMillis()));
+                            // A Pure date is always understood as UTC, so the instant it starts at
+                            // is what the requested zone renders.
+                            calendar = new GregorianCalendar(timeZone);
+                            calendar.setTimeInMillis(PureDateToJava.start().toInstant(date).toEpochMilli());
                         }
                     }
                     break;

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -211,8 +211,9 @@ public class DateFormat
                     {
                         throw new IllegalArgumentException("Date has no second: " + date);
                     }
+                    int displaySecond = (calendar == null) ? date.getSecond() : calendar.get(Calendar.SECOND);
                     int count = getCharCountFrom(character, formatString, i);
-                    appendZeroPaddedInt(safeAppendable, date.getSecond(), count + 1);
+                    appendZeroPaddedInt(safeAppendable, displaySecond, count + 1);
                     i += count;
                     break;
                 }

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -15,6 +15,7 @@
 package org.finos.legend.pure.m4.coreinstance.primitive.date;
 
 import org.finos.legend.pure.m4.tools.SafeAppendable;
+import org.finos.legend.pure.m4.tools.TextTools;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
@@ -392,136 +393,135 @@ public class DateFormat
     public static PureDate parsePureDate(String string, int start, int end)
     {
         // Skip whitespace at start and end
-        while ((start < end) && (string.charAt(start) <= ' '))
+        int low = TextTools.indexOfNonWhitespace(string, start, end);
+        if (low < 0)
         {
-            start++;
+            throwInvalidDateString(string, start, end);
         }
-
-        do
+        int high = TextTools.lastIndexOfNonWhitespace(string, low, end);
+        if (high < 0)
         {
-            end--;
+            throwInvalidDateString(string, low, high);
         }
-        while ((end > start) && (string.charAt(end) <= ' '));
-
-        end++;
-        if (start >= end)
+        high += Character.charCount(string.codePointAt(high));
+        if (low >= high)
         {
-            throwInvalidDateString(string);
+            throwInvalidDateString(string, start, end);
         }
 
         // Skip Pure date prefix character if present
-        if (string.charAt(start) == DATE_PREFIX)
+        if (string.charAt(low) == DATE_PREFIX)
         {
-            start++;
-            if (start >= end)
+            low++;
+            if (low >= high)
             {
-                throwInvalidDateString(string);
+                throwInvalidDateString(string, start, end);
             }
         }
 
         // Year
         int year = -1;
-        int previous = (string.charAt(start) == '-') ? start + 1 : start;
-        int index = findNonDigit(string, previous, end);
+        int previous = (string.charAt(low) == '-') ? low + 1 : low;
+        int index = findNonDigit(string, previous, high);
         try
         {
-            year = Integer.parseInt(string.substring(start, index));
+            year = Integer.parseInt(string.substring(low, index));
         }
         catch (NumberFormatException e)
         {
-            throwInvalidDateString("Error parsing year", string, start, end);
+            throwInvalidDateString("Error parsing year", string, low, high);
         }
 
-        if (index == end)
+        if (index == high)
         {
             return Year.newYear(year);
         }
         if (string.charAt(index++) != DATE_SEPARATOR)
         {
-            throwInvalidDateString(string, start, end);
+            throwInvalidDateString(string, low, high);
         }
 
         // Month
         int month = -1;
         previous = index;
-        index = findNonDigit(string, previous, end);
+        index = findNonDigit(string, previous, high);
         try
         {
             month = Integer.parseInt(string.substring(previous, index));
         }
         catch (NumberFormatException e)
         {
-            throwInvalidDateString("Error parsing month", string, start, end);
+            throwInvalidDateString("Error parsing month", string, low, high);
         }
 
-        if (index == end)
+        if (index == high)
         {
             return YearMonth.newYearMonth(year, month);
         }
         if (string.charAt(index++) != DATE_SEPARATOR)
         {
-            throwInvalidDateString(string, start, end);
+            throwInvalidDateString(string, low, high);
         }
 
         // Day
         int day = -1;
         previous = index;
-        index = findNonDigit(string, previous, end);
+        index = findNonDigit(string, previous, high);
         try
         {
             day = Integer.parseInt(string.substring(previous, index));
         }
         catch (NumberFormatException e)
         {
-            throwInvalidDateString("Error parsing day", string, start, end);
+            throwInvalidDateString("Error parsing day", string, low, high);
         }
 
-        if (index == end)
+        if (index == high)
         {
             return StrictDate.newStrictDate(year, month, day);
         }
         if (string.charAt(index++) != DATE_TIME_SEPARATOR)
         {
-            throwInvalidDateString(string, start, end);
+            throwInvalidDateString(string, low, high);
         }
 
         // Hour
         int hour = -1;
         previous = index;
-        index = findNonDigit(string, previous, end);
+        index = findNonDigit(string, previous, high);
         try
         {
             hour = Integer.parseInt(string.substring(previous, index));
         }
         catch (NumberFormatException e)
         {
-            throwInvalidDateString("Error parsing hour", string, start, end);
+            throwInvalidDateString("Error parsing hour", string, low, high);
         }
 
-        if (index == end)
+        if (index == high)
         {
             return DateWithHour.newDateWithHour(year, month, day, hour);
         }
 
         if (string.charAt(index++) != TIME_SEPARATOR)
         {
-            throwInvalidDateString(string, start, end);
+            throwInvalidDateString(string, low, high);
         }
 
         // Minute
         int minute = -1;
         previous = index;
-        index = findNonDigit(string, previous, end);
+        index = findNonDigit(string, previous, high);
         try
         {
             minute = Integer.parseInt(string.substring(previous, index));
         }
         catch (NumberFormatException e)
         {
-            throwInvalidDateString("Error parsing minute", string, start, end);
+            throwInvalidDateString("Error parsing minute", string, low, high);
         }
 
-        if (index == end)
+        if (index == high)
         {
             return DateWithMinute.newDateWithMinute(year, month, day, hour, minute);
         }
@@ -530,24 +530,24 @@ public class DateFormat
         {
             // Time zone
             DateWithMinute date = DateWithMinute.newDateWithMinute(year, month, day, hour, minute);
-            int offsetInMinutes = getTimeZoneOffsetInMinutes(string, index - 1, end);
+            int offsetInMinutes = getTimeZoneOffsetInMinutes(string, index - 1, high);
             return date.addMinutes(-offsetInMinutes);
         }
 
         // Second
         int second = -1;
         previous = index;
-        index = findNonDigit(string, previous, end);
+        index = findNonDigit(string, previous, high);
         try
         {
             second = Integer.parseInt(string.substring(previous, index));
         }
         catch (NumberFormatException e)
         {
-            throwInvalidDateString("Error parsing second", string, start, end);
+            throwInvalidDateString("Error parsing second", string, low, high);
         }
 
-        if (index == end)
+        if (index == high)
         {
             return DateWithSecond.newDateWithSecond(year, month, day, hour, minute, second);
         }
@@ -557,10 +557,10 @@ public class DateFormat
         {
             // Subsecond
             previous = index + 1;
-            index = findNonDigit(string, previous, end);
+            index = findNonDigit(string, previous, high);
             if (index == previous)
             {
-                throwInvalidDateString(string, start, end);
+                throwInvalidDateString(string, low, high);
             }
             String subsecond = string.substring(previous, index);
             date = DateWithSubsecond.newDateWithSubsecond(year, month, day, hour, minute, second, subsecond);
@@ -570,10 +570,10 @@ public class DateFormat
             date = DateWithSecond.newDateWithSecond(year, month, day, hour, minute, second);
         }
 
-        if (index < end)
+        if (index < high)
         {
             // Time zone
-            int offsetInMinutes = getTimeZoneOffsetInMinutes(string, index, end);
+            int offsetInMinutes = getTimeZoneOffsetInMinutes(string, index, high);
             return date.addMinutes(-offsetInMinutes);
         }
 
@@ -732,11 +732,6 @@ public class DateFormat
     private static boolean isDigit(char character)
     {
         return ('0' <= character) && (character <= '9');
-    }
-
-    private static void throwInvalidDateString(String string)
-    {
-        throwInvalidDateString(string, 0, string.length());
     }
 
     private static void throwInvalidDateString(String string, int start, int end)

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -17,8 +17,7 @@ package org.finos.legend.pure.m4.coreinstance.primitive.date;
 import org.finos.legend.pure.m4.tools.SafeAppendable;
 
 import java.io.IOException;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
+import java.time.ZonedDateTime;
 import java.util.TimeZone;
 
 public class DateFormat
@@ -33,7 +32,7 @@ public class DateFormat
     {
         SafeAppendable safeAppendable = SafeAppendable.wrap(appendable);
         int length = formatString.length();
-        GregorianCalendar calendar = null;
+        ZonedDateTime zoned = null;
         StringBuilder timeZoneId = new StringBuilder();
         int i = 0;
         while (i < length)
@@ -97,12 +96,11 @@ public class DateFormat
 
                     if (date.hasHour())
                     {
-                        if (calendar == null)
+                        if (zoned == null)
                         {
                             // A Pure date is always understood as UTC, so the instant it starts at
                             // is what the requested zone renders.
-                            calendar = new GregorianCalendar(timeZone);
-                            calendar.setTimeInMillis(PureDateToJava.start().toInstant(date).toEpochMilli());
+                            zoned = PureDateToJava.start().toInstant(date).atZone(timeZone.toZoneId());
                         }
                     }
                     break;
@@ -110,7 +108,7 @@ public class DateFormat
                 // Year
                 case 'y':
                 {
-                    int displayYear = (calendar == null) ? date.getYear() : calendar.get(Calendar.YEAR);
+                    int displayYear = (zoned == null) ? date.getYear() : zoned.getYear();
                     int count = getCharCountFrom(character, formatString, i);
                     if (count < 3)
                     {
@@ -133,7 +131,7 @@ public class DateFormat
                     {
                         throw new IllegalArgumentException("Date has no month: " + date);
                     }
-                    int displayMonth = (calendar == null) ? date.getMonth() : (calendar.get(Calendar.MONTH) + 1);
+                    int displayMonth = (zoned == null) ? date.getMonth() : zoned.getMonthValue();
                     int count = getCharCountFrom(character, formatString, i);
                     appendZeroPaddedInt(safeAppendable, displayMonth, count + 1);
                     i += count;
@@ -146,7 +144,7 @@ public class DateFormat
                     {
                         throw new IllegalArgumentException("Date has no day: " + date);
                     }
-                    int displayDay = (calendar == null) ? date.getDay() : calendar.get(Calendar.DAY_OF_MONTH);
+                    int displayDay = (zoned == null) ? date.getDay() : zoned.getDayOfMonth();
                     int count = getCharCountFrom(character, formatString, i);
                     appendZeroPaddedInt(safeAppendable, displayDay, count + 1);
                     i += count;
@@ -159,7 +157,7 @@ public class DateFormat
                     {
                         throw new IllegalArgumentException("Date has no hour: " + date);
                     }
-                    int preDisplayHour = (calendar == null) ? date.getHour() : calendar.get(Calendar.HOUR_OF_DAY);
+                    int preDisplayHour = (zoned == null) ? date.getHour() : zoned.getHour();
                     int displayHour = (preDisplayHour == 0) ? 12 : ((preDisplayHour > 12) ? (preDisplayHour - 12) : preDisplayHour);
                     int count = getCharCountFrom(character, formatString, i);
                     appendZeroPaddedInt(safeAppendable, displayHour, count + 1);
@@ -173,7 +171,7 @@ public class DateFormat
                     {
                         throw new IllegalArgumentException("Date has no hour: " + date);
                     }
-                    int displayHour = (calendar == null) ? date.getHour() : calendar.get(Calendar.HOUR_OF_DAY);
+                    int displayHour = (zoned == null) ? date.getHour() : zoned.getHour();
                     int count = getCharCountFrom(character, formatString, i);
                     appendZeroPaddedInt(safeAppendable, displayHour, count + 1);
                     i += count;
@@ -186,7 +184,7 @@ public class DateFormat
                     {
                         throw new IllegalArgumentException("Date has no hour: " + date);
                     }
-                    int displayHour = (calendar == null) ? date.getHour() : calendar.get(Calendar.HOUR_OF_DAY);
+                    int displayHour = (zoned == null) ? date.getHour() : zoned.getHour();
                     safeAppendable.append((displayHour < 12) ? "AM" : "PM");
                     break;
                 }
@@ -197,7 +195,7 @@ public class DateFormat
                     {
                         throw new IllegalArgumentException("Date has no minute: " + date);
                     }
-                    int displayMinute = (calendar == null) ? date.getMinute() : calendar.get(Calendar.MINUTE);
+                    int displayMinute = (zoned == null) ? date.getMinute() : zoned.getMinute();
                     int count = getCharCountFrom(character, formatString, i);
                     appendZeroPaddedInt(safeAppendable, displayMinute, count + 1);
                     i += count;
@@ -210,7 +208,7 @@ public class DateFormat
                     {
                         throw new IllegalArgumentException("Date has no second: " + date);
                     }
-                    int displaySecond = (calendar == null) ? date.getSecond() : calendar.get(Calendar.SECOND);
+                    int displaySecond = (zoned == null) ? date.getSecond() : zoned.getSecond();
                     int count = getCharCountFrom(character, formatString, i);
                     appendZeroPaddedInt(safeAppendable, displaySecond, count + 1);
                     i += count;
@@ -252,7 +250,7 @@ public class DateFormat
                 case 'z':
                 {
                     int count = getCharCountFrom(character, formatString, i);
-                    safeAppendable.append((calendar == null) ? "GMT" : timeZoneId);
+                    safeAppendable.append((zoned == null) ? "GMT" : timeZoneId);
                     i += count;
                     break;
                 }
@@ -260,7 +258,7 @@ public class DateFormat
                 case 'Z':
                 {
                     int count = getCharCountFrom(character, formatString, i);
-                    appendRFC822TimeZone(safeAppendable, getOffsetInMinutes(calendar));
+                    appendRFC822TimeZone(safeAppendable, getOffsetInMinutes(zoned));
                     i += count;
                     break;
                 }
@@ -268,7 +266,7 @@ public class DateFormat
                 case 'X':
                 {
                     int count = getCharCountFrom(character, formatString, i);
-                    appendISO8601TimeZone(safeAppendable, getOffsetInMinutes(calendar));
+                    appendISO8601TimeZone(safeAppendable, getOffsetInMinutes(zoned));
                     i += count;
                     break;
                 }
@@ -621,17 +619,17 @@ public class DateFormat
     }
 
     /**
-     * Get the offset from UTC the given calendar is rendering at, in whole minutes. A null calendar
+     * Get the offset from UTC the given date and time is at, in whole minutes. A null argument
      * means no time zone was asked for, and a Pure date with no time zone is UTC. Time zones that
      * are not a whole number of minutes from UTC are rounded towards it, as neither notation below
      * can express the seconds.
      *
-     * @param calendar calendar being rendered, or null for UTC
+     * @param zoned date and time being rendered, or null for UTC
      * @return offset from UTC in minutes
      */
-    private static int getOffsetInMinutes(Calendar calendar)
+    private static int getOffsetInMinutes(ZonedDateTime zoned)
     {
-        return (calendar == null) ? 0 : ((calendar.get(Calendar.ZONE_OFFSET) + calendar.get(Calendar.DST_OFFSET)) / 60_000);
+        return (zoned == null) ? 0 : (zoned.getOffset().getTotalSeconds() / 60);
     }
 
     /**

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -17,7 +17,6 @@ package org.finos.legend.pure.m4.coreinstance.primitive.date;
 import org.finos.legend.pure.m4.tools.SafeAppendable;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
@@ -268,16 +267,7 @@ public class DateFormat
                 case 'Z':
                 {
                     int count = getCharCountFrom(character, formatString, i);
-                    if (calendar == null)
-                    {
-                        safeAppendable.append("+0000");
-                    }
-                    else
-                    {
-                        SimpleDateFormat dateFormat = new SimpleDateFormat("Z");
-                        dateFormat.setTimeZone(calendar.getTimeZone());
-                        safeAppendable.append(dateFormat.format(calendar.getTime()));
-                    }
+                    appendRFC822TimeZone(safeAppendable, getOffsetInMinutes(calendar));
                     i += count;
                     break;
                 }
@@ -285,16 +275,7 @@ public class DateFormat
                 case 'X':
                 {
                     int count = getCharCountFrom(character, formatString, i);
-                    if (calendar == null)
-                    {
-                        safeAppendable.append("Z");
-                    }
-                    else
-                    {
-                        SimpleDateFormat dateFormat = new SimpleDateFormat("X");
-                        dateFormat.setTimeZone(calendar.getTimeZone());
-                        safeAppendable.append(dateFormat.format(calendar.getTime()));
-                    }
+                    appendISO8601TimeZone(safeAppendable, getOffsetInMinutes(calendar));
                     i += count;
                     break;
                 }
@@ -644,6 +625,61 @@ public class DateFormat
         int minuteOffset = Integer.parseInt(string.substring(start + 2, end));
         int totalOffset = (hourOffset * 60) + minuteOffset;
         return negative ? -totalOffset : totalOffset;
+    }
+
+    /**
+     * Get the offset from UTC the given calendar is rendering at, in whole minutes. A null calendar
+     * means no time zone was asked for, and a Pure date with no time zone is UTC. Time zones that
+     * are not a whole number of minutes from UTC are rounded towards it, as neither notation below
+     * can express the seconds.
+     *
+     * @param calendar calendar being rendered, or null for UTC
+     * @return offset from UTC in minutes
+     */
+    private static int getOffsetInMinutes(Calendar calendar)
+    {
+        return (calendar == null) ? 0 : ((calendar.get(Calendar.ZONE_OFFSET) + calendar.get(Calendar.DST_OFFSET)) / 60_000);
+    }
+
+    /**
+     * Append an offset in the RFC 822 notation, which is a sign, two digits of hours, and two of
+     * minutes, with no separator and nothing omitted: UTC is written {@code +0000}.
+     *
+     * @param appendable      appendable to write to
+     * @param offsetInMinutes offset from UTC in minutes
+     */
+    private static void appendRFC822TimeZone(SafeAppendable appendable, int offsetInMinutes)
+    {
+        int absolute = Math.abs(offsetInMinutes);
+        appendable.append((offsetInMinutes < 0) ? '-' : '+');
+        appendNonNegTwoDigitInt(appendable, absolute / 60);
+        appendNonNegTwoDigitInt(appendable, absolute % 60);
+    }
+
+    /**
+     * Append an offset in the ISO 8601 notation, which writes UTC as {@code Z} and omits the
+     * minutes of an offset that has none, but keeps them where there are any: an offset of five and
+     * a half hours is {@code +0530}, not {@code +05}.
+     *
+     * @param appendable      appendable to write to
+     * @param offsetInMinutes offset from UTC in minutes
+     */
+    private static void appendISO8601TimeZone(SafeAppendable appendable, int offsetInMinutes)
+    {
+        if (offsetInMinutes == 0)
+        {
+            appendable.append('Z');
+            return;
+        }
+
+        int absolute = Math.abs(offsetInMinutes);
+        appendable.append((offsetInMinutes < 0) ? '-' : '+');
+        appendNonNegTwoDigitInt(appendable, absolute / 60);
+        int minutes = absolute % 60;
+        if (minutes != 0)
+        {
+            appendNonNegTwoDigitInt(appendable, minutes);
+        }
     }
 
     private static void appendNonNegTwoDigitInt(SafeAppendable appendable, int integer)

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -1,0 +1,455 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m4.coreinstance.primitive.date;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+
+/**
+ * Tests for {@link DateFormat}: rendering a Pure date through a format string, writing the
+ * canonical Pure date string, and parsing one back.
+ *
+ * <p>{@link TestPureDate} covers the rendering through {@link PureDate#format(String)} and
+ * {@link PureDate#toString()}, which delegate here. These tests go at {@link DateFormat} directly,
+ * so they can also reach the parse methods and the substring overload nothing else exercises.
+ */
+public class TestDateFormat
+{
+    private static final PureDate DATE = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070004235");
+
+    /**
+     * The same date at every granularity, each rendered as the canonical Pure date string.
+     */
+    private static final PureDate[] DATES = {
+            DateFunctions.newPureDate(2014),
+            DateFunctions.newPureDate(2014, 3),
+            DateFunctions.newPureDate(2014, 3, 10),
+            DateFunctions.newPureDate(2014, 3, 10, 16),
+            DateFunctions.newPureDate(2014, 3, 10, 16, 12),
+            DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35),
+            DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070004235")
+    };
+
+    private static final String[] CANONICAL_STRINGS = {
+            "2014",
+            "2014-03",
+            "2014-03-10",
+            "2014-03-10T16",
+            "2014-03-10T16:12+0000",
+            "2014-03-10T16:12:35+0000",
+            "2014-03-10T16:12:35.070004235+0000"
+    };
+
+    // Format: date components
+
+    /**
+     * The year is written in full only from four letters on, and the full form is not padded, so a
+     * year of fewer than four digits is shorter than the format string suggests.
+     */
+    @Test
+    public void testFormatYear()
+    {
+        Assert.assertEquals("14", format("y", DATE));
+        Assert.assertEquals("14", format("yy", DATE));
+        Assert.assertEquals("14", format("yyy", DATE));
+        Assert.assertEquals("2014", format("yyyy", DATE));
+        Assert.assertEquals("2014", format("yyyyy", DATE));
+
+        Assert.assertEquals("00", format("yy", DateFunctions.newPureDate(2000, 3, 10)));
+        Assert.assertEquals("05", format("yy", DateFunctions.newPureDate(5, 3, 10)));
+        Assert.assertEquals("5", format("yyyy", DateFunctions.newPureDate(5, 3, 10)));
+        Assert.assertEquals("23", format("yy", DateFunctions.newPureDate(123, 3, 10)));
+        Assert.assertEquals("123", format("yyyy", DateFunctions.newPureDate(123, 3, 10)));
+        Assert.assertEquals("00", format("yy", DateFunctions.newPureDate(0, 3, 10)));
+        Assert.assertEquals("0", format("yyyy", DateFunctions.newPureDate(0, 3, 10)));
+        Assert.assertEquals("-44", format("yyyy", DateFunctions.newPureDate(-44, 3, 10)));
+    }
+
+    /**
+     * The month, day, hour, minute, and second are padded to one more digit than the format string
+     * repeats the letter, so a single letter gives no padding at all.
+     */
+    @Test
+    public void testFormatZeroPaddedComponents()
+    {
+        Assert.assertEquals("3", format("M", DATE));
+        Assert.assertEquals("03", format("MM", DATE));
+        Assert.assertEquals("003", format("MMM", DATE));
+
+        Assert.assertEquals("10", format("d", DATE));
+        Assert.assertEquals("10", format("dd", DATE));
+        Assert.assertEquals("010", format("ddd", DATE));
+
+        Assert.assertEquals("12", format("m", DATE));
+        Assert.assertEquals("12", format("mm", DATE));
+        Assert.assertEquals("012", format("mmm", DATE));
+
+        Assert.assertEquals("35", format("s", DATE));
+        Assert.assertEquals("35", format("ss", DATE));
+        Assert.assertEquals("035", format("sss", DATE));
+
+        // a single digit component is padded only as far as it is asked to be
+        PureDate single = DateFunctions.newPureDate(2014, 3, 5, 6, 7, 8);
+        Assert.assertEquals("3", format("M", single));
+        Assert.assertEquals("03", format("MM", single));
+        Assert.assertEquals("5", format("d", single));
+        Assert.assertEquals("05", format("dd", single));
+        Assert.assertEquals("7", format("m", single));
+        Assert.assertEquals("07", format("mm", single));
+        Assert.assertEquals("8", format("s", single));
+        Assert.assertEquals("08", format("ss", single));
+    }
+
+    /**
+     * The hour is written either on the 24 hour clock, or on the 12 hour clock with midnight and
+     * noon both written as 12.
+     */
+    @Test
+    public void testFormatHourAndAmPm()
+    {
+        int[] hours = {0, 1, 11, 12, 13, 23};
+        String[] onTwelveHourClock = {"12", "1", "11", "12", "1", "11"};
+        String[] onTwelveHourClockPadded = {"12", "01", "11", "12", "01", "11"};
+        String[] onTwentyFourHourClock = {"0", "1", "11", "12", "13", "23"};
+        String[] amPm = {"AM", "AM", "AM", "PM", "PM", "PM"};
+        for (int i = 0; i < hours.length; i++)
+        {
+            PureDate date = DateFunctions.newPureDate(2014, 3, 10, hours[i], 12);
+            Assert.assertEquals(date.toString(), onTwelveHourClock[i], format("h", date));
+            Assert.assertEquals(date.toString(), onTwelveHourClockPadded[i], format("hh", date));
+            Assert.assertEquals(date.toString(), onTwentyFourHourClock[i], format("H", date));
+            Assert.assertEquals(date.toString(), amPm[i], format("a", date));
+        }
+    }
+
+    /**
+     * The subsecond is cut to one more digit than the format string repeats the letter, but from
+     * four letters on it is written in full however many digits it has. It is never padded, so a
+     * date with fewer digits than were asked for gives all it has and no more.
+     */
+    @Test
+    public void testFormatSubsecond()
+    {
+        Assert.assertEquals("0", format("S", DATE));
+        Assert.assertEquals("07", format("SS", DATE));
+        Assert.assertEquals("070", format("SSS", DATE));
+        Assert.assertEquals("070004235", format("SSSS", DATE));
+        Assert.assertEquals("070004235", format("SSSSSSSSSS", DATE));
+
+        PureDate hundredths = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "07");
+        Assert.assertEquals("0", format("S", hundredths));
+        Assert.assertEquals("07", format("SS", hundredths));
+        Assert.assertEquals("07", format("SSS", hundredths));
+        Assert.assertEquals("07", format("SSSS", hundredths));
+    }
+
+    // Format: literals
+
+    @Test
+    public void testFormatSeparatorsAndLiteralText()
+    {
+        Assert.assertEquals("2014-03-10", format("yyyy-MM-dd", DATE));
+        Assert.assertEquals("2014/03/10", format("yyyy/MM/dd", DATE));
+        Assert.assertEquals("2014.03.10", format("yyyy.MM.dd", DATE));
+        Assert.assertEquals("16:12:35", format("HH:mm:ss", DATE));
+        Assert.assertEquals("2014 03 10", format("yyyy MM dd", DATE));
+        Assert.assertEquals("2014\t03", format("yyyy\tMM", DATE));
+        Assert.assertEquals("", format("", DATE));
+
+        // quoted text is written out as it stands, and a backslash escapes a quote within it
+        Assert.assertEquals("2014T03", format("yyyy\"T\"MM", DATE));
+        Assert.assertEquals("at 16", format("\"at\" HH", DATE));
+        Assert.assertEquals("a\"b 16", format("\"a\\\"b\" HH", DATE));
+        Assert.assertEquals("yyyy", format("\"yyyy\"", DATE));
+    }
+
+    // Format: time zones
+
+    /**
+     * Without a time zone the date is written as what it is, a time in UTC, in each of the three
+     * time zone notations.
+     */
+    @Test
+    public void testFormatTimeZoneOfADateWithNoTimeZoneGiven()
+    {
+        Assert.assertEquals("GMT", format("z", DATE));
+        Assert.assertEquals("GMT", format("zzzz", DATE));
+        Assert.assertEquals("+0000", format("Z", DATE));
+        Assert.assertEquals("Z", format("X", DATE));
+        Assert.assertEquals("2014-03-10 16:12:35.070+0000", format("yyyy-MM-dd HH:mm:ss.SSSZ", DATE));
+    }
+
+    /**
+     * A time zone at the head of the format string shifts the date into that zone. The zone name
+     * may be quoted, and a backslash escapes a character within it; whichever way it is written, it
+     * is the text as given that a general time zone renders.
+     */
+    @Test
+    public void testFormatWithTimeZone()
+    {
+        Assert.assertEquals("2014-03-10 11:12:35.070-0500", format("[EST]yyyy-MM-dd HH:mm:ss.SSSZ", DATE));
+        Assert.assertEquals("2014-03-10 17:12:35.070+0100", format("[CET]yyyy-MM-dd HH:mm:ss.SSSZ", DATE));
+        Assert.assertEquals("2014-03-10 17:12:35.070+0100", format("[\"CET\"]yyyy-MM-dd HH:mm:ss.SSSZ", DATE));
+        Assert.assertEquals("2014-03-10 17:12:35.070+0100", format("[CE\\T]yyyy-MM-dd HH:mm:ss.SSSZ", DATE));
+
+        Assert.assertEquals("CET", format("[CET]z", DATE));
+        Assert.assertEquals("CET", format("[CE\\T]z", DATE));
+        Assert.assertEquals("+01", format("[CET]X", DATE));
+
+        // an unknown zone is GMT, but a general time zone still renders the name as given
+        Assert.assertEquals("2014-03-10 16:12:35.070+0000", format("[Europe/Lissabon]yyyy-MM-dd HH:mm:ss.SSSZ", DATE));
+        Assert.assertEquals("Europe/Lissabon", format("[Europe/Lissabon]z", DATE));
+
+        // a date with no hour is never shifted
+        PureDate day = DateFunctions.newPureDate(2015, 8, 15);
+        Assert.assertEquals("2015-08-15", format("[EST]yyyy-MM-dd", day));
+        Assert.assertEquals("GMT", format("[EST]z", day));
+    }
+
+    /**
+     * A shifted date is rendered at the instant it stands for, whatever the zone happens to be
+     * doing around it, so it has to agree with {@code java.time} for the same instant and zone -
+     * including across the hour a zone skips when daylight saving time begins and the hour it
+     * repeats when it ends, where a wall clock reading of the date would not.
+     */
+    @Test
+    public void testFormatWithTimeZoneAgreesWithJavaTime()
+    {
+        String[] zoneIds = {"GMT", "UTC", "EST", "CET", "America/New_York", "Europe/London", "Asia/Tokyo", "Australia/Adelaide"};
+        PureDate[] dates = {
+                DateFunctions.parsePureDate("2014-01-15T23:45:00"),
+                DateFunctions.parsePureDate("2014-03-09T02:30:00"),   // in the hour New York skips
+                DateFunctions.parsePureDate("2014-03-09T07:00:00"),   // the instant it skips to
+                DateFunctions.parsePureDate("2014-11-02T05:30:00"),   // the first pass through the hour it repeats
+                DateFunctions.parsePureDate("2014-11-02T06:30:00"),   // the second
+                DateFunctions.parsePureDate("2014-03-30T01:30:00"),   // London, an hour into summer time
+                DateFunctions.parsePureDate("2014-07-04T12:00:00")
+        };
+        DateTimeFormatter expectedFormat = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss Z");
+        for (String zoneId : zoneIds)
+        {
+            ZoneId zone = TimeZone.getTimeZone(zoneId).toZoneId();
+            for (PureDate date : dates)
+            {
+                String expected = PureDateToJava.start().toInstant(date).atZone(zone).format(expectedFormat);
+                Assert.assertEquals(zoneId + " " + date, expected, format("[" + zoneId + "]yyyy-MM-dd HH:mm:ss Z", date));
+            }
+        }
+    }
+
+    // Format: errors
+
+    /**
+     * A format string may only ask for components the date has, since there is nothing to write for
+     * one it does not carry and no reason to think a date of that granularity was intended.
+     */
+    @Test
+    public void testFormatOfAComponentTheDateDoesNotHave()
+    {
+        assertFormatFails("Date has no month: 2014", "yyyy-MM", DATES[0]);
+        assertFormatFails("Date has no day: 2014-03", "yyyy-MM-dd", DATES[1]);
+        assertFormatFails("Date has no hour: 2014-03-10", "yyyy-MM-dd HH", DATES[2]);
+        assertFormatFails("Date has no hour: 2014-03-10", "h", DATES[2]);
+        assertFormatFails("Date has no hour: 2014-03-10", "a", DATES[2]);
+        assertFormatFails("Date has no minute: 2014-03-10T16", "HH:mm", DATES[3]);
+        assertFormatFails("Date has no second: 2014-03-10T16:12+0000", "HH:mm:ss", DATES[4]);
+        assertFormatFails("Date has no sub-second: 2014-03-10T16:12:35+0000", "HH:mm:ss.SSS", DATES[5]);
+    }
+
+    @Test
+    public void testFormatWithAnInvalidFormatString()
+    {
+        assertFormatFails("Invalid format control character 'Q' in format string: yyyy-Q", "yyyy-Q", DATE);
+        assertFormatFails("Invalid format control character '#' in format string: #", "#", DATE);
+        assertFormatFails("Missing closing quote in format string: \"abc", "\"abc", DATE);
+        assertFormatFails("Missing closing bracket in format string: [EST", "[EST", DATE);
+        assertFormatFails("Missing closing quotes in time zone definition: [\"EST]yyyy", "[\"EST]yyyy", DATE);
+        assertFormatFails("Time zone can only be set at the beginning of the format string", "yyyy[EST]", DATE);
+        assertFormatFails("Time zone can only be set at the beginning of the format string", "[EST]yyyy[EST]", DATE);
+    }
+
+    /**
+     * {@link LatestDate} has no components to write, so it can be neither formatted nor appended.
+     */
+    @Test
+    public void testLatestDateCannotBeWritten()
+    {
+        Assert.assertEquals(
+                "Invalid operation for LatestDate",
+                Assert.assertThrows(UnsupportedOperationException.class, () -> format("yyyy", LatestDate.instance)).getMessage());
+        Assert.assertEquals(
+                "Invalid operation for LatestDate",
+                Assert.assertThrows(UnsupportedOperationException.class, () -> DateFormat.append(new StringBuilder(), LatestDate.instance)).getMessage());
+    }
+
+    // Append
+
+    @Test
+    public void testAppendWritesTheCanonicalString()
+    {
+        for (int i = 0; i < DATES.length; i++)
+        {
+            Assert.assertEquals(CANONICAL_STRINGS[i], DateFormat.append(new StringBuilder(), DATES[i]).toString());
+
+            // which is what the date renders itself as
+            Assert.assertEquals(CANONICAL_STRINGS[i], DATES[i].toString());
+        }
+
+        // the offset is written from minute granularity on, where there is a time to which it applies
+        Assert.assertEquals("2014-03-10T16", DateFormat.append(new StringBuilder(), DATES[3]).toString());
+        Assert.assertEquals("-44-03-10", DateFormat.append(new StringBuilder(), DateFunctions.newPureDate(-44, 3, 10)).toString());
+    }
+
+    /**
+     * Both writers append to what they are given and hand it back, rather than returning something
+     * of their own, so a caller can keep building on it.
+     */
+    @Test
+    public void testTheWritersReturnTheAppendableTheyWereGiven()
+    {
+        StringBuilder builder = new StringBuilder("date: ");
+        Assert.assertSame(builder, DateFormat.append(builder, DATE));
+        Assert.assertSame(builder, DateFormat.format(builder, " \"(\"yyyy\")\"", DATE));
+        Assert.assertEquals("date: 2014-03-10T16:12:35.070004235+0000 (2014)", builder.toString());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testWriteWritesTheCanonicalString() throws IOException
+    {
+        StringWriter writer = new StringWriter();
+        DateFormat.write(writer, DATE);
+        Assert.assertEquals("2014-03-10T16:12:35.070004235+0000", writer.toString());
+    }
+
+    // Parse
+
+    @Test
+    public void testParsePureDateAtEachGranularity()
+    {
+        for (int i = 0; i < DATES.length; i++)
+        {
+            Assert.assertEquals(CANONICAL_STRINGS[i], DATES[i], DateFormat.parsePureDate(CANONICAL_STRINGS[i]));
+        }
+    }
+
+    /**
+     * Parsing and appending are inverse: every date writes a string that parses back to it.
+     */
+    @Test
+    public void testAppendAndParseRoundTrip()
+    {
+        for (PureDate date : DATES)
+        {
+            Assert.assertEquals(date, DateFormat.parsePureDate(DateFormat.append(new StringBuilder(), date).toString()));
+        }
+    }
+
+    /**
+     * The overload taking a range parses a date out of the middle of a larger string, which is how
+     * a date embedded in Pure source is read.
+     */
+    @Test
+    public void testParsePureDateWithinALargerString()
+    {
+        String string = "xx%2014-03-10T16:12:35zz";
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35), DateFormat.parsePureDate(string, 2, 22));
+
+        // the range decides what is parsed, not the string
+        Assert.assertEquals(DateFunctions.newPureDate(2014), DateFormat.parsePureDate("2014-03-10", 0, 4));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3), DateFormat.parsePureDate("2014-03-10", 0, 7));
+
+        // whitespace within the range is skipped, at either end
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3), DateFormat.parsePureDate("  2014-03  ", 0, 11));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3), DateFormat.parsePureDate("\t2014-03\n", 0, 9));
+    }
+
+    /**
+     * The typed parse methods are the plain one with a cast, so a string of the wrong granularity
+     * fails as a cast rather than as a parse.
+     */
+    @Test
+    public void testParseStrictDateAndParseDateTime()
+    {
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10), DateFormat.parseStrictDate("2014-03-10"));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10), DateFormat.parseStrictDate("%2014-03-10"));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10, 16), DateFormat.parseDateTime("2014-03-10T16"));
+        Assert.assertEquals(DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070"), DateFormat.parseDateTime("2014-03-10T16:12:35.070"));
+
+        Assert.assertThrows(ClassCastException.class, () -> DateFormat.parseStrictDate("2014"));
+        Assert.assertThrows(ClassCastException.class, () -> DateFormat.parseStrictDate("2014-03-10T16"));
+        Assert.assertThrows(ClassCastException.class, () -> DateFormat.parseDateTime("2014-03-10"));
+    }
+
+    @Test
+    public void testParseTimeZoneOffsets()
+    {
+        PureDate expected = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35);
+        Assert.assertEquals(expected, DateFormat.parsePureDate("2014-03-10T16:12:35"));
+        Assert.assertEquals(expected, DateFormat.parsePureDate("2014-03-10T16:12:35Z"));
+        Assert.assertEquals(expected, DateFormat.parsePureDate("2014-03-10T16:12:35+0000"));
+        Assert.assertEquals(expected, DateFormat.parsePureDate("2014-03-10T11:12:35-0500"));
+        Assert.assertEquals(expected, DateFormat.parsePureDate("2014-03-10T17:12:35+0100"));
+        Assert.assertEquals(expected, DateFormat.parsePureDate("2014-03-10T16:42:35+0030"));
+
+        // an offset can carry the date into the next day
+        Assert.assertEquals(
+                DateFunctions.newPureDate(2014, 3, 11, 2, 12),
+                DateFormat.parsePureDate("2014-03-10T21:12-0500"));
+    }
+
+    @Test
+    public void testParseInvalidDateStrings()
+    {
+        assertParseFails("Invalid date string: ''", "");
+        assertParseFails("Invalid date string: '   '", "   ");
+        assertParseFails("Invalid date string: '%'", "%");
+        assertParseFails("Error parsing year: 'not a date'", "not a date");
+        assertParseFails("Invalid date string: '2014/03'", "2014/03");
+        assertParseFails("Invalid time zone: +5", "2014-03-10T16:12:35+5");
+
+        // a quote in the offending string is escaped in the message
+        assertParseFails("Error parsing month: '2014-\\'x'", "2014-'x");
+    }
+
+    // Helpers
+
+    private static String format(String formatString, PureDate date)
+    {
+        return DateFormat.format(new StringBuilder(), formatString, date).toString();
+    }
+
+    private static void assertFormatFails(String expectedMessage, String formatString, PureDate date)
+    {
+        Assert.assertEquals(
+                formatString,
+                expectedMessage,
+                Assert.assertThrows(formatString, IllegalArgumentException.class, () -> format(formatString, date)).getMessage());
+    }
+
+    private static void assertParseFails(String expectedMessage, String string)
+    {
+        Assert.assertEquals(
+                string,
+                expectedMessage,
+                Assert.assertThrows(string, IllegalArgumentException.class, () -> DateFormat.parsePureDate(string)).getMessage());
+    }
+}

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -84,9 +84,8 @@ public class TestDateFormat
     }
 
     /**
-     * A year before the era has last two digits like any other. They used to be written as the two
-     * characters below '0' by however much the year was negative, so -44 wrote a start of text
-     * control character and -1 wrote a slash.
+     * A year before the era has last two digits like any other, and the two digit form drops the
+     * sign along with the century.
      */
     @Test
     public void testFormatTwoDigitYearBeforeTheEra()

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -242,6 +242,33 @@ public class TestDateFormat
     }
 
     /**
+     * A Pure date is a proleptic Gregorian date, which is the calendar it is built on, and asking
+     * for a time zone does not change the calendar it is read in. The Gregorian calendar was not
+     * adopted until 1582, so a date before that is nine days from what the same date would be on
+     * the Julian calendar in use at the time, but it is the Pure date that is being written out.
+     */
+    @Test
+    public void testFormatBeforeTheGregorianCalendarWasAdopted()
+    {
+        PureDate date = DateFunctions.parsePureDate("1500-01-15T12:00:00");
+        Assert.assertEquals("1500-01-15 12:00:00 +0000", format("yyyy-MM-dd HH:mm:ss Z", date));
+        Assert.assertEquals("1500-01-15 12:00:00 +0000", format("[GMT]yyyy-MM-dd HH:mm:ss Z", date));
+        Assert.assertEquals("1500-01-15 17:00:00 +0500", format("[GMT+5]yyyy-MM-dd HH:mm:ss Z", date));
+    }
+
+    /**
+     * Before standard time a zone was whatever its own noon made it, which was rarely a whole
+     * number of hours from UTC: New York was 4 hours 56 minutes behind it until 1883.
+     */
+    @Test
+    public void testFormatBeforeStandardTime()
+    {
+        PureDate date = DateFunctions.parsePureDate("1800-01-15T12:00:00");
+        Assert.assertEquals("1800-01-15 07:03:58 -0456", format("[America/New_York]yyyy-MM-dd HH:mm:ss Z", date));
+        Assert.assertEquals("1800-01-15 11:58:45 -0001", format("[Europe/London]yyyy-MM-dd HH:mm:ss Z", date));
+    }
+
+    /**
      * The two numeric time zone notations differ in how they write UTC and in what they leave out:
      * RFC 822 always writes a sign, two digits of hours and two of minutes, while ISO 8601 writes
      * UTC as Z and omits the minutes of an offset that has none. Neither may drop minutes an offset
@@ -298,6 +325,8 @@ public class TestDateFormat
     {
         String[] zoneIds = {"GMT", "UTC", "EST", "CET", "America/New_York", "Europe/London", "Asia/Tokyo", "Australia/Adelaide", "Asia/Kathmandu", "Pacific/Chatham", "Africa/Monrovia"};
         PureDate[] dates = {
+                DateFunctions.parsePureDate("1500-01-15T12:00:00"),   // before the Gregorian calendar was adopted
+                DateFunctions.parsePureDate("1800-01-15T12:00:00"),   // before standard time
                 DateFunctions.parsePureDate("1960-01-01T12:00:30"),   // Monrovia, not a whole minute from UTC
                 DateFunctions.parsePureDate("2014-01-15T23:45:00"),
                 DateFunctions.parsePureDate("2014-03-09T02:30:00"),   // in the hour New York skips

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -84,6 +84,24 @@ public class TestDateFormat
     }
 
     /**
+     * A year before the era has last two digits like any other. They used to be written as the two
+     * characters below '0' by however much the year was negative, so -44 wrote a start of text
+     * control character and -1 wrote a slash.
+     */
+    @Test
+    public void testFormatTwoDigitYearBeforeTheEra()
+    {
+        Assert.assertEquals("44", format("yy", DateFunctions.newPureDate(-44, 3, 10)));
+        Assert.assertEquals("01", format("yy", DateFunctions.newPureDate(-1, 3, 10)));
+        Assert.assertEquals("14", format("yy", DateFunctions.newPureDate(-2014, 3, 10)));
+        Assert.assertEquals("00", format("yy", DateFunctions.newPureDate(-100, 3, 10)));
+
+        // the full form keeps the sign
+        Assert.assertEquals("-1", format("yyyy", DateFunctions.newPureDate(-1, 3, 10)));
+        Assert.assertEquals("-2014", format("yyyy", DateFunctions.newPureDate(-2014, 3, 10)));
+    }
+
+    /**
      * The month, day, hour, minute, and second are padded to one more digit than the format string
      * repeats the letter, so a single letter gives no padding at all.
      */

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -243,6 +243,18 @@ public class TestDateFormat
     }
 
     /**
+     * A zone need not be a whole number of minutes from UTC: Liberia was 44 minutes and 30 seconds
+     * behind it until 1972. The second is part of the shift there, so it comes from the shifted
+     * time along with every other component.
+     */
+    @Test
+    public void testFormatWithATimeZoneThatIsNotAWholeNumberOfMinutesFromUTC()
+    {
+        PureDate date = DateFunctions.parsePureDate("1960-01-01T12:00:30");
+        Assert.assertEquals("1960-01-01 11:16:00 -0044", format("[Africa/Monrovia]yyyy-MM-dd HH:mm:ss Z", date));
+    }
+
+    /**
      * A shifted date is rendered at the instant it stands for, whatever the zone happens to be
      * doing around it, so it has to agree with {@code java.time} for the same instant and zone -
      * including across the hour a zone skips when daylight saving time begins and the hour it
@@ -251,8 +263,9 @@ public class TestDateFormat
     @Test
     public void testFormatWithTimeZoneAgreesWithJavaTime()
     {
-        String[] zoneIds = {"GMT", "UTC", "EST", "CET", "America/New_York", "Europe/London", "Asia/Tokyo", "Australia/Adelaide"};
+        String[] zoneIds = {"GMT", "UTC", "EST", "CET", "America/New_York", "Europe/London", "Asia/Tokyo", "Australia/Adelaide", "Africa/Monrovia"};
         PureDate[] dates = {
+                DateFunctions.parsePureDate("1960-01-01T12:00:30"),   // Monrovia, not a whole minute from UTC
                 DateFunctions.parsePureDate("2014-01-15T23:45:00"),
                 DateFunctions.parsePureDate("2014-03-09T02:30:00"),   // in the hour New York skips
                 DateFunctions.parsePureDate("2014-03-09T07:00:00"),   // the instant it skips to

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.TimeZone;
 
@@ -229,7 +230,6 @@ public class TestDateFormat
 
         Assert.assertEquals("CET", format("[CET]z", DATE));
         Assert.assertEquals("CET", format("[CE\\T]z", DATE));
-        Assert.assertEquals("+01", format("[CET]X", DATE));
 
         // an unknown zone is GMT, but a general time zone still renders the name as given
         Assert.assertEquals("2014-03-10 16:12:35.070+0000", format("[Europe/Lissabon]yyyy-MM-dd HH:mm:ss.SSSZ", DATE));
@@ -242,15 +242,49 @@ public class TestDateFormat
     }
 
     /**
+     * The two numeric time zone notations differ in how they write UTC and in what they leave out:
+     * RFC 822 always writes a sign, two digits of hours and two of minutes, while ISO 8601 writes
+     * UTC as Z and omits the minutes of an offset that has none. Neither may drop minutes an offset
+     * does have, and plenty of zones have them: India is five and a half hours ahead of UTC, not
+     * five.
+     */
+    @Test
+    public void testFormatNumericTimeZones()
+    {
+        Assert.assertEquals("+0000", format("Z", DATE));
+        Assert.assertEquals("Z", format("X", DATE));
+        Assert.assertEquals("+0000", format("[GMT]Z", DATE));
+        Assert.assertEquals("Z", format("[GMT]X", DATE));
+
+        // a whole number of hours
+        Assert.assertEquals("-0500", format("[EST]Z", DATE));
+        Assert.assertEquals("-05", format("[EST]X", DATE));
+        Assert.assertEquals("+0100", format("[CET]Z", DATE));
+        Assert.assertEquals("+01", format("[CET]X", DATE));
+
+        // and half or a quarter of one
+        Assert.assertEquals("+0530", format("[Asia/Kolkata]Z", DATE));
+        Assert.assertEquals("+0530", format("[Asia/Kolkata]X", DATE));
+        Assert.assertEquals("+0545", format("[Asia/Kathmandu]Z", DATE));
+        Assert.assertEquals("+0545", format("[Asia/Kathmandu]X", DATE));
+        Assert.assertEquals("-0230", format("[America/St_Johns]Z", DATE));
+        Assert.assertEquals("-0230", format("[America/St_Johns]X", DATE));
+        Assert.assertEquals("+1345", format("[Pacific/Chatham]Z", DATE));
+        Assert.assertEquals("+1345", format("[Pacific/Chatham]X", DATE));
+    }
+
+    /**
      * A zone need not be a whole number of minutes from UTC: Liberia was 44 minutes and 30 seconds
      * behind it until 1972. The second is part of the shift there, so it comes from the shifted
-     * time along with every other component.
+     * time along with every other component, and neither notation can express it, so both round
+     * the offset towards UTC.
      */
     @Test
     public void testFormatWithATimeZoneThatIsNotAWholeNumberOfMinutesFromUTC()
     {
         PureDate date = DateFunctions.parsePureDate("1960-01-01T12:00:30");
         Assert.assertEquals("1960-01-01 11:16:00 -0044", format("[Africa/Monrovia]yyyy-MM-dd HH:mm:ss Z", date));
+        Assert.assertEquals("1960-01-01 11:16:00 -0044", format("[Africa/Monrovia]yyyy-MM-dd HH:mm:ss X", date));
     }
 
     /**
@@ -262,7 +296,7 @@ public class TestDateFormat
     @Test
     public void testFormatWithTimeZoneAgreesWithJavaTime()
     {
-        String[] zoneIds = {"GMT", "UTC", "EST", "CET", "America/New_York", "Europe/London", "Asia/Tokyo", "Australia/Adelaide", "Africa/Monrovia"};
+        String[] zoneIds = {"GMT", "UTC", "EST", "CET", "America/New_York", "Europe/London", "Asia/Tokyo", "Australia/Adelaide", "Asia/Kathmandu", "Pacific/Chatham", "Africa/Monrovia"};
         PureDate[] dates = {
                 DateFunctions.parsePureDate("1960-01-01T12:00:30"),   // Monrovia, not a whole minute from UTC
                 DateFunctions.parsePureDate("2014-01-15T23:45:00"),
@@ -273,14 +307,16 @@ public class TestDateFormat
                 DateFunctions.parsePureDate("2014-03-30T01:30:00"),   // London, an hour into summer time
                 DateFunctions.parsePureDate("2014-07-04T12:00:00")
         };
-        DateTimeFormatter expectedFormat = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss Z");
+        DateTimeFormatter rfc822 = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss Z");
+        DateTimeFormatter iso8601 = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss X");
         for (String zoneId : zoneIds)
         {
             ZoneId zone = TimeZone.getTimeZone(zoneId).toZoneId();
             for (PureDate date : dates)
             {
-                String expected = PureDateToJava.start().toInstant(date).atZone(zone).format(expectedFormat);
-                Assert.assertEquals(zoneId + " " + date, expected, format("[" + zoneId + "]yyyy-MM-dd HH:mm:ss Z", date));
+                ZonedDateTime zoned = PureDateToJava.start().toInstant(date).atZone(zone);
+                Assert.assertEquals(zoneId + " " + date, zoned.format(rfc822), format("[" + zoneId + "]yyyy-MM-dd HH:mm:ss Z", date));
+                Assert.assertEquals(zoneId + " " + date, zoned.format(iso8601), format("[" + zoneId + "]yyyy-MM-dd HH:mm:ss X", date));
             }
         }
     }

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestPureDate.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestPureDate.java
@@ -80,6 +80,23 @@ public class TestPureDate
                 Assert.assertThrows(IllegalArgumentException.class, () -> date.format("[\"CET]yyyy-MM-dd HH:mm:ss.SSS z")).getMessage());
     }
 
+    /**
+     * A date is rendered at the instant it stands for, whatever the target zone happens to be doing
+     * around it. 2014-03-09T02:30 UTC is in the hour America/New_York skips when daylight saving
+     * time begins, so reading the date as a wall clock in that zone lands on an hour that does not
+     * exist there.
+     */
+    @Test
+    public void testFormatWithTimeZoneShiftAcrossADaylightSavingGap()
+    {
+        PureDate date = DateFunctions.newPureDate(2014, 3, 9, 2, 30, 0);
+        Assert.assertEquals("2014-03-08 21:30:00-0500", date.format("[America/New_York]yyyy-MM-dd HH:mm:ssZ"));
+
+        // and the hour repeated when it ends
+        PureDate overlap = DateFunctions.newPureDate(2014, 11, 2, 5, 30, 0);
+        Assert.assertEquals("2014-11-02 01:30:00-0400", overlap.format("[America/New_York]yyyy-MM-dd HH:mm:ssZ"));
+    }
+
     @Test
     public void testFormatWithTimeZoneShiftButNoHour()
     {


### PR DESCRIPTION
Remove usage of PureDate.getCalendar from DateFormat, and replace it with PureDateToJava. Replace the use of GregorianCalendar for time zone handling with ZonedDateTime. Fix several small bugs, including formatting negative years in two year format, handling timezones with a second offset, and formatting timezones with a minute offset.

Also, add direct tests for DateFormat. Previous tests were for PureDate.format, which called DateFormat.