### PR TITLE
Fix hidden locale dependency in sub-seconds in dates

### DIFF
--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractDateWithSubsecond.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/AbstractDateWithSubsecond.java
@@ -70,7 +70,7 @@ abstract class AbstractDateWithSubsecond extends AbstractDateWithSecond
         }
 
         long secondsToAdd = milliseconds / 1000L;
-        String subseconds = String.format("%03d", Math.abs(milliseconds % 1000L));
+        String subseconds = DateFunctions.subsecondFromMilliseconds(milliseconds);
         return adjustSubseconds(subseconds, milliseconds > 0).addSeconds(secondsToAdd);
     }
 
@@ -88,7 +88,7 @@ abstract class AbstractDateWithSubsecond extends AbstractDateWithSecond
         }
 
         long secondsToAdd = microseconds / 1_000_000L;
-        String subseconds = String.format("%06d", Math.abs(microseconds % 1_000_000L));
+        String subseconds = DateFunctions.subsecondFromMicroseconds(microseconds);
         return adjustSubseconds(subseconds, microseconds > 0).addSeconds(secondsToAdd);
     }
 
@@ -106,7 +106,7 @@ abstract class AbstractDateWithSubsecond extends AbstractDateWithSecond
         }
 
         long secondsToAdd = nanoseconds / 1_000_000_000L;
-        String subseconds = String.format("%09d", Math.abs(nanoseconds % 1_000_000_000L));
+        String subseconds = DateFunctions.subsecondFromNanoseconds(nanoseconds);
         return adjustSubseconds(subseconds, nanoseconds > 0).addSeconds(secondsToAdd);
     }
 

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFunctions.java
@@ -27,6 +27,7 @@ import java.time.chrono.IsoChronology;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Locale;
 import java.util.TimeZone;
 
 /**
@@ -210,7 +211,7 @@ public class DateFunctions extends TimeFunctions
             }
             case Calendar.MILLISECOND:
             {
-                return DateWithSubsecond.newDateWithSubsecond(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH), calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), calendar.get(Calendar.SECOND), String.format("%03d", calendar.get(Calendar.MILLISECOND)));
+                return DateWithSubsecond.newDateWithSubsecond(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH), calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), calendar.get(Calendar.SECOND), TimeFunctions.subsecondFromMilliseconds(calendar.get(Calendar.MILLISECOND)));
             }
             default:
             {
@@ -586,7 +587,7 @@ public class DateFunctions extends TimeFunctions
     {
         if ((year < MIN_YEAR) || (year > MAX_YEAR))
         {
-            throw new IllegalArgumentException(String.format("Invalid year (valid [%,d, %,d]): %,d", MIN_YEAR, MAX_YEAR, year));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Invalid year (valid [%,d, %,d]): %,d", MIN_YEAR, MAX_YEAR, year));
         }
     }
 

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithSubsecond.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateWithSubsecond.java
@@ -54,7 +54,7 @@ public class DateWithSubsecond extends AbstractDateWithSubsecond
     {
         GregorianCalendar calendar = new GregorianCalendar(DateFunctions.GMT_TIME_ZONE);
         calendar.setTime(timestamp);
-        String subsecond = String.format("%09d", timestamp.getNanos());
+        String subsecond = TimeFunctions.subsecondFromNanoseconds(timestamp.getNanos());
         return new DateWithSubsecond(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH), calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), calendar.get(Calendar.SECOND), subsecond);
     }
 
@@ -75,7 +75,7 @@ public class DateWithSubsecond extends AbstractDateWithSubsecond
         {
             throw new IllegalArgumentException("Invalid subsecond precision: " + subsecondPrecision);
         }
-        String string = String.format("%09d", time.getNano());
+        String string = TimeFunctions.subsecondFromNanoseconds(time.getNano());
         return (subsecondPrecision == 9) ? string : string.substring(0, subsecondPrecision);
     }
 }

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TimeFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TimeFunctions.java
@@ -46,10 +46,21 @@ public abstract class TimeFunctions
         {
             throw new IllegalArgumentException("Invalid subsecond value: null");
         }
-        if (subsecond.isEmpty() || !subsecond.codePoints().allMatch(Character::isDigit))
+        if (subsecond.isEmpty() || !subsecond.codePoints().allMatch(TimeFunctions::isAsciiDigit))
         {
             throw new IllegalArgumentException("Invalid subsecond value: \"" + subsecond + "\"");
         }
+    }
+
+    /**
+     * A subsecond has to be written in the digits it will be read in. Character.isDigit is true of
+     * every decimal digit Unicode has, so it would accept a subsecond written in, say, Persian or
+     * Devanagari digits, which the code that adds to one a character at a time would then read as
+     * something other than a number.
+     */
+    private static boolean isAsciiDigit(int codePoint)
+    {
+        return ('0' <= codePoint) && (codePoint <= '9');
     }
 
     /**

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TimeFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TimeFunctions.java
@@ -51,4 +51,57 @@ public abstract class TimeFunctions
             throw new IllegalArgumentException("Invalid subsecond value: \"" + subsecond + "\"");
         }
     }
+
+    /**
+     * Get the subsecond part of a number of milliseconds, to three digits.
+     *
+     * @param milliseconds number of milliseconds, of either sign
+     * @return subsecond part, without a sign
+     */
+    public static String subsecondFromMilliseconds(long milliseconds)
+    {
+        return zeroPadded(Math.abs(milliseconds % 1_000L), 3);
+    }
+
+    /**
+     * Get the subsecond part of a number of microseconds, to six digits.
+     *
+     * @param microseconds number of microseconds, of either sign
+     * @return subsecond part, without a sign
+     */
+    public static String subsecondFromMicroseconds(long microseconds)
+    {
+        return zeroPadded(Math.abs(microseconds % 1_000_000L), 6);
+    }
+
+    /**
+     * Get the subsecond part of a number of nanoseconds, to nine digits.
+     *
+     * @param nanoseconds number of nanoseconds, of either sign
+     * @return subsecond part, without a sign
+     */
+    public static String subsecondFromNanoseconds(long nanoseconds)
+    {
+        return zeroPadded(Math.abs(nanoseconds % 1_000_000_000L), 9);
+    }
+
+    /**
+     * A subsecond is held as text so that it keeps the precision it was written with: 1 is a tenth
+     * of a second and 100 is a hundred milliseconds, which the same number could not tell apart.
+     * Everything that reads one back reads it as digits, comparing them and adding to them a
+     * character at a time, so the digits are built here rather than formatted: String.format
+     * without a locale numbers in whatever the default locale asks for, and not every locale asks
+     * for 0 to 9.
+     */
+    private static String zeroPadded(long value, int digits)
+    {
+        char[] chars = new char[digits];
+        long remaining = value;
+        for (int i = digits - 1; i >= 0; i--)
+        {
+            chars[i] = (char) ('0' + (remaining % 10L));
+            remaining /= 10L;
+        }
+        return new String(chars);
+    }
 }

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/strictTime/AbstractStrictTimeWithSubsecond.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/strictTime/AbstractStrictTimeWithSubsecond.java
@@ -62,7 +62,7 @@ abstract class AbstractStrictTimeWithSubsecond extends AbstractStrictTimeWithSec
         }
 
         int secondsToAdd = milliseconds / 1000;
-        String subseconds = String.format("%03d", Math.abs(milliseconds % 1000L));
+        String subseconds = StrictTimeFunctions.subsecondFromMilliseconds(milliseconds);
         return adjustSubseconds(subseconds, milliseconds > 0).addSeconds(secondsToAdd);
     }
 
@@ -80,7 +80,7 @@ abstract class AbstractStrictTimeWithSubsecond extends AbstractStrictTimeWithSec
         }
 
         int secondsToAdd = microseconds / 1_000_000;
-        String subseconds = String.format("%06d", Math.abs(microseconds % 1_000_000L));
+        String subseconds = StrictTimeFunctions.subsecondFromMicroseconds(microseconds);
         return adjustSubseconds(subseconds, microseconds > 0).addSeconds(secondsToAdd);
     }
 
@@ -98,7 +98,7 @@ abstract class AbstractStrictTimeWithSubsecond extends AbstractStrictTimeWithSec
         }
 
         long secondsToAdd = (nanoseconds / 1_000_000_000L);
-        String subseconds = String.format("%09d", Math.abs(nanoseconds % 1_000_000_000L));
+        String subseconds = StrictTimeFunctions.subsecondFromNanoseconds(nanoseconds);
         PureStrictTime result = adjustSubseconds(subseconds, nanoseconds > 0);
         if (secondsToAdd > 0)
         {

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFunctions.java
@@ -28,6 +28,7 @@ import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Locale;
 import java.util.TimeZone;
 
 /**
@@ -102,11 +103,59 @@ public class TestDateFunctions
         Assert.assertNotEquals(DateFunctions.newPureDate(2014, 1, 1), DateFunctions.newPureDate(2014, 1, 1, 0));
     }
 
+    /**
+     * A subsecond is a run of digits that the rest of the class reads back as digits, so it has to
+     * be written in the digits it will be read in. Some locales number in something other than
+     * 0 to 9 - Persian and any locale asking for a numbering system, as the tags below do - and a
+     * subsecond written in those is not merely printed oddly: incrementing one does arithmetic on
+     * the characters, so the answer comes back wrong rather than failing.
+     */
+    @Test
+    public void testSubsecondsAreWrittenInASCIIDigitsWhateverTheLocale()
+    {
+        Locale before = Locale.getDefault();
+        try
+        {
+            for (String tag : new String[]{"en-US", "fa-IR", "hi-IN-u-nu-deva", "ar-EG-u-nu-arab", "bn-IN-u-nu-beng"})
+            {
+                Locale.setDefault(Locale.forLanguageTag(tag));
+
+                // built from an instant, where the subsecond is written straight into the date
+                PureDate fromInstant = DateFunctions.fromInstant(Instant.parse("2015-08-15T10:20:30.123456789Z"), 9);
+                Assert.assertEquals(tag, "123456789", fromInstant.getSubsecond());
+                Assert.assertEquals(tag, "2015-08-15T10:20:30.123456789+0000", fromInstant.toString());
+
+                // and from a calendar, which keeps only milliseconds
+                GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
+                calendar.clear();
+                calendar.set(2015, Calendar.AUGUST, 15, 10, 20, 30);
+                calendar.set(Calendar.MILLISECOND, 7);
+                Assert.assertEquals(tag, "007", DateFunctions.fromCalendar(calendar).getSubsecond());
+
+                // incrementing reads the digits back, so a subsecond written in any other numbering
+                // system would come out wrong here rather than throwing
+                PureDate base = DateFunctions.parsePureDate("2015-08-15T10:20:30.000");
+                Assert.assertEquals(tag, "2015-08-15T10:20:30.001+0000", base.addMilliseconds(1).toString());
+                Assert.assertEquals(tag, "2015-08-15T10:20:29.999+0000", base.addMilliseconds(-1).toString());
+
+                PureDate micros = DateFunctions.parsePureDate("2015-08-15T10:20:30.000000");
+                Assert.assertEquals(tag, "2015-08-15T10:20:30.000001+0000", micros.addMicroseconds(1).toString());
+
+                PureDate nanos = DateFunctions.parsePureDate("2015-08-15T10:20:30.000000000");
+                Assert.assertEquals(tag, "2015-08-15T10:20:30.000000001+0000", nanos.addNanoseconds(1).toString());
+            }
+        }
+        finally
+        {
+            Locale.setDefault(before);
+        }
+    }
+
     @Test
     public void testNewPureDateValidation()
     {
         Assert.assertEquals(
-                String.format("Invalid year (valid [%,d, %,d]): %,d", java.time.Year.MIN_VALUE, java.time.Year.MAX_VALUE, java.time.Year.MAX_VALUE + 1L),
+                String.format(Locale.ROOT, "Invalid year (valid [%,d, %,d]): %,d", java.time.Year.MIN_VALUE, java.time.Year.MAX_VALUE, java.time.Year.MAX_VALUE + 1L),
                 Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(java.time.Year.MAX_VALUE + 1)).getMessage());
         Assert.assertEquals("Invalid month: 13", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(2014, 13)).getMessage());
         Assert.assertEquals("Invalid month: 0", Assert.assertThrows(IllegalArgumentException.class, () -> DateFunctions.newPureDate(2014, 0)).getMessage());

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestTimeFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestTimeFunctions.java
@@ -1,0 +1,103 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m4.coreinstance.primitive.date;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Locale;
+
+public class TestTimeFunctions
+{
+    /**
+     * Each takes a whole quantity and gives back the part of it below a second, padded out to the
+     * digits that quantity measures in.
+     */
+    @Test
+    public void testSubsecondPartOfAQuantity()
+    {
+        Assert.assertEquals("000", TimeFunctions.subsecondFromMilliseconds(0L));
+        Assert.assertEquals("007", TimeFunctions.subsecondFromMilliseconds(7L));
+        Assert.assertEquals("070", TimeFunctions.subsecondFromMilliseconds(70L));
+        Assert.assertEquals("999", TimeFunctions.subsecondFromMilliseconds(999L));
+
+        Assert.assertEquals("000000", TimeFunctions.subsecondFromMicroseconds(0L));
+        Assert.assertEquals("000007", TimeFunctions.subsecondFromMicroseconds(7L));
+        Assert.assertEquals("999999", TimeFunctions.subsecondFromMicroseconds(999_999L));
+
+        Assert.assertEquals("000000000", TimeFunctions.subsecondFromNanoseconds(0L));
+        Assert.assertEquals("000000007", TimeFunctions.subsecondFromNanoseconds(7L));
+        Assert.assertEquals("123456789", TimeFunctions.subsecondFromNanoseconds(123_456_789L));
+        Assert.assertEquals("999999999", TimeFunctions.subsecondFromNanoseconds(999_999_999L));
+    }
+
+    /**
+     * Whole seconds are carried by the caller, so what is left here is only the remainder.
+     */
+    @Test
+    public void testWholeSecondsAreDroppedFromTheSubsecondPart()
+    {
+        Assert.assertEquals("000", TimeFunctions.subsecondFromMilliseconds(1_000L));
+        Assert.assertEquals("001", TimeFunctions.subsecondFromMilliseconds(1_001L));
+        Assert.assertEquals("500", TimeFunctions.subsecondFromMilliseconds(90_500L));
+
+        Assert.assertEquals("000001", TimeFunctions.subsecondFromMicroseconds(1_000_001L));
+        Assert.assertEquals("000000001", TimeFunctions.subsecondFromNanoseconds(1_000_000_001L));
+    }
+
+    /**
+     * The sign belongs to the direction the caller is adjusting in, not to the digits, so a
+     * negative quantity gives the same digits as its positive counterpart.
+     */
+    @Test
+    public void testTheSubsecondPartCarriesNoSign()
+    {
+        Assert.assertEquals("001", TimeFunctions.subsecondFromMilliseconds(-1L));
+        Assert.assertEquals("999", TimeFunctions.subsecondFromMilliseconds(-999L));
+        Assert.assertEquals("001", TimeFunctions.subsecondFromMilliseconds(-1_001L));
+        Assert.assertEquals("000001", TimeFunctions.subsecondFromMicroseconds(-1L));
+        Assert.assertEquals("000000001", TimeFunctions.subsecondFromNanoseconds(-1L));
+
+        // taking the remainder first keeps the sign flip inside the range the digits can hold,
+        // which negating the quantity itself would not for the smallest long
+        Assert.assertEquals("808", TimeFunctions.subsecondFromMilliseconds(Long.MIN_VALUE));
+        Assert.assertEquals("775808", TimeFunctions.subsecondFromMicroseconds(Long.MIN_VALUE));
+        Assert.assertEquals("854775808", TimeFunctions.subsecondFromNanoseconds(Long.MIN_VALUE));
+    }
+
+    /**
+     * The digits are the digits 0 to 9 whatever the default locale numbers in, since everything
+     * that reads a subsecond back reads it as those.
+     */
+    @Test
+    public void testDigitsAreASCIIWhateverTheLocale()
+    {
+        Locale before = Locale.getDefault();
+        try
+        {
+            for (String tag : new String[]{"en-US", "fa-IR", "hi-IN-u-nu-deva", "ar-EG-u-nu-arab", "bn-IN-u-nu-beng"})
+            {
+                Locale.setDefault(Locale.forLanguageTag(tag));
+                Assert.assertEquals(tag, "007", TimeFunctions.subsecondFromMilliseconds(7L));
+                Assert.assertEquals(tag, "000007", TimeFunctions.subsecondFromMicroseconds(7L));
+                Assert.assertEquals(tag, "123456789", TimeFunctions.subsecondFromNanoseconds(123_456_789L));
+            }
+        }
+        finally
+        {
+            Locale.setDefault(before);
+        }
+    }
+}

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestTimeFunctions.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestTimeFunctions.java
@@ -22,6 +22,40 @@ import java.util.Locale;
 public class TestTimeFunctions
 {
     /**
+     * A subsecond is only the digits 0 to 9. Unicode has decimal digits beyond those, and the code
+     * that adds to a subsecond a character at a time would read them as something other than a
+     * number, so they are rejected rather than stored and misread later.
+     */
+    @Test
+    public void testValidateSubsecondTakesOnlyASCIIDigits()
+    {
+        TimeFunctions.validateSubsecond("0");
+        TimeFunctions.validateSubsecond("000");
+        TimeFunctions.validateSubsecond("123456789");
+
+        assertInvalidSubsecond("\u06F1\u06F2\u06F3");   // Persian
+        assertInvalidSubsecond("\u0967\u0968\u0969");   // Devanagari
+        assertInvalidSubsecond("\u0661\u0662\u0663");   // Arabic-Indic
+        assertInvalidSubsecond("12\u06F3");             // one stray digit is enough
+        assertInvalidSubsecond("1 2");
+        assertInvalidSubsecond("1.2");
+        assertInvalidSubsecond("-12");
+        assertInvalidSubsecond("");
+
+        Assert.assertEquals(
+                "Invalid subsecond value: null",
+                Assert.assertThrows(IllegalArgumentException.class, () -> TimeFunctions.validateSubsecond(null)).getMessage());
+    }
+
+    private static void assertInvalidSubsecond(String subsecond)
+    {
+        Assert.assertEquals(
+                subsecond,
+                "Invalid subsecond value: \"" + subsecond + "\"",
+                Assert.assertThrows(IllegalArgumentException.class, () -> TimeFunctions.validateSubsecond(subsecond)).getMessage());
+    }
+
+    /**
      * Each takes a whole quantity and gives back the part of it below a second, padded out to the
      * digits that quantity measures in.
      */

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/strictTime/TestPureStrictTime.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/strictTime/TestPureStrictTime.java
@@ -17,6 +17,8 @@ package org.finos.legend.pure.m4.coreinstance.primitive.strictTime;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Locale;
+
 public class TestPureStrictTime
 {
     @Test
@@ -33,6 +35,39 @@ public class TestPureStrictTime
         Assert.assertEquals("16:12:35", strictTimeWithHourMinSecSubSec.format("H:mm:ss"));
         Assert.assertEquals("16:12:35.070004235", strictTimeWithHourMinSecSubSec.format("HH:mm:ss.SSSS"));
         Assert.assertEquals("16:12:35.070", strictTimeWithHourMinSecSubSec.format("HH:mm:ss.SSS"));
+    }
+
+    /**
+     * A subsecond is a run of digits that the rest of the class reads back as digits, so it has to
+     * be written in the digits it will be read in. Some locales number in something other than
+     * 0 to 9, and a subsecond written in those is not merely printed oddly: incrementing one does
+     * arithmetic on the characters, so the answer comes back wrong rather than failing.
+     */
+    @Test
+    public void testSubsecondsAreWrittenInASCIIDigitsWhateverTheLocale()
+    {
+        Locale before = Locale.getDefault();
+        try
+        {
+            for (String tag : new String[]{"en-US", "fa-IR", "hi-IN-u-nu-deva", "ar-EG-u-nu-arab", "bn-IN-u-nu-beng"})
+            {
+                Locale.setDefault(Locale.forLanguageTag(tag));
+
+                PureStrictTime millis = StrictTimeFunctions.parsePureStrictTime("10:20:30.000");
+                Assert.assertEquals(tag, "10:20:30.001", millis.addMilliseconds(1).toString());
+                Assert.assertEquals(tag, "10:20:29.999", millis.addMilliseconds(-1).toString());
+
+                PureStrictTime micros = StrictTimeFunctions.parsePureStrictTime("10:20:30.000000");
+                Assert.assertEquals(tag, "10:20:30.000001", micros.addMicroseconds(1).toString());
+
+                PureStrictTime nanos = StrictTimeFunctions.parsePureStrictTime("10:20:30.000000000");
+                Assert.assertEquals(tag, "10:20:30.000000001", nanos.addNanoseconds(1).toString());
+            }
+        }
+        finally
+        {
+            Locale.setDefault(before);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

A Pure date or time of day holds its subsecond as text, so that it keeps the precision it was written with: `1` is a tenth of a second and `100` is a hundred milliseconds, which the same number could not tell apart. Nine places built one with `String.format("%03d", ...)` and friends, and `String.format` without a locale numbers in whatever the default locale asks for. Not every locale asks for 0 to 9.

Under `fa-IR` — which needs no `-u-nu-` extension, Persian simply defaults to Extended Arabic-Indic digits — a date built from an instant held U+06F1 through U+06F9 in its subsecond field.

## Why this is a correctness bug, not a formatting one

Everything that reads a subsecond back reads it as digits: comparing them, and adding to them a character at a time. Given digits it does not expect, that arithmetic produces a wrong answer rather than an error.

```
fa-IR:  10:20:30.000 plus one millisecond  ->  10:20:31 with a subsecond of characters that are not digits at all
en-US:  10:20:30.000 plus one millisecond  ->  10:20:30.001
```

Nothing on the way in objected either. `validateSubsecond` used `Character::isDigit`, which is true of every decimal digit Unicode has, and `Integer.parseInt` reads those digits too — so the value was accepted, stored, and only misread later.

## What changed

**Building a subsecond.** The nine sites now share three methods on `TimeFunctions`, alongside the validation those same values already pass through:

```java
TimeFunctions.subsecondFromMilliseconds(long)   // 3 digits
TimeFunctions.subsecondFromMicroseconds(long)   // 6 digits
TimeFunctions.subsecondFromNanoseconds(long)    // 9 digits
```

Each takes a whole quantity and returns the part below a second, so the three callers that already held an in-range value (`calendar.get(MILLISECOND)`, `timestamp.getNanos()`, `time.getNano()`) use them unchanged. They build the digits rather than formatting them, so the result is ASCII by construction rather than by remembering to pass a locale. `DateFunctions` and `StrictTimeFunctions` both extend `TimeFunctions`, so each package calls through its own class and no cross-package import is needed.

**Validating a subsecond.** `validateSubsecond` now takes only `0` to `9`, closing the gate a caller could still walk through by hand: `newPureDate(2015, 8, 15, 10, 20, 30, "\u06F1\u06F2\u06F3")` was accepted before this change and would misbehave when incremented. This is the one behavior change in the PR — input that used to be accepted is now rejected.

**One `String.format` remains**, in `validateYear`. It is there for the commas grouping a year's digits rather than to pad anything, so it keeps `String.format` but names `Locale.ROOT` so those commas do not move either. The assertion mirroring that message in `TestDateFunctions` names the same locale, so the two cannot drift apart.

## Verification

- 562 tests pass in `legend-pure-m4`, 0 checkstyle violations.
- `TestTimeFunctions` covers the helpers directly: padding, whole-second remainders, sign, and `Long.MIN_VALUE` at each scale, which is where taking the remainder before negating matters (`Math.abs(Long.MIN_VALUE)` overflows; `Math.abs(Long.MIN_VALUE % 1_000_000L)` is 775808).
- `TestDateFunctions` and `TestPureStrictTime` exercise the paths end to end under `en-US`, `fa-IR`, `hi-IN-u-nu-deva`, `ar-EG-u-nu-arab` and `bn-IN-u-nu-beng`. Against the unfixed code they fail with `fa-IR expected:<123456789> but was:<...>` and `fa-IR expected:<10:20:30.001> but was:<10:20:31...>`.
- The validation test fails against the old `Character::isDigit` with *"expected IllegalArgumentException to be thrown, but nothing was thrown"*.
- Test sources are ASCII: the non-Latin digits are written as `\uXXXX` escapes.

## Scope

Only `legend-pure-m4`, and only the writing and validating of subseconds. Two related items are deliberately not here:

- The same `String.format` pattern exists in legend-engine's copy of `PureDate`, to be handled separately.
- `z` in legend-engine's `PureDate.format` renders zone short names in the format locale. Also separate, and arguably subsumed by the question of whether that fork survives at all.

## Commits

1. `Write subseconds in ASCII digits whatever the locale`
2. `Take only ASCII digits as a subsecond`
