### PR TITLE
Fix time zone handling in DateFormat, and document the format string

### DIFF
--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -18,8 +18,9 @@ import org.finos.legend.pure.m4.tools.SafeAppendable;
 import org.finos.legend.pure.m4.tools.TextTools;
 
 import java.io.IOException;
+import java.time.DateTimeException;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.TimeZone;
 
 public class DateFormat
 {
@@ -34,7 +35,7 @@ public class DateFormat
         SafeAppendable safeAppendable = SafeAppendable.wrap(appendable);
         int length = formatString.length();
         ZonedDateTime zoned = null;
-        StringBuilder timeZoneId = new StringBuilder();
+        String timeZoneId = null;
         int i = 0;
         while (i < length)
         {
@@ -49,6 +50,7 @@ public class DateFormat
                         throw new IllegalArgumentException("Time zone can only be set at the beginning of the format string");
                     }
 
+                    StringBuilder tzBuilder = new StringBuilder();
                     boolean done = false;
                     boolean escaped = false;
                     boolean inQuotes = false;
@@ -57,7 +59,7 @@ public class DateFormat
                         char next = formatString.charAt(i++);
                         if (escaped)
                         {
-                            timeZoneId.append(next);
+                            tzBuilder.append(next);
                             escaped = false;
                         }
                         else if (next == '"')
@@ -74,7 +76,7 @@ public class DateFormat
                         }
                         else
                         {
-                            timeZoneId.append(next);
+                            tzBuilder.append(next);
                         }
                     }
                     if (inQuotes)
@@ -85,24 +87,22 @@ public class DateFormat
                     {
                         throw new IllegalArgumentException("Missing closing bracket in format string: " + formatString);
                     }
-                    TimeZone timeZone;
+                    timeZoneId = tzBuilder.toString();
+                    ZoneId timeZone;
                     try
                     {
-                        timeZone = TimeZone.getTimeZone(timeZoneId.toString());
+                        timeZone = ZoneId.of(timeZoneId, ZoneId.SHORT_IDS);
                     }
-                    catch (RuntimeException e)
+                    catch (DateTimeException e)
                     {
-                        throw new IllegalArgumentException("Unknown time zone: " + timeZoneId);
+                        throw new IllegalArgumentException("Unknown time zone: " + timeZoneId, e);
                     }
 
                     if (date.hasHour())
                     {
-                        if (zoned == null)
-                        {
-                            // A Pure date is always understood as UTC, so the instant it starts at
-                            // is what the requested zone renders.
-                            zoned = PureDateToJava.start().toInstant(date).atZone(timeZone.toZoneId());
-                        }
+                        // A Pure date is always understood as UTC, so the instant it starts at
+                        // is what the requested zone renders.
+                        zoned = PureDateToJava.start().toInstant(date).atZone(timeZone);
                     }
                     break;
                 }
@@ -251,7 +251,7 @@ public class DateFormat
                 case 'z':
                 {
                     int count = getCharCountFrom(character, formatString, i);
-                    safeAppendable.append((zoned == null) ? "GMT" : timeZoneId);
+                    safeAppendable.append((timeZoneId == null) ? "GMT" : timeZoneId);
                     i += count;
                     break;
                 }

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -30,6 +30,61 @@ public class DateFormat
 
     private static final char DATE_PREFIX = '%';
 
+    /**
+     * Write a Pure date to an appendable in the form a format string describes.
+     *
+     * <p>Each character of the format string is a control character standing for one component of
+     * the date, except for the separators {@code - / : . }, tab and space, which are written out as
+     * they appear, and text in double quotes, which is written out without them. A backslash escapes
+     * the character after it. Repeating a control character widens the field it writes: {@code d}
+     * gives 1 where {@code dd} gives 01.
+     *
+     * <table border="1">
+     * <caption>Control characters</caption>
+     * <tr><th>Character</th><th>Component</th><th>Example</th></tr>
+     * <tr><td>{@code y}</td><td>year; one or two of them write the last two digits, three or more
+     * the whole year</td><td>{@code yy} 14, {@code yyyy} 2014</td></tr>
+     * <tr><td>{@code M}</td><td>month</td><td>{@code MM} 03</td></tr>
+     * <tr><td>{@code d}</td><td>day of the month</td><td>{@code dd} 10</td></tr>
+     * <tr><td>{@code H}</td><td>hour, 0 to 23</td><td>{@code HH} 16</td></tr>
+     * <tr><td>{@code h}</td><td>hour, 1 to 12</td><td>{@code hh} 04</td></tr>
+     * <tr><td>{@code a}</td><td>AM or PM</td><td>PM</td></tr>
+     * <tr><td>{@code m}</td><td>minute</td><td>{@code mm} 12</td></tr>
+     * <tr><td>{@code s}</td><td>second</td><td>{@code ss} 35</td></tr>
+     * <tr><td>{@code S}</td><td>sub-second; up to three of them truncate the date's own digits,
+     * more write them all</td><td>{@code SSS} 070</td></tr>
+     * <tr><td>{@code z}</td><td>general time zone: the zone as written in the format string, or GMT
+     * if none was</td><td>{@code z} EST</td></tr>
+     * <tr><td>{@code Z}</td><td>RFC 822 time zone: always a sign, two digits of hours and two of
+     * minutes; requires an hour</td><td>{@code Z} -0500</td></tr>
+     * <tr><td>{@code X}</td><td>ISO 8601 time zone: Z for UTC, otherwise a sign, hours, and minutes
+     * only when the offset has them; requires an hour</td><td>{@code X} -05</td></tr>
+     * </table>
+     *
+     * <p>A format string may open with a time zone in square brackets, as in
+     * {@code [America/New_York]yyyy-MM-dd HH:mm:ss}, and only open with one: a zone appearing after
+     * anything has been written is an error, since the components before it would already have been
+     * written in another zone. The name may be anything {@link ZoneId#of(String, java.util.Map)}
+     * accepts against {@link ZoneId#SHORT_IDS} - a region such as {@code America/New_York}, one of
+     * the three letter abbreviations such as {@code EST}, or an offset such as {@code GMT+5} or
+     * {@code +05:30} - and a name it does not accept is an error rather than a silent fall back to
+     * UTC.
+     *
+     * <p>A Pure date is always understood as UTC, so a zone shifts the date to the instant it
+     * stands for as that zone reads it, and every component comes from the shifted reading. A date
+     * with no hour is not an instant and so is never shifted; {@code z} still names the zone that
+     * was asked for, but {@code Z} and {@code X} are an error, since an offset belongs to an
+     * instant and a zone can be keeping more than one over a date that broad.
+     *
+     * @param appendable   appendable to write to
+     * @param formatString format string
+     * @param date         date to write
+     * @param <T>          appendable type
+     * @return the appendable
+     * @throws IllegalArgumentException if the format string is malformed, names a time zone that
+     *                                  cannot be resolved, sets a time zone anywhere but at the
+     *                                  start, or asks for a component the date does not have
+     */
     public static <T extends Appendable> T format(T appendable, String formatString, PureDate date)
     {
         SafeAppendable safeAppendable = SafeAppendable.wrap(appendable);

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -258,6 +258,10 @@ public class DateFormat
                 // RFC 822 time zone
                 case 'Z':
                 {
+                    if (!date.hasHour())
+                    {
+                        throw new IllegalArgumentException("Date has no hour (required for Z): " + date);
+                    }
                     int count = getCharCountFrom(character, formatString, i);
                     appendRFC822TimeZone(safeAppendable, getOffsetInMinutes(zoned));
                     i += count;
@@ -266,6 +270,10 @@ public class DateFormat
                 // ISO 8601 time zone
                 case 'X':
                 {
+                    if (!date.hasHour())
+                    {
+                        throw new IllegalArgumentException("Date has no hour (required for X): " + date);
+                    }
                     int count = getCharCountFrom(character, formatString, i);
                     appendISO8601TimeZone(safeAppendable, getOffsetInMinutes(zoned));
                     i += count;
@@ -627,6 +635,7 @@ public class DateFormat
      * @param zoned date and time being rendered, or null for UTC
      * @return offset from UTC in minutes
      */
+
     private static int getOffsetInMinutes(ZonedDateTime zoned)
     {
         return (zoned == null) ? 0 : (zoned.getOffset().getTotalSeconds() / 60);

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -690,7 +690,6 @@ public class DateFormat
      * @param zoned date and time being rendered, or null for UTC
      * @return offset from UTC in minutes
      */
-
     private static int getOffsetInMinutes(ZonedDateTime zoned)
     {
         return (zoned == null) ? 0 : (zoned.getOffset().getTotalSeconds() / 60);

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -14,6 +14,8 @@
 
 package org.finos.legend.pure.m4.coreinstance.primitive.date;
 
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -22,7 +24,6 @@ import java.io.StringWriter;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.TimeZone;
 
 /**
  * Tests for {@link DateFormat}: rendering a Pure date through a format string, writing the
@@ -301,6 +302,27 @@ public class TestDateFormat
     }
 
     /**
+     * A zone may be named by an offset rather than a place, in any of the forms
+     * {@link ZoneId#of(String, java.util.Map)} takes, and the offset is then fixed rather than
+     * something the zone varies over the year. Note that the Etc zones invert the sign, as POSIX
+     * has them count hours west of Greenwich: Etc/GMT+5 is five hours behind UTC, not ahead.
+     */
+    @Test
+    public void testFormatWithATimeZoneNamedByItsOffset()
+    {
+        Assert.assertEquals("2014-03-10 21:12:35 +0500", format("[GMT+5]yyyy-MM-dd HH:mm:ss Z", DATE));
+        Assert.assertEquals("2014-03-10 21:12:35 +0500", format("[GMT+05:00]yyyy-MM-dd HH:mm:ss Z", DATE));
+        Assert.assertEquals("2014-03-10 19:12:35 +0300", format("[UTC+3]yyyy-MM-dd HH:mm:ss Z", DATE));
+        Assert.assertEquals("2014-03-10 21:42:35 +0530", format("[+05:30]yyyy-MM-dd HH:mm:ss Z", DATE));
+        Assert.assertEquals("2014-03-10 11:12:35 -0500", format("[Etc/GMT+5]yyyy-MM-dd HH:mm:ss Z", DATE));
+
+        // UTC by any of its names leaves the date where it is
+        Assert.assertEquals("2014-03-10 16:12:35 +0000", format("[UTC]yyyy-MM-dd HH:mm:ss Z", DATE));
+        Assert.assertEquals("2014-03-10 16:12:35 +0000", format("[UT]yyyy-MM-dd HH:mm:ss Z", DATE));
+        Assert.assertEquals("2014-03-10 16:12:35 +0000", format("[Z]yyyy-MM-dd HH:mm:ss Z", DATE));
+    }
+
+    /**
      * A zone need not be a whole number of minutes from UTC: Liberia was 44 minutes and 30 seconds
      * behind it until 1972. The second is part of the shift there, so it comes from the shifted
      * time along with every other component, and neither notation can express it, so both round
@@ -323,7 +345,8 @@ public class TestDateFormat
     @Test
     public void testFormatWithTimeZoneAgreesWithJavaTime()
     {
-        String[] zoneIds = {"GMT", "UTC", "EST", "CET", "America/New_York", "Europe/London", "Asia/Tokyo", "Australia/Adelaide", "Asia/Kathmandu", "Pacific/Chatham", "Africa/Monrovia"};
+        MutableList<String> zoneIds = Lists.mutable.with("GMT", "UTC", "CET", "America/New_York", "Europe/London", "Asia/Tokyo", "Australia/Adelaide", "Asia/Kathmandu", "Pacific/Chatham", "Africa/Monrovia", "Australia/Lord_Howe");
+        zoneIds.addAllIterable(ZoneId.SHORT_IDS.keySet());
         PureDate[] dates = {
                 DateFunctions.parsePureDate("1500-01-15T12:00:00"),   // before the Gregorian calendar was adopted
                 DateFunctions.parsePureDate("1800-01-15T12:00:00"),   // before standard time
@@ -340,7 +363,7 @@ public class TestDateFormat
         DateTimeFormatter iso8601 = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss X");
         for (String zoneId : zoneIds)
         {
-            ZoneId zone = TimeZone.getTimeZone(zoneId).toZoneId();
+            ZoneId zone = ZoneId.of(zoneId, ZoneId.SHORT_IDS);
             for (PureDate date : dates)
             {
                 ZonedDateTime zoned = PureDateToJava.start().toInstant(date).atZone(zone);

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -240,6 +240,12 @@ public class TestDateFormat
         PureDate day = DateFunctions.newPureDate(2015, 8, 15);
         Assert.assertEquals("2015-08-15", format("[EST]yyyy-MM-dd", day));
         Assert.assertEquals("EST", format("[EST]z", day));
+
+        // date is shifted even if zone is not printed
+        Assert.assertEquals("2014-03-10 21:42:35.070004235", format("[+0530]yyyy-MM-dd HH:mm:ss.SSSSSS", DATE));
+        Assert.assertEquals("2014-03-10 21:42:35", format("[+0530]yyyy-MM-dd HH:mm:ss", DATE));
+        Assert.assertEquals("2014-03-10 21:42:35.070004235", format("[Asia/Kolkata]yyyy-MM-dd HH:mm:ss.SSSSSS", DATE));
+        Assert.assertEquals("2014-03-10 21:42:35", format("[Asia/Kolkata]yyyy-MM-dd HH:mm:ss", DATE));
     }
 
     /**
@@ -314,6 +320,7 @@ public class TestDateFormat
         Assert.assertEquals("2014-03-10 21:12:35 +0500", format("[GMT+05:00]yyyy-MM-dd HH:mm:ss Z", DATE));
         Assert.assertEquals("2014-03-10 19:12:35 +0300", format("[UTC+3]yyyy-MM-dd HH:mm:ss Z", DATE));
         Assert.assertEquals("2014-03-10 21:42:35 +0530", format("[+05:30]yyyy-MM-dd HH:mm:ss Z", DATE));
+        Assert.assertEquals("2014-03-10 21:42:35 +0530", format("[+0530]yyyy-MM-dd HH:mm:ss Z", DATE));
         Assert.assertEquals("2014-03-10 11:12:35 -0500", format("[Etc/GMT+5]yyyy-MM-dd HH:mm:ss Z", DATE));
 
         // UTC by any of its names leaves the date where it is

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -323,6 +323,88 @@ public class TestDateFormat
     }
 
     /**
+     * A date with no hour is not an instant, so no offset from UTC belongs to it: a zone can be
+     * keeping several across a date that broad, and which one it is keeping is just what knowing the
+     * time would have told us. The numeric notations therefore fail on such a date, exactly as
+     * asking for the hour itself does, whether or not a zone was named. The general notation still
+     * works, because it names a zone rather than measuring one.
+     */
+    @Test
+    public void testFormatOffsetOfADateWithNoHour()
+    {
+        PureDate day = DateFunctions.newPureDate(2015, 8, 15);
+        PureDate month = DateFunctions.newPureDate(2015, 8);
+        PureDate year = DateFunctions.newPureDate(2015);
+
+        assertFormatFails("Date has no hour (required for Z): 2015-08-15", "[America/New_York]Z", day);
+        assertFormatFails("Date has no hour (required for X): 2015-08-15", "[America/New_York]X", day);
+        assertFormatFails("Date has no hour (required for Z): 2015-08", "[America/New_York]Z", month);
+        assertFormatFails("Date has no hour (required for Z): 2015", "[America/New_York]Z", year);
+
+        // a zone that never moves is no different: the date still does not say when
+        assertFormatFails("Date has no hour (required for Z): 2015-08-15", "[Asia/Kolkata]Z", day);
+        assertFormatFails("Date has no hour (required for Z): 2015-08-15", "[GMT]Z", day);
+        assertFormatFails("Date has no hour (required for X): 2015-08-15", "[+05:30]X", day);
+
+        // nor is naming no zone at all, since the offset is still not a thing the date carries
+        assertFormatFails("Date has no hour (required for Z): 2015-08-15", "Z", day);
+        assertFormatFails("Date has no hour (required for X): 2015-08-15", "X", day);
+        assertFormatFails("Date has no hour (required for Z): 2015-08-15", "yyyy-MM-dd Z", day);
+
+        // the general notation asks only what the format string said, so it still answers
+        Assert.assertEquals("2015-08-15 America/New_York", format("[America/New_York]yyyy-MM-dd z", day));
+        Assert.assertEquals("2015-08 America/New_York", format("[America/New_York]yyyy-MM z", month));
+        Assert.assertEquals("2015 America/New_York", format("[America/New_York]yyyy z", year));
+        Assert.assertEquals("2015-08-15 GMT", format("yyyy-MM-dd z", day));
+
+        // and the date itself is not shifted by naming a zone
+        Assert.assertEquals("2015-08-15", format("[Pacific/Auckland]yyyy-MM-dd", day));
+        Assert.assertEquals("2015-08-15", format("[Pacific/Honolulu]yyyy-MM-dd", day));
+    }
+
+    /**
+     * Once a date has an hour it stands for an instant, and every zone the format string can name
+     * renders it the same way: the general notation gives back the name as written, and the two
+     * numeric notations agree with each other and with the offset the zone was keeping then.
+     */
+    @Test
+    public void testFormatTimeZoneIsConsistentAcrossZones()
+    {
+        MutableList<String> zoneIds = Lists.mutable.with("GMT", "UTC", "CET", "America/New_York", "Asia/Kolkata", "Australia/Lord_Howe", "GMT+5", "UTC+3", "+05:30", "Etc/GMT+5");
+        zoneIds.addAllIterable(ZoneId.SHORT_IDS.keySet());
+        for (String zoneId : zoneIds)
+        {
+            ZoneId zone = ZoneId.of(zoneId, ZoneId.SHORT_IDS);
+            for (PureDate date : DATES)
+            {
+                String context = zoneId + " " + date;
+
+                // the general notation is the name as written, whatever the date carries
+                Assert.assertEquals(context, zoneId, format("[" + zoneId + "]z", date));
+
+                if (!date.hasHour())
+                {
+                    assertFormatFails("Date has no hour (required for Z): " + date, "[" + zoneId + "]Z", date);
+                    assertFormatFails("Date has no hour (required for X): " + date, "[" + zoneId + "]X", date);
+                    continue;
+                }
+
+                // the numeric notations agree with each other, and with the offset java.time gives
+                // for the instant the date stands for
+                int offsetSeconds = PureDateToJava.start().toInstant(date).atZone(zone).getOffset().getTotalSeconds();
+                int minutes = Math.abs(offsetSeconds / 60);
+                String sign = (offsetSeconds < 0) ? "-" : "+";
+                String rfc822 = String.format("%s%02d%02d", sign, minutes / 60, minutes % 60);
+                String iso8601 = (offsetSeconds == 0) ? "Z" :
+                        ((minutes % 60 == 0) ? String.format("%s%02d", sign, minutes / 60) : rfc822);
+
+                Assert.assertEquals(context, rfc822, format("[" + zoneId + "]Z", date));
+                Assert.assertEquals(context, iso8601, format("[" + zoneId + "]X", date));
+            }
+        }
+    }
+
+    /**
      * A zone need not be a whole number of minutes from UTC: Liberia was 44 minutes and 30 seconds
      * behind it until 1972. The second is part of the shift there, so it comes from the shifted
      * time along with every other component, and neither notation can express it, so both round
@@ -387,6 +469,8 @@ public class TestDateFormat
         assertFormatFails("Date has no hour: 2014-03-10", "yyyy-MM-dd HH", DATES[2]);
         assertFormatFails("Date has no hour: 2014-03-10", "h", DATES[2]);
         assertFormatFails("Date has no hour: 2014-03-10", "a", DATES[2]);
+        assertFormatFails("Date has no hour (required for Z): 2014-03-10", "Z", DATES[2]);
+        assertFormatFails("Date has no hour (required for X): 2014-03-10", "X", DATES[2]);
         assertFormatFails("Date has no minute: 2014-03-10T16", "HH:mm", DATES[3]);
         assertFormatFails("Date has no second: 2014-03-10T16:12+0000", "HH:mm:ss", DATES[4]);
         assertFormatFails("Date has no sub-second: 2014-03-10T16:12:35+0000", "HH:mm:ss.SSS", DATES[5]);

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -231,14 +231,14 @@ public class TestDateFormat
         Assert.assertEquals("CET", format("[CET]z", DATE));
         Assert.assertEquals("CET", format("[CE\\T]z", DATE));
 
-        // an unknown zone is GMT, but a general time zone still renders the name as given
-        Assert.assertEquals("2014-03-10 16:12:35.070+0000", format("[Europe/Lissabon]yyyy-MM-dd HH:mm:ss.SSSZ", DATE));
-        Assert.assertEquals("Europe/Lissabon", format("[Europe/Lissabon]z", DATE));
+        // an unknown zone results in an error
+        assertFormatFails("Unknown time zone: Europe/Lissabon", "[Europe/Lissabon]yyyy-MM-dd HH:mm:ss.SSSZ", DATE);
+        assertFormatFails("Unknown time zone: Europe/Lissabon", "[Europe/Lissabon]z", DATE);
 
         // a date with no hour is never shifted
         PureDate day = DateFunctions.newPureDate(2015, 8, 15);
         Assert.assertEquals("2015-08-15", format("[EST]yyyy-MM-dd", day));
-        Assert.assertEquals("GMT", format("[EST]z", day));
+        Assert.assertEquals("EST", format("[EST]z", day));
     }
 
     /**

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestPureDate.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestPureDate.java
@@ -58,14 +58,19 @@ public class TestPureDate
         Assert.assertEquals("2014-01-01 02:01:01.070 CET", date.format("[\"CET\"]yyyy-MM-dd HH:mm:ss.SSS z"));
 
         // Longer time zone names
-        Assert.assertEquals("2014-01-01 01:01:01.070+0000", date.format("[Europe/Lissabon]yyyy-MM-dd HH:mm:ss.SSSZ"));
-        Assert.assertEquals("2014-01-01 01:01:01.070 Europe/Lissabon", date.format("[Europe/Lissabon]yyyy-MM-dd HH:mm:ss.SSS z"));
-        Assert.assertEquals("2014-01-01 01:01:01.070Z", date.format("[Lissabon]yyyy-MM-dd HH:mm:ss.SSSX"));
-        Assert.assertEquals("2014-01-01 01:01:01.070 Europe/Lissabon", date.format("[\"Europe/Lissabon\"]yyyy-MM-dd HH:mm:ss.SSS z"));
-
         Assert.assertEquals("2014-01-01 00:01:01.070-0100", date.format("[Atlantic/Azores]yyyy-MM-dd HH:mm:ss.SSSZ"));
         Assert.assertEquals("2014-01-01 00:01:01.070 Atlantic/Azores", date.format("[Atlantic/Azores]yyyy-MM-dd HH:mm:ss.SSS z"));
         Assert.assertEquals("2014-01-01 00:01:01.070-01", date.format("[Atlantic/Azores]yyyy-MM-dd HH:mm:ss.SSSX"));
+
+        // Unknown time zones
+        Assert.assertEquals("Unknown time zone: Europe/Lissabon",
+                Assert.assertThrows(IllegalArgumentException.class, () -> date.format("[Europe/Lissabon]yyyy-MM-dd HH:mm:ss.SSSZ")).getMessage());
+        Assert.assertEquals("Unknown time zone: Europe/Lissabon",
+                Assert.assertThrows(IllegalArgumentException.class, () -> date.format("[Europe/Lissabon]yyyy-MM-dd HH:mm:ss.SSS z")).getMessage());
+        Assert.assertEquals("Unknown time zone: Lissabon",
+                Assert.assertThrows(IllegalArgumentException.class, () -> date.format("[Lissabon]yyyy-MM-dd HH:mm:ss.SSSX")).getMessage());
+        Assert.assertEquals("Unknown time zone: Europe/Lissabon",
+                Assert.assertThrows(IllegalArgumentException.class, () -> date.format("[\"Europe/Lissabon\"]yyyy-MM-dd HH:mm:ss.SSS z")).getMessage());
 
         // Time zone is illegal after date or time has been formatted and written out
         Assert.assertEquals("Time zone can only be set at the beginning of the format string",


### PR DESCRIPTION
# Fix time zone handling in DateFormat, and document the format string

## The problem

`DateFormat.format` resolved the time zone at the head of a format string with `TimeZone.getTimeZone`, which answers GMT for any id it cannot parse. Three problems followed.

**A zone it could not resolve was silently GMT.** `format("[Europe/Lissabon]yyyy-MM-dd HH:mm:ss.SSSZ", date)` rendered in GMT and said nothing, so a misspelled zone was indistinguishable from a correct one. `TestPureDate` had that written down as the expected answer.

**Zones named by a bare offset were among the ones it could not resolve.** `java.util.TimeZone` recognizes custom ids only in the `GMT±h` form, so `[+05:30]`, `[+0530]`, `[-0500]` and `[UTC+3]` all rendered in GMT while `[GMT+5]` and `[Etc/GMT+5]` worked. Nothing said which spellings were live, and the ones that quietly were not are the ones a caller reaches for first.

**`z` and `Z`/`X` disagreed about a date with no hour.** Such a date is not an instant, so no offset from UTC belongs to it — a zone can be keeping several across a date that broad, and which one is exactly what knowing the time would have told you. `Z` and `X` answered `+0000` and `Z` regardless, as though the zone named had been GMT, while `z` printed `GMT` instead of the name it had been given.

And nothing in the repo said what a format string may contain.

## What changed

- Zones resolve through `ZoneId.of(id, ZoneId.SHORT_IDS)`, so every spelling `java.time` accepts works — regions, the 28 short ids, and offsets in any form — and a name it does not accept raises `IllegalArgumentException: Unknown time zone: <name>`.
- `Z` and `X` require an hour and fail the way asking for the hour itself does: `Date has no hour (required for Z): 2015-08-15`. The message names the control character, since unlike `H` or `h` neither looks like a request for one.
- `z` prints the zone the format string named, or `GMT` when none was, whether or not the date has an hour. It names a zone rather than measuring one, so a date with no hour is no obstacle.
- `DateFormat.format` now has javadoc: the control characters and what each writes, the quoting and escaping rules, and the time zone prefix — where it may appear, which names it takes, and that one it cannot resolve is an error.

Failing `Z` and `X` was chosen over picking an offset because every way of picking one has to invent an instant the date does not carry. It is particularly problematic for dates that span multiple offsets, such as those containing DST changes. For example, resolving at the start of the span reports the offset covering two of the twenty-three hours of a spring-forward day, and reports one the day never has at all where a zone begins summer time at midnight, as Brazil used to.

## Compatibility

| format string                               | before          | after                      |
| ------------------------------------------- | --------------- | -------------------------- |
| a zone name that will not resolve           | rendered in GMT | `IllegalArgumentException` |
| `[+05:30]`, `[+0530]`, `[-0500]`, `[UTC+3]` | rendered in GMT | rendered at that offset    |
| `[EST]z` on a date with no hour             | `GMT`           | `EST`                      |
| `Z` / `X` on a date with no hour            | `+0000` / `Z`   | `IllegalArgumentException` |

Regions, the three-letter ids, `[GMT±h]` and `[Etc/GMT±h]` are unchanged.

The second row is the one that reaches downstream quietly. legend-engine builds `'%t{[' + connection.timeZone + ']yyyy-MM-dd HH:mm:ss}'` in `convertDateToSqlString`, so a relational connection whose `timeZone` is written `+0530` rather than `GMT+05:30` now yields SQL literals at that offset instead of UTC — which is what a connection time zone already did for every spelling that resolved.

## Verification

`TestDateFormat` (28) and `TestPureDate` (15) pass, checkstyle clean.

The zone tests used to resolve their ids through `TimeZone.getTimeZone` while the code resolved them through `ZoneId.of` — a resolver the code no longer calls, which on JDK 25 also warned about deprecated three-letter ids. They now resolve them as the code does, and `testFormatTimeZoneIsConsistentAcrossZones` sweeps 38 zones (including all 28 of `SHORT_IDS`) against the date at each of its 7 granularities, checking that `z` gives back the name as written, that `Z` and `X` agree with each other and with the offset `java.time` gives for the instant, and that both fail below an hour.