### PR TITLE
Deprecate PureDate.getCalendar

### DIFF
--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractPureDate.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractPureDate.java
@@ -77,6 +77,7 @@ abstract class AbstractPureDate implements PureDate, Serializable
         return appendString(new StringBuilder(32)).toString();
     }
 
+    @Deprecated
     @Override
     public GregorianCalendar getCalendar()
     {

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/LatestDate.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/LatestDate.java
@@ -14,8 +14,6 @@
 
 package org.finos.legend.pure.m4.coreinstance.primitive.date;
 
-import java.util.GregorianCalendar;
-
 public class LatestDate implements PureDate
 {
     private static final String latestDateConstant = "%latest";
@@ -171,13 +169,6 @@ public class LatestDate implements PureDate
 
     @Override
     public PureDate subtractSubseconds(String subseconds)
-    {
-        throw new UnsupportedOperationException("Invalid operation for LatestDate");
-    }
-
-    @Deprecated
-    @Override
-    public GregorianCalendar getCalendar()
     {
         throw new UnsupportedOperationException("Invalid operation for LatestDate");
     }

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/LatestDate.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/LatestDate.java
@@ -175,6 +175,7 @@ public class LatestDate implements PureDate
         throw new UnsupportedOperationException("Invalid operation for LatestDate");
     }
 
+    @Deprecated
     @Override
     public GregorianCalendar getCalendar()
     {

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/PureDate.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/PureDate.java
@@ -74,7 +74,16 @@ public interface PureDate extends Comparable<PureDate>
      * precision greater than millisecond.
      *
      * @return Gregorian calendar for Pure date
+     * @deprecated Use {@link PureDateToJava} instead. A Pure date is a span of time rather than an
+     * instant, and this method resolves it to the start of that span, so
+     * {@code PureDateToJava.start().toInstant(date)} is the same instant without the loss of
+     * precision below the millisecond; {@link PureDateToJava#end()} and
+     * {@link PureDateToJava#exclusiveEnd()} give the other end of the span, which a calendar cannot
+     * express at all. A {@link GregorianCalendar} also reads dates before 1582 on the Julian
+     * calendar and knows no time zone history before 1900, neither of which is true of a Pure date.
+     * Retained temporarily for callers that have not moved.
      */
+    @Deprecated
     GregorianCalendar getCalendar();
 
     default <T extends Appendable> T appendString(T appendable)

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/PureDate.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/PureDate.java
@@ -84,7 +84,10 @@ public interface PureDate extends Comparable<PureDate>
      * Retained temporarily for callers that have not moved.
      */
     @Deprecated
-    GregorianCalendar getCalendar();
+    default GregorianCalendar getCalendar()
+    {
+        throw new UnsupportedOperationException();
+    }
 
     default <T extends Appendable> T appendString(T appendable)
     {

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFunctions.java
@@ -238,6 +238,7 @@ public class TestDateFunctions
      * to the millisecond precision a {@link GregorianCalendar} can carry.
      */
     @Test
+    @SuppressWarnings("deprecation")
     public void testFromCalendarRoundTripsGetCalendar()
     {
         assertRoundTripsThroughCalendar(DateFunctions.newPureDate(2014), Calendar.YEAR);
@@ -556,6 +557,7 @@ public class TestDateFunctions
 
     // Helpers
 
+    @SuppressWarnings("deprecation")
     private static void assertRoundTripsThroughCalendar(PureDate date, int precision)
     {
         Assert.assertEquals(date, DateFunctions.fromCalendar(date.getCalendar(), precision));

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestPureDateToJava.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestPureDateToJava.java
@@ -468,11 +468,13 @@ public class TestPureDateToJava
     // getCalendar
 
     /**
-     * {@link PureDate#getCalendar()} resolves a date to the start of its span, so the start
-     * resolution agrees with it wherever a {@link java.util.GregorianCalendar} can hold the answer.
-     * Beyond millisecond precision it cannot, which is one of the reasons to replace it.
+     * {@link PureDate#getCalendar()}, which this class is the replacement for, resolves a date to
+     * the start of its span, so the start resolution agrees with it wherever a
+     * {@link java.util.GregorianCalendar} can hold the answer. Beyond millisecond precision it
+     * cannot, which is one of the reasons it is deprecated.
      */
     @Test
+    @SuppressWarnings("deprecation")
     public void testStartAgreesWithGetCalendar()
     {
         PureDate[] dates = {


### PR DESCRIPTION
Deprecate PureDate.getCalendar. Use PureDateToJava instead.  In many cases, PureDateToJava.start().toInstant(date) is the most appropriate method to call. This will return a Java Instant that represents the starting nanosecond of the given PureDate.