### PR TITLE
Default RuntimeOptions consistently and snapshot them once per VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@
 /.h2Start.sh.swp
 
 **/.DS_Store
-**/pure-duckDB-test-Db
+**/pure-duckDB-test-Db*

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/CachedSystemPropertyOptions.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/CachedSystemPropertyOptions.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2026 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/CachedSystemPropertyOptions.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/CachedSystemPropertyOptions.java
@@ -1,0 +1,66 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.runtime;
+
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.api.set.SetIterable;
+
+import java.util.Properties;
+
+/**
+ * {@link RuntimeOptions} backed by a snapshot of properties with a given prefix, taken once at construction.
+ * Properties set after the snapshot are not visible.
+ */
+class CachedSystemPropertyOptions implements RuntimeOptions
+{
+    static final RuntimeOptions DEFAULT = new CachedSystemPropertyOptions(System.getProperties(), RuntimeOptions.DEFAULT_OPTION_PREFIX);
+
+    private final SetIterable<String> setOptions;
+
+    CachedSystemPropertyOptions(Properties properties, String prefix)
+    {
+        this.setOptions = scanProperties(properties, prefix).toImmutable();
+    }
+
+    @Override
+    public boolean isOptionSet(String name)
+    {
+        return this.setOptions.contains(name);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "<CachedSystemPropertyOptions " + this.setOptions + ">";
+    }
+
+    /**
+     * Names (with the prefix stripped) of the properties starting with the given prefix whose value is
+     * {@code true}, matching the case insensitive semantics of {@link Boolean#getBoolean}.
+     */
+    static MutableSet<String> scanProperties(Properties properties, String prefix)
+    {
+        MutableSet<String> result = Sets.mutable.empty();
+        properties.stringPropertyNames().forEach(key ->
+        {
+            if (key.startsWith(prefix) && Boolean.parseBoolean(properties.getProperty(key)))
+            {
+                result.add(key.substring(prefix.length()));
+            }
+        });
+        return result;
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/MutableRuntimeOptions.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/MutableRuntimeOptions.java
@@ -1,0 +1,103 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.runtime;
+
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.map.ConcurrentMutableMap;
+import org.eclipse.collections.api.set.SetIterable;
+import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
+
+import java.util.Properties;
+
+/**
+ * {@link RuntimeOptions} held in memory and togglable at runtime. It may be seeded from system properties,
+ * but it never writes them: toggling an option here is visible only to code holding this instance.
+ * <p>
+ * Safe for concurrent use.
+ */
+public final class MutableRuntimeOptions implements RuntimeOptions
+{
+    private final ConcurrentMutableMap<String, Boolean> options = ConcurrentHashMap.newMap();
+
+    private MutableRuntimeOptions(SetIterable<String> initiallySet)
+    {
+        initiallySet.forEach(name -> this.options.put(name, Boolean.TRUE));
+    }
+
+    @Override
+    public boolean isOptionSet(String name)
+    {
+        return this.options.containsKey(name);
+    }
+
+    /**
+     * Sets or clears an option, returning the new effective value of {@link #isOptionSet}.
+     */
+    public boolean setOption(String name, boolean value)
+    {
+        if (value)
+        {
+            this.options.put(name, Boolean.TRUE);
+        }
+        else
+        {
+            this.options.remove(name);
+        }
+        return value;
+    }
+
+    /**
+     * The names of the options currently set.
+     */
+    public SetIterable<String> getSetOptions()
+    {
+        return this.options.keysView().toSet();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "<MutableRuntimeOptions " + getSetOptions() + ">";
+    }
+
+    public static MutableRuntimeOptions empty()
+    {
+        return new MutableRuntimeOptions(Sets.immutable.empty());
+    }
+
+    /**
+     * Seeded from the system properties prefixed with {@value RuntimeOptions#DEFAULT_OPTION_PREFIX}, read once.
+     */
+    public static MutableRuntimeOptions fromSystemProperties()
+    {
+        return fromSystemProperties(RuntimeOptions.DEFAULT_OPTION_PREFIX);
+    }
+
+    /**
+     * Seeded from the system properties with the given prefix, read once.
+     */
+    public static MutableRuntimeOptions fromSystemProperties(String prefix)
+    {
+        return fromProperties(System.getProperties(), prefix);
+    }
+
+    /**
+     * Seeded from the given properties with the given prefix, read once.
+     */
+    static MutableRuntimeOptions fromProperties(Properties properties, String prefix)
+    {
+        return new MutableRuntimeOptions(CachedSystemPropertyOptions.scanProperties(properties, prefix));
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/MutableRuntimeOptions.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/MutableRuntimeOptions.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2026 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 package org.finos.legend.pure.m3.serialization.runtime;
 
 import org.eclipse.collections.api.factory.Sets;
-import org.eclipse.collections.api.map.ConcurrentMutableMap;
+import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.SetIterable;
-import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
+import org.finos.legend.pure.m4.tools.ConcurrentHashSet;
 
 import java.util.Properties;
 
@@ -29,17 +29,17 @@ import java.util.Properties;
  */
 public final class MutableRuntimeOptions implements RuntimeOptions
 {
-    private final ConcurrentMutableMap<String, Boolean> options = ConcurrentHashMap.newMap();
+    private final MutableSet<String> options = ConcurrentHashSet.newSet();
 
     private MutableRuntimeOptions(SetIterable<String> initiallySet)
     {
-        initiallySet.forEach(name -> this.options.put(name, Boolean.TRUE));
+        this.options.addAllIterable(initiallySet);
     }
 
     @Override
     public boolean isOptionSet(String name)
     {
-        return this.options.containsKey(name);
+        return this.options.contains(name);
     }
 
     /**
@@ -49,7 +49,7 @@ public final class MutableRuntimeOptions implements RuntimeOptions
     {
         if (value)
         {
-            this.options.put(name, Boolean.TRUE);
+            this.options.add(name);
         }
         else
         {
@@ -63,7 +63,7 @@ public final class MutableRuntimeOptions implements RuntimeOptions
      */
     public SetIterable<String> getSetOptions()
     {
-        return this.options.keysView().toSet();
+        return this.options.toSet();
     }
 
     @Override

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/PureRuntime.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/PureRuntime.java
@@ -113,7 +113,7 @@ public class PureRuntime
 
         this.executedTestTracker = executedTestTracker;
 
-        this.options = options;
+        this.options = (options == null) ? RuntimeOptions.defaultOptions() : options;
     }
 
     public void initialize()

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/PureRuntimeBuilder.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/PureRuntimeBuilder.java
@@ -39,7 +39,7 @@ public class PureRuntimeBuilder
     private boolean isTransactionalByDefault = true;
     private boolean useFastCompiler = true;
     private ExecutedTestTracker executedTestTracker;
-    private RuntimeOptions options = RuntimeOptions.systemPropertyOptions("pure.options.");
+    private RuntimeOptions options = RuntimeOptions.defaultOptions();
 
     public PureRuntimeBuilder(MutableRepositoryCodeStorage codeStorage)
     {
@@ -103,7 +103,7 @@ public class PureRuntimeBuilder
 
     public PureRuntimeBuilder withOptions(RuntimeOptions options)
     {
-        this.options = options;
+        this.options = (options == null) ? RuntimeOptions.defaultOptions() : options;
         return this;
     }
 

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/RuntimeOptions.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/serialization/runtime/RuntimeOptions.java
@@ -16,6 +16,8 @@ package org.finos.legend.pure.m3.serialization.runtime;
 
 public interface RuntimeOptions
 {
+    String DEFAULT_OPTION_PREFIX = "pure.options.";
+
     boolean isOptionSet(String name);
 
     static RuntimeOptions noOptionsSet()
@@ -31,5 +33,16 @@ public interface RuntimeOptions
     static RuntimeOptions systemPropertyOptions(String prefix)
     {
         return (prefix == null) ? Boolean::getBoolean : name -> Boolean.getBoolean(prefix + name);
+    }
+
+    /**
+     * The options used wherever none are explicitly supplied: the system properties prefixed with
+     * {@value #DEFAULT_OPTION_PREFIX}, snapshotted once per VM on first use of the default options.
+     * Properties set after that snapshot are not visible; use {@link MutableRuntimeOptions} where options
+     * must be togglable at runtime.
+     */
+    static RuntimeOptions defaultOptions()
+    {
+        return CachedSystemPropertyOptions.DEFAULT;
     }
 }

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestMutableRuntimeOptions.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestMutableRuntimeOptions.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2026 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestMutableRuntimeOptions.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestMutableRuntimeOptions.java
@@ -1,0 +1,120 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.runtime;
+
+import org.eclipse.collections.api.factory.Sets;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+
+/**
+ * Seeded from a {@link Properties} instance built by the test rather than the system properties, so nothing
+ * here depends on JVM wide state or on test ordering.
+ */
+public class TestMutableRuntimeOptions
+{
+    private static final String PREFIX = RuntimeOptions.DEFAULT_OPTION_PREFIX;
+
+    @Test
+    public void testEmptyHasNothingSet()
+    {
+        MutableRuntimeOptions options = MutableRuntimeOptions.empty();
+        Assert.assertFalse(options.isOptionSet("Added"));
+        Assert.assertEquals(Sets.mutable.empty(), options.getSetOptions());
+    }
+
+    @Test
+    public void testSeedingFromProperties()
+    {
+        MutableRuntimeOptions options = seeded("Seeded", "true", "NonBoolean", "yes");
+
+        Assert.assertTrue(options.isOptionSet("Seeded"));
+        Assert.assertFalse(options.isOptionSet("NonBoolean"));
+        Assert.assertEquals(Sets.mutable.with("Seeded"), options.getSetOptions());
+    }
+
+    @Test
+    public void testTogglingOnAndOff()
+    {
+        MutableRuntimeOptions options = seeded("Seeded", "true");
+
+        Assert.assertFalse(options.setOption("Seeded", false));
+        Assert.assertFalse(options.isOptionSet("Seeded"));
+
+        Assert.assertTrue(options.setOption("Added", true));
+        Assert.assertTrue(options.isOptionSet("Added"));
+        Assert.assertEquals(Sets.mutable.with("Added"), options.getSetOptions());
+    }
+
+    @Test
+    public void testTogglingIsIdempotent()
+    {
+        MutableRuntimeOptions options = MutableRuntimeOptions.empty();
+        options.setOption("Added", true);
+        options.setOption("Added", true);
+        Assert.assertEquals(Sets.mutable.with("Added"), options.getSetOptions());
+
+        options.setOption("Added", false);
+        options.setOption("Added", false);
+        Assert.assertEquals(Sets.mutable.empty(), options.getSetOptions());
+    }
+
+    @Test
+    public void testTogglingDoesNotWriteTheSeedProperties()
+    {
+        Properties properties = new Properties();
+        properties.setProperty(PREFIX + "Seeded", "true");
+        MutableRuntimeOptions options = MutableRuntimeOptions.fromProperties(properties, PREFIX);
+
+        options.setOption("Added", true);
+        options.setOption("Seeded", false);
+
+        Assert.assertNull("setting an option must not write a property", properties.getProperty(PREFIX + "Added"));
+        Assert.assertEquals("clearing an option must not write a property", "true", properties.getProperty(PREFIX + "Seeded"));
+    }
+
+    @Test
+    public void testFromSystemPropertiesDoesNotWriteSystemProperties()
+    {
+        String name = "TestMutableRuntimeOptionsNeverWritten";
+        MutableRuntimeOptions options = MutableRuntimeOptions.fromSystemProperties();
+        options.setOption(name, true);
+
+        Assert.assertTrue(options.isOptionSet(name));
+        Assert.assertNull(System.getProperty(PREFIX + name));
+    }
+
+    @Test
+    public void testGetSetOptionsIsNotALiveView()
+    {
+        MutableRuntimeOptions options = MutableRuntimeOptions.empty();
+        options.setOption("Seeded", true);
+        Object snapshot = options.getSetOptions();
+        options.setOption("Added", true);
+
+        Assert.assertEquals(Sets.mutable.with("Seeded"), snapshot);
+    }
+
+    private static MutableRuntimeOptions seeded(String... namesAndValues)
+    {
+        Properties properties = new Properties();
+        for (int i = 0; i < namesAndValues.length; i += 2)
+        {
+            properties.setProperty(PREFIX + namesAndValues[i], namesAndValues[i + 1]);
+        }
+        return MutableRuntimeOptions.fromProperties(properties, PREFIX);
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestRuntimeOptions.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestRuntimeOptions.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2026 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestRuntimeOptions.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/serialization/runtime/TestRuntimeOptions.java
@@ -1,0 +1,115 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.serialization.runtime;
+
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
+import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+
+/**
+ * Content is asserted against a {@link Properties} instance built by the test, never against the system
+ * properties: the VM wide snapshot behind {@link RuntimeOptions#defaultOptions()} is taken once per JVM, so
+ * any assertion on its contents would depend on which test happened to load the class first. Tests that do
+ * involve the default options assert identity only.
+ */
+public class TestRuntimeOptions
+{
+    private static final String PREFIX = RuntimeOptions.DEFAULT_OPTION_PREFIX;
+
+    @Test
+    public void testSnapshotOfProperties()
+    {
+        Properties properties = properties(
+                PREFIX + "Enabled", "true",
+                PREFIX + "NonBoolean", "yes",
+                PREFIX + "Disabled", "false",
+                "some.other.prefix.Enabled", "true");
+
+        RuntimeOptions options = new CachedSystemPropertyOptions(properties, PREFIX);
+
+        Assert.assertTrue(options.isOptionSet("Enabled"));
+        Assert.assertFalse(options.isOptionSet("NonBoolean"));
+        Assert.assertFalse(options.isOptionSet("Disabled"));
+        Assert.assertFalse(options.isOptionSet("Absent"));
+        Assert.assertFalse("the prefix must be stripped, not retained", options.isOptionSet(PREFIX + "Enabled"));
+        Assert.assertFalse("only the configured prefix is scanned", options.isOptionSet("some.other.prefix.Enabled"));
+    }
+
+    @Test
+    public void testTrueIsCaseInsensitive()
+    {
+        Assert.assertTrue(new CachedSystemPropertyOptions(properties(PREFIX + "Enabled", "TRUE"), PREFIX).isOptionSet("Enabled"));
+        Assert.assertTrue(new CachedSystemPropertyOptions(properties(PREFIX + "Enabled", "True"), PREFIX).isOptionSet("Enabled"));
+    }
+
+    @Test
+    public void testPropertiesSetAfterTheSnapshotAreNotVisible()
+    {
+        Properties properties = properties();
+        RuntimeOptions options = new CachedSystemPropertyOptions(properties, PREFIX);
+        properties.setProperty(PREFIX + "SetLate", "true");
+        Assert.assertFalse(options.isOptionSet("SetLate"));
+    }
+
+    @Test
+    public void testDefaultOptionsAreSnapshottedOncePerVM()
+    {
+        Assert.assertSame(RuntimeOptions.defaultOptions(), RuntimeOptions.defaultOptions());
+    }
+
+    @Test
+    public void testBuilderDefaultsToDefaultOptions()
+    {
+        Assert.assertSame(RuntimeOptions.defaultOptions(), newRuntimeBuilder().build().getOptions());
+    }
+
+    @Test
+    public void testNullOptionsMeanDefaultOptions()
+    {
+        Assert.assertSame(RuntimeOptions.defaultOptions(), newRuntimeBuilder().withOptions(null).build().getOptions());
+    }
+
+    @Test
+    public void testExplicitOptionsAreHonored()
+    {
+        RuntimeOptions explicit = RuntimeOptions.noOptionsSet();
+        Assert.assertSame(explicit, newRuntimeBuilder().withOptions(explicit).build().getOptions());
+    }
+
+    @Test
+    public void testNoOptionsSet()
+    {
+        Assert.assertFalse(RuntimeOptions.noOptionsSet().isOptionSet("Enabled"));
+    }
+
+    private static PureRuntimeBuilder newRuntimeBuilder()
+    {
+        return new PureRuntimeBuilder(new CompositeCodeStorage(new ClassLoaderCodeStorage(CodeRepositoryProviderHelper.findPlatformCodeRepository())));
+    }
+
+    private static Properties properties(String... keysAndValues)
+    {
+        Properties properties = new Properties();
+        for (int i = 0; i < keysAndValues.length; i += 2)
+        {
+            properties.setProperty(keysAndValues[i], keysAndValues[i + 1]);
+        }
+        return properties;
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractPureTestWithCoreCompiled.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/AbstractPureTestWithCoreCompiled.java
@@ -308,7 +308,7 @@ public abstract class AbstractPureTestWithCoreCompiled
 
     protected static RuntimeOptions getOptions()
     {
-        return RuntimeOptions.noOptionsSet();
+        return RuntimeOptions.defaultOptions();
     }
 
     /**

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LegendPureLspServer.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LegendPureLspServer.java
@@ -333,19 +333,14 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
         });
     }
 
-    static final String PURE_OPTION_PREFIX = "pure.options.";
-
     /**
-     * Sets or clears a Pure runtime option in this JVM so that isOptionSet('&lt;name&gt;') reflects it
-     * live, without restarting the server. The Pure runtime resolves options through
-     * RuntimeOptions.systemPropertyOptions(PURE_OPTION_PREFIX) - i.e. isOptionSet("X") is
-     * Boolean.getBoolean("pure.options.X"), read on every call - so toggling the system property here
-     * takes effect immediately for subsequent go()/execute() runs in this session.
+     * Sets or clears a Pure runtime option so that isOptionSet('&lt;name&gt;') reflects it live, without
+     * restarting the server. The session holds a MutableRuntimeOptions, seeded once from the
+     * "pure.options.*" system properties and thereafter mutated in memory, so the change takes effect
+     * immediately for subsequent go()/execute() runs.
      * <p>
-     * value == true  -&gt; System.setProperty("pure.options." + name, "true")
-     * value == false -&gt; System.clearProperty("pure.options." + name)
-     * (clearing rather than storing "false" keeps the property table clean; Boolean.getBoolean
-     * returns false for an absent property either way.)
+     * The option is scoped to this session: no system property is written, so other code in this JVM
+     * reading "pure.options.*" directly will not observe the toggle.
      */
     @JsonRequest("legend/setOption")
     public CompletableFuture<SetOptionResult> setOption(SetOptionParams params)
@@ -356,17 +351,13 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
             {
                 return new SetOptionResult(false, params == null ? null : params.getName(), false, "Option name is required");
             }
+            LegendPureSession session = getSession();
+            if (session == null)
+            {
+                return new SetOptionResult(false, params.getName(), false, "Session is not available");
+            }
             String name = params.getName().trim();
-            String key = PURE_OPTION_PREFIX + name;
-            if (params.isValue())
-            {
-                System.setProperty(key, "true");
-            }
-            else
-            {
-                System.clearProperty(key);
-            }
-            boolean effective = Boolean.getBoolean(key);
+            boolean effective = session.setOption(name, params.isValue());
             LspLog.info("setOption: " + name + " -> " + effective + " (isOptionSet('" + name + "') now returns " + effective + ")");
             return new SetOptionResult(true, name, effective, null);
         });

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LegendPureSession.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LegendPureSession.java
@@ -37,8 +37,10 @@ import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.Reposit
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
 import org.finos.legend.pure.m3.serialization.runtime.Message;
+import org.finos.legend.pure.m3.serialization.runtime.MutableRuntimeOptions;
 import org.finos.legend.pure.m3.serialization.runtime.PureRuntime;
 import org.finos.legend.pure.m3.serialization.runtime.PureRuntimeBuilder;
+import org.finos.legend.pure.m3.serialization.runtime.RuntimeOptions;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.exception.PureException;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
@@ -53,6 +55,11 @@ public class LegendPureSession
     private volatile PureRuntime pureRuntime;
     private volatile FunctionExecution functionExecution;
     private volatile boolean initialized;
+
+    // Session-scoped and mutable, so legend/setOption can toggle options live without writing JVM system
+    // properties. Created eagerly and never replaced, so toggles survive a runtime rebuild.
+    private final MutableRuntimeOptions runtimeOptions = MutableRuntimeOptions.fromSystemProperties();
+
     private final SourceMutationService mutationService = new SourceMutationService(this);
 
     // Readers-writers lock protecting the compiled graph. Graph MUTATION (compile/reinitialize) is a
@@ -90,7 +97,7 @@ public class LegendPureSession
         this.classpathRepositoryNames = normalizeRepositoryNames(classpathRepositoryNames);
 
         this.pureRuntime = newRuntime(scanner, true, this.classpathRepositoryNames, Collections.emptySet(),
-                false, Collections.emptySet(), this.progressListener);
+                false, Collections.emptySet(), this.progressListener, this.runtimeOptions);
 
         this.functionExecution = initializeFunctionExecution(
                 new StackPreservingFunctionExecutionInterpreted(),
@@ -143,13 +150,14 @@ public class LegendPureSession
                                           Collection<String> excludedWorkspaceRepositoryNames)
     {
         return newRuntime(scanner, includeWorkspaceStorages, classpathRepositoryNames, additionalWorkspaceDependencies,
-                workspaceDefinitionsOnly, excludedWorkspaceRepositoryNames, null);
+                workspaceDefinitionsOnly, excludedWorkspaceRepositoryNames, null, RuntimeOptions.defaultOptions());
     }
 
     private static PureRuntime newRuntime(RepositoryScanner scanner, boolean includeWorkspaceStorages, Collection<String> classpathRepositoryNames,
                                           Collection<String> additionalWorkspaceDependencies, boolean workspaceDefinitionsOnly,
                                           Collection<String> excludedWorkspaceRepositoryNames,
-                                          java.util.function.Consumer<String> progressListener)
+                                          java.util.function.Consumer<String> progressListener,
+                                          RuntimeOptions options)
     {
         Set<String> normalizedClasspathRepositoryNames = normalizeRepositoryNames(classpathRepositoryNames);
         MutableList<RepositoryCodeStorage> storages = Lists.mutable.empty();
@@ -216,6 +224,7 @@ public class LegendPureSession
         PureRuntime runtime = new PureRuntimeBuilder(codeStorage)
                 .withMessage(new Message(""))
                 .setUseFastCompiler(true)
+                .withOptions(options)
                 .build();
 
         LOGGER.info("Initializing Pure runtime...");
@@ -597,6 +606,20 @@ public class LegendPureSession
     public PureRuntime getPureRuntime()
     {
         return this.pureRuntime;
+    }
+
+    public MutableRuntimeOptions getRuntimeOptions()
+    {
+        return this.runtimeOptions;
+    }
+
+    /**
+     * Sets or clears a Pure runtime option for this session, returning its new effective value. In-memory
+     * only: no system property is written, and the change is visible to this session's runtime immediately.
+     */
+    public boolean setOption(String name, boolean value)
+    {
+        return this.runtimeOptions.setOption(name, value);
     }
 
     public FunctionExecution getFunctionExecution()

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/SetOptionParams.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/SetOptionParams.java
@@ -16,13 +16,11 @@ package org.finos.legend.pure.lsp.protocol;
 
 /**
  * Params for legend/setOption. Sets or clears a Pure runtime option so isOptionSet('&lt;name&gt;')
- * reflects it live in this JVM, without a restart.
+ * reflects it live in the session, without a restart.
  * <p>
- * The Pure runtime resolves options via RuntimeOptions.systemPropertyOptions("pure.options."),
- * i.e. isOptionSet("X") == Boolean.getBoolean("pure.options.X"), read on every call. So this handler
- * maps to a System.setProperty("pure.options." + name, "true") when value is true, and a
- * System.clearProperty("pure.options." + name) when value is false (clearing, not "false", so
- * Boolean.getBoolean returns false either way but the property does not linger).
+ * The session's runtime resolves options against a MutableRuntimeOptions, seeded once from the
+ * "pure.options.*" system properties and thereafter mutated in memory. No system property is written,
+ * so the toggle is scoped to the session rather than the JVM.
  */
 public class SetOptionParams
 {

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/SetOptionResult.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/SetOptionResult.java
@@ -16,7 +16,7 @@ package org.finos.legend.pure.lsp.protocol;
 
 /**
  * Result of legend/setOption. Echoes back the resolved state so a caller can confirm
- * isOptionSet('&lt;name&gt;') now returns {@link #isEffective()} in this JVM.
+ * isOptionSet('&lt;name&gt;') now returns {@link #isEffective()} in this session.
  */
 public class SetOptionResult
 {

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/LspEndToEndTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/LspEndToEndTest.java
@@ -476,22 +476,20 @@ public class LspEndToEndTest
     {
         String optionName = "E2eTestOption" + System.currentTimeMillis();
         String key = "pure.options." + optionName;
-        try
-        {
-            SetOptionResult on = server.setOption(new SetOptionParams(optionName, true)).get(10, TimeUnit.SECONDS);
-            Assert.assertTrue("setOption(true) should succeed", on.isSuccess());
-            Assert.assertTrue("Option should now be effective", on.isEffective());
-            Assert.assertEquals("System property should be set", "true", System.getProperty(key));
 
-            SetOptionResult off = server.setOption(new SetOptionParams(optionName, false)).get(10, TimeUnit.SECONDS);
-            Assert.assertTrue("setOption(false) should succeed", off.isSuccess());
-            Assert.assertFalse("Option should no longer be effective", off.isEffective());
-            Assert.assertNull("Property should be cleared, not stored as 'false'", System.getProperty(key));
-        }
-        finally
-        {
-            System.clearProperty(key);
-        }
+        SetOptionResult on = server.setOption(new SetOptionParams(optionName, true)).get(10, TimeUnit.SECONDS);
+        Assert.assertTrue("setOption(true) should succeed", on.isSuccess());
+        Assert.assertTrue("Option should now be effective", on.isEffective());
+        Assert.assertTrue("The session runtime should see the option",
+                server.getSession().getPureRuntime().getOptions().isOptionSet(optionName));
+        Assert.assertNull("setOption must not write a system property", System.getProperty(key));
+
+        SetOptionResult off = server.setOption(new SetOptionParams(optionName, false)).get(10, TimeUnit.SECONDS);
+        Assert.assertTrue("setOption(false) should succeed", off.isSuccess());
+        Assert.assertFalse("Option should no longer be effective", off.isEffective());
+        Assert.assertFalse("The session runtime should no longer see the option",
+                server.getSession().getPureRuntime().getOptions().isOptionSet(optionName));
+        Assert.assertNull("setOption must not write a system property", System.getProperty(key));
     }
 
     @Test

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledExecutionSupport.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/execution/CompiledExecutionSupport.java
@@ -84,7 +84,7 @@ public class CompiledExecutionSupport implements ExecutionSupport
         this.processorSupport = processorSupport;
         this.metadataAccessor = new MetadataHolder(processorSupport.getMetadata());
         this.extraSupportedTypes = extraSupportedTypes;
-        this.options = (options == null) ? name -> false : options;
+        this.options = (options == null) ? RuntimeOptions.defaultOptions() : options;
         this.compiledExtensions = compiledExtensions;
     }
 


### PR DESCRIPTION
## Problem

`RuntimeOptions` had two different "no options were supplied" defaults:

| Path | Default |
|---|---|
| `PureRuntimeBuilder` | `systemPropertyOptions("pure.options.")` |
| `CompiledExecutionSupport` (`options == null`) | `name -> false` |

Three of `CompiledExecutionSupport`'s convenience constructors pass `null`, so every standalone compiled execution silently saw *no* options — including the bootstrap code emitted by `ExternalClassBuilder`, `PureTestBuilderCompiled`, and downstream callers using the shorter overloads. A `pure.options.*` property was honoured by a builder-built runtime and ignored by a standalone one.

Separately, `systemPropertyOptions(prefix)` is `name -> Boolean.getBoolean(prefix + name)`: a string concat plus a synchronized `Properties` lookup on *every* `isOptionSet` call.

## Change

**One default everywhere.** `RuntimeOptions.defaultOptions()` resolves `pure.options.*` from a snapshot taken once per VM; `isOptionSet` becomes a set lookup. `PureRuntimeBuilder`, `PureRuntimeBuilder.withOptions(null)`, the `PureRuntime` constructor, and `CompiledExecutionSupport`'s null-fallback all route to it. The `ExternalClassBuilder`-generated bootstrap and `PureTestBuilderCompiled` inherit it through the existing overloads with no edits.

**Additive API.** `noOptionsSet()`, `systemPropertyOptions()` and `systemPropertyOptions(String)` are unchanged, so nothing downstream shifts behaviour on recompile. `systemPropertyOptions` stays live for callers that need per-call reads. New: `DEFAULT_OPTION_PREFIX`, `defaultOptions()`, `MutableRuntimeOptions`, and the package-private `CachedSystemPropertyOptions`.

**Timing contract.** The snapshot freezes at first use of the default options — in practice the first `new PureRuntimeBuilder(...)`. Properties set after that are not visible. This is documented on `defaultOptions()`.

**LSP no longer writes system properties.** `legend/setOption` previously did `System.setProperty` / `System.clearProperty` — a language-server RPC mutating global JVM state, and incompatible with a snapshot. The session now owns a `MutableRuntimeOptions`, seeded from `pure.options.*` once and mutated in memory. It is created eagerly and never replaced, so toggles survive a runtime rebuild. The trade, documented in the handler javadoc: the toggle is scoped to the session, so other code in the JVM reading `pure.options.*` directly will not observe it.

## Reviewer notes

- **`AbstractPureTestWithCoreCompiled.getOptions()` moves from `noOptionsSet()` to `defaultOptions()`.** Tests now resolve options like every other execution path. This means a `pure.options.*` in the surefire `argLine` reaches the ~30 test suites that call `getOptions()` — by design rather than by omission. No pom or surefire config sets one today (verified by grep), so current behaviour is unchanged.
- **`isOptionSet` has no consumer in this repo.** The native `meta::core::runtime::isOptionSet` was removed in `23fc77a63` along with the `legend-pure-functions` module; `PureRuntime.getOptions()` and `CompiledExecutionSupport.getRuntimeOptions()` are read by `legend-engine`. So this is a public-contract change, not a hot-path optimisation with an in-repo benchmark.

## Testing

`CachedSystemPropertyOptions` takes a `Properties` rather than reading `System.getProperties()` internally, so tests assert content against an instance they construct (no mocking framework, per ADR-003 — a real object). Consequences:

- No test mutates system properties, so the VM-wide snapshot is empty in every fork regardless of class order.
- Tests involving `defaultOptions()` assert **identity only** (`assertSame`), never contents, so none can depend on which test loaded the class first.

`TestRuntimeOptions` (8) covers prefix stripping, case-insensitive `true` matching `Boolean.getBoolean`, non-boolean and `false` values, the post-snapshot timing contract, and that the builder / `withOptions(null)` / explicit options resolve as expected. `TestMutableRuntimeOptions` (7) covers seeding, toggling, idempotence, the non-live `getSetOptions()` view, and that toggling never writes a property.

`LspEndToEndTest#setOption_rpc_togglesRuntimeOptionLive` now asserts `session.getPureRuntime().getOptions().isOptionSet(name)` — which passes only if the session → builder → runtime wiring is live — and that the system property stays null.

Full `mvn clean install` from the root: **BUILD SUCCESS**, 107 modules, **6803 tests, 0 failures, 0 errors**, 0 Checkstyle violations. That matters here because the `CompiledExecutionSupport` fallback flip touches every compiled-engine and PCT execution path.
