### PR TITLE
Various LSP enhancements

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/execution/test/TestTools.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/execution/test/TestTools.java
@@ -15,8 +15,10 @@
 package org.finos.legend.pure.m3.execution.test;
 
 import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
 import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 
@@ -82,6 +84,53 @@ public class TestTools
     public static boolean hasAfterPackageStereotype(CoreInstance node, ProcessorSupport processorSupport)
     {
         return hasTestStereotypeWithValue(node, AFTER_PACKAGE_STEREOTYPE, processorSupport);
+    }
+
+    /**
+     * Find the nearest {@code <<test.BeforePackage>>} function to {@code function}: walk up its
+     * package chain from its own package to the root, returning the first match found at the
+     * closest level. Unlike {@code TestCollection}'s suite-wide collection (which gathers every
+     * Before/After function from root to leaf for a whole-package run), this stops at the first
+     * hit - the right granularity for running/debugging a single test with just its own setup.
+     *
+     * @return the nearest before-package function, or null if none exists anywhere up the chain
+     */
+    public static CoreInstance findNearestBeforePackageFunction(CoreInstance function, ProcessorSupport processorSupport)
+    {
+        return findNearestPackageFunction(function, BEFORE_PACKAGE_STEREOTYPE, processorSupport);
+    }
+
+    /**
+     * Find the nearest {@code <<test.AfterPackage>>} function to {@code function} - see
+     * {@link #findNearestBeforePackageFunction} for the walk semantics.
+     *
+     * @return the nearest after-package function, or null if none exists anywhere up the chain
+     */
+    public static CoreInstance findNearestAfterPackageFunction(CoreInstance function, ProcessorSupport processorSupport)
+    {
+        return findNearestPackageFunction(function, AFTER_PACKAGE_STEREOTYPE, processorSupport);
+    }
+
+    private static CoreInstance findNearestPackageFunction(CoreInstance function, String stereotype, ProcessorSupport processorSupport)
+    {
+        CoreInstance functionPackage = Instance.getValueForMetaPropertyToOneResolved(function, M3Properties._package, processorSupport);
+        if (functionPackage == null)
+        {
+            return null;
+        }
+        MutableList<CoreInstance> packages = PackageableElement.getUserObjectPathForPackageableElement(functionPackage);
+        for (CoreInstance pkg : packages.asReversed())
+        {
+            for (CoreInstance child : Instance.getValueForMetaPropertyToManyResolved(pkg, M3Properties.children, processorSupport))
+            {
+                if (org.finos.legend.pure.m3.navigation.function.Function.isFunctionDefinition(child, processorSupport)
+                        && hasTestStereotypeWithValue(child, stereotype, processorSupport))
+                {
+                    return child;
+                }
+            }
+        }
+        return null;
     }
 
     public static boolean hasAnyTestStereotype(CoreInstance node, ProcessorSupport processorSupport)

--- a/legend-pure-lsp/README.md
+++ b/legend-pure-lsp/README.md
@@ -54,6 +54,8 @@ The thin jar remains the default: the VS Code extension ignores `-shaded.jar` wh
 
 Workspace repositories are discovered from `*.definition.json` files under the opened workspace. Runtime extensions and any classpath repositories not already represented by the workspace are discovered from the Java classpath.
 
+Add `--socket <port>` (or `-Dlegend.lsp.socketPort=<port>`) to run as a standalone TCP daemon instead of over stdio. The size of the thread pool that serves every LSP request (executions, compiles, hover, completion, ...) is configurable at startup via `-Dlegend.lsp.requestPoolSize=<N>` (default `12`) - raise it on a box with more available cores to let more concurrent executions/tests actually run in parallel instead of queuing.
+
 ## VS Code Packaging
 
 Build the server and package the extension:

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/ClientBroadcaster.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/ClientBroadcaster.java
@@ -1,0 +1,225 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.finos.legend.pure.lsp.protocol.LegendLanguageClient;
+import org.finos.legend.pure.lsp.protocol.LegendLogEvent;
+import org.finos.legend.pure.lsp.protocol.LockContentionEvent;
+import org.finos.legend.pure.lsp.protocol.LspStatus;
+import org.finos.legend.pure.lsp.protocol.WorkspaceDriftEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Fans out every server-initiated push (diagnostics, status changes, log output, show-message) to
+ * every currently-connected LSP client, instead of a single overwritten "most recent" client - see
+ * {@link LegendPureLspServer#runSocketMode(LegendPureLspServer, int)}, whose accept loop genuinely
+ * supports multiple concurrent connections (an IDE session plus separate agent/CLI tooling sharing
+ * one warm compiled session). Implements {@link LegendLanguageClient} itself so it can be handed to
+ * {@link org.finos.legend.pure.lsp.diagnostics.DiagnosticService},
+ * {@link org.finos.legend.pure.lsp.runtime.PureRuntimeManager}, and {@link LspLog}'s sink exactly
+ * like a single client - none of them need to know they're actually talking to N clients.
+ * <p>
+ * A broadcast failure to one client (e.g. a socket that's mid-close) is logged and that client is
+ * deregistered; it never blocks delivery to the others.
+ */
+public class ClientBroadcaster implements LegendLanguageClient
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClientBroadcaster.class);
+
+    // Keyed by the raw client reference (the exact LanguageClient passed to register()/deregister())
+    // rather than the wrapped LegendLanguageClient - register() may wrap a plain LanguageClient in a
+    // fresh LegendLanguageClientAdapter each time it's called, and two such wrappers around the same
+    // raw client are reference-distinct (no equals()/hashCode() override), so keying by the wrapper
+    // would make deregister() silently fail to find/remove the entry.
+    private final Map<LanguageClient, LegendLanguageClient> clients = new ConcurrentHashMap<>();
+
+    /**
+     * @return the wrapped client, so the caller can immediately push a catch-up snapshot (e.g. current
+     * status) to exactly this new registrant - registering alone never does this (see class javadoc:
+     * broadcasts only fire on future pushes), so a client connecting to an ALREADY-ready session would
+     * otherwise never receive a legend/statusChanged notification at all.
+     */
+    public LegendLanguageClient register(LanguageClient rawClient)
+    {
+        LegendLanguageClient wrapped = (rawClient instanceof LegendLanguageClient)
+                ? (LegendLanguageClient) rawClient
+                : new LegendLanguageClientAdapter(rawClient);
+        this.clients.put(rawClient, wrapped);
+        return wrapped;
+    }
+
+    public void deregister(LanguageClient rawClient)
+    {
+        this.clients.remove(rawClient);
+    }
+
+    public int connectedClientCount()
+    {
+        return this.clients.size();
+    }
+
+    @Override
+    public void telemetryEvent(Object object)
+    {
+        broadcast(c -> c.telemetryEvent(object));
+    }
+
+    @Override
+    public void publishDiagnostics(PublishDiagnosticsParams diagnostics)
+    {
+        broadcast(c -> c.publishDiagnostics(diagnostics));
+    }
+
+    @Override
+    public void showMessage(MessageParams messageParams)
+    {
+        broadcast(c -> c.showMessage(messageParams));
+    }
+
+    @Override
+    public void logMessage(MessageParams message)
+    {
+        broadcast(c -> c.logMessage(message));
+    }
+
+    @Override
+    public void statusChanged(LspStatus status)
+    {
+        broadcast(c -> c.statusChanged(status));
+    }
+
+    @Override
+    public void logOutput(LegendLogEvent event)
+    {
+        broadcast(c -> c.logOutput(event));
+    }
+
+    @Override
+    public void workspaceDriftDetected(WorkspaceDriftEvent event)
+    {
+        broadcast(c -> c.workspaceDriftDetected(event));
+    }
+
+    @Override
+    public void lockContention(LockContentionEvent event)
+    {
+        broadcast(c -> c.lockContention(event));
+    }
+
+    /**
+     * No natural multi-client fan-out for a request/response call (whose answer would win?) - this
+     * method isn't actually invoked anywhere in this server today. Best-effort: delegate to any one
+     * currently-connected client, or resolve to a null action if none are connected.
+     */
+    @Override
+    public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams)
+    {
+        for (LegendLanguageClient client : this.clients.values())
+        {
+            return client.showMessageRequest(requestParams);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private void broadcast(Consumer<LegendLanguageClient> action)
+    {
+        for (Map.Entry<LanguageClient, LegendLanguageClient> entry : this.clients.entrySet())
+        {
+            try
+            {
+                action.accept(entry.getValue());
+            }
+            catch (Exception e)
+            {
+                // Deregister before logging: LOGGER here is a plain SLF4J logger, never LspLog,
+                // specifically so this failure path can never re-enter
+                // LspLog.publish() -> this.logOutput() -> broadcast() over a registry that still
+                // contains the same dead client.
+                this.clients.remove(entry.getKey());
+                LOGGER.warn("Broadcast to a connected LSP client failed; deregistering it", e);
+            }
+        }
+    }
+
+    private static final class LegendLanguageClientAdapter implements LegendLanguageClient
+    {
+        private final LanguageClient delegate;
+
+        private LegendLanguageClientAdapter(LanguageClient delegate)
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void telemetryEvent(Object object)
+        {
+            this.delegate.telemetryEvent(object);
+        }
+
+        @Override
+        public void publishDiagnostics(PublishDiagnosticsParams diagnostics)
+        {
+            this.delegate.publishDiagnostics(diagnostics);
+        }
+
+        @Override
+        public void showMessage(MessageParams messageParams)
+        {
+            this.delegate.showMessage(messageParams);
+        }
+
+        @Override
+        public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams)
+        {
+            return this.delegate.showMessageRequest(requestParams);
+        }
+
+        @Override
+        public void logMessage(MessageParams message)
+        {
+            this.delegate.logMessage(message);
+        }
+
+        @Override
+        public void statusChanged(LspStatus status)
+        {
+        }
+
+        @Override
+        public void logOutput(LegendLogEvent event)
+        {
+        }
+
+        @Override
+        public void workspaceDriftDetected(WorkspaceDriftEvent event)
+        {
+        }
+
+        @Override
+        public void lockContention(LockContentionEvent event)
+        {
+        }
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/ExecutionFailureFormatter.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/ExecutionFailureFormatter.java
@@ -1,0 +1,86 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.finos.legend.pure.m3.exception.PureExecutionException;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m4.exception.PureException;
+
+/**
+ * Renders a full Pure stack trace for an execution failure - the same causal-chain/pure-stack-trace
+ * logic used by the non-debug {@code legend/execute} path - so debug execution failures
+ * (LegendDebugSession/DebugService) surface as much detail as a normal execution failure instead of
+ * a bare exception message.
+ */
+public final class ExecutionFailureFormatter
+{
+    private ExecutionFailureFormatter()
+    {
+    }
+
+    public static String format(Exception e, String capturedOutput, ProcessorSupport processorSupport)
+    {
+        StringBuilder builder = new StringBuilder();
+        if (capturedOutput != null && !capturedOutput.isEmpty())
+        {
+            builder.append(capturedOutput);
+            if (!capturedOutput.endsWith("\n"))
+            {
+                builder.append('\n');
+            }
+        }
+
+        PureException pureException = PureException.findPureException(e);
+        if (pureException != null)
+        {
+            PureException original = pureException.getOriginatingPureException();
+            if (original == null)
+            {
+                original = pureException;
+            }
+            if (processorSupport != null && pureException instanceof PureExecutionException)
+            {
+                builder.append(original.getMessage()).append('\n');
+                StringBuffer buffer = new StringBuffer();
+                ((PureExecutionException) pureException).printPureStackTrace(buffer, "", processorSupport);
+                builder.append(buffer);
+            }
+            else if (pureException.hasPureStackTrace())
+            {
+                builder.append(original.getMessage()).append('\n')
+                        .append(pureException.getPureStackTrace("    "));
+            }
+            else
+            {
+                builder.append(original.getMessage());
+            }
+        }
+        else
+        {
+            StringWriter writer = new StringWriter();
+            e.printStackTrace(new PrintWriter(writer));
+            builder.append(writer);
+        }
+
+        return builder.toString();
+    }
+
+    public static String format(Exception e, ProcessorSupport processorSupport)
+    {
+        return format(e, null, processorSupport);
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/FileChangeHandler.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/FileChangeHandler.java
@@ -50,6 +50,12 @@ public class FileChangeHandler
             }
 
             String sourceId = this.uriMapper.toSourceId(event.getUri());
+            if (sourceId == null)
+            {
+                // Not part of any registered Pure module (e.g. a fixture resource that merely has a
+                // .pure extension) - nothing for the runtime to create, modify, or delete.
+                continue;
+            }
 
             if (event.getType() == FileChangeType.Deleted)
             {

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/FoldingRangeProvider.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/FoldingRangeProvider.java
@@ -1,0 +1,218 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import org.eclipse.lsp4j.FoldingRange;
+import org.eclipse.lsp4j.FoldingRangeKind;
+import org.finos.legend.pure.m3.serialization.runtime.PureRuntime;
+import org.finos.legend.pure.m3.serialization.runtime.Source;
+
+/**
+ * Computes folding ranges from a source file's raw text rather than the compiled AST: brace
+ * positions, block comments, and {@code ###} section markers are lexical/structural concepts Pure's
+ * AST doesn't expose per-element the way SourceInformation does for whole elements, so a lightweight
+ * stack-based scan of the text is the simplest robust way to find them - the same approach used for
+ * this exact problem in other LSP servers.
+ */
+public class FoldingRangeProvider
+{
+    public static List<FoldingRange> getFoldingRanges(PureRuntime runtime, String sourceId)
+    {
+        Source source = runtime.getSourceById(sourceId);
+        if (source == null)
+        {
+            return Collections.emptyList();
+        }
+        String content = source.getContent();
+        if (content == null || content.isEmpty())
+        {
+            return Collections.emptyList();
+        }
+
+        List<FoldingRange> ranges = new ArrayList<>();
+        collectBraceAndCommentRanges(content, ranges);
+        collectSectionRanges(content, ranges);
+        return ranges;
+    }
+
+    /**
+     * One pass over the raw text tracking brace nesting and block comments, skipping over
+     * single-quoted string literals and {@code //} line comments so braces/comment markers inside
+     * them are never mistaken for structural ones.
+     */
+    private static void collectBraceAndCommentRanges(String content, List<FoldingRange> ranges)
+    {
+        int n = content.length();
+        int line = 0;
+        boolean inLineComment = false;
+        boolean inBlockComment = false;
+        boolean inString = false;
+        int blockCommentStartLine = -1;
+        Deque<Integer> braceStartLines = new ArrayDeque<>();
+
+        int i = 0;
+        while (i < n)
+        {
+            char c = content.charAt(i);
+
+            if (c == '\n')
+            {
+                inLineComment = false;
+                line++;
+                i++;
+                continue;
+            }
+
+            if (inLineComment)
+            {
+                i++;
+                continue;
+            }
+
+            if (inBlockComment)
+            {
+                if (c == '*' && i + 1 < n && content.charAt(i + 1) == '/')
+                {
+                    inBlockComment = false;
+                    i += 2;
+                    if (line > blockCommentStartLine)
+                    {
+                        ranges.add(newRange(blockCommentStartLine, line, FoldingRangeKind.Comment));
+                    }
+                    continue;
+                }
+                i++;
+                continue;
+            }
+
+            if (inString)
+            {
+                if (c == '\\' && i + 1 < n)
+                {
+                    i += 2;
+                    continue;
+                }
+                if (c == '\'')
+                {
+                    inString = false;
+                }
+                i++;
+                continue;
+            }
+
+            // Outside any comment/string: the only place braces and comment/string openers count.
+            if (c == '/' && i + 1 < n && content.charAt(i + 1) == '/')
+            {
+                inLineComment = true;
+                i += 2;
+                continue;
+            }
+            if (c == '/' && i + 1 < n && content.charAt(i + 1) == '*')
+            {
+                inBlockComment = true;
+                blockCommentStartLine = line;
+                i += 2;
+                continue;
+            }
+            if (c == '\'')
+            {
+                inString = true;
+                i++;
+                continue;
+            }
+            if (c == '{')
+            {
+                braceStartLines.push(line);
+                i++;
+                continue;
+            }
+            if (c == '}')
+            {
+                if (!braceStartLines.isEmpty())
+                {
+                    int startLine = braceStartLines.pop();
+                    if (line > startLine)
+                    {
+                        ranges.add(newRange(startLine, line, FoldingRangeKind.Region));
+                    }
+                }
+                i++;
+                continue;
+            }
+            i++;
+        }
+    }
+
+    /**
+     * A {@code ###X} multi-parser section marker runs from its own line to the line before the next
+     * marker (or EOF). Markers found inside a block comment (already collected above) are excluded,
+     * since those are comment text, not real section boundaries.
+     */
+    private static void collectSectionRanges(String content, List<FoldingRange> ranges)
+    {
+        List<int[]> commentSpans = new ArrayList<>();
+        for (FoldingRange range : ranges)
+        {
+            if (FoldingRangeKind.Comment.equals(range.getKind()))
+            {
+                commentSpans.add(new int[]{range.getStartLine(), range.getEndLine()});
+            }
+        }
+
+        String[] lines = content.split("\r\n|\r|\n", -1);
+        List<Integer> markerLines = new ArrayList<>();
+        for (int lineIndex = 0; lineIndex < lines.length; lineIndex++)
+        {
+            if (lines[lineIndex].trim().startsWith("###") && !withinAnyCommentSpan(lineIndex, commentSpans))
+            {
+                markerLines.add(lineIndex);
+            }
+        }
+
+        for (int idx = 0; idx < markerLines.size(); idx++)
+        {
+            int startLine = markerLines.get(idx);
+            int endLine = (idx + 1 < markerLines.size()) ? markerLines.get(idx + 1) - 1 : lines.length - 1;
+            if (endLine > startLine)
+            {
+                ranges.add(newRange(startLine, endLine, FoldingRangeKind.Region));
+            }
+        }
+    }
+
+    private static boolean withinAnyCommentSpan(int line, List<int[]> commentSpans)
+    {
+        for (int[] span : commentSpans)
+        {
+            if (line >= span[0] && line <= span[1])
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static FoldingRange newRange(int startLine, int endLine, String kind)
+    {
+        FoldingRange range = new FoldingRange(startLine, endLine);
+        range.setKind(kind);
+        return range;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LegendPureLspServer.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LegendPureLspServer.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -70,8 +71,17 @@ import org.finos.legend.pure.lsp.protocol.DeleteFileParams;
 import org.finos.legend.pure.lsp.protocol.DeleteFileResult;
 import org.finos.legend.pure.lsp.protocol.LegendLanguageClient;
 import org.finos.legend.pure.lsp.protocol.LspStatus;
+import org.finos.legend.pure.lsp.protocol.PCTAdapterInfo;
+import org.finos.legend.pure.lsp.protocol.ResolveSourceUriParams;
+import org.finos.legend.pure.lsp.protocol.ResolveSourceUriResult;
 import org.finos.legend.pure.lsp.protocol.SetOptionParams;
 import org.finos.legend.pure.lsp.protocol.SetOptionResult;
+import org.finos.legend.pure.lsp.protocol.SyncWorkspaceParams;
+import org.finos.legend.pure.lsp.protocol.SyncWorkspaceResult;
+import org.finos.legend.pure.lsp.protocol.GetSetupTeardownParams;
+import org.finos.legend.pure.lsp.protocol.SetupTeardownInfo;
+import org.finos.legend.pure.lsp.protocol.TestFunctionInfo;
+import org.finos.legend.pure.lsp.protocol.TestFunctionsParams;
 import org.finos.legend.pure.lsp.runtime.PureRuntimeManager;
 import org.finos.legend.pure.m3.serialization.runtime.Source;
 import org.slf4j.Logger;
@@ -82,9 +92,19 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
     private static final Logger LOGGER = LoggerFactory.getLogger(LegendPureLspServer.class);
     private static final String VERSION = "0.3.0-2026-04-01";
 
-    private LanguageClient rawClient;
-    private LegendLanguageClient client;
-    private DiagnosticService diagnosticService;
+    // Configurable at startup only (read once, here) via -Dlegend.lsp.requestPoolSize=<N> - e.g. via
+    // the launcher scripts' generic --jvm-arg passthrough. Default of 12 is deliberately well above
+    // the old hardcoded 4: this environment's cgroup caps the JVM at 16 available processors (see
+    // Runtime.getRuntime().availableProcessors()), and every LSP request type (executeGo/execute,
+    // hover, completion, diagnostics, ...) funnels through this one pool, so 4 left most of that
+    // capacity unused and made concurrent test/execute traffic queue well before hardware was the
+    // limit. 12 leaves headroom for GC and the daemon's other background threads (drift-watcher,
+    // compile-debounce) rather than claiming the full 16.
+    private static final String REQUEST_POOL_SIZE_PROPERTY = "legend.lsp.requestPoolSize";
+    private static final int DEFAULT_REQUEST_POOL_SIZE = 12;
+
+    private final ClientBroadcaster clientBroadcaster = new ClientBroadcaster();
+    private final DiagnosticService diagnosticService;
 
     private final UriMapper uriMapper = new UriMapper();
     private final RepositoryScanner repositoryScanner = new RepositoryScanner();
@@ -94,21 +114,44 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
     private final PureRuntimeManager runtimeManager;
     private final DebugService debugService;
     private final LegendDebugSocketServer debugSocketServer;
-    private final ExecutorService requestExecutor = Executors.newFixedThreadPool(4, r ->
+    private final WorkspaceDriftWatcher driftWatcher;
+    private final int requestPoolSize = resolveRequestPoolSize();
+    private final ExecutorService requestExecutor = Executors.newFixedThreadPool(this.requestPoolSize, r ->
     {
         Thread t = new Thread(r, "legend-pure-lsp-request");
         t.setDaemon(true);
         return t;
     });
 
+    // Set once, by whichever fires first: preconfigureAndWarm() (a config-driven launcher) or the
+    // first connecting client's initialize/initialized. Every later connection's initialize/initialized
+    // is a pure attach to the already-warm session - see the javadoc on preconfigureAndWarm() for why
+    // this matters (a second IDE window's handshake used to silently force a full recompile).
+    private final AtomicBoolean workspaceConfigured = new AtomicBoolean(false);
+    private final AtomicBoolean runtimeInitializeStarted = new AtomicBoolean(false);
+
+    // True only for the socket-daemon accept loop (runSocketMode), never for the classic single-client
+    // stdio main() path. Guards shutdown()/exit(): in stdio mode there's exactly one client and exiting
+    // the JVM on its request is correct LSP behaviour; in daemon mode the same process outlives any one
+    // connection, so a client's own shutdown/exit must only ever end its own connection.
+    private volatile boolean daemonMode = false;
+
+    // Observability only (see status()): which port/transport this daemon is actually reachable on,
+    // so a client polling legend/status doesn't need to already know how it was launched.
+    private volatile int port = -1;
+    private volatile String transport = "stdio";
+
     public LegendPureLspServer()
     {
+        this.diagnosticService = new DiagnosticService(this.clientBroadcaster, this.uriMapper);
         this.textDocumentService = new LegendTextDocumentService(this);
         this.runtimeManager = new PureRuntimeManager(
                 this.repositoryScanner,
                 this.uriMapper,
                 this.symbolProvider,
-                this.textDocumentService::compileOpenDocuments);
+                this.textDocumentService::compileOpenDocuments,
+                this.diagnosticService);
+        this.runtimeManager.setClient(this.clientBroadcaster);
         this.debugService = new DebugService(
                 this.runtimeManager,
                 this.repositoryScanner,
@@ -116,22 +159,61 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
                 this.textDocumentService::getOpenDocumentSourceSnapshot);
         this.debugSocketServer = new LegendDebugSocketServer(this.debugService);
         this.workspaceService = new LegendWorkspaceService(this);
+        this.driftWatcher = new WorkspaceDriftWatcher(
+                this.repositoryScanner,
+                this.uriMapper,
+                this.textDocumentService::hasOpenDocument,
+                this.clientBroadcaster::workspaceDriftDetected);
+        LspLog.setSink(this.clientBroadcaster::logOutput);
+    }
+
+    /**
+     * Configures and compiles the workspace up front, from explicit roots, instead of waiting for a
+     * connecting client's {@code initialize} request to supply {@code workspaceFolders} - lets a
+     * config-driven launcher (e.g. a plain, IDE-runnable {@code main()} that isn't itself an LSP client)
+     * produce an already-warm session before any client connects. Any client that connects later - the
+     * first one, or a second/third IDE window joining an already-warm daemon - just attaches to this
+     * same session; its {@code initialize}/{@code initialized} handshake no longer reconfigures or
+     * recompiles anything (see {@link #initialize(InitializeParams)}/{@link #initialized(InitializedParams)}).
+     */
+    public void preconfigureAndWarm(List<Path> repoRoots, Set<String> classpathRepositoryNames)
+    {
+        LspLog.info("Pre-configuring workspace from " + repoRoots.size()
+                + " repo root(s) (config-driven, before any client connects)");
+        this.workspaceConfigured.set(true);
+        this.runtimeInitializeStarted.set(true);
+        this.runtimeManager.configure(repoRoots, classpathRepositoryNames);
+        this.runtimeManager.initialize();
+        startOrRestartDriftWatcher();
     }
 
     @Override
     public void connect(LanguageClient client)
     {
-        this.rawClient = client;
-        this.client = (client instanceof LegendLanguageClient)
-                ? (LegendLanguageClient) client
-                : new LegendLanguageClientAdapter(client);
-        this.runtimeManager.setClient(this.client);
-        this.diagnosticService = new DiagnosticService(client, this.uriMapper);
+        LegendLanguageClient wrapped = this.clientBroadcaster.register(client);
+        // Catch up this newly-connected client on current status right away. Without this, a client
+        // connecting to a session that's already "ready" (a reconnect, or a second client joining an
+        // existing warm daemon) never receives a legend/statusChanged notification at all - nothing
+        // has "changed" from the server's perspective - so any client-side readiness gate that waits
+        // for that notification (e.g. the IntelliJ plugin's Execute Go action awaiting whenReady())
+        // hangs indefinitely instead of observing the session is already up.
+        wrapped.statusChanged(this.runtimeManager.currentStatus());
+    }
+
+    /**
+     * Deregisters a client whose connection has ended, so future broadcasts (diagnostics, status,
+     * log output, show-message) stop targeting it - called from {@link #serveSocketConnection} once
+     * that connection's {@code startListening()} future completes. Package-private: only the socket
+     * accept loop needs this; the stdio {@code main()} path never disconnects (see its call site).
+     */
+    void disconnect(LanguageClient client)
+    {
+        this.clientBroadcaster.deregister(client);
     }
 
     LanguageClient getClient()
     {
-        return this.rawClient;
+        return this.clientBroadcaster;
     }
 
     DiagnosticService getDiagnosticService()
@@ -159,16 +241,33 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
         return this.symbolProvider;
     }
 
+    RepositoryScanner getRepositoryScanner()
+    {
+        return this.repositoryScanner;
+    }
+
+    WorkspaceDriftWatcher getDriftWatcher()
+    {
+        return this.driftWatcher;
+    }
+
     @Override
     @SuppressWarnings("deprecation")
     public CompletableFuture<InitializeResult> initialize(InitializeParams params)
     {
         List<Path> workspaceRoots = extractWorkspaceRoots(params);
         Set<String> classpathRepositoryNames = new LinkedHashSet<>(extractClasspathRepositoryNames(params));
-        this.runtimeManager.configure(workspaceRoots, classpathRepositoryNames);
-
-        LspLog.info("Legend Pure LSP v" + VERSION + " starting");
-        LspLog.info("Workspace roots: " + workspaceRoots);
+        if (this.workspaceConfigured.compareAndSet(false, true))
+        {
+            this.runtimeManager.configure(workspaceRoots, classpathRepositoryNames);
+            LspLog.info("Legend Pure LSP v" + VERSION + " starting");
+            LspLog.info("Workspace roots: " + workspaceRoots);
+        }
+        else
+        {
+            LspLog.info("Legend Pure LSP v" + VERSION + ": new client attaching to the already-configured"
+                    + " session; ignoring this client's workspace roots (" + workspaceRoots + ")");
+        }
 
         ServerCapabilities caps = new ServerCapabilities();
         caps.setTextDocumentSync(TextDocumentSyncKind.Full);
@@ -179,6 +278,7 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
         caps.setDocumentSymbolProvider(true);
         caps.setWorkspaceSymbolProvider(true);
         caps.setCodeActionProvider(new CodeActionOptions(Collections.singletonList(org.eclipse.lsp4j.CodeActionKind.QuickFix)));
+        caps.setFoldingRangeProvider(true);
 
         SemanticTokensLegend legend = new SemanticTokensLegend(
                 SemanticTokensProvider.TOKEN_TYPES,
@@ -194,7 +294,15 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
     @Override
     public void initialized(InitializedParams params)
     {
-        runAsync(this.runtimeManager::initialize);
+        if (this.runtimeInitializeStarted.compareAndSet(false, true))
+        {
+            runAsync(this.runtimeManager::initialize).thenRun(this::startOrRestartDriftWatcher);
+        }
+        else
+        {
+            LspLog.info("Runtime already initializing/initialized; skipping a redundant full compile"
+                    + " for this newly-connected client");
+        }
     }
 
     void triggerRecovery()
@@ -202,9 +310,20 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
         runAsync(this.runtimeManager::triggerRecovery);
     }
 
+    /**
+     * (Re)starts {@link #driftWatcher} against whatever resource roots {@link #repositoryScanner} just
+     * discovered - called after every full scan (initial warm-up, first client's initialize/initialized,
+     * and reindex), since a reindex can discover modules that did not exist at the previous scan.
+     */
+    private void startOrRestartDriftWatcher()
+    {
+        this.driftWatcher.stop();
+        this.driftWatcher.start(this.repositoryScanner.getMappings().values());
+    }
+
     CompletableFuture<Void> reindex()
     {
-        return runAsync(this.runtimeManager::reindex);
+        return runAsync(this.runtimeManager::reindex).thenRun(this::startOrRestartDriftWatcher);
     }
 
     @Override
@@ -215,10 +334,18 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
     @Override
     public CompletableFuture<Object> shutdown()
     {
+        if (this.daemonMode)
+        {
+            // Shared across every connected client - tearing these down for one connection's shutdown
+            // request would break every other window still attached to this daemon. This connection's
+            // own teardown happens on socket close (see disconnect(LanguageClient), serveSocketConnection).
+            return CompletableFuture.completedFuture(null);
+        }
         this.debugService.shutdown();
         this.debugSocketServer.close();
         this.textDocumentService.shutdown();
         this.runtimeManager.shutdown();
+        this.driftWatcher.stop();
         this.requestExecutor.shutdownNow();
         return CompletableFuture.completedFuture(null);
     }
@@ -226,13 +353,54 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
     @Override
     public void exit()
     {
+        if (this.daemonMode)
+        {
+            // A client's exit() ends its own connection, not the shared daemon process - see shutdown()
+            // above. The client is expected to close its side of the socket after this notification,
+            // which is what actually unblocks serveSocketConnection()'s accept-loop thread and runs the
+            // existing disconnect(LanguageClient) cleanup for just that one connection.
+            return;
+        }
         System.exit(0);
     }
 
     @JsonRequest("legend/status")
     public CompletableFuture<LspStatus> status()
     {
-        return CompletableFuture.completedFuture(this.runtimeManager.currentStatus());
+        return CompletableFuture.completedFuture(buildStatus());
+    }
+
+    /**
+     * Merges server/session-level observability (client count, port/transport, launch config, recent
+     * errors, live lock contention) onto PureRuntimeManager's compile-progress status, so a client
+     * polling legend/status - not just one live-streaming legend/lockContention or legend/logOutput
+     * notifications - gets the full picture in one call. Kept here (not in PureRuntimeManager) because
+     * every one of these fields describes the SERVER/session, not compile progress.
+     */
+    private LspStatus buildStatus()
+    {
+        LspStatus status = this.runtimeManager.currentStatus();
+        status.setConnectedClientCount(this.clientBroadcaster.connectedClientCount());
+        status.setPort(this.port);
+        status.setTransport(this.transport);
+        status.setRequestPoolSize(this.requestPoolSize);
+        List<Path> workspaceRoots = this.runtimeManager.getWorkspaceRoots();
+        List<String> repoRoots = new ArrayList<>(workspaceRoots.size());
+        for (Path root : workspaceRoots)
+        {
+            repoRoots.add(root.toString());
+        }
+        status.setRepoRoots(repoRoots);
+        status.setJvmArgs(new ArrayList<>(
+                java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
+        status.setRecentErrors(LspLog.recentErrors());
+        LegendPureSession session = getSession();
+        if (session != null)
+        {
+            status.setLockContended(session.isLockContended());
+            status.setLockContentionReason(session.lockContentionReason());
+        }
+        return status;
     }
 
     <T> CompletableFuture<T> supplyAsync(Supplier<T> supplier)
@@ -269,6 +437,37 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
             }
             return session.withGraphReadLock(() ->
                     PackageTreeProvider.getChildren(session.getPureRuntime(), this.uriMapper, packagePath));
+        });
+    }
+
+    /**
+     * Finds real compiled functions carrying the &lt;&lt;test.Test&gt;&gt; stereotype in the given source,
+     * for gutter-icon placement client-side. See TestFunctionProvider for why this is a semantic
+     * stereotype check (TestTools#hasTestStereotype) rather than a text/regex scan.
+     */
+    @JsonRequest("legend/testFunctions")
+    public CompletableFuture<List<TestFunctionInfo>> testFunctions(TestFunctionsParams params)
+    {
+        return supplyAsync(() ->
+        {
+            LegendPureSession session = getSession();
+            if (session == null || !session.isInitialized() || params == null || params.getUri() == null)
+            {
+                return Collections.<TestFunctionInfo>emptyList();
+            }
+
+            String rawUri = params.getUri();
+            String sourceId = rawUri.startsWith("pure://")
+                    ? rawUri.substring("pure://".length())
+                    : this.uriMapper.toSourceId(rawUri);
+            String resolvedId = session.resolveSourceId(sourceId);
+            if (resolvedId == null)
+            {
+                return Collections.<TestFunctionInfo>emptyList();
+            }
+
+            return session.withGraphReadLock(() ->
+                    TestFunctionProvider.getTestFunctions(session.getPureRuntime(), resolvedId));
         });
     }
 
@@ -328,10 +527,57 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
                     return new ExecuteGoResult(false, batchResult.getError(), null, batchResult.getErrorUri());
                 }
             }
-            LegendPureSession.ExecuteResult result = session.executeFunction(params.getFunction());
+            LegendPureSession.ExecuteResult result = session.executeFunction(params.getFunction(), params.getPctAdapterPath(),
+                    params.getBeforeFunctionPath(), params.getAfterFunctionPath());
             return new ExecuteGoResult(result.isSuccess(), result.getError(), result.getOutput(), null);
         });
     }
+
+    /**
+     * Finds the nearest &lt;&lt;test.BeforePackage&gt;&gt;/&lt;&lt;test.AfterPackage&gt;&gt; functions to
+     * {@code params.functionPath} (see TestTools#findNearestBeforePackageFunction in legend-pure-core),
+     * for the gutter's "Run/Debug with Setup/Teardown" actions to discover what to bracket a test with
+     * before threading the result into {@link #execute(ExecuteFunctionParams)} via
+     * {@link ExecuteFunctionParams#setBeforeFunctionPath}/{@link ExecuteFunctionParams#setAfterFunctionPath}.
+     */
+    @JsonRequest("legend/getSetupTeardown")
+    public CompletableFuture<SetupTeardownInfo> getSetupTeardown(GetSetupTeardownParams params)
+    {
+        return supplyAsync(() ->
+        {
+            LegendPureSession session = getSession();
+            if (session == null || !session.isInitialized() || params == null || params.getFunctionPath() == null)
+            {
+                return new SetupTeardownInfo(null, null, null, null);
+            }
+            LegendPureSession.SetupTeardownResult result = session.findSetupTeardown(params.getFunctionPath());
+            return new SetupTeardownInfo(result.getBeforeFunctionPath(), result.getBeforeFunctionName(),
+                    result.getAfterFunctionPath(), result.getAfterFunctionName());
+        });
+    }
+
+    /**
+     * Finds every element in the currently-loaded graph carrying the &lt;&lt;PCT.adapter&gt;&gt;
+     * stereotype - the same discovery meta::pure::ide::testing::getPCTAdapters() performs in Pure -
+     * so a client can offer a choice of adapters (e.g. in-memory vs. a real relational execution
+     * strategy) when running a &lt;&lt;PCT.test&gt;&gt; function via {@link #execute(ExecuteFunctionParams)}.
+     */
+    @JsonRequest("legend/getPCTAdapters")
+    public CompletableFuture<List<PCTAdapterInfo>> getPCTAdapters()
+    {
+        return supplyAsync(() ->
+        {
+            LegendPureSession session = getSession();
+            if (session == null || !session.isInitialized())
+            {
+                return Collections.<PCTAdapterInfo>emptyList();
+            }
+            return session.withGraphReadLock(() ->
+                    PCTAdapterProvider.getPCTAdapters(session.getPureRuntime()));
+        });
+    }
+
+    static final String PURE_OPTION_PREFIX = "pure.options.";
 
     /**
      * Sets or clears a Pure runtime option so that isOptionSet('&lt;name&gt;') reflects it live, without
@@ -360,6 +606,29 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
             boolean effective = session.setOption(name, params.isValue());
             LspLog.info("setOption: " + name + " -> " + effective + " (isOptionSet('" + name + "') now returns " + effective + ")");
             return new SetOptionResult(true, name, effective, null);
+        });
+    }
+
+    /**
+     * Reports the live set of Pure runtime options currently in effect, closing the gap where
+     * setOption can only confirm the value it just set, never the full current state. Scans this
+     * JVM's system properties for the PURE_OPTION_PREFIX namespace and returns the bare option names
+     * - i.e. every name for which isOptionSet(name) currently returns true.
+     */
+    @JsonRequest("legend/getOptions")
+    public CompletableFuture<List<String>> getOptions()
+    {
+        return supplyAsync(() ->
+        {
+            List<String> options = new ArrayList<>();
+            for (String key : System.getProperties().stringPropertyNames())
+            {
+                if (key.startsWith(PURE_OPTION_PREFIX))
+                {
+                    options.add(key.substring(PURE_OPTION_PREFIX.length()));
+                }
+            }
+            return options;
         });
     }
 
@@ -400,9 +669,7 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
             // Drop it from the open-document set first so a subsequent compile does not re-add it.
             this.textDocumentService.removeOpenDocument(uri);
 
-            java.util.concurrent.locks.Lock writeLock = session.graphWriteLock();
-            writeLock.lock();
-            try
+            try (LegendPureSession.LockHandle ignored = session.acquireGraphWriteLock())
             {
                 // Resolve to the sourceId the runtime actually registered. The input may be a file://
                 // uri, an absolute path, or a raw sourceId, and the uriMapper's derivation for a
@@ -440,11 +707,13 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
                 LspLog.info("deleteFile: removed " + sourceId + " from session");
                 return new DeleteFileResult(true, sourceId, true, null);
             }
-            finally
-            {
-                writeLock.unlock();
-            }
         });
+    }
+
+    @JsonRequest("legend/syncWorkspace")
+    public CompletableFuture<SyncWorkspaceResult> syncWorkspace(SyncWorkspaceParams params)
+    {
+        return supplyAsync(() -> this.workspaceService.syncWorkspace(params));
     }
 
     @JsonRequest("legend/checkBatch")
@@ -484,6 +753,13 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
         for (FileEntry file : files)
         {
             String sourceId = this.uriMapper.toSourceId(file.getUri());
+            if (sourceId == null)
+            {
+                // Not part of any registered Pure module (e.g. a fixture resource that merely has a
+                // .pure extension) - must not poison an otherwise-valid atomic batch compile.
+                LspLog.debug("Skipping non-module file in batch: " + file.getUri());
+                continue;
+            }
             changes.add(new LegendPureSession.FileChange(sourceId, file.getContent(), LegendPureSession.FileChangeType.CREATE_OR_MODIFY));
         }
 
@@ -491,9 +767,7 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
         // refresh are one atomic unit that no mutation can interleave - which is what lets executeGo /
         // execute call this with no outer lock. applyBulkChangesAndCompile re-takes the (reentrant)
         // write lock internally.
-        java.util.concurrent.locks.Lock writeLock = session.graphWriteLock();
-        writeLock.lock();
-        try
+        try (LegendPureSession.LockHandle ignored = session.acquireGraphWriteLock())
         {
             LegendPureSession.CompileResult result = session.getMutationService().applyBulkChangesAndCompile(changes);
 
@@ -551,10 +825,6 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
             }
             return CheckBatchResult.failure(error.getMessage(), publishUri, errorDiagnostics);
         }
-        finally
-        {
-            writeLock.unlock();
-        }
     }
 
     @JsonRequest("legend/getSourceContent")
@@ -589,6 +859,24 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
 
             LspLog.debug("getSourceContent: serving " + resolvedId + " (" + source.getContent().length() + " chars)");
             return source.getContent();
+        });
+    }
+
+    /**
+     * Resolves a Pure internal sourceId (as embedded in a "resource:&lt;sourceId&gt; line:.. column:.."
+     * stack-trace location reference) to an editor-navigable URI, so a client can turn stack trace
+     * lines into clickable links. Delegates to the same {@link UriMapper#toUri} logic already used
+     * internally (see compileBatch). Null/empty uri in the result means unresolvable.
+     */
+    @JsonRequest("legend/resolveSourceUri")
+    public CompletableFuture<ResolveSourceUriResult> resolveSourceUri(ResolveSourceUriParams params)
+    {
+        return supplyAsync(() ->
+        {
+            ResolveSourceUriResult result = new ResolveSourceUriResult();
+            String sourceId = params == null ? null : params.getSourceId();
+            result.setUri(sourceId == null ? null : this.uriMapper.toUri(sourceId));
+            return result;
         });
     }
 
@@ -802,7 +1090,10 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
             Class.forName("org.finos.legend.pure.lsp.DocumentOutlineProvider");
             Class.forName("org.finos.legend.pure.lsp.PackageTreeProvider");
             Class.forName("org.finos.legend.pure.lsp.WorkspaceSymbolProvider");
+            Class.forName("org.finos.legend.pure.lsp.TestFunctionProvider");
             Class.forName("org.finos.legend.pure.lsp.CompletionProvider");
+            Class.forName("org.finos.legend.pure.lsp.FoldingRangeProvider");
+            Class.forName("org.finos.legend.pure.lsp.PCTAdapterProvider");
         }
         catch (ClassNotFoundException e)
         {
@@ -865,22 +1156,77 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
         return -1;
     }
 
+    static int resolveRequestPoolSize()
+    {
+        String prop = System.getProperty(REQUEST_POOL_SIZE_PROPERTY);
+        if (prop == null || prop.trim().isEmpty())
+        {
+            return DEFAULT_REQUEST_POOL_SIZE;
+        }
+        try
+        {
+            int size = Integer.parseInt(prop.trim());
+            if (size > 0)
+            {
+                return size;
+            }
+            LspLog.warn(REQUEST_POOL_SIZE_PROPERTY + "=" + prop + " must be positive; using default " + DEFAULT_REQUEST_POOL_SIZE);
+        }
+        catch (NumberFormatException e)
+        {
+            LspLog.warn("Invalid " + REQUEST_POOL_SIZE_PROPERTY + "=" + prop + "; using default " + DEFAULT_REQUEST_POOL_SIZE);
+        }
+        return DEFAULT_REQUEST_POOL_SIZE;
+    }
+
     /**
      * Daemon mode: bind a TCP socket on 127.0.0.1:port and serve LSP JSON-RPC over accepted
      * connections instead of over System.in/out. ONE LegendPureLspServer (one warm Pure runtime) is
-     * created up front and reused across every client connection, so a client (the bridge) can
-     * disconnect and reconnect without losing the compiled session - the whole point of decoupling
-     * the JVM's lifecycle from any single client. Connections are handled one at a time (the bridge
-     * holds a single long-lived connection); when a client drops, we loop back to accept the next.
+     * created up front and reused across every client connection, so a client can disconnect and
+     * reconnect without losing the compiled session - the whole point of decoupling the JVM's
+     * lifecycle from any single client.
+     * <p>
+     * Connections are accepted and served CONCURRENTLY (each on its own thread from
+     * {@code connectionExecutor}), not one-at-a-time: this lets, e.g., an IntelliJ session and a
+     * separate CLI dev-loop bridge both hold a live connection to the same warm daemon at once instead
+     * of one blocking the other's accept. All graph mutation/read still funnels through
+     * {@link LegendPureSession}'s {@code graphLock}, so concurrent requests from different connections
+     * are safe at that level. Asynchronous pushes (diagnostics, {@code legend/statusChanged}, log
+     * output, show-message) are broadcast to every currently-connected client via
+     * {@link ClientBroadcaster} - registered in {@link #connect(LanguageClient)}, deregistered in
+     * {@link #serveSocketConnection} once that connection ends - so an IntelliJ session and a
+     * separately-connected CLI/agent bridge both keep receiving live updates. A concurrent
+     * {@link DebugService} debug session remains a single active slot: two clients racing a debug
+     * start will have one preempt the other (unrelated to, and not fixed by, the broadcast above).
      */
     private static void runSocketMode(int port, PrintStream stderrOut) throws Exception
     {
-        LegendPureLspServer server = new LegendPureLspServer();
+        runSocketMode(new LegendPureLspServer(), port);
+    }
+
+    /**
+     * Same daemon loop as {@link #runSocketMode(int, PrintStream)}, but against a caller-supplied,
+     * already-constructed server instance instead of always creating a fresh one. This lets a launcher
+     * (e.g. a config-driven, IDE-runnable bootstrap) pre-configure the workspace via
+     * {@link #preconfigureAndWarm(List, Set)} before any client connects, rather than waiting on the
+     * first client's {@code initialize} request to supply workspace roots.
+     */
+    public static void runSocketMode(LegendPureLspServer server, int port) throws Exception
+    {
+        server.daemonMode = true;
+        server.port = port;
+        server.transport = "socket";
+        ExecutorService connectionExecutor = Executors.newCachedThreadPool(r ->
+        {
+            Thread t = new Thread(r, "legend-pure-lsp-socket-connection");
+            t.setDaemon(true);
+            return t;
+        });
         // Bind only on loopback: this is a local dev-loop daemon, never exposed off-box.
         try (ServerSocket serverSocket = new ServerSocket(port, 0, InetAddress.getByName("127.0.0.1")))
         {
             System.err.println("[LSP] socket daemon listening on 127.0.0.1:" + port
-                    + " (pid decoupled from any launcher; reconnectable)");
+                    + " (pid decoupled from any launcher; reconnectable; concurrent connections supported)");
             // Signal readiness to a spawner watching stderr for a fixed marker.
             System.err.println("[LSP] SOCKET_READY " + port);
             while (true)
@@ -893,83 +1239,56 @@ public class LegendPureLspServer implements LanguageServer, LanguageClientAware
                 catch (Exception e)
                 {
                     System.err.println("[LSP] accept failed, daemon exiting: " + e.getMessage());
+                    connectionExecutor.shutdownNow();
                     return;
                 }
-                socket.setTcpNoDelay(true);
                 System.err.println("[LSP] client connected from " + socket.getRemoteSocketAddress());
-                try
-                {
-                    Launcher<LegendLanguageClient> launcher = new Launcher.Builder<LegendLanguageClient>()
-                            .setLocalService(server)
-                            .setRemoteInterface(LegendLanguageClient.class)
-                            .setInput(socket.getInputStream())
-                            .setOutput(socket.getOutputStream())
-                            .create();
-                    server.connect(launcher.getRemoteProxy());
-                    // Blocks until this client disconnects (stream EOF); then we loop to accept again.
-                    launcher.startListening().get();
-                }
-                catch (Exception e)
-                {
-                    System.err.println("[LSP] client session ended: " + e.getMessage());
-                }
-                finally
-                {
-                    try
-                    {
-                        socket.close();
-                    }
-                    catch (Exception ignored)
-                    {
-                    }
-                    System.err.println("[LSP] client disconnected; awaiting reconnect (session kept warm)");
-                }
+                connectionExecutor.submit(() -> serveSocketConnection(server, socket));
             }
+        }
+        finally
+        {
+            connectionExecutor.shutdownNow();
         }
     }
 
-    private static class LegendLanguageClientAdapter implements LegendLanguageClient
+    private static void serveSocketConnection(LegendPureLspServer server, Socket socket)
     {
-        private final LanguageClient delegate;
-
-        private LegendLanguageClientAdapter(LanguageClient delegate)
+        LanguageClient remoteClient = null;
+        try
         {
-            this.delegate = delegate;
+            socket.setTcpNoDelay(true);
+            Launcher<LegendLanguageClient> launcher = new Launcher.Builder<LegendLanguageClient>()
+                    .setLocalService(server)
+                    .setRemoteInterface(LegendLanguageClient.class)
+                    .setInput(socket.getInputStream())
+                    .setOutput(socket.getOutputStream())
+                    .create();
+            remoteClient = launcher.getRemoteProxy();
+            server.connect(remoteClient);
+            // Blocks (on this connection's own thread) until this client disconnects (stream EOF).
+            launcher.startListening().get();
         }
-
-        @Override
-        public void telemetryEvent(Object object)
+        catch (Exception e)
         {
-            this.delegate.telemetryEvent(object);
+            System.err.println("[LSP] client session ended: " + e.getMessage());
         }
-
-        @Override
-        public void publishDiagnostics(org.eclipse.lsp4j.PublishDiagnosticsParams diagnostics)
+        finally
         {
-            this.delegate.publishDiagnostics(diagnostics);
-        }
-
-        @Override
-        public void showMessage(MessageParams messageParams)
-        {
-            this.delegate.showMessage(messageParams);
-        }
-
-        @Override
-        public CompletableFuture<org.eclipse.lsp4j.MessageActionItem> showMessageRequest(org.eclipse.lsp4j.ShowMessageRequestParams requestParams)
-        {
-            return this.delegate.showMessageRequest(requestParams);
-        }
-
-        @Override
-        public void logMessage(MessageParams message)
-        {
-            this.delegate.logMessage(message);
-        }
-
-        @Override
-        public void statusChanged(LspStatus status)
-        {
+            if (remoteClient != null)
+            {
+                // This is the only disconnect signal LSP4J gives us - startListening().get() above
+                // returning/throwing on this connection's own thread - so deregister right here.
+                server.disconnect(remoteClient);
+            }
+            try
+            {
+                socket.close();
+            }
+            catch (Exception ignored)
+            {
+            }
+            System.err.println("[LSP] client disconnected (session kept warm)");
         }
     }
 }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LegendPureSession.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LegendPureSession.java
@@ -16,33 +16,42 @@ package org.finos.legend.pure.lsp;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.finos.legend.pure.lsp.mutation.SourceMutationService;
+import org.finos.legend.pure.lsp.protocol.LegendLanguageClient;
+import org.finos.legend.pure.lsp.protocol.LockContentionEvent;
 import org.finos.legend.pure.m3.execution.Console;
 import org.finos.legend.pure.m3.execution.FunctionExecution;
-import org.finos.legend.pure.m3.exception.PureExecutionException;
+import org.finos.legend.pure.m3.execution.test.TestTools;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.RepositoryCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.composite.CompositeCodeStorage;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.ValueSpecificationBootstrap;
+import org.finos.legend.pure.m3.navigation._package._Package;
 import org.finos.legend.pure.m3.serialization.runtime.Message;
 import org.finos.legend.pure.m3.serialization.runtime.MutableRuntimeOptions;
 import org.finos.legend.pure.m3.serialization.runtime.PureRuntime;
 import org.finos.legend.pure.m3.serialization.runtime.PureRuntimeBuilder;
 import org.finos.legend.pure.m3.serialization.runtime.RuntimeOptions;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
-import org.finos.legend.pure.m4.exception.PureException;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 import org.finos.legend.pure.runtime.java.mixed.LegendCompileMixedProcessorSupport;
 import org.slf4j.Logger;
@@ -67,17 +76,93 @@ public class LegendPureSession
     // what guarantees "no mutation while an execution is in flight": a compile must acquire the write
     // lock, which cannot be granted while any execution holds a read lock, and vice versa. Fair mode
     // prevents a stream of executions from starving a pending compile (the auto-sync hook compiles
-    // often). Replaces the old blanket `synchronized` that serialized everything.
-    private final java.util.concurrent.locks.ReadWriteLock graphLock =
+    // often). Replaces the old blanket `synchronized` that serialized everything. Declared as the
+    // concrete ReentrantReadWriteLock (not the ReadWriteLock interface) so isWriteLocked()/
+    // getReadLockCount()/getQueueLength() are available to describe contention in legend/lockContention.
+    private final java.util.concurrent.locks.ReentrantReadWriteLock graphLock =
             new java.util.concurrent.locks.ReentrantReadWriteLock(true);
+
+    // Count of threads currently blocked waiting to acquire the read/write side of graphLock. A
+    // 0->1 transition means a caller just started waiting with nothing previously waiting - the
+    // moment worth telling clients about; a 1->0 transition clears it. See acquireLock().
+    private final AtomicInteger blockedReaders = new AtomicInteger();
+    private final AtomicInteger blockedWriters = new AtomicInteger();
+
+    // Most contention episodes clear within a few hundred ms (a routine auto-compile racing a hover/
+    // definition request) and are not worth interrupting a client about. The active notification is
+    // debounced behind this delay - see scheduleLockContentionNotification() - so only genuinely
+    // long stalls get reported. Package-private (not final) so tests can shrink it instead of
+    // sleeping for the real default.
+    private static final long DEFAULT_LOCK_CONTENTION_NOTIFICATION_DELAY_MS = 5_000L;
+    private long lockContentionNotificationDelayMs = DEFAULT_LOCK_CONTENTION_NOTIFICATION_DELAY_MS;
+
+    private static final ScheduledExecutorService LOCK_CONTENTION_SCHEDULER = Executors.newSingleThreadScheduledExecutor(r ->
+    {
+        Thread t = new Thread(r, "legend-pure-lsp-lock-contention-notifier");
+        t.setDaemon(true);
+        return t;
+    });
+
+    private final AtomicReference<ScheduledFuture<?>> pendingReadContentionNotification = new AtomicReference<>();
+    private final AtomicReference<ScheduledFuture<?>> pendingWriteContentionNotification = new AtomicReference<>();
+    private final AtomicBoolean readContentionPublished = new AtomicBoolean(false);
+    private final AtomicBoolean writeContentionPublished = new AtomicBoolean(false);
+
+    // Tracks whether the graph might have an uncompiled mutation pending - see ensureCompiled().
+    // Conservative by construction: SourceMutationService marks this true before attempting any
+    // runtime mutation and clears it only once that same mutation's own compile() call actually
+    // succeeds (markGraphDirty()/markGraphCompiled()). A caller that marks dirty but never confirms
+    // compiled (an early "nothing to do" return, or a failure) just costs the next ensureCompiled()
+    // one extra (harmless) write-lock round-trip - it can never incorrectly report clean.
+    private final AtomicBoolean graphDirty = new AtomicBoolean(false);
 
     private volatile RepositoryScanner workspaceScanner;
     private volatile Set<String> classpathRepositoryNames = Collections.emptySet();
     private volatile java.util.function.Consumer<String> progressListener;
+    private volatile LegendLanguageClient client;
 
     public void setProgressListener(java.util.function.Consumer<String> progressListener)
     {
         this.progressListener = progressListener;
+    }
+
+    /**
+     * Wired by whoever owns this session's client connection(s) (see LegendPureLspServer/
+     * PureRuntimeManager) so that lock-contention events (see acquireLock()) can be pushed to
+     * connected clients the same way status/log/drift notifications already are.
+     */
+    public void setClient(LegendLanguageClient client)
+    {
+        this.client = client;
+    }
+
+    /**
+     * Test seam for {@link #DEFAULT_LOCK_CONTENTION_NOTIFICATION_DELAY_MS} - lets tests exercise the
+     * debounce without a real multi-second sleep.
+     */
+    void setLockContentionNotificationDelayMs(long delayMs)
+    {
+        this.lockContentionNotificationDelayMs = delayMs;
+    }
+
+    /**
+     * Called by SourceMutationService before it attempts any runtime mutation, so a concurrent
+     * caller's ensureCompiled() knows it can no longer take the fast (no-write-lock) path. Paired
+     * with markGraphCompiled().
+     */
+    public void markGraphDirty()
+    {
+        this.graphDirty.set(true);
+    }
+
+    /**
+     * Called by SourceMutationService once its own compile() call has actually succeeded (or once
+     * it's confirmed nothing needed to change, e.g. an edit to an immutable source). Must NOT be
+     * called from a failure path - see the class javadoc on graphDirty.
+     */
+    public void markGraphCompiled()
+    {
+        this.graphDirty.set(false);
     }
 
     public void initialize()
@@ -106,6 +191,7 @@ public class LegendPureSession
         LspLog.info("StackPreservingFunctionExecutionInterpreted initialized");
 
         this.initialized = true;
+        this.graphDirty.set(false);
         long elapsed = (System.currentTimeMillis() - start) / 1000;
         LOGGER.info("Pure runtime initialized in {}s", elapsed);
     }
@@ -118,8 +204,13 @@ public class LegendPureSession
     public static PureRuntime newDebugRuntime(RepositoryScanner scanner, Collection<String> classpathRepositoryNames)
     {
         Set<String> normalizedClasspathRepositoryNames = normalizeRepositoryNames(classpathRepositoryNames);
+        // excludedWorkspaceRepositoryNames must stay empty here: classpathRepositoryNames is only meant to
+        // identify which repos are classpath-sourced, not to strip same-named repos out of the workspace
+        // definition set. Passing it as both caused those repos to load wholesale from the classpath JAR
+        // instead of the small scoped workspace directory, ballooning the debug compile far beyond what's
+        // actually open (e.g. 2775 sources instead of ~261).
         return newRuntime(scanner, true, normalizedClasspathRepositoryNames, Collections.emptySet(),
-                true, normalizedClasspathRepositoryNames);
+                true, Collections.emptySet());
     }
 
     public static <T extends FunctionExecutionInterpreted> T initializeFunctionExecution(T functionExecution, PureRuntime runtime, Message message)
@@ -262,29 +353,31 @@ public class LegendPureSession
 
     public void reinitialize()
     {
-        this.graphLock.writeLock().lock();
-        try
+        try (LockHandle ignored = acquireGraphWriteLock())
         {
-            this.initialized = false;
-            this.pureRuntime = null;
-            initialize(this.workspaceScanner, this.classpathRepositoryNames);
-        }
-        finally
-        {
-            this.graphLock.writeLock().unlock();
+            // Deliberately do not clear pureRuntime/initialized up front: initialize() only
+            // overwrites those fields once the new compile actually succeeds (each assignment
+            // completes or not atomically), so a bad reindex/warm-up - e.g. a newly-scanned module
+            // with one unparsable fixture file - leaves the previous, still-working session serving
+            // requests instead of going permanently dark until a manual restart. Mirrors
+            // SourceMutationService's restore-on-failure behavior for incremental edits.
+            try
+            {
+                initialize(this.workspaceScanner, this.classpathRepositoryNames);
+            }
+            catch (Throwable e)
+            {
+                LspLog.warn("Reinitialize failed, keeping previous compiled session: " + e.getMessage());
+                throw e;
+            }
         }
     }
 
     public void setClasspathRepositoryNames(Collection<String> classpathRepositoryNames)
     {
-        this.graphLock.writeLock().lock();
-        try
+        try (LockHandle ignored = acquireGraphWriteLock())
         {
             this.classpathRepositoryNames = normalizeRepositoryNames(classpathRepositoryNames);
-        }
-        finally
-        {
-            this.graphLock.writeLock().unlock();
         }
     }
 
@@ -295,21 +388,25 @@ public class LegendPureSession
 
     /**
      * The compiled graph is guarded by a single fair {@link java.util.concurrent.locks.ReadWriteLock}
-     * ({@code graphLock}): every graph MUTATION (compile/reinitialize) takes {@link #graphWriteLock()}
+     * ({@code graphLock}): every graph MUTATION (compile/reinitialize) takes {@link #acquireGraphWriteLock()}
      * (exclusive) and every graph READ - function execution AND the LSP providers (hover, completion,
-     * references, ...) - takes {@link #graphReadLock()}. This single mechanism guarantees no mutation
+     * references, ...) - takes {@link #acquireGraphReadLock()}. This single mechanism guarantees no mutation
      * runs while a read/execution is in flight, while still letting independent reads/executions run
      * concurrently. All production mutation paths funnel through {@link SourceMutationService}, which
      * acquires the write lock, so callers must NOT rely on the object monitor for graph exclusion.
+     * <p>
+     * Both accessors route through {@link #acquireLock(java.util.concurrent.locks.Lock, LockKind)} so
+     * that a caller forced to actually wait (as opposed to acquiring immediately) is reflected in a
+     * {@code legend/lockContention} notification to connected clients - see that method's javadoc.
      */
-    public java.util.concurrent.locks.Lock graphReadLock()
+    public LockHandle acquireGraphReadLock()
     {
-        return this.graphLock.readLock();
+        return acquireLock(this.graphLock.readLock(), LockKind.READ);
     }
 
-    public java.util.concurrent.locks.Lock graphWriteLock()
+    public LockHandle acquireGraphWriteLock()
     {
-        return this.graphLock.writeLock();
+        return acquireLock(this.graphLock.writeLock(), LockKind.WRITE);
     }
 
     /**
@@ -318,15 +415,141 @@ public class LegendPureSession
      */
     public <T> T withGraphReadLock(java.util.function.Supplier<T> action)
     {
-        this.graphLock.readLock().lock();
-        try
+        try (LockHandle ignored = acquireGraphReadLock())
         {
             return action.get();
         }
-        finally
+    }
+
+    private enum LockKind
+    {
+        READ, WRITE
+    }
+
+    /**
+     * A held graphLock permit; {@link #close()} releases it (equivalent to {@code Lock.unlock()}). A
+     * plain method reference to {@code Lock::unlock} is enough to implement this, so callers get a
+     * try-with-resources-friendly handle without any extra wrapper object.
+     */
+    public interface LockHandle extends AutoCloseable
+    {
+        @Override
+        void close();
+    }
+
+    /**
+     * Acquires {@code lock}, but only broadcasts a {@code legend/lockContention} notification if this
+     * call actually has to wait for it (a caller granted the lock immediately produces no event, since
+     * there is nothing to tell a client about). Concurrent waiters collapse to a single active/cleared
+     * pair via {@link #blockedReaders}/{@link #blockedWriters}: the notification fires on the 0-&gt;1
+     * transition (first waiter) and clears on the 1-&gt;0 transition (last waiter granted the lock), so
+     * a burst of contending callers produces one "please wait" / one "cleared" pair rather than one
+     * per thread. The active side of that pair is itself debounced - see scheduleLockContentionNotification().
+     */
+    private LockHandle acquireLock(java.util.concurrent.locks.Lock lock, LockKind kind)
+    {
+        if (!lock.tryLock())
         {
-            this.graphLock.readLock().unlock();
+            onBlockStart(kind);
+            lock.lock();
+            onBlockEnd(kind);
         }
+        return lock::unlock;
+    }
+
+    private void onBlockStart(LockKind kind)
+    {
+        AtomicInteger gauge = kind == LockKind.READ ? this.blockedReaders : this.blockedWriters;
+        if (gauge.incrementAndGet() == 1)
+        {
+            scheduleLockContentionNotification(kind);
+        }
+    }
+
+    private void onBlockEnd(LockKind kind)
+    {
+        AtomicInteger gauge = kind == LockKind.READ ? this.blockedReaders : this.blockedWriters;
+        if (gauge.decrementAndGet() == 0)
+        {
+            ScheduledFuture<?> pending = pendingNotificationRef(kind).getAndSet(null);
+            if (pending != null)
+            {
+                pending.cancel(false);
+            }
+            if (publishedFlag(kind).getAndSet(false))
+            {
+                publishLockContention(false, kind);
+            }
+        }
+    }
+
+    /**
+     * Delays the "active" half of the notification pair by {@link #lockContentionNotificationDelayMs}:
+     * most contention clears before the timer fires (a routine compile racing a hover/definition call),
+     * in which case onBlockEnd() cancels this task and neither half of the pair is ever published - a
+     * client only hears about contention that actually outlasts the debounce window.
+     */
+    private void scheduleLockContentionNotification(LockKind kind)
+    {
+        AtomicInteger gauge = kind == LockKind.READ ? this.blockedReaders : this.blockedWriters;
+        ScheduledFuture<?> future = LOCK_CONTENTION_SCHEDULER.schedule(() ->
+        {
+            if (gauge.get() > 0)
+            {
+                publishedFlag(kind).set(true);
+                publishLockContention(true, kind);
+            }
+        }, this.lockContentionNotificationDelayMs, TimeUnit.MILLISECONDS);
+        pendingNotificationRef(kind).set(future);
+    }
+
+    private AtomicReference<ScheduledFuture<?>> pendingNotificationRef(LockKind kind)
+    {
+        return kind == LockKind.READ ? this.pendingReadContentionNotification : this.pendingWriteContentionNotification;
+    }
+
+    private AtomicBoolean publishedFlag(LockKind kind)
+    {
+        return kind == LockKind.READ ? this.readContentionPublished : this.writeContentionPublished;
+    }
+
+    private void publishLockContention(boolean active, LockKind kind)
+    {
+        LegendLanguageClient currentClient = this.client;
+        if (currentClient == null)
+        {
+            return;
+        }
+        try
+        {
+            currentClient.lockContention(new LockContentionEvent(active, kind == LockKind.READ ? "read" : "write",
+                    lockContentionReason(), this.graphLock.getQueueLength()));
+        }
+        catch (Exception e)
+        {
+            LOGGER.debug("Failed to publish lock contention notification", e);
+        }
+    }
+
+    /**
+     * Whether some caller is currently blocked waiting on either side of graphLock - folded into
+     * legend/status (see LspStatus) so a client polling status, not just one live-streaming
+     * legend/lockContention notifications, can also see it.
+     */
+    public boolean isLockContended()
+    {
+        return this.blockedReaders.get() > 0 || this.blockedWriters.get() > 0;
+    }
+
+    public String lockContentionReason()
+    {
+        if (!isLockContended())
+        {
+            return null;
+        }
+        return this.graphLock.isWriteLocked()
+                ? "write lock held (a compile is running)"
+                : "read lock(s) held (an execution is running)";
     }
 
     // These delegate straight to SourceMutationService, which takes the write lock itself (the single
@@ -351,29 +574,38 @@ public class LegendPureSession
      * Execution paths call this first (outside their read lock) so that by the time they hold the read
      * lock the graph is fully compiled and stable. When nothing is pending, compile() is a no-op.
      */
+    /**
+     * Compile any pending (uncompiled) sources. Every SourceMutationService mutation already
+     * compiles before releasing the write lock (the graphLock javadoc's single chokepoint), so by
+     * the time any caller reaches here the graph is provably already compiled in the common case -
+     * graphDirty lets that common case skip the write lock entirely instead of paying for a
+     * round-trip that can only ever find nothing to do. See the graphDirty field javadoc for why
+     * this is still correct (not just "usually correct") even if that invariant is ever violated by
+     * a future change.
+     */
     private void ensureCompiled()
     {
-        this.graphLock.writeLock().lock();
-        try
+        if (!this.graphDirty.get())
         {
-            if (this.pureRuntime != null)
+            return;
+        }
+        try (LockHandle ignored = acquireGraphWriteLock())
+        {
+            if (this.graphDirty.compareAndSet(true, false) && this.pureRuntime != null)
             {
                 this.pureRuntime.compile();
             }
-        }
-        finally
-        {
-            this.graphLock.writeLock().unlock();
         }
     }
 
     public ExecuteResult executeGo()
     {
-        return executeFunctionByCandidates(
+        FunctionCandidates candidates = new FunctionCandidates(
                 Lists.mutable.with("go():Any[*]", "go():String[*]", "go():String[1]"),
-                Lists.mutable.with("go__Any_MANY_", "go__String_MANY_", "go__String_1_"),
-                "go()",
-                "No go() function found in compiled sources. Define: function go():Any[*] { ... }");
+                Lists.mutable.with("go__Any_MANY_", "go__String_MANY_", "go__String_1_"));
+        return executeFunctionByCandidates(candidates, "go()",
+                "No go() function found in compiled sources. Define: function go():Any[*] { ... }",
+                null, null, null);
     }
 
     /**
@@ -388,12 +620,92 @@ public class LegendPureSession
      */
     public ExecuteResult executeFunction(String functionPath)
     {
+        return executeFunction(functionPath, null);
+    }
+
+    /**
+     * Same as {@link #executeFunction(String)}, but for a &lt;&lt;PCT.test&gt;&gt; function that takes
+     * exactly one parameter: the adapter {@code Function} resolved from {@code pctAdapterPath} (e.g.
+     * an in-memory vs. a real relational execution strategy). Mirrors the substitution
+     * {@code TestRunner#executeTestFunc} already performs for bulk PCT runs
+     * (org.finos.legend.pure.m3.execution.test.TestRunner in legend-pure-core) - resolve the adapter
+     * by path and pass it as the sole wrapped argument - without pulling in that class's
+     * TestCollection/TestCallBack machinery, which is built for running a whole suite rather than one
+     * function invoked from an IDE gutter icon. A null/blank pctAdapterPath behaves exactly like
+     * {@link #executeFunction(String)} (zero-argument call).
+     */
+    public ExecuteResult executeFunction(String functionPath, String pctAdapterPath)
+    {
+        return executeFunction(functionPath, pctAdapterPath, null, null);
+    }
+
+    /**
+     * Same as {@link #executeFunction(String, String)}, but additionally runs {@code beforeFunctionPath}
+     * (if set) immediately before, and {@code afterFunctionPath} (if set) immediately after, the target
+     * function - all three within the same read-lock/transaction/console-capture as a single atomic
+     * call. Mirrors {@code TestRunner#runTestsFromCollection}'s bracketing semantics at single-test
+     * granularity: a before-function failure aborts the whole call (the target function and after are
+     * never run); an after-function failure is appended to the output but never flips an otherwise
+     * successful target-function result to failure. Either path may be null/blank to skip that step.
+     */
+    public ExecuteResult executeFunction(String functionPath, String pctAdapterPath, String beforeFunctionPath, String afterFunctionPath)
+    {
         if (functionPath == null || functionPath.trim().isEmpty())
         {
             return new ExecuteResult(false, "Function path is required", null);
         }
         String path = functionPath.trim();
-        // Derive candidate lookups: the caller may pass a signature ("a::b():Any[*]") or a mangled id.
+        return executeFunctionByCandidates(buildFunctionCandidates(path), path,
+                "No function '" + path + "' found in compiled sources.", pctAdapterPath,
+                blankToNull(beforeFunctionPath), blankToNull(afterFunctionPath));
+    }
+
+    /**
+     * Finds the nearest {@code <<test.BeforePackage>>}/{@code <<test.AfterPackage>>} functions to
+     * {@code functionPath} (see {@link TestTools#findNearestBeforePackageFunction}) - used by the IDE
+     * gutter's "Run/Debug with Setup/Teardown" actions to discover what to bracket a test with before
+     * offering it as a follow-up execution.
+     */
+    public SetupTeardownResult findSetupTeardown(String functionPath)
+    {
+        if (functionPath == null || functionPath.trim().isEmpty() || !this.initialized)
+        {
+            return new SetupTeardownResult(null, null, null, null);
+        }
+
+        ensureCompiled();
+        try (LockHandle ignored = acquireGraphReadLock())
+        {
+            PureRuntime runtime = this.pureRuntime;
+            if (runtime == null)
+            {
+                return new SetupTeardownResult(null, null, null, null);
+            }
+            CoreInstance function = resolveFunction(runtime, buildFunctionCandidates(functionPath.trim()));
+            if (function == null)
+            {
+                return new SetupTeardownResult(null, null, null, null);
+            }
+            ProcessorSupport processorSupport = runtime.getProcessorSupport();
+            CoreInstance before = TestTools.findNearestBeforePackageFunction(function, processorSupport);
+            CoreInstance after = TestTools.findNearestAfterPackageFunction(function, processorSupport);
+            return new SetupTeardownResult(
+                    before == null ? null : PackageableElement.getUserPathForPackageableElement(before),
+                    before == null ? null : DocumentOutlineProvider.getSimpleFunctionName(before),
+                    after == null ? null : PackageableElement.getUserPathForPackageableElement(after),
+                    after == null ? null : DocumentOutlineProvider.getSimpleFunctionName(after));
+        }
+    }
+
+    private static String blankToNull(String value)
+    {
+        return (value == null || value.trim().isEmpty()) ? null : value.trim();
+    }
+
+    // Derive candidate lookups: the caller may pass a signature ("a::b():Any[*]"), a mangled id
+    // ("a::b__Any_MANY_"), or a bare path ("a::b") in which case common zero-arg return shapes are tried.
+    private static FunctionCandidates buildFunctionCandidates(String path)
+    {
         MutableList<String> signatureCandidates = Lists.mutable.empty();
         MutableList<String> idCandidates = Lists.mutable.empty();
         if (path.contains("("))
@@ -406,7 +718,6 @@ public class LegendPureSession
         }
         else
         {
-            // Bare path with no signature/mangling: try common zero-arg return shapes.
             signatureCandidates.add(path + "():Any[*]");
             signatureCandidates.add(path + "():Boolean[1]");
             signatureCandidates.add(path + "():String[*]");
@@ -416,13 +727,47 @@ public class LegendPureSession
             idCandidates.add(path + "__String_MANY_");
             idCandidates.add(path + "__String_1_");
         }
-        return executeFunctionByCandidates(signatureCandidates, idCandidates, path,
-                "No function '" + path + "' found in compiled sources.");
+        return new FunctionCandidates(signatureCandidates, idCandidates);
     }
 
-    private ExecuteResult executeFunctionByCandidates(MutableList<String> signatureCandidates,
-                                                      MutableList<String> idCandidates,
-                                                      String label, String notFoundMessage)
+    // Resolves a function against an already-fully-compiled runtime by trying each signature
+    // candidate first, then each mangled-id candidate. Caller must hold graphLock.readLock().
+    private static CoreInstance resolveFunction(PureRuntime runtime, FunctionCandidates candidates)
+    {
+        for (String sig : candidates.signatures)
+        {
+            CoreInstance function = runtime.getFunction(sig);
+            if (function != null)
+            {
+                return function;
+            }
+        }
+        for (String id : candidates.ids)
+        {
+            CoreInstance function = runtime.getCoreInstance(id);
+            if (function != null)
+            {
+                return function;
+            }
+        }
+        return null;
+    }
+
+    private static final class FunctionCandidates
+    {
+        final MutableList<String> signatures;
+        final MutableList<String> ids;
+
+        FunctionCandidates(MutableList<String> signatures, MutableList<String> ids)
+        {
+            this.signatures = signatures;
+            this.ids = ids;
+        }
+    }
+
+    private ExecuteResult executeFunctionByCandidates(FunctionCandidates candidates, String label,
+                                                        String notFoundMessage, String pctAdapterPath,
+                                                        String beforeFunctionPath, String afterFunctionPath)
     {
         if (!this.initialized)
         {
@@ -433,38 +778,54 @@ public class LegendPureSession
         // against a stable, fully-compiled graph.
         ensureCompiled();
 
-        this.graphLock.readLock().lock();
-        try
+        try (LockHandle ignored = acquireGraphReadLock())
         {
             PureRuntime runtime = this.pureRuntime;
             if (runtime == null)
             {
                 return new ExecuteResult(false, "Runtime not initialized", null);
             }
-            CoreInstance function = null;
-            for (String sig : signatureCandidates)
-            {
-                function = runtime.getFunction(sig);
-                if (function != null)
-                {
-                    break;
-                }
-            }
-            if (function == null)
-            {
-                for (String id : idCandidates)
-                {
-                    function = runtime.getCoreInstance(id);
-                    if (function != null)
-                    {
-                        break;
-                    }
-                }
-            }
+            CoreInstance function = resolveFunction(runtime, candidates);
             if (function == null)
             {
                 LspLog.info("execute: no function found for " + label);
                 return new ExecuteResult(false, notFoundMessage, null);
+            }
+
+            // Resolved eagerly (before anything runs) so a missing setup/teardown function fails fast
+            // rather than after the target function has already produced side effects/output.
+            CoreInstance beforeFunction = null;
+            if (beforeFunctionPath != null)
+            {
+                beforeFunction = resolveFunction(runtime, buildFunctionCandidates(beforeFunctionPath));
+                if (beforeFunction == null)
+                {
+                    return new ExecuteResult(false, "Before function '" + beforeFunctionPath + "' not found in compiled sources", null);
+                }
+            }
+            CoreInstance afterFunction = null;
+            if (afterFunctionPath != null)
+            {
+                afterFunction = resolveFunction(runtime, buildFunctionCandidates(afterFunctionPath));
+                if (afterFunction == null)
+                {
+                    return new ExecuteResult(false, "After function '" + afterFunctionPath + "' not found in compiled sources", null);
+                }
+            }
+
+            // A <<PCT.test>> function takes exactly one parameter: the adapter Function itself
+            // (see TestRunner#executeTestFunc in legend-pure-core, which this mirrors). Resolving the
+            // adapter and wrapping it as the sole argument here - rather than always calling with zero
+            // args - is what lets a PCT test be run directly by path from this session.
+            MutableList<CoreInstance> args = Lists.mutable.empty();
+            if (pctAdapterPath != null && !pctAdapterPath.trim().isEmpty())
+            {
+                CoreInstance adapter = _Package.getByUserPath(pctAdapterPath.trim(), runtime.getProcessorSupport());
+                if (adapter == null)
+                {
+                    return new ExecuteResult(false, "PCT adapter '" + pctAdapterPath.trim() + "' not found in compiled sources", null);
+                }
+                args.add(ValueSpecificationBootstrap.wrapValueSpecification(adapter, false, runtime.getProcessorSupport()));
             }
 
             // Fresh executor per call => own console + own cancelExecution flag (no cross-talk between
@@ -480,27 +841,67 @@ public class LegendPureSession
                     runtime.getModelRepository().newTransaction(false);
             try (org.finos.legend.pure.m4.transaction.framework.ThreadLocalTransactionContext ignore = txn.openInCurrentThread())
             {
-                LspLog.debug("execute: found " + label + " at "
-                        + (function.getSourceInformation() != null ? function.getSourceInformation().getSourceId() : "unknown"));
                 PrintStream capturePrintStream = new PrintStream(baos, true);
                 console.setPrintStream(capturePrintStream);
                 console.setConsole(true);
 
-                exec.start(function, FastList.newList());
-
-                String consoleOutput = baosToString(baos);
-                if (consoleOutput.isEmpty())
+                // Before-function failure aborts the whole call (target function and after never run) -
+                // mirrors TestRunner#runTestsFromCollection's fail-fast setup handling.
+                if (beforeFunction != null)
                 {
-                    consoleOutput = "(" + label + " returned successfully with no console output. Use print() to see results.)";
+                    try
+                    {
+                        exec.start(beforeFunction, Lists.mutable.empty());
+                    }
+                    catch (Exception e)
+                    {
+                        LOGGER.error("execute: before-function '" + beforeFunctionPath + "' failed for " + label, e);
+                        String errorText = "Setup function '" + beforeFunctionPath + "' failed:\n"
+                                + ExecutionFailureFormatter.format(e, baosToString(baos), this.functionExecution.getProcessorSupport());
+                        return new ExecuteResult(false, errorText, errorText);
+                    }
                 }
-                LspLog.debug("execute completed for " + label + ", output length: " + consoleOutput.length());
-                return new ExecuteResult(true, null, consoleOutput);
-            }
-            catch (Exception e)
-            {
-                LOGGER.error("execute failed for " + label, e);
-                String errorText = formatExecutionFailure(e, baos);
-                return new ExecuteResult(false, errorText, errorText);
+
+                LspLog.debug("execute: found " + label + " at "
+                        + (function.getSourceInformation() != null ? function.getSourceInformation().getSourceId() : "unknown"));
+
+                ExecuteResult mainResult;
+                try
+                {
+                    exec.start(function, args);
+                    String consoleOutput = baosToString(baos);
+                    if (consoleOutput.isEmpty())
+                    {
+                        consoleOutput = "(" + label + " returned successfully with no console output. Use print() to see results.)";
+                    }
+                    LspLog.debug("execute completed for " + label + ", output length: " + consoleOutput.length());
+                    mainResult = new ExecuteResult(true, null, consoleOutput);
+                }
+                catch (Exception e)
+                {
+                    LOGGER.error("execute failed for " + label, e);
+                    String errorText = ExecutionFailureFormatter.format(e, baosToString(baos), this.functionExecution.getProcessorSupport());
+                    mainResult = new ExecuteResult(false, errorText, errorText);
+                }
+
+                // After-function failure never overrides the target function's own success/failure -
+                // mirrors TestRunner#runTestsFromCollection, which likewise swallows teardown failures.
+                if (afterFunction != null)
+                {
+                    try
+                    {
+                        exec.start(afterFunction, Lists.mutable.empty());
+                    }
+                    catch (Exception e)
+                    {
+                        LOGGER.warn("execute: after-function '" + afterFunctionPath + "' failed for " + label, e);
+                        String afterError = "Teardown function '" + afterFunctionPath + "' failed: " + e.getMessage();
+                        String combinedOutput = (mainResult.getOutput() == null ? "" : mainResult.getOutput() + "\n") + afterError;
+                        mainResult = new ExecuteResult(mainResult.isSuccess(), mainResult.getError(), combinedOutput);
+                    }
+                }
+
+                return mainResult;
             }
             finally
             {
@@ -509,59 +910,6 @@ public class LegendPureSession
                 txn.rollback();
             }
         }
-        finally
-        {
-            this.graphLock.readLock().unlock();
-        }
-    }
-
-    private String formatExecutionFailure(Exception e, ByteArrayOutputStream consoleOutput)
-    {
-        StringBuilder builder = new StringBuilder();
-        String printed = baosToString(consoleOutput);
-        if (!printed.isEmpty())
-        {
-            builder.append(printed);
-            if (!printed.endsWith("\n"))
-            {
-                builder.append('\n');
-            }
-        }
-
-        PureException pureException = PureException.findPureException(e);
-        if (pureException != null)
-        {
-            PureException original = pureException.getOriginatingPureException();
-            if (original == null)
-            {
-                original = pureException;
-            }
-            if (pureException instanceof PureExecutionException)
-            {
-                builder.append(original.getMessage()).append('\n');
-                StringBuffer buffer = new StringBuffer();
-                ((PureExecutionException) pureException).printPureStackTrace(
-                        buffer, "", this.functionExecution.getProcessorSupport());
-                builder.append(buffer);
-            }
-            else if (pureException.hasPureStackTrace())
-            {
-                builder.append(original.getMessage()).append('\n')
-                        .append(pureException.getPureStackTrace("    "));
-            }
-            else
-            {
-                builder.append(original.getMessage());
-            }
-        }
-        else
-        {
-            StringWriter writer = new StringWriter();
-            e.printStackTrace(new PrintWriter(writer));
-            builder.append(writer);
-        }
-
-        return builder.toString();
     }
 
     private static String baosToString(ByteArrayOutputStream baos)
@@ -639,6 +987,10 @@ public class LegendPureSession
 
     public String resolveSourceId(String sourceId)
     {
+        if (sourceId == null)
+        {
+            return null;
+        }
         if (this.pureRuntime.getSourceById(sourceId) != null)
         {
             return sourceId;
@@ -677,6 +1029,42 @@ public class LegendPureSession
         public String getOutput()
         {
             return this.output;
+        }
+    }
+
+    public static class SetupTeardownResult
+    {
+        private final String beforeFunctionPath;
+        private final String beforeFunctionName;
+        private final String afterFunctionPath;
+        private final String afterFunctionName;
+
+        SetupTeardownResult(String beforeFunctionPath, String beforeFunctionName, String afterFunctionPath, String afterFunctionName)
+        {
+            this.beforeFunctionPath = beforeFunctionPath;
+            this.beforeFunctionName = beforeFunctionName;
+            this.afterFunctionPath = afterFunctionPath;
+            this.afterFunctionName = afterFunctionName;
+        }
+
+        public String getBeforeFunctionPath()
+        {
+            return this.beforeFunctionPath;
+        }
+
+        public String getBeforeFunctionName()
+        {
+            return this.beforeFunctionName;
+        }
+
+        public String getAfterFunctionPath()
+        {
+            return this.afterFunctionPath;
+        }
+
+        public String getAfterFunctionName()
+        {
+            return this.afterFunctionName;
         }
     }
 

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LegendTextDocumentService.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LegendTextDocumentService.java
@@ -37,6 +37,8 @@ import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
+import org.eclipse.lsp4j.FoldingRange;
+import org.eclipse.lsp4j.FoldingRangeRequestParams;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.Location;
@@ -76,7 +78,7 @@ public class LegendTextDocumentService implements TextDocumentService
     public void didOpen(DidOpenTextDocumentParams params)
     {
         String uri = params.getTextDocument().getUri();
-        if (uri.startsWith("pure://"))
+        if (uri.startsWith("pure://") || isIgnored(uri))
         {
             return;
         }
@@ -89,7 +91,7 @@ public class LegendTextDocumentService implements TextDocumentService
     public void didChange(DidChangeTextDocumentParams params)
     {
         String uri = params.getTextDocument().getUri();
-        if (uri.startsWith("pure://"))
+        if (uri.startsWith("pure://") || isIgnored(uri))
         {
             return;
         }
@@ -113,9 +115,24 @@ public class LegendTextDocumentService implements TextDocumentService
         if (session != null && session.isInitialized() && this.server.getMutationService() != null && !uri.startsWith("pure://"))
         {
             String sourceId = this.server.getUriMapper().toSourceId(uri);
+            if (sourceId == null)
+            {
+                return;
+            }
             LegendPureSession.CompileResult result = this.server.getMutationService().restoreFromDisk(sourceId);
             handleResult(uri, result);
         }
+    }
+
+    /**
+     * True if this uri is not part of any registered Pure module (a fixture/resource file that merely
+     * has a .pure extension, e.g. a ###Lakehouse test template read as raw text by a Java test harness).
+     * Such files must never be compiled, diagnosed, or restored-from-disk - they are opaque to the LSP,
+     * exactly like a .java file would be. See UriMapper.deriveSourceId for the actual determination.
+     */
+    private boolean isIgnored(String uri)
+    {
+        return this.server.getUriMapper().toSourceId(uri) == null;
     }
 
     @Override
@@ -411,6 +428,40 @@ public class LegendTextDocumentService implements TextDocumentService
         });
     }
 
+    @Override
+    public CompletableFuture<List<FoldingRange>> foldingRange(FoldingRangeRequestParams params)
+    {
+        return this.server.supplyAsync(() ->
+        {
+            try
+            {
+                LegendPureSession session = this.server.getSession();
+                if (session == null || !session.isInitialized())
+                {
+                    return Collections.<FoldingRange>emptyList();
+                }
+
+                String uri = params.getTextDocument().getUri();
+                String sourceId = uri.startsWith("pure://")
+                        ? uri.substring("pure://".length())
+                        : this.server.getUriMapper().toSourceId(uri);
+                String resolvedId = session.resolveSourceId(sourceId);
+                if (resolvedId == null)
+                {
+                    return Collections.<FoldingRange>emptyList();
+                }
+
+                return session.withGraphReadLock(() ->
+                        FoldingRangeProvider.getFoldingRanges(session.getPureRuntime(), resolvedId));
+            }
+            catch (Exception e)
+            {
+                LOGGER.error("Error in folding range", e);
+                return Collections.<FoldingRange>emptyList();
+            }
+        });
+    }
+
     private void scheduleCompile(String uri, String content)
     {
         cancelPending(uri);
@@ -522,7 +573,15 @@ public class LegendTextDocumentService implements TextDocumentService
             String uri = entry.getKey();
             if (!uri.startsWith("pure://"))
             {
-                snapshot.put(this.server.getUriMapper().toSourceId(uri), entry.getValue());
+                // openDocuments is only ever populated via didOpen/didChange, both already gated by
+                // isIgnored - toSourceId(uri) is non-null in practice - but snapshot is a TreeMap, whose
+                // natural-ordering put() rejects a null key outright, so guard here too rather than lean
+                // on that invariant holding forever.
+                String sourceId = this.server.getUriMapper().toSourceId(uri);
+                if (sourceId != null)
+                {
+                    snapshot.put(sourceId, entry.getValue());
+                }
             }
         }
         return snapshot;

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LegendWorkspaceService.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LegendWorkspaceService.java
@@ -14,10 +14,17 @@
 
 package org.finos.legend.pure.lsp;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
@@ -27,6 +34,8 @@ import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.WorkspaceService;
+import org.finos.legend.pure.lsp.protocol.SyncWorkspaceParams;
+import org.finos.legend.pure.lsp.protocol.SyncWorkspaceResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,13 +112,25 @@ public class LegendWorkspaceService implements WorkspaceService
             return;
         }
 
+        applyChanges(session, changes);
+    }
+
+    /**
+     * Shared tail for anything that hands a batch of externally-derived {@link LegendPureSession.FileChange}s
+     * to the mutation service - today {@link #handleFileChanges} (client-reported watched-file events) and
+     * {@link #syncWorkspace} (server-detected drift). Compiles the batch, then on success clears stale
+     * diagnostics and rebuilds the symbol index; on a non-internal error, attributes it to one of the
+     * changed files so it's visible somewhere rather than silently dropped.
+     */
+    private LegendPureSession.CompileResult applyChanges(LegendPureSession session, List<LegendPureSession.FileChange> changes)
+    {
         LegendPureSession.CompileResult result = this.server.getMutationService().applyBulkChangesAndCompile(changes);
 
         if (result.isInternalError())
         {
             LOGGER.error("Internal error after file changes, triggering recovery", result.getError());
             this.server.triggerRecovery();
-            return;
+            return result;
         }
 
         if (result.isSuccess())
@@ -124,7 +145,7 @@ public class LegendWorkspaceService implements WorkspaceService
             }
             this.server.getSymbolProvider().buildIndex(session.getPureRuntime());
         }
-        else if (!result.isInternalError() && result.getError() != null)
+        else if (result.getError() != null)
         {
             String fallbackUri = null;
             for (LegendPureSession.FileChange change : changes)
@@ -140,6 +161,7 @@ public class LegendWorkspaceService implements WorkspaceService
                 this.server.getDiagnosticService().publishException(fallbackUri, result.getError(), session);
             }
         }
+        return result;
     }
 
     private List<LegendPureSession.FileChange> filterOpenDocumentConflicts(List<LegendPureSession.FileChange> changes)
@@ -172,5 +194,121 @@ public class LegendWorkspaceService implements WorkspaceService
             return this.server.reindex().thenApply(ignored -> null);
         }
         return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Applies only the files the {@link WorkspaceDriftWatcher} (or an explicit uri selection) says are
+     * actually out of sync, instead of a full {@link #executeCommand reindex} - see the watcher's javadoc
+     * for why this stays a deliberate, user/client-triggered call rather than something the watcher fires
+     * on its own.
+     */
+    SyncWorkspaceResult syncWorkspace(SyncWorkspaceParams params)
+    {
+        LegendPureSession session = this.server.getSession();
+        if (session == null || !session.isInitialized())
+        {
+            return SyncWorkspaceResult.failure("Runtime not initialized");
+        }
+        if (this.server.getMutationService() == null)
+        {
+            return SyncWorkspaceResult.failure("Mutation service not available");
+        }
+
+        Collection<String> sourceIds = (params == null || params.getUris() == null || params.getUris().isEmpty())
+                ? this.server.getDriftWatcher().getDirtySourceIds()
+                : deriveSourceIds(params.getUris());
+
+        if (sourceIds.isEmpty())
+        {
+            return SyncWorkspaceResult.success(0, 0, 0);
+        }
+
+        RepositoryScanner scanner = this.server.getRepositoryScanner();
+        List<LegendPureSession.FileChange> changes = new ArrayList<>();
+        int created = 0;
+        int modified = 0;
+        int deleted = 0;
+        for (String sourceId : sourceIds)
+        {
+            Path path = scanner.resolve(sourceId);
+            if (path == null)
+            {
+                changes.add(new LegendPureSession.FileChange(sourceId, null, LegendPureSession.FileChangeType.DELETE));
+                deleted++;
+                continue;
+            }
+            String content;
+            try
+            {
+                content = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+            }
+            catch (IOException e)
+            {
+                LOGGER.warn("Sync: failed to read {}: {}", path, e.getMessage());
+                continue;
+            }
+            boolean existedBefore = session.getPureRuntime().getSourceById(sourceId) != null;
+            changes.add(new LegendPureSession.FileChange(sourceId, content, LegendPureSession.FileChangeType.CREATE_OR_MODIFY));
+            if (existedBefore)
+            {
+                modified++;
+            }
+            else
+            {
+                created++;
+            }
+        }
+
+        // Only ever clear entries that were actually, successfully applied - a failed compile or an
+        // open-document conflict means the drift is still real, so it must stay in the watcher's
+        // dirty set (and stay visible to the next notification) rather than being silently dropped.
+        List<LegendPureSession.FileChange> filtered = filterOpenDocumentConflicts(changes);
+        if (filtered.isEmpty())
+        {
+            return SyncWorkspaceResult.success(0, 0, 0);
+        }
+
+        LegendPureSession.CompileResult result = applyChanges(session, filtered);
+
+        if (result.isInternalError())
+        {
+            return SyncWorkspaceResult.failure("Internal error during sync; recovery triggered");
+        }
+        if (!result.isSuccess() && result.getError() != null)
+        {
+            return SyncWorkspaceResult.failure(result.getError().getMessage());
+        }
+
+        // Only the entries actually in the applied (post-filter) batch resolved - anything dropped by
+        // filterOpenDocumentConflicts is still genuinely out of sync and must stay reported as such.
+        List<String> appliedSourceIds = new ArrayList<>(filtered.size());
+        for (LegendPureSession.FileChange change : filtered)
+        {
+            appliedSourceIds.add(change.getSourceId());
+        }
+        this.server.getDriftWatcher().clear(appliedSourceIds);
+        this.server.getDriftWatcher().publishNow();
+
+        LspLog.info("Synced workspace from disk: " + created + " created, " + modified + " modified, " + deleted + " deleted");
+        return SyncWorkspaceResult.success(created, modified, deleted);
+    }
+
+    private Collection<String> deriveSourceIds(List<String> uris)
+    {
+        Set<String> sourceIds = new LinkedHashSet<>();
+        for (String uri : uris)
+        {
+            // PureAutoSyncListener passes every changed .pure path unfiltered, including genuine
+            // non-module fixtures (see UriMapper#deriveSourceId) - toSourceId(uri) legitimately
+            // returns null for those, and a null sourceId must never enter the changes pipeline: it
+            // would otherwise reach applyChanges/the mutation service as a FileChange with no real
+            // source ID to compile against.
+            String sourceId = this.server.getUriMapper().toSourceId(uri);
+            if (sourceId != null)
+            {
+                sourceIds.add(sourceId);
+            }
+        }
+        return sourceIds;
     }
 }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LspLog.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/LspLog.java
@@ -14,33 +14,94 @@
 
 package org.finos.legend.pure.lsp;
 
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.function.Consumer;
+import org.finos.legend.pure.lsp.protocol.LegendLogEvent;
+import org.finos.legend.pure.lsp.protocol.LogErrorEntry;
+
 /**
- * Logs to stderr; stdout is reserved for JSON-RPC.
+ * Logs to stderr; stdout is reserved for JSON-RPC. Also broadcasts to an optional sink (set by
+ * LegendPureLspServer.connect()) so a connected client can show these lines in a live log view - this
+ * is the only way a client sees them once the server is run as a socket daemon it didn't spawn, since
+ * there's no owned child process whose stdout/stderr IntelliJ (or any other launcher) can capture.
  */
 public class LspLog
 {
+    // Bounded so a noisy failure mode can't grow this unboundedly; recent enough to diagnose "what
+    // just went wrong" from legend/status without needing a live logOutput subscriber attached at
+    // the time. Surfaced via LspStatus#getRecentErrors().
+    private static final int MAX_RECENT_ERRORS = 20;
+    private static final Deque<LogErrorEntry> recentErrors = new ConcurrentLinkedDeque<>();
+
+    private static volatile Consumer<LegendLogEvent> sink;
+
+    public static void setSink(Consumer<LegendLogEvent> newSink)
+    {
+        sink = newSink;
+    }
+
     public static void info(String message)
     {
         System.err.println("[LSP] " + message);
+        publish("INFO", message);
     }
 
     public static void info(String format, Object... args)
     {
-        System.err.println("[LSP] " + String.format(format.replace("{}", "%s"), args));
+        String message = String.format(format.replace("{}", "%s"), args);
+        System.err.println("[LSP] " + message);
+        publish("INFO", message);
     }
 
     public static void warn(String message)
     {
         System.err.println("[LSP-WARN] " + message);
+        publish("WARN", message);
     }
 
     public static void error(String message)
     {
         System.err.println("[LSP-ERROR] " + message);
+        recordError(message);
+        publish("ERROR", message);
     }
 
     public static void debug(String message)
     {
         System.err.println("[LSP-DEBUG] " + message);
+        publish("DEBUG", message);
+    }
+
+    public static List<LogErrorEntry> recentErrors()
+    {
+        return new ArrayList<>(recentErrors);
+    }
+
+    private static void recordError(String message)
+    {
+        recentErrors.addLast(new LogErrorEntry(System.currentTimeMillis(), message));
+        while (recentErrors.size() > MAX_RECENT_ERRORS)
+        {
+            recentErrors.pollFirst();
+        }
+    }
+
+    private static void publish(String level, String message)
+    {
+        Consumer<LegendLogEvent> currentSink = sink;
+        if (currentSink != null)
+        {
+            try
+            {
+                currentSink.accept(new LegendLogEvent(level, message));
+            }
+            catch (Exception ignored)
+            {
+                // Never let a broken client-side log sink take down server logging itself.
+            }
+        }
     }
 }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/OverlayWorkspaceCodeStorage.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/OverlayWorkspaceCodeStorage.java
@@ -16,8 +16,11 @@ package org.finos.legend.pure.lsp;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -26,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.collection.MutableCollection;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
@@ -40,6 +44,17 @@ import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.fs.FSCo
  */
 public class OverlayWorkspaceCodeStorage extends FSCodeStorage implements MutableRepositoryCodeStorage
 {
+    // A repo's own top-level "data" folder is conventionally a runtime test-fixture area (e.g. a
+    // ###Lakehouse/template .pure file an integration-test harness reads as a raw string and
+    // string-substitutes, the same role ".legend" fixtures play elsewhere) rather than real package
+    // structure, so it is excluded from compilable workspace sources. Scoped to the repo root only
+    // (not any depth) so this can never shadow a legitimate nested package that happens to be named
+    // "data" (e.g. core::pure::data, a real, deeper-nested package in legend-engine's "core" repo).
+    private static final String FIXTURE_DIR_NAME = "data";
+    // Conventional go() entry-point file (see WelcomeCodeStorage) - always compilable even if it
+    // happens to sit under an otherwise-excluded fixture folder.
+    private static final String ENTRY_POINT_FILE_NAME = "welcome.pure";
+
     private final Map<String, String> contentByPath = new ConcurrentHashMap<>();
     private final Set<String> deletedPaths = ConcurrentHashMap.newKeySet();
     private final Set<String> createdFolders = ConcurrentHashMap.newKeySet();
@@ -47,6 +62,39 @@ public class OverlayWorkspaceCodeStorage extends FSCodeStorage implements Mutabl
     public OverlayWorkspaceCodeStorage(CodeRepository repository, Path root)
     {
         super(repository, root);
+    }
+
+    /**
+     * Overrides FSCodeStorage's unfiltered recursive walk (inherited by getUserFiles()/
+     * getFileOrFiles()) to apply the fixture-folder exclusion above.
+     */
+    @Override
+    protected void getFilesRecursive(Path dir, MutableCollection<String> result) throws IOException
+    {
+        try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(dir))
+        {
+            for (Path dirEntry : dirStream)
+            {
+                if (Files.isDirectory(dirEntry))
+                {
+                    getFilesRecursive(dirEntry, result);
+                }
+                else if (CodeStorageTools.hasPureFileExtension(dirEntry.toString()) && isCompilableWorkspaceFile(dirEntry))
+                {
+                    result.add(getUserPath(dirEntry));
+                }
+            }
+        }
+    }
+
+    private boolean isCompilableWorkspaceFile(Path file)
+    {
+        if (ENTRY_POINT_FILE_NAME.equals(file.getFileName().toString()))
+        {
+            return true;
+        }
+        Path relative = getRoot().relativize(file);
+        return relative.getNameCount() == 0 || !FIXTURE_DIR_NAME.equals(relative.getName(0).toString());
     }
 
     @Override

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/PCTAdapterProvider.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/PCTAdapterProvider.java
@@ -1,0 +1,90 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.eclipse.collections.api.list.ListIterable;
+import org.finos.legend.pure.lsp.protocol.PCTAdapterInfo;
+import org.finos.legend.pure.m3.coreinstance.Package;
+import org.finos.legend.pure.m3.navigation.Instance;
+import org.finos.legend.pure.m3.navigation.M3Properties;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.profile.Profile;
+import org.finos.legend.pure.m3.pct.shared.PCTTools;
+import org.finos.legend.pure.m3.serialization.runtime.PureRuntime;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+/**
+ * Finds every element in the currently-loaded graph carrying the &lt;&lt;PCT.adapter&gt;&gt;
+ * stereotype - the same discovery meta::pure::ide::testing::getPCTAdapters() performs in Pure
+ * (see pct_core.pure), reimplemented here in Java so the LSP can expose it without evaluating Pure
+ * code. An "adapter" is a Function substituted in as the sole argument to a &lt;&lt;PCT.test&gt;&gt;
+ * test function (see TestRunner#executeTestFunc in legend-pure-core).
+ */
+public class PCTAdapterProvider
+{
+    public static List<PCTAdapterInfo> getPCTAdapters(PureRuntime runtime)
+    {
+        ProcessorSupport processorSupport = runtime.getProcessorSupport();
+        CoreInstance adapterStereotype = Profile.findStereotype(PCTTools.PCT_PROFILE, "adapter", processorSupport, false);
+        if (adapterStereotype == null)
+        {
+            // The PCT profile itself is not loaded in this graph (e.g. a minimal/non-test session) -
+            // nothing can carry the stereotype.
+            return Collections.emptyList();
+        }
+
+        CoreInstance root = runtime.getCoreInstance("::");
+        if (!(root instanceof Package))
+        {
+            return Collections.emptyList();
+        }
+
+        List<PCTAdapterInfo> result = new ArrayList<>();
+        collectAdapters((Package) root, adapterStereotype, processorSupport, result);
+        return result;
+    }
+
+    private static void collectAdapters(Package pkg, CoreInstance adapterStereotype,
+                                         ProcessorSupport processorSupport, List<PCTAdapterInfo> result)
+    {
+        ListIterable<? extends CoreInstance> children = pkg.getValueForMetaPropertyToMany(M3Properties.children);
+        for (CoreInstance child : children)
+        {
+            if (child instanceof Package)
+            {
+                collectAdapters((Package) child, adapterStereotype, processorSupport, result);
+                continue;
+            }
+
+            ListIterable<? extends CoreInstance> stereotypes =
+                    Instance.getValueForMetaPropertyToManyResolved(child, M3Properties.stereotypes, processorSupport);
+            if (stereotypes == null || !stereotypes.contains(adapterStereotype))
+            {
+                continue;
+            }
+
+            String path = PackageableElement.getUserPathForPackageableElement(child);
+            String adapterName = Profile.getTaggedValue(child, PCTTools.PCT_PROFILE, "adapterName", processorSupport);
+            String name = (adapterName == null || adapterName.isEmpty())
+                    ? DocumentOutlineProvider.getSimpleFunctionName(child)
+                    : adapterName;
+            result.add(new PCTAdapterInfo(name, path));
+        }
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/ReferencesProvider.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/ReferencesProvider.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 public class ReferencesProvider
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReferencesProvider.class);
+    // Silent cap: results beyond this are dropped rather than reported as truncated to the client.
     private static final int MAX_REFERENCES = 1000;
 
     public static List<Location> references(PureRuntime runtime, UriMapper uriMapper,
@@ -75,9 +76,14 @@ public class ReferencesProvider
             }
         }
 
-        // Check classifier name (not Java instanceof) — Pure graph objects are plain CoreInstance
+        // Check classifier name (not Java instanceof) — Pure graph objects are plain CoreInstance.
+        // Property/QualifiedProperty are invocable Functions too (via .prop or ->prop()), so call
+        // sites are tracked through 'applications' the same way as ConcreteFunctionDefinition/NativeFunction;
+        // Association end properties are plain Property/QualifiedProperty instances, so no separate case is needed.
         if ("ConcreteFunctionDefinition".equals(classifierName)
-                || "NativeFunction".equals(classifierName))
+                || "NativeFunction".equals(classifierName)
+                || "Property".equals(classifierName)
+                || "QualifiedProperty".equals(classifierName))
         {
             ListIterable<? extends CoreInstance> applications =
                     element.getValueForMetaPropertyToMany(M3Properties.applications);
@@ -96,6 +102,18 @@ public class ReferencesProvider
                     }
                 }
             }
+        }
+
+        // Enum literal (e.g. Country.US): the literal carries no back-references of its own —
+        // Pure compiles the access to a call taking the Enumeration and the literal's name as a
+        // plain string (see Source.navigate()'s "extractEnumValue" handling for the resolve-side
+        // counterpart), so a reference usage only tells us the Enumeration was accessed. Walk the
+        // Enumeration's own referenceUsages and filter down to accesses naming this specific literal.
+        CoreInstance elementClassifier = element.getClassifier();
+        if (elementClassifier != null && elementClassifier.getClassifier() != null
+                && "Enumeration".equals(elementClassifier.getClassifier().getName()))
+        {
+            addEnumLiteralUsages(locations, seen, elementClassifier, element.getName(), uriMapper);
         }
 
         // For all elements: read 'referenceUsages' (structural type references)
@@ -134,6 +152,85 @@ public class ReferencesProvider
         }
 
         return locations;
+    }
+
+    // Mirrors the approach of meta::pure::ide::findusages::findUsagesForEnum (legend-engine, Pure-level):
+    // walk the Enumeration's referenceUsages, then for each usage owned by an InstanceValue used as a
+    // function parameter, check whether the enclosing call is the compiled enum accessor and whether its
+    // literal-name argument matches the target value — that's the only way to tell which literal was used.
+    private static void addEnumLiteralUsages(List<Location> locations, Set<String> seen,
+                                             CoreInstance enumeration, String enumValueName, UriMapper uriMapper)
+    {
+        if (enumValueName == null)
+        {
+            return;
+        }
+        try
+        {
+            ListIterable<? extends CoreInstance> refUsages =
+                    enumeration.getValueForMetaPropertyToMany(M3Properties.referenceUsages);
+            if (refUsages == null)
+            {
+                return;
+            }
+            for (CoreInstance refUsage : refUsages)
+            {
+                if (locations.size() >= MAX_REFERENCES)
+                {
+                    LspLog.debug("references: truncated at " + MAX_REFERENCES + " results");
+                    break;
+                }
+                SourceInformation accessSi = matchEnumLiteralAccess(refUsage, enumValueName);
+                if (accessSi != null)
+                {
+                    addLocation(locations, seen, accessSi, uriMapper);
+                }
+            }
+        }
+        catch (Exception ignored)
+        {
+            // Reference usage shape not as expected; skip enum-literal-specific matching
+        }
+    }
+
+    private static SourceInformation matchEnumLiteralAccess(CoreInstance refUsage, String enumValueName)
+    {
+        try
+        {
+            CoreInstance owner = refUsage.getValueForMetaPropertyToOne(M3Properties.owner);
+            if (owner == null || owner.getClassifier() == null || !"InstanceValue".equals(owner.getClassifier().getName()))
+            {
+                return null;
+            }
+            CoreInstance usageContext = owner.getValueForMetaPropertyToOne(M3Properties.usageContext);
+            if (usageContext == null || usageContext.getClassifier() == null
+                    || !"ParameterValueSpecificationContext".equals(usageContext.getClassifier().getName()))
+            {
+                return null;
+            }
+            CoreInstance functionExpression = usageContext.getValueForMetaPropertyToOne(M3Properties.functionExpression);
+            if (functionExpression == null || functionExpression.getClassifier() == null
+                    || !"SimpleFunctionExpression".equals(functionExpression.getClassifier().getName()))
+            {
+                return null;
+            }
+            ListIterable<? extends CoreInstance> params =
+                    functionExpression.getValueForMetaPropertyToMany(M3Properties.parametersValues);
+            if (params == null || params.size() < 2)
+            {
+                return null;
+            }
+            ListIterable<? extends CoreInstance> nameValues = params.get(1).getValueForMetaPropertyToMany(M3Properties.values);
+            if (nameValues == null || nameValues.size() != 1 || !enumValueName.equals(nameValues.get(0).getName()))
+            {
+                return null;
+            }
+            return functionExpression.getSourceInformation();
+        }
+        catch (Exception ignored)
+        {
+            return null;
+        }
     }
 
     private static void addLocation(List<Location> locations, Set<String> seen,

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/RepositoryScanner.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/RepositoryScanner.java
@@ -180,19 +180,47 @@ public class RepositoryScanner
         return (path != null) ? path.toUri().toString() : null;
     }
 
+    // Mirrors OverlayWorkspaceCodeStorage's compilable-file convention: a repo's own top-level "data"
+    // folder holds runtime fixtures (e.g. a ###Lakehouse template), never real Pure source. Callers here
+    // (WorkspaceDriftWatcher's filesystem watch, UriMapper's fallback) treat any non-null result as a
+    // real, compilable source, so this must apply the same exclusion the bulk workspace scan does -
+    // otherwise a fixture edit outside the editor (a rebase, a checkout) gets fed straight into
+    // modifyAndCompile, reintroducing the fixture-file compile crash on a path OverlayWorkspaceCodeStorage
+    // alone can't guard.
+    private static final String FIXTURE_DIR_NAME = "data";
+    private static final String ENTRY_POINT_FILE_NAME = "welcome.pure";
+
     public String deriveSourceIdFromPath(Path filePath)
     {
         Path normalized = filePath.toAbsolutePath().normalize();
         for (Map.Entry<String, Path> entry : this.repoToResourcesRoot.entrySet())
         {
+            String repoName = entry.getKey();
             Path resourcesRoot = entry.getValue().toAbsolutePath().normalize();
-            if (normalized.startsWith(resourcesRoot))
+            // Must match the repo's own directory (resourcesRoot/repoName), not merely fall anywhere
+            // under resourcesRoot - a sibling folder there (e.g. another module's data without its own
+            // definition.json) is not part of THIS repo just because it shares the same
+            // src/main/resources parent.
+            Path repoDir = resourcesRoot.resolve(repoName).toAbsolutePath().normalize();
+            if (normalized.startsWith(repoDir))
             {
-                Path relative = resourcesRoot.relativize(normalized);
-                return "/" + relative.toString().replace('\\', '/');
+                Path relative = repoDir.relativize(normalized);
+                if (isFixturePath(relative))
+                {
+                    return null;
+                }
+                String relativeStr = relative.toString().replace('\\', '/');
+                return relativeStr.isEmpty() ? "/" + repoName : "/" + repoName + "/" + relativeStr;
             }
         }
         return null;
+    }
+
+    private static boolean isFixturePath(Path pathRelativeToRepoDir)
+    {
+        return pathRelativeToRepoDir.getNameCount() > 0
+                && FIXTURE_DIR_NAME.equals(pathRelativeToRepoDir.getName(0).toString())
+                && !ENTRY_POINT_FILE_NAME.equals(pathRelativeToRepoDir.getFileName().toString());
     }
 
     public MutableList<RepositoryCodeStorage> buildWorkspaceStorages()

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/SemanticTokensProvider.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/SemanticTokensProvider.java
@@ -66,6 +66,10 @@ public class SemanticTokensProvider
 
     private static final int MAX_WALK_DEPTH = 50;
 
+    // Kept tight so a token can only ever move across adjacent punctuation ('.', '::', '->'),
+    // never onto an unrelated identifier that happens to repeat the same name
+    private static final int NAME_SNAP_WINDOW = 4;
+
     public static List<Integer> getTokens(PureRuntime runtime, String sourceId)
     {
         Source source = runtime.getSourceById(sourceId);
@@ -75,7 +79,7 @@ public class SemanticTokensProvider
         }
 
         List<RawToken> tokens = new ArrayList<>();
-        collectTokensFromSource(source, runtime, tokens);
+        collectTokensFromSource(new SourceContext(source), runtime, tokens);
 
         tokens.sort(Comparator.comparingInt((RawToken t) -> t.line)
                 .thenComparingInt(t -> t.column));
@@ -83,7 +87,7 @@ public class SemanticTokensProvider
         return encodeDelta(tokens);
     }
 
-    private static void collectTokensFromSource(Source source, PureRuntime runtime, List<RawToken> tokens)
+    private static void collectTokensFromSource(SourceContext source, PureRuntime runtime, List<RawToken> tokens)
     {
         ListIterable<? extends CoreInstance> newInstances = source.getNewInstances();
         if (newInstances == null)
@@ -108,26 +112,26 @@ public class SemanticTokensProvider
             switch (classifierName)
             {
                 case "Class":
-                    addDefinitionToken(tokens, instance, TYPE_CLASS);
+                    addDefinitionToken(tokens, instance, TYPE_CLASS, source);
                     addClassMembers(tokens, instance, runtime, source);
                     break;
                 case "Enumeration":
-                    addDefinitionToken(tokens, instance, TYPE_ENUM);
+                    addDefinitionToken(tokens, instance, TYPE_ENUM, source);
                     addEnumValues(tokens, instance, source);
                     break;
                 case "ConcreteFunctionDefinition":
-                    addDefinitionToken(tokens, instance, TYPE_FUNCTION);
+                    addDefinitionToken(tokens, instance, TYPE_FUNCTION, source);
                     addFunctionSignatureTokens(tokens, instance, runtime, source);
                     addFunctionBodyTokens(tokens, instance, runtime, source);
                     break;
                 case "NativeFunction":
-                    addDefinitionToken(tokens, instance, TYPE_FUNCTION);
+                    addDefinitionToken(tokens, instance, TYPE_FUNCTION, source);
                     break;
                 case "Profile":
-                    addDefinitionToken(tokens, instance, TYPE_INTERFACE);
+                    addDefinitionToken(tokens, instance, TYPE_INTERFACE, source);
                     break;
                 case "Association":
-                    addDefinitionToken(tokens, instance, TYPE_STRUCT);
+                    addDefinitionToken(tokens, instance, TYPE_STRUCT, source);
                     addClassMembers(tokens, instance, runtime, source);
                     break;
                 default:
@@ -136,7 +140,7 @@ public class SemanticTokensProvider
         }
     }
 
-    private static void addDefinitionToken(List<RawToken> tokens, CoreInstance element, int tokenType)
+    private static void addDefinitionToken(List<RawToken> tokens, CoreInstance element, int tokenType, SourceContext source)
     {
         SourceInformation si = element.getSourceInformation();
         if (si == null)
@@ -161,10 +165,10 @@ public class SemanticTokensProvider
             }
         }
 
-        tokens.add(new RawToken(si.getLine(), si.getColumn(), shortName.length(), tokenType, MOD_DEFINITION));
+        tokens.add(source.token(si.getLine(), si.getColumn(), shortName, tokenType, MOD_DEFINITION));
     }
 
-    private static void addClassMembers(List<RawToken> tokens, CoreInstance classElement, PureRuntime runtime, Source source)
+    private static void addClassMembers(List<RawToken> tokens, CoreInstance classElement, PureRuntime runtime, SourceContext source)
     {
         try
         {
@@ -182,8 +186,8 @@ public class SemanticTokensProvider
                     String propName = prop.getName();
                     if (propName != null && !propName.startsWith("@"))
                     {
-                        tokens.add(new RawToken(propSi.getStartLine(), propSi.getStartColumn(),
-                                propName.length(), TYPE_PROPERTY, MOD_DEFINITION));
+                        tokens.add(source.token(propSi.getStartLine(), propSi.getStartColumn(),
+                                propName, TYPE_PROPERTY, MOD_DEFINITION));
                     }
 
                     addTypeReference(tokens, prop, runtime, source);
@@ -196,7 +200,7 @@ public class SemanticTokensProvider
         }
     }
 
-    private static void addTypeReference(List<RawToken> tokens, CoreInstance prop, PureRuntime runtime, Source source)
+    private static void addTypeReference(List<RawToken> tokens, CoreInstance prop, PureRuntime runtime, SourceContext source)
     {
         try
         {
@@ -222,8 +226,8 @@ public class SemanticTokensProvider
             String typeName = rawType.getName();
             if (typeName != null && !typeName.startsWith("@"))
             {
-                tokens.add(new RawToken(typeSi.getStartLine(), typeSi.getStartColumn(),
-                        typeName.length(), TYPE_TYPE, 0));
+                tokens.add(source.token(typeSi.getStartLine(), typeSi.getStartColumn(),
+                        typeName, TYPE_TYPE, 0));
             }
         }
         catch (Exception ignored)
@@ -232,7 +236,7 @@ public class SemanticTokensProvider
         }
     }
 
-    private static void addEnumValues(List<RawToken> tokens, CoreInstance enumeration, Source source)
+    private static void addEnumValues(List<RawToken> tokens, CoreInstance enumeration, SourceContext source)
     {
         try
         {
@@ -249,8 +253,8 @@ public class SemanticTokensProvider
                     String valName = val.getName();
                     if (valName != null)
                     {
-                        tokens.add(new RawToken(valSi.getStartLine(), valSi.getStartColumn(),
-                                valName.length(), TYPE_ENUM_MEMBER, 0));
+                        tokens.add(source.token(valSi.getStartLine(), valSi.getStartColumn(),
+                                valName, TYPE_ENUM_MEMBER, 0));
                     }
                 }
             }
@@ -262,7 +266,7 @@ public class SemanticTokensProvider
     }
 
     private static void addFunctionSignatureTokens(List<RawToken> tokens, CoreInstance function,
-                                                    PureRuntime runtime, Source source)
+                                                    PureRuntime runtime, SourceContext source)
     {
         try
         {
@@ -298,8 +302,8 @@ public class SemanticTokensProvider
                     String paramName = nameCI != null ? nameCI.getName() : null;
                     if (paramName != null)
                     {
-                        tokens.add(new RawToken(paramSi.getLine(), paramSi.getColumn(),
-                                paramName.length(), TYPE_PARAMETER, 0));
+                        tokens.add(source.token(paramSi.getLine(), paramSi.getColumn(),
+                                paramName, TYPE_PARAMETER, 0));
                     }
                     addTypeReference(tokens, param, runtime, source);
                 }
@@ -321,8 +325,8 @@ public class SemanticTokensProvider
                         String typeName = rawReturnType.getName();
                         if (typeName != null && !typeName.startsWith("@"))
                         {
-                            tokens.add(new RawToken(retSi.getStartLine(), retSi.getStartColumn(),
-                                    typeName.length(), TYPE_TYPE, 0));
+                            tokens.add(source.token(retSi.getStartLine(), retSi.getStartColumn(),
+                                    typeName, TYPE_TYPE, 0));
                         }
                     }
                 }
@@ -337,7 +341,7 @@ public class SemanticTokensProvider
     // ── Function body expression tree walker ──────────────────────────────────
 
     private static void addFunctionBodyTokens(List<RawToken> tokens, CoreInstance function,
-                                               PureRuntime runtime, Source source)
+                                               PureRuntime runtime, SourceContext source)
     {
         try
         {
@@ -356,7 +360,7 @@ public class SemanticTokensProvider
     }
 
     private static void walkExpression(List<RawToken> tokens, CoreInstance expr,
-                                        PureRuntime runtime, Source source, int depth)
+                                        PureRuntime runtime, SourceContext source, int depth)
     {
         if (expr == null || depth > MAX_WALK_DEPTH)
         {
@@ -386,7 +390,7 @@ public class SemanticTokensProvider
     }
 
     private static void walkSimpleFunctionExpression(List<RawToken> tokens, CoreInstance expr,
-                                                      PureRuntime runtime, Source source, int depth)
+                                                      PureRuntime runtime, SourceContext source, int depth)
     {
         try
         {
@@ -407,8 +411,7 @@ public class SemanticTokensProvider
                     String propName = func.getName();
                     if (propName != null && !propName.startsWith("@"))
                     {
-                        tokens.add(new RawToken(si.getLine(), si.getColumn(),
-                                propName.length(), TYPE_PROPERTY, 0));
+                        tokens.add(source.token(si.getLine(), si.getColumn(), propName, TYPE_PROPERTY, 0));
                     }
                 }
                 else
@@ -424,8 +427,7 @@ public class SemanticTokensProvider
                     }
                     else if (fnName != null && !OPERATOR_FUNCTION_NAMES.contains(fnName))
                     {
-                        tokens.add(new RawToken(si.getLine(), si.getColumn(),
-                                fnName.length(), TYPE_FUNCTION, 0));
+                        tokens.add(source.token(si.getLine(), si.getColumn(), fnName, TYPE_FUNCTION, 0));
                     }
                 }
             }
@@ -446,7 +448,7 @@ public class SemanticTokensProvider
     }
 
     // In letFunction, the variable name is the first InstanceValue argument
-    private static void addLetVariableName(List<RawToken> tokens, CoreInstance letExpr, Source source)
+    private static void addLetVariableName(List<RawToken> tokens, CoreInstance letExpr, SourceContext source)
     {
         try
         {
@@ -463,8 +465,8 @@ public class SemanticTokensProvider
                         String varName = vals.get(0).getName();
                         if (varName != null)
                         {
-                            tokens.add(new RawToken(nameSi.getLine(), nameSi.getColumn(),
-                                    varName.length(), TYPE_VARIABLE, MOD_DEFINITION));
+                            tokens.add(source.token(nameSi.getLine(), nameSi.getColumn(),
+                                    varName, TYPE_VARIABLE, MOD_DEFINITION));
                         }
                     }
                 }
@@ -475,7 +477,7 @@ public class SemanticTokensProvider
         }
     }
 
-    private static void walkVariableExpression(List<RawToken> tokens, CoreInstance expr, Source source)
+    private static void walkVariableExpression(List<RawToken> tokens, CoreInstance expr, SourceContext source)
     {
         try
         {
@@ -488,8 +490,7 @@ public class SemanticTokensProvider
             String varName = nameCI != null ? nameCI.getName() : null;
             if (varName != null)
             {
-                tokens.add(new RawToken(si.getLine(), si.getColumn(),
-                        varName.length(), TYPE_VARIABLE, 0));
+                tokens.add(source.token(si.getLine(), si.getColumn(), varName, TYPE_VARIABLE, 0));
             }
         }
         catch (Exception ignored)
@@ -498,7 +499,7 @@ public class SemanticTokensProvider
     }
 
     private static void walkInstanceValue(List<RawToken> tokens, CoreInstance expr,
-                                           PureRuntime runtime, Source source, int depth)
+                                           PureRuntime runtime, SourceContext source, int depth)
     {
         try
         {
@@ -522,10 +523,12 @@ public class SemanticTokensProvider
     }
 
     private static void walkLambdaFunction(List<RawToken> tokens, CoreInstance expr,
-                                            PureRuntime runtime, Source source, int depth)
+                                            PureRuntime runtime, SourceContext source, int depth)
     {
         try
         {
+            addLambdaParameterTokens(tokens, expr, source);
+
             ListIterable<? extends CoreInstance> exprs = expr.getValueForMetaPropertyToMany(M3Properties.expressionSequence);
             if (exprs != null)
             {
@@ -540,8 +543,56 @@ public class SemanticTokensProvider
         }
     }
 
+    // A lambda's own bound parameters (e.g. "a" in "a | $a->..." ) live before the expressionSequence,
+    // reached the same way a top-level function's parameters are in addFunctionSignatureTokens().
+    private static void addLambdaParameterTokens(List<RawToken> tokens, CoreInstance lambda, SourceContext source)
+    {
+        try
+        {
+            CoreInstance classifierGT = lambda.getValueForMetaPropertyToOne(M3Properties.classifierGenericType);
+            if (classifierGT == null)
+            {
+                return;
+            }
+            ListIterable<? extends CoreInstance> typeArgs = classifierGT.getValueForMetaPropertyToMany(M3Properties.typeArguments);
+            if (typeArgs == null || typeArgs.isEmpty())
+            {
+                return;
+            }
+            CoreInstance functionTypeGT = typeArgs.get(0);
+            CoreInstance functionType = functionTypeGT.getValueForMetaPropertyToOne(M3Properties.rawType);
+            if (functionType == null)
+            {
+                return;
+            }
+
+            ListIterable<? extends CoreInstance> params = functionType.getValueForMetaPropertyToMany(M3Properties.parameters);
+            if (params != null)
+            {
+                for (CoreInstance param : params)
+                {
+                    SourceInformation paramSi = param.getSourceInformation();
+                    if (paramSi == null || !sourceId(source).equals(paramSi.getSourceId()))
+                    {
+                        continue;
+                    }
+                    CoreInstance nameCI = param.getValueForMetaPropertyToOne(M3Properties.name);
+                    String paramName = nameCI != null ? nameCI.getName() : null;
+                    if (paramName != null)
+                    {
+                        tokens.add(source.token(paramSi.getLine(), paramSi.getColumn(),
+                                paramName, TYPE_PARAMETER, 0));
+                    }
+                }
+            }
+        }
+        catch (Exception ignored)
+        {
+        }
+    }
+
     private static void walkChildren(List<RawToken> tokens, CoreInstance expr,
-                                      PureRuntime runtime, Source source, int depth)
+                                      PureRuntime runtime, SourceContext source, int depth)
     {
         try
         {
@@ -567,9 +618,130 @@ public class SemanticTokensProvider
         }
     }
 
-    private static String sourceId(Source source)
+    private static String sourceId(SourceContext source)
     {
-        return source.getId();
+        return source.id;
+    }
+
+    /**
+     * Resolves the 1-based column at which {@code name} actually starts on the given line.
+     *
+     * <p>A Pure {@code SourceInformation} column can point at the punctuation introducing the
+     * identifier rather than the identifier itself (the {@code .} of a property access, the
+     * {@code ::} before a function's simple name), which would paint the token's fixed length
+     * starting too early. Falls back to the reported column when the name cannot be located,
+     * so a token is never moved somewhere less accurate than before.</p>
+     */
+    static int snapToNameColumn(String[] sourceLines, int line1Based, int reportedColumn1Based, String name)
+    {
+        if (sourceLines == null || name == null || name.isEmpty()
+                || line1Based < 1 || line1Based > sourceLines.length || reportedColumn1Based < 1)
+        {
+            return Math.max(1, reportedColumn1Based);
+        }
+
+        String lineText = sourceLines[line1Based - 1];
+        int reportedIndex = reportedColumn1Based - 1;
+        if (lineText == null || reportedIndex >= lineText.length())
+        {
+            return reportedColumn1Based;
+        }
+
+        if (lineText.startsWith(name, reportedIndex))
+        {
+            return reportedColumn1Based;
+        }
+
+        // Nearest occurrence within the window, preferring one after the reported column
+        for (int offset = 1; offset <= NAME_SNAP_WINDOW; offset++)
+        {
+            if (lineText.startsWith(name, reportedIndex + offset))
+            {
+                return reportedIndex + offset + 1;
+            }
+            if (reportedIndex - offset >= 0 && lineText.startsWith(name, reportedIndex - offset))
+            {
+                return reportedIndex - offset + 1;
+            }
+        }
+        return reportedColumn1Based;
+    }
+
+    /**
+     * Measures the identifier that actually starts at the given column, so a token paints exactly
+     * that identifier.
+     *
+     * <p>A name taken from the model can be longer than the text at the token's column — a call's
+     * {@code functionName} is package-qualified and a qualified property's name carries its
+     * parameter types — which would spill the token over the following punctuation. Falls back to
+     * {@code fallbackLength} whenever the column does not begin an identifier.</p>
+     *
+     * <p>Matches the M3 grammar's {@code ValidString}: {@code [A-Za-z0-9_] [A-Za-z0-9_$]*}.</p>
+     */
+    static int identifierLengthAt(String[] sourceLines, int line1Based, int column1Based, int fallbackLength)
+    {
+        if (sourceLines == null || line1Based < 1 || line1Based > sourceLines.length || column1Based < 1)
+        {
+            return Math.max(1, fallbackLength);
+        }
+
+        String lineText = sourceLines[line1Based - 1];
+        int start = column1Based - 1;
+        if (lineText == null || start >= lineText.length() || !isIdentifierStart(lineText.charAt(start)))
+        {
+            return Math.max(1, fallbackLength);
+        }
+
+        int end = start + 1;
+        while (end < lineText.length() && isIdentifierPart(lineText.charAt(end)))
+        {
+            end++;
+        }
+        return end - start;
+    }
+
+    private static boolean isIdentifierStart(char c)
+    {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (c == '_');
+    }
+
+    private static boolean isIdentifierPart(char c)
+    {
+        return isIdentifierStart(c) || (c == '$');
+    }
+
+    // Splits the source once per request; snapping every named token would otherwise re-split the whole file
+    private static final class SourceContext
+    {
+        private final String id;
+        private final String[] lines;
+        private final Source source;
+
+        SourceContext(Source source)
+        {
+            this.source = source;
+            this.id = source.getId();
+            String content = source.getContent();
+            this.lines = (content == null) ? new String[0] : content.split("\\R", -1);
+        }
+
+        ListIterable<? extends CoreInstance> getNewInstances()
+        {
+            return this.source.getNewInstances();
+        }
+
+        int snap(int line1Based, int reportedColumn1Based, String name)
+        {
+            return snapToNameColumn(this.lines, line1Based, reportedColumn1Based, name);
+        }
+
+        // Column and length are resolved together so a token always spans exactly the identifier it lands on
+        RawToken token(int line1Based, int reportedColumn1Based, String name, int tokenType, int tokenModifiers)
+        {
+            int column = snap(line1Based, reportedColumn1Based, name);
+            int length = identifierLengthAt(this.lines, line1Based, column, name.length());
+            return new RawToken(line1Based, column, length, tokenType, tokenModifiers);
+        }
     }
 
     /**

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/TestFunctionProvider.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/TestFunctionProvider.java
@@ -1,0 +1,93 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.eclipse.collections.api.list.ListIterable;
+import org.finos.legend.pure.lsp.protocol.TestFunctionInfo;
+import org.finos.legend.pure.m3.execution.test.TestTools;
+import org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.pct.shared.PCTTools;
+import org.finos.legend.pure.m3.serialization.runtime.PureRuntime;
+import org.finos.legend.pure.m3.serialization.runtime.Source;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.coreinstance.SourceInformation;
+
+/**
+ * Finds real compiled functions carrying the meta::pure::profiles::test "Test" stereotype, the PCT
+ * "test" stereotype (meta::pure::test::pct::PCT.test), or the "BeforePackage"/"AfterPackage"
+ * stereotypes in a given source - the same semantic check Pure IDE's own
+ * meta::pure::ide::testing::isTest() uses, not a text/regex scan for the literal annotation. That
+ * distinction matters: a stereotype can be commented out, aliased through a different qualification,
+ * or accompany other stereotypes, none of which change whether the compiled function is actually a
+ * test. A PCT test (TestFunctionInfo#isPCTTest) additionally requires an adapter to run (see
+ * ExecuteFunctionParams#pctAdapterPath, legend/getPCTAdapters); a Before/After function
+ * (TestFunctionInfo#isBeforeFunction/isAfterFunction) is included so it can be run/debugged directly
+ * from its own gutter marker - each distinguished by its flag so a client can offer the right actions.
+ */
+public class TestFunctionProvider
+{
+    public static List<TestFunctionInfo> getTestFunctions(PureRuntime runtime, String sourceId)
+    {
+        Source source = runtime.getSourceById(sourceId);
+        if (source == null)
+        {
+            return Collections.emptyList();
+        }
+
+        ListIterable<? extends CoreInstance> instances = source.getNewInstances();
+        if (instances == null || instances.isEmpty())
+        {
+            return Collections.emptyList();
+        }
+
+        ProcessorSupport processorSupport = runtime.getProcessorSupport();
+        List<TestFunctionInfo> result = new ArrayList<>();
+        for (CoreInstance instance : instances)
+        {
+            if (!isFunction(instance))
+            {
+                continue;
+            }
+            boolean isPCTTest = PCTTools.isPCTTest(instance, processorSupport);
+            boolean isBeforeFunction = TestTools.hasBeforePackageStereotype(instance, processorSupport);
+            boolean isAfterFunction = TestTools.hasAfterPackageStereotype(instance, processorSupport);
+            if (!isPCTTest && !isBeforeFunction && !isAfterFunction && !TestTools.hasTestStereotype(instance, processorSupport))
+            {
+                continue;
+            }
+
+            SourceInformation si = instance.getSourceInformation();
+            if (si == null)
+            {
+                continue;
+            }
+
+            String functionPath = PackageableElement.getUserPathForPackageableElement(instance);
+            String simpleName = DocumentOutlineProvider.getSimpleFunctionName(instance);
+            result.add(new TestFunctionInfo(functionPath, simpleName, si.getStartLine(), isPCTTest, isBeforeFunction, isAfterFunction));
+        }
+        return result;
+    }
+
+    private static boolean isFunction(CoreInstance instance)
+    {
+        String classifierName = instance.getClassifier() == null ? null : instance.getClassifier().getName();
+        return "ConcreteFunctionDefinition".equals(classifierName) || "NativeFunction".equals(classifierName);
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/UriMapper.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/UriMapper.java
@@ -55,6 +55,12 @@ public class UriMapper
         }
 
         String sourceId = deriveSourceId(uri);
+        if (sourceId == null)
+        {
+            // Not part of any registered Pure module (see deriveSourceId) - nothing to cache either
+            // direction; ConcurrentHashMap also rejects null values outright.
+            return null;
+        }
         this.uriToSourceId.put(uri, sourceId);
         this.sourceIdToUri.put(sourceId, uri);
         return sourceId;
@@ -72,6 +78,16 @@ public class UriMapper
 
     public String toUri(String sourceId)
     {
+        if (sourceId == null)
+        {
+            // A null sourceId means "no known Pure module for this file" (see deriveSourceId) - callers
+            // that map a FileChange list back to URIs (e.g. syncWorkspace's open-document-conflict
+            // filter) can legitimately hit this for a real, non-module .pure fixture file scanned off
+            // disk. ConcurrentHashMap.get(null) throws NPE outright, unlike HashMap, so this must be
+            // handled before ever reaching the map lookups below.
+            return null;
+        }
+
         String cached = this.sourceIdToUri.get(sourceId);
         if (cached != null)
         {
@@ -203,7 +219,17 @@ public class UriMapper
         int idx = path.indexOf(RESOURCES_MARKER);
         if (idx >= 0)
         {
-            return "/" + path.substring(idx + RESOURCES_MARKER.length());
+            String candidate = "/" + path.substring(idx + RESOURCES_MARKER.length());
+            // A src/main/resources-rooted path is only trustworthy as-is when there's no scanner to
+            // check it against (kept for minimal/unit-test setups); once a real workspace scan is
+            // available, the leading segment must name an actually-registered repo (a <name>.definition.json
+            // module) - otherwise this is some other module's stray .pure file (e.g. a data fixture in a
+            // sibling module with no definition.json of its own) that merely happens to sit under a
+            // src/main/resources directory, and must not be treated as compilable.
+            if (this.repositoryScanner == null || isKnownWorkspaceSource(candidate))
+            {
+                return candidate;
+            }
         }
 
         RepositoryScanner scanner = this.repositoryScanner;
@@ -230,22 +256,74 @@ public class UriMapper
             if (secondSlash > 1)
             {
                 String firstSegment = path.substring(1, secondSlash);
-                if (!firstSegment.contains(".") && !firstSegment.contains(" ") && firstSegment.length() < 60)
+                if (!firstSegment.contains(".") && !firstSegment.contains(" ") && firstSegment.length() < 60
+                        && isKnownWorkspaceSource(path))
                 {
-                    RepositoryScanner repoScanner = this.repositoryScanner;
-                    PureRuntime rt = this.pureRuntime;
-                    if ((repoScanner != null && repoScanner.getWorkspaceRepoNames().contains(firstSegment))
-                            || (rt != null && rt.getSourceById(path) != null))
-                    {
-                        return path;
-                    }
+                    return path;
                 }
             }
         }
 
         int lastSlash = path.lastIndexOf('/');
         String filename = (lastSlash >= 0) ? path.substring(lastSlash + 1) : path;
-        LspLog.debug("Scratch file (in-memory): " + filename + " (from " + path + ")");
+
+        // Nothing above recognized this as part of any registered Pure module. A .pure file that
+        // genuinely exists on local disk at this exact path (e.g. a ###Lakehouse test fixture in a
+        // module with no definition.json of its own) has a real on-disk identity that simply isn't Pure
+        // source - unlike a jar-embedded platform source navigated to via go-to-definition, whose
+        // literal ("!"-joined jar-entry-style) path never exists as a real file, so it correctly keeps
+        // falling through to the scratch/in-memory handling below. Treating the former as scratch would
+        // still attempt (and fail) to compile it, and worse, leaves nothing registered for its id, so a
+        // later didClose's restoreFromDisk has nothing to restore. Must be ignored outright - the same
+        // as a .java file would be - rather than routed through compilation at all.
+        // Exception: welcome.pure is the standing go()-scratch convention for this dev loop (see
+        // pure-lsp-go/pure-lsp-start skills) - a real repo-root file with no definition.json by design,
+        // always meant to be edited and executed as scratch, never a genuine non-Pure fixture.
+        if (scanner != null && !"welcome.pure".equals(filename) && isRealLocalFile(path))
+        {
+            LspLog.debug("Local .pure file is not part of any registered Pure module, ignoring: " + path);
+            return null;
+        }
+
+        LspLog.debug("Non-workspace .pure file, treating as scratch (in-memory): " + filename + " (from " + path + ")");
         return filename;
+    }
+
+    private static boolean isRealLocalFile(String path)
+    {
+        if (!path.startsWith("/"))
+        {
+            return false;
+        }
+        try
+        {
+            return java.nio.file.Files.isRegularFile(java.nio.file.Paths.get(path));
+        }
+        catch (Exception e)
+        {
+            return false;
+        }
+    }
+
+    /**
+     * True if the leading path segment of a candidate sourceId (e.g. "/core/foo.pure" -> "core") names
+     * a repo the workspace scan actually found a &lt;name&gt;.definition.json for, or the runtime already
+     * has this exact source loaded (e.g. from classpath). This is the "is it part of a Pure module"
+     * check the callers above rely on before treating a raw file path as a real, compilable source.
+     */
+    private boolean isKnownWorkspaceSource(String candidateSourceId)
+    {
+        String relative = candidateSourceId.startsWith("/") ? candidateSourceId.substring(1) : candidateSourceId;
+        int slash = relative.indexOf('/');
+        String firstSegment = slash > 0 ? relative.substring(0, slash) : relative;
+
+        RepositoryScanner scanner = this.repositoryScanner;
+        if (scanner != null && scanner.getWorkspaceRepoNames().contains(firstSegment))
+        {
+            return true;
+        }
+
+        PureRuntime runtime = this.pureRuntime;
+        return runtime != null && runtime.getSourceById(candidateSourceId) != null;
     }
 }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/WorkspaceDriftWatcher.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/WorkspaceDriftWatcher.java
@@ -1,0 +1,346 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import org.finos.legend.pure.lsp.protocol.DriftChangeType;
+import org.finos.legend.pure.lsp.protocol.WorkspaceDriftEntry;
+import org.finos.legend.pure.lsp.protocol.WorkspaceDriftEvent;
+
+/**
+ * Watches the workspace's resource roots for out-of-band {@code .pure} file changes - a rebase, a
+ * checkout, a patch applied outside the editor - none of which generate a
+ * {@code textDocument/didChange} (nothing typed anything) or reach the compiled graph any other way.
+ * Purely observational: it only accumulates a dirty set and, after a short debounce settles, broadcasts
+ * it via {@link org.finos.legend.pure.lsp.protocol.LegendLanguageClient#workspaceDriftDetected}. It never
+ * triggers a recompile itself - that stays a deliberate, user-initiated {@code legend/syncWorkspace} call
+ * (see {@link LegendWorkspaceService}), so a large burst of events (a rebase touching hundreds of files)
+ * never causes surprise recompiles mid-operation.
+ * <p>
+ * Scope matches {@link FileChangeHandler}'s existing convention: {@code .pure} files only. Non-source
+ * fixtures under a repo (e.g. {@code .legend}/{@code .json} test resources) are read directly off disk by
+ * Pure's own {@code readFile(...)} at execution time and were never part of the compiled graph to begin
+ * with, so drift in them isn't meaningful here.
+ */
+public class WorkspaceDriftWatcher
+{
+    private static final long DEBOUNCE_MS = 10_000;
+
+    private final RepositoryScanner repositoryScanner;
+    private final UriMapper uriMapper;
+    private final Predicate<String> isDocumentOpen;
+    private final Consumer<WorkspaceDriftEvent> publisher;
+
+    private final Map<String, DriftChangeType> dirty = new ConcurrentHashMap<>();
+    private final Map<WatchKey, Path> watchKeyToDir = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService debounceExecutor = Executors.newSingleThreadScheduledExecutor(r ->
+    {
+        Thread t = new Thread(r, "legend-pure-lsp-drift-watcher-debounce");
+        t.setDaemon(true);
+        return t;
+    });
+
+    private volatile ScheduledFuture<?> pendingPublish;
+    private volatile WatchService watchService;
+    private volatile Thread watchThread;
+    private volatile boolean running = false;
+
+    public WorkspaceDriftWatcher(RepositoryScanner repositoryScanner, UriMapper uriMapper,
+            Predicate<String> isDocumentOpen, Consumer<WorkspaceDriftEvent> publisher)
+    {
+        this.repositoryScanner = repositoryScanner;
+        this.uriMapper = uriMapper;
+        this.isDocumentOpen = isDocumentOpen;
+        this.publisher = publisher;
+    }
+
+    public synchronized void start(Collection<Path> resourceRoots)
+    {
+        if (this.running)
+        {
+            return;
+        }
+        try
+        {
+            this.watchService = FileSystems.getDefault().newWatchService();
+        }
+        catch (IOException e)
+        {
+            LspLog.warn("Could not start workspace drift watcher: " + e.getMessage());
+            return;
+        }
+        this.running = true;
+        for (Path root : resourceRoots)
+        {
+            registerRecursively(root);
+        }
+        this.watchThread = new Thread(this::watchLoop, "legend-pure-lsp-drift-watcher");
+        this.watchThread.setDaemon(true);
+        this.watchThread.start();
+        LspLog.info("Workspace drift watcher started over " + resourceRoots.size()
+                + " root(s), watching " + this.watchKeyToDir.size() + " director(y/ies)");
+    }
+
+    public synchronized void stop()
+    {
+        if (!this.running)
+        {
+            return;
+        }
+        this.running = false;
+        if (this.watchThread != null)
+        {
+            this.watchThread.interrupt();
+        }
+        if (this.watchService != null)
+        {
+            try
+            {
+                this.watchService.close();
+            }
+            catch (IOException ignored)
+            {
+            }
+        }
+        this.debounceExecutor.shutdownNow();
+    }
+
+    private void registerRecursively(Path root)
+    {
+        if (!Files.isDirectory(root))
+        {
+            return;
+        }
+        try
+        {
+            Files.walkFileTree(root, new SimpleFileVisitor<Path>()
+            {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                {
+                    String name = dir.getFileName() == null ? "" : dir.getFileName().toString();
+                    if (name.startsWith(".") || "target".equals(name) || "node_modules".equals(name))
+                    {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    registerDir(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        catch (IOException e)
+        {
+            LspLog.warn("Failed to register drift watches under " + root + ": " + e.getMessage());
+        }
+    }
+
+    private void registerDir(Path dir)
+    {
+        try
+        {
+            WatchKey key = dir.register(this.watchService,
+                    StandardWatchEventKinds.ENTRY_CREATE,
+                    StandardWatchEventKinds.ENTRY_MODIFY,
+                    StandardWatchEventKinds.ENTRY_DELETE);
+            this.watchKeyToDir.put(key, dir);
+        }
+        catch (IOException e)
+        {
+            LspLog.warn("Failed to watch directory " + dir + ": " + e.getMessage());
+        }
+    }
+
+    private void watchLoop()
+    {
+        while (this.running)
+        {
+            WatchKey key;
+            try
+            {
+                key = this.watchService.take();
+            }
+            catch (InterruptedException | ClosedWatchServiceException e)
+            {
+                return;
+            }
+
+            Path dir = this.watchKeyToDir.get(key);
+            if (dir != null)
+            {
+                for (WatchEvent<?> event : key.pollEvents())
+                {
+                    handleEvent(dir, event);
+                }
+            }
+            boolean valid = key.reset();
+            if (!valid)
+            {
+                this.watchKeyToDir.remove(key);
+            }
+        }
+    }
+
+    private void handleEvent(Path dir, WatchEvent<?> event)
+    {
+        WatchEvent.Kind<?> kind = event.kind();
+        if (kind == StandardWatchEventKinds.OVERFLOW)
+        {
+            // The OS-level event queue dropped events - our dirty set can no longer be trusted as
+            // complete. Surface this via a log line rather than silently under-reporting drift; a full
+            // Reindex is the correct recovery, not something this watcher should force on its own.
+            LspLog.warn("Workspace drift watcher event queue overflowed; some external file changes may"
+                    + " not be reflected. Run Reindex Pure Workspace if the workspace seems out of sync.");
+            return;
+        }
+
+        Path name = (Path) event.context();
+        Path fullPath = dir.resolve(name);
+
+        if (kind == StandardWatchEventKinds.ENTRY_CREATE && Files.isDirectory(fullPath))
+        {
+            registerRecursively(fullPath);
+            return;
+        }
+
+        if (!name.toString().endsWith(".pure"))
+        {
+            return;
+        }
+
+        String sourceId = this.repositoryScanner.deriveSourceIdFromPath(fullPath);
+        if (sourceId == null)
+        {
+            return;
+        }
+
+        DriftChangeType type = (kind == StandardWatchEventKinds.ENTRY_DELETE) ? DriftChangeType.DELETED
+                : (kind == StandardWatchEventKinds.ENTRY_CREATE) ? DriftChangeType.CREATED
+                : DriftChangeType.MODIFIED;
+        this.dirty.compute(sourceId, (id, existing) -> mergeType(existing, type));
+        schedulePublish();
+    }
+
+    /**
+     * A plain open+write+close (what any normal file save does) fires CREATE immediately followed by
+     * MODIFY on most watch implementations - naively taking "whatever arrived last" would label every
+     * brand-new file as "modified" instead of "created". CREATED sticks until an explicit DELETE; a
+     * DELETE immediately after a not-yet-synced CREATED means the file never existed as far as anyone
+     * downstream is concerned, so the entry is dropped entirely rather than reported as either.
+     */
+    private static DriftChangeType mergeType(DriftChangeType existing, DriftChangeType incoming)
+    {
+        if (existing == null)
+        {
+            return incoming;
+        }
+        if (incoming == DriftChangeType.DELETED)
+        {
+            return (existing == DriftChangeType.CREATED) ? null : DriftChangeType.DELETED;
+        }
+        return (existing == DriftChangeType.CREATED) ? DriftChangeType.CREATED : incoming;
+    }
+
+    private synchronized void schedulePublish()
+    {
+        if (this.pendingPublish != null)
+        {
+            this.pendingPublish.cancel(false);
+        }
+        try
+        {
+            this.pendingPublish = this.debounceExecutor.schedule(this::publish, DEBOUNCE_MS, TimeUnit.MILLISECONDS);
+        }
+        catch (java.util.concurrent.RejectedExecutionException ignored)
+        {
+            // Watcher is stopping/stopped.
+        }
+    }
+
+    private void publish()
+    {
+        List<WorkspaceDriftEntry> entries = new ArrayList<>();
+        for (Map.Entry<String, DriftChangeType> e : this.dirty.entrySet())
+        {
+            String uri = this.uriMapper.toUri(e.getKey());
+            if (uri == null || this.isDocumentOpen.test(uri))
+            {
+                continue;
+            }
+            entries.add(new WorkspaceDriftEntry(uri, e.getValue()));
+        }
+        if (entries.isEmpty())
+        {
+            return;
+        }
+        this.publisher.accept(new WorkspaceDriftEvent(entries));
+    }
+
+    /**
+     * Re-broadcasts the current (post-filter) drift state immediately, bypassing the debounce - used
+     * after a sync applies some but not all dirty entries, so every connected client's view of "what's
+     * still out of sync" updates right away instead of waiting for the next unrelated file event.
+     */
+    public void publishNow()
+    {
+        List<WorkspaceDriftEntry> entries = new ArrayList<>();
+        for (Map.Entry<String, DriftChangeType> e : this.dirty.entrySet())
+        {
+            String uri = this.uriMapper.toUri(e.getKey());
+            if (uri == null || this.isDocumentOpen.test(uri))
+            {
+                continue;
+            }
+            entries.add(new WorkspaceDriftEntry(uri, e.getValue()));
+        }
+        this.publisher.accept(new WorkspaceDriftEvent(entries));
+    }
+
+    public Set<String> getDirtySourceIds()
+    {
+        return new LinkedHashSet<>(this.dirty.keySet());
+    }
+
+    public void clear(Collection<String> sourceIds)
+    {
+        for (String id : sourceIds)
+        {
+            this.dirty.remove(id);
+        }
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/debug/DebugService.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/debug/DebugService.java
@@ -18,11 +18,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import org.finos.legend.pure.lsp.ExecutionFailureFormatter;
 import org.finos.legend.pure.lsp.LegendPureSession;
 import org.finos.legend.pure.lsp.RepositoryScanner;
 import org.finos.legend.pure.lsp.UriMapper;
 import org.finos.legend.pure.lsp.protocol.LegendDebug;
 import org.finos.legend.pure.lsp.runtime.PureRuntimeManager;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,16 +67,24 @@ public class DebugService
         }
         stopSession(previousSession);
 
+        LegendDebug.ExecutionMode mode = params == null ? LegendDebug.ExecutionMode.SHARED : params.getMode();
         LegendDebugSession nextSession = null;
         try
         {
-            nextSession = LegendDebugSession.create(
-                    session,
-                    this.repositoryScanner,
-                    this.uriMapper,
-                    this.openDocumentSourceSnapshot.get(),
-                    params == null ? null : params.getFunction(),
-                    params == null ? Collections.emptyList() : params.getBreakpoints());
+            nextSession = mode == LegendDebug.ExecutionMode.SHARED
+                    ? LegendDebugSession.createShared(
+                            session,
+                            this.repositoryScanner,
+                            this.uriMapper,
+                            params == null ? null : params.getFunction(),
+                            params == null ? Collections.emptyList() : params.getBreakpoints())
+                    : LegendDebugSession.create(
+                            session,
+                            this.repositoryScanner,
+                            this.uriMapper,
+                            this.openDocumentSourceSnapshot.get(),
+                            params == null ? null : params.getFunction(),
+                            params == null ? Collections.emptyList() : params.getBreakpoints());
             if (!setActiveSession(startGeneration, nextSession))
             {
                 nextSession.stop();
@@ -88,12 +98,29 @@ public class DebugService
         catch (Exception e)
         {
             LOGGER.error("Debug start failed", e);
+            String capturedOutput = nextSession == null ? null : nextSession.snapshotCapturedOutput();
+            ProcessorSupport processorSupport = nextSession == null ? null : nextSession.processorSupport();
             if (nextSession != null)
             {
                 clearIfTerminal(nextSession, LegendDebug.Response.completed(null));
                 nextSession.stop();
             }
-            return LegendDebug.Response.error(message(e));
+            return LegendDebug.Response.error(ExecutionFailureFormatter.format(e, capturedOutput, processorSupport));
+        }
+    }
+
+    /**
+     * Pushes a fresh full breakpoint list into the active session, if any, so add/remove/condition-edit
+     * requests that arrive after {@link #start} has already begun running take effect immediately
+     * instead of only being picked up by a future session. A no-op before a session exists - the initial
+     * breakpoint list is already correctly picked up by {@link #start}.
+     */
+    public void updateBreakpoints(List<LegendDebug.Breakpoint> breakpoints)
+    {
+        LegendDebugSession active = this.debugSession;
+        if (active != null)
+        {
+            active.updateBreakpoints(breakpoints == null ? Collections.emptyList() : breakpoints);
         }
     }
 
@@ -209,10 +236,5 @@ public class DebugService
         {
             session.stop();
         }
-    }
-
-    private static String message(Exception e)
-    {
-        return e.getMessage() == null ? e.toString() : e.getMessage();
     }
 }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/debug/LegendDebugSession.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/debug/LegendDebugSession.java
@@ -21,20 +21,20 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.TreeSet;
 import org.eclipse.collections.impl.list.mutable.FastList;
+import org.finos.legend.pure.lsp.ExecutionFailureFormatter;
 import org.finos.legend.pure.lsp.LegendPureSession;
 import org.finos.legend.pure.lsp.LspLog;
 import org.finos.legend.pure.lsp.RepositoryScanner;
 import org.finos.legend.pure.lsp.UriMapper;
 import org.finos.legend.pure.lsp.protocol.LegendDebug;
 import org.finos.legend.pure.m3.execution.Console;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
 import org.finos.legend.pure.m3.serialization.runtime.Message;
 import org.finos.legend.pure.m3.serialization.runtime.PureRuntime;
 import org.finos.legend.pure.m3.serialization.runtime.Source;
@@ -52,19 +52,36 @@ class LegendDebugSession
     private final LegendDebugFunctionExecution functionExecution;
     private final CoreInstance function;
     private final Map<String, LineMap> lineMaps;
+    private final UriMapper uriMapper;
     private final ByteArrayOutputStream output = new ByteArrayOutputStream();
     private final Object executionLock = new Object();
     private final Object pauseStateLock = new Object();
+    // Non-null only for a SHARED-mode session: the main session's graph read lock, held from creation
+    // until this session goes terminal (completed/error) or is explicitly stopped - see terminal(...)
+    // and stop(). Held across an in-between pause so main-session compiles block while paused; that is
+    // the deliberate tradeoff of SHARED mode (see LegendDebug.ExecutionMode).
+    private final LegendPureSession.LockHandle heldMainSessionReadLock;
+    private final java.util.concurrent.atomic.AtomicBoolean sharedLockReleased = new java.util.concurrent.atomic.AtomicBoolean(false);
 
     private volatile boolean stopped;
     private volatile LegendDebugState visiblePausedState;
     private int outputOffset;
 
-    private LegendDebugSession(LegendDebugFunctionExecution functionExecution, CoreInstance function, Map<String, LineMap> lineMaps)
+    private LegendDebugSession(LegendDebugFunctionExecution functionExecution, CoreInstance function,
+                               Map<String, LineMap> lineMaps, UriMapper uriMapper)
+    {
+        this(functionExecution, function, lineMaps, uriMapper, null);
+    }
+
+    private LegendDebugSession(LegendDebugFunctionExecution functionExecution, CoreInstance function,
+                               Map<String, LineMap> lineMaps, UriMapper uriMapper,
+                               LegendPureSession.LockHandle heldMainSessionReadLock)
     {
         this.functionExecution = functionExecution;
         this.function = function;
         this.lineMaps = lineMaps;
+        this.uriMapper = uriMapper;
+        this.heldMainSessionReadLock = heldMainSessionReadLock;
 
         Console console = this.functionExecution.getConsole();
         console.setPrintStream(new PrintStream(this.output, true));
@@ -76,7 +93,7 @@ class LegendDebugSession
                                      String functionName, List<LegendDebug.Breakpoint> breakpoints)
     {
         Map<String, String> sources = snapshotSources(mainSession, repositoryScanner, openDocuments);
-        Map<String, List<Integer>> breakpointsBySource = groupBreakpointsBySource(uriMapper, sources, breakpoints);
+        Map<String, List<LegendDebug.Breakpoint>> breakpointsBySource = groupBreakpointsBySource(uriMapper, sources, breakpoints);
         Map<String, LineMap> lineMaps = new TreeMap<>();
         LspLog.info("Debug snapshot contains " + sources.size()
                 + " source(s); requested " + breakpointCount(breakpoints)
@@ -103,7 +120,72 @@ class LegendDebugSession
             throw new IllegalArgumentException("No zero-argument function found for " + normalizeFunctionName(functionName));
         }
 
-        return new LegendDebugSession(debugExecution, function, lineMaps);
+        return new LegendDebugSession(debugExecution, function, lineMaps, uriMapper);
+    }
+
+    /**
+     * SHARED mode: attach directly to the main session's already-compiled PureRuntime under its graph
+     * read lock instead of building/compiling a second runtime - mirrors how normal (non-debug)
+     * execution attaches a fresh FunctionExecutionInterpreted to the shared runtime
+     * (LegendPureSession#executeFunctionByCandidates). No unsaved-editor-buffer overlay is possible here
+     * (only what's already compiled into the live graph is debuggable), and the read lock is held for
+     * this session's whole lifetime, released in terminal(...)/stop().
+     */
+    static LegendDebugSession createShared(LegendPureSession mainSession, RepositoryScanner repositoryScanner,
+                                           UriMapper uriMapper, String functionName,
+                                           List<LegendDebug.Breakpoint> breakpoints)
+    {
+        LegendPureSession.LockHandle readLock = mainSession.acquireGraphReadLock();
+        boolean releaseOnFailure = true;
+        try
+        {
+            PureRuntime runtime = mainSession.getPureRuntime();
+            Set<String> workspaceRepositoryNames = repositoryScanner == null
+                    ? Collections.emptySet()
+                    : repositoryScanner.getWorkspaceRepoNames();
+            Set<String> runtimeDependencyRepositoryNames = mainSession.getClasspathRepositoryNames();
+            Map<String, String> sources = new TreeMap<>();
+            for (Source source : runtime.getSourceRegistry().getSources())
+            {
+                if (isDebuggableSource(source, workspaceRepositoryNames, runtimeDependencyRepositoryNames))
+                {
+                    sources.put(source.getId(), source.getContent());
+                }
+            }
+
+            Map<String, List<LegendDebug.Breakpoint>> breakpointsBySource = groupBreakpointsBySource(uriMapper, sources, breakpoints);
+            Map<String, LineMap> lineMaps = new TreeMap<>();
+            for (Map.Entry<String, String> entry : sources.entrySet())
+            {
+                lineMaps.put(entry.getKey(), lineMapForSource(entry.getValue(), breakpointsBySource.get(entry.getKey())));
+            }
+            LspLog.info("Shared debug session attached to main runtime (" + sources.size()
+                    + " debuggable source(s)); requested " + breakpointCount(breakpoints)
+                    + " breakpoint(s); mapped " + groupedBreakpointCount(breakpointsBySource)
+                    + " breakpoint(s) across " + breakpointsBySource.size() + " source(s)");
+
+            LegendDebugFunctionExecution debugExecution = LegendPureSession.initializeFunctionExecution(
+                    new LegendDebugFunctionExecution(lineMaps.keySet(), uriMapper),
+                    runtime,
+                    new Message(""));
+
+            CoreInstance function = findZeroArgumentFunction(runtime, functionName);
+            if (function == null)
+            {
+                throw new IllegalArgumentException("No zero-argument function found for " + normalizeFunctionName(functionName));
+            }
+
+            LegendDebugSession session = new LegendDebugSession(debugExecution, function, lineMaps, uriMapper, readLock);
+            releaseOnFailure = false;
+            return session;
+        }
+        finally
+        {
+            if (releaseOnFailure)
+            {
+                readLock.close();
+            }
+        }
     }
 
     private static void overlaySource(PureRuntime runtime, String sourceId, String content)
@@ -129,6 +211,37 @@ class LegendDebugSession
         {
             runtime.modify(sourceId, content);
         }
+    }
+
+    /**
+     * Re-derives every known source's breakpoint lines (and conditions) from a fresh full breakpoint
+     * list, so a client's add/remove/edit while this session is already running takes effect on the
+     * very next line check - {@link LineMap} swaps its breakpoint map atomically, so this is safe to
+     * call concurrently with an in-flight {@link #runUntilPauseOrCompletion}. A source not known to this
+     * session (e.g. opened only after the session started) is left alone; {@link #groupBreakpointsBySource}
+     * already logs that case.
+     */
+    void updateBreakpoints(List<LegendDebug.Breakpoint> breakpoints)
+    {
+        Map<String, String> knownSources = new TreeMap<>();
+        for (Map.Entry<String, LineMap> entry : this.lineMaps.entrySet())
+        {
+            String content = debugSourceContent(entry.getKey());
+            if (content != null)
+            {
+                knownSources.put(entry.getKey(), content);
+            }
+        }
+
+        Map<String, List<LegendDebug.Breakpoint>> breakpointsBySource = groupBreakpointsBySource(this.uriMapper, knownSources, breakpoints);
+        for (Map.Entry<String, String> entry : knownSources.entrySet())
+        {
+            String[] lines = entry.getValue().split("\\R", -1);
+            this.lineMaps.get(entry.getKey()).replace(validatedBreakpointLines(lines, breakpointsBySource.get(entry.getKey())));
+        }
+        LspLog.info("Updated debug breakpoints: requested " + breakpointCount(breakpoints)
+                + " breakpoint(s); mapped " + groupedBreakpointCount(breakpointsBySource)
+                + " breakpoint(s) across " + breakpointsBySource.size() + " source(s)");
     }
 
     LegendDebug.Response start()
@@ -162,7 +275,28 @@ class LegendDebugSession
         clearVisiblePausedState();
         this.functionExecution.abortDebug();
         this.functionExecution.getConsole().setConsole(false);
+        releaseSharedRuntimeLockIfHeld();
         return LegendDebug.Response.completed(readNewUserOutput());
+    }
+
+    /**
+     * Releases the SHARED-mode main-session read lock exactly once, whether reached via an explicit
+     * stop() or via a terminal (non-paused) response falling out of runUntilPauseOrCompletion - both
+     * paths can race (e.g. stop() called from another thread while the run loop is mid-flight), so this
+     * must be idempotent.
+     */
+    private void releaseSharedRuntimeLockIfHeld()
+    {
+        if (this.heldMainSessionReadLock != null && this.sharedLockReleased.compareAndSet(false, true))
+        {
+            this.heldMainSessionReadLock.close();
+        }
+    }
+
+    private LegendDebug.Response terminal(LegendDebug.Response response)
+    {
+        releaseSharedRuntimeLockIfHeld();
+        return response;
     }
 
     LegendDebug.EvaluateResult evaluate(String expression, int frameId)
@@ -221,6 +355,24 @@ class LegendDebugSession
         return source == null ? null : source.getContent();
     }
 
+    /**
+     * Same captured-output text {@link #readNewUserOutput()} would return, but as a peek: it does not
+     * advance {@link #outputOffset}, since a caller inspecting output after a failed
+     * {@link #runUntilPauseOrCompletion} (e.g. {@code DebugService#start}, which has no local
+     * {@code visibleOutput} of its own) must not disturb what a subsequent real read would see.
+     */
+    String snapshotCapturedOutput()
+    {
+        String value = new String(this.output.toByteArray(), StandardCharsets.UTF_8);
+        int offset = this.outputOffset > value.length() ? 0 : this.outputOffset;
+        return stripDebugConsoleText(value.substring(offset));
+    }
+
+    ProcessorSupport processorSupport()
+    {
+        return this.functionExecution.getProcessorSupport();
+    }
+
     private LegendDebugState getVisiblePausedState()
     {
         synchronized (this.pauseStateLock)
@@ -251,7 +403,7 @@ class LegendDebugSession
         {
             if (requirePaused && getVisiblePausedState() == null)
             {
-                return LegendDebug.Response.error("Debug execution is not paused");
+                return terminal(LegendDebug.Response.error("Debug execution is not paused"));
             }
 
             PauseLocation startLocation = currentPauseLocation();
@@ -264,7 +416,7 @@ class LegendDebugSession
                 {
                     clearVisiblePausedState();
                     visibleOutput.append(readNewUserOutput());
-                    return LegendDebug.Response.completed(visibleOutput.toString());
+                    return terminal(LegendDebug.Response.completed(visibleOutput.toString()));
                 }
 
                 try
@@ -278,10 +430,11 @@ class LegendDebugSession
                     visibleOutput.append(readNewUserOutput());
                     if (this.stopped)
                     {
-                        return LegendDebug.Response.completed(visibleOutput.toString());
+                        return terminal(LegendDebug.Response.completed(visibleOutput.toString()));
                     }
                     LOGGER.debug("Debug execution failed", e);
-                    return LegendDebug.Response.error(message(e));
+                    String formatted = ExecutionFailureFormatter.format(e, visibleOutput.toString(), this.functionExecution.getProcessorSupport());
+                    return terminal(LegendDebug.Response.error(formatted));
                 }
 
                 visibleOutput.append(readNewUserOutput());
@@ -290,11 +443,15 @@ class LegendDebugSession
                 {
                     this.functionExecution.getConsole().setConsole(false);
                     clearVisiblePausedState();
-                    return LegendDebug.Response.completed(visibleOutput.toString());
+                    return terminal(LegendDebug.Response.completed(visibleOutput.toString()));
                 }
 
                 PauseLocation pauseLocation = currentPauseLocation(state);
-                PauseDecision decision = pauseDecision(effectiveMode, startLocation, pauseLocation);
+                PauseDecision decision = pauseDecision(effectiveMode, startLocation, pauseLocation, state);
+                if (decision.note != null)
+                {
+                    visibleOutput.append(decision.note);
+                }
                 if (decision.pause)
                 {
                     setVisiblePausedState(state);
@@ -307,7 +464,7 @@ class LegendDebugSession
         }
     }
 
-    private PauseDecision pauseDecision(RunMode mode, PauseLocation startLocation, PauseLocation pauseLocation)
+    private PauseDecision pauseDecision(RunMode mode, PauseLocation startLocation, PauseLocation pauseLocation, LegendDebugState state)
     {
         if (pauseLocation == null)
         {
@@ -323,7 +480,102 @@ class LegendDebugSession
                 return isStepOutTarget(startLocation, pauseLocation) ? PauseDecision.pause("step") : PauseDecision.resume();
             case CONTINUE:
             default:
-                return pauseLocation.userBreakpoint ? PauseDecision.pause("breakpoint") : PauseDecision.resume();
+                if (!pauseLocation.userBreakpoint)
+                {
+                    return PauseDecision.resume();
+                }
+                return breakpointDecision(pauseLocation, state);
+        }
+    }
+
+    /**
+     * A blank condition always fires. A non-blank condition is evaluated in the paused frame via the
+     * already-suppressed-pauses {@link LegendDebugState#evaluate(String, int)} mini-REPL; a broken
+     * condition fails OPEN (pauses anyway, and says why on the console) since silently running past a
+     * breakpoint the user is relying on is worse than a spurious pause, matching IntelliJ's Java
+     * debugger. A breakpoint carrying a log message is a DAP logpoint: it logs and keeps running.
+     */
+    private PauseDecision breakpointDecision(PauseLocation pauseLocation, LegendDebugState state)
+    {
+        BreakpointSpec spec = pauseLocation.breakpointSpec;
+        String condition = spec == null ? null : spec.condition;
+        String logMessage = spec == null ? null : spec.logMessage;
+
+        if (condition != null)
+        {
+            LegendDebug.EvaluateResult result;
+            try
+            {
+                result = state.evaluate(condition, 0);
+            }
+            catch (Exception e)
+            {
+                LOGGER.warn("Breakpoint condition '" + condition + "' threw; pausing", e);
+                return PauseDecision.pause("breakpoint", conditionFailureNote(condition, e.toString()));
+            }
+
+            if (!result.isSuccess())
+            {
+                LOGGER.warn("Breakpoint condition '{}' failed to evaluate ({}); pausing", condition, result.getError());
+                return PauseDecision.pause("breakpoint", conditionFailureNote(condition, result.getError()));
+            }
+            if (!"true".equals(result.getResult()))
+            {
+                return PauseDecision.resume();
+            }
+        }
+
+        return logMessage == null
+                ? PauseDecision.pause("breakpoint")
+                : PauseDecision.resume(interpolateLogMessage(logMessage, pauseLocation, state));
+    }
+
+    private static String conditionFailureNote(String condition, String error)
+    {
+        return "Breakpoint condition \"" + condition + "\" could not be evaluated ("
+                + (error == null ? "unknown error" : error) + "); pausing.\n";
+    }
+
+    /**
+     * Substitutes each {@code {expression}} segment with its value evaluated in the paused frame,
+     * leaving the placeholder text in place (rather than aborting the whole line) if one fails - a
+     * logpoint that partly resolves is more useful than no output at all.
+     */
+    private String interpolateLogMessage(String logMessage, PauseLocation pauseLocation, LegendDebugState state)
+    {
+        StringBuilder rendered = new StringBuilder();
+        int index = 0;
+        while (index < logMessage.length())
+        {
+            int open = logMessage.indexOf('{', index);
+            int close = open < 0 ? -1 : logMessage.indexOf('}', open + 1);
+            if (open < 0 || close < 0)
+            {
+                rendered.append(logMessage, index, logMessage.length());
+                break;
+            }
+            rendered.append(logMessage, index, open);
+            String expression = logMessage.substring(open + 1, close).trim();
+            rendered.append(expression.isEmpty() ? "" : evaluateForLog(expression, state));
+            index = close + 1;
+        }
+        String location = pauseLocation.location == null
+                ? ""
+                : " (" + pauseLocation.location.getSourceId() + ":" + pauseLocation.location.getLine() + ")";
+        return rendered.toString() + location + "\n";
+    }
+
+    private String evaluateForLog(String expression, LegendDebugState state)
+    {
+        try
+        {
+            LegendDebug.EvaluateResult result = state.evaluate(expression, 0);
+            return result.isSuccess() ? String.valueOf(result.getResult()) : "{" + expression + "=?}";
+        }
+        catch (Exception e)
+        {
+            LOGGER.debug("Logpoint expression evaluation failed", e);
+            return "{" + expression + "=?}";
         }
     }
 
@@ -368,7 +620,14 @@ class LegendDebugSession
     private PauseLocation currentPauseLocation(LegendDebugState state)
     {
         DebugExecutionLocation location = state.getCurrentLocation();
-        return location == null ? null : new PauseLocation(location, isUserBreakpoint(location));
+        if (location == null)
+        {
+            return null;
+        }
+        LineMap lineMap = this.lineMaps.get(location.getSourceId());
+        boolean userBreakpoint = lineMap != null && lineMap.isUserBreakpoint(location.getLine());
+        BreakpointSpec spec = lineMap == null ? null : lineMap.specForLine(location.getLine());
+        return new PauseLocation(location, userBreakpoint, spec);
     }
 
     private List<LegendDebug.StackFrame> stackFrames(LegendDebugState state)
@@ -392,12 +651,6 @@ class LegendDebugSession
                     frame.getVariablesReference()));
         }
         return result;
-    }
-
-    private boolean isUserBreakpoint(DebugExecutionLocation location)
-    {
-        LineMap lineMap = location == null ? null : this.lineMaps.get(location.getSourceId());
-        return lineMap != null && lineMap.isUserBreakpoint(location.getLine());
     }
 
     private String readNewUserOutput()
@@ -427,9 +680,7 @@ class LegendDebugSession
                 ? Collections.emptySet()
                 : repositoryScanner.getWorkspaceRepoNames();
         Set<String> runtimeDependencyRepositoryNames = mainSession.getClasspathRepositoryNames();
-        java.util.concurrent.locks.Lock readLock = mainSession.graphReadLock();
-        readLock.lock();
-        try
+        try (LegendPureSession.LockHandle ignored = mainSession.acquireGraphReadLock())
         {
             for (Source source : mainSession.getPureRuntime().getSourceRegistry().getSources())
             {
@@ -439,10 +690,6 @@ class LegendDebugSession
                 }
                 sources.put(source.getId(), source.getContent());
             }
-        }
-        finally
-        {
-            readLock.unlock();
         }
         if (openDocuments != null)
         {
@@ -491,10 +738,10 @@ class LegendDebugSession
         return nextSlash < 0 ? sourceId.substring(1) : sourceId.substring(1, nextSlash);
     }
 
-    private static Map<String, List<Integer>> groupBreakpointsBySource(UriMapper uriMapper, Map<String, String> sources,
-                                                                        List<LegendDebug.Breakpoint> breakpoints)
+    private static Map<String, List<LegendDebug.Breakpoint>> groupBreakpointsBySource(UriMapper uriMapper, Map<String, String> sources,
+                                                                                       List<LegendDebug.Breakpoint> breakpoints)
     {
-        Map<String, List<Integer>> grouped = new TreeMap<>();
+        Map<String, List<LegendDebug.Breakpoint>> grouped = new TreeMap<>();
         if (breakpoints == null)
         {
             return grouped;
@@ -508,6 +755,15 @@ class LegendDebugSession
             }
 
             String sourceId = uriMapper.toSourceId(breakpoint.getUri());
+            if (sourceId == null)
+            {
+                // A client can set a breakpoint in any .pure-suffixed file it has open, including a
+                // genuine non-module fixture (see UriMapper#deriveSourceId) - sources is a TreeMap, whose
+                // natural-ordering containsKey/put reject a null key outright, so this must be filtered
+                // before it ever reaches that map.
+                LspLog.info("Skipping debug breakpoint for non-module source: " + breakpoint.getUri());
+                continue;
+            }
             if (!sources.containsKey(sourceId))
             {
                 String alternate = sourceId.startsWith("/") ? sourceId.substring(1) : "/" + sourceId;
@@ -523,7 +779,7 @@ class LegendDebugSession
                 }
             }
 
-            grouped.computeIfAbsent(sourceId, ignored -> new ArrayList<>()).add(breakpoint.getLine());
+            grouped.computeIfAbsent(sourceId, ignored -> new ArrayList<>()).add(breakpoint);
         }
         return grouped;
     }
@@ -533,10 +789,10 @@ class LegendDebugSession
         return breakpoints == null ? 0 : breakpoints.size();
     }
 
-    private static int groupedBreakpointCount(Map<String, List<Integer>> breakpointsBySource)
+    private static int groupedBreakpointCount(Map<String, List<LegendDebug.Breakpoint>> breakpointsBySource)
     {
         int count = 0;
-        for (List<Integer> sourceBreakpoints : breakpointsBySource.values())
+        for (List<LegendDebug.Breakpoint> sourceBreakpoints : breakpointsBySource.values())
         {
             count += sourceBreakpoints.size();
         }
@@ -561,29 +817,35 @@ class LegendDebugSession
         }
     }
 
-    private static LineMap lineMapForSource(String content, List<Integer> breakpointLines)
+    private static LineMap lineMapForSource(String content, List<LegendDebug.Breakpoint> breakpoints)
     {
         String[] lines = content == null ? new String[0] : content.split("\\R", -1);
-        LineMap lineMap = new LineMap();
-        lineMap.addUserBreakpoints(validatedBreakpointLines(lines, breakpointLines));
-        return lineMap;
+        return new LineMap(validatedBreakpointLines(lines, breakpoints));
     }
 
-    private static Set<Integer> validatedBreakpointLines(String[] lines, List<Integer> breakpointLines)
+    private static Map<Integer, BreakpointSpec> validatedBreakpointLines(String[] lines, List<LegendDebug.Breakpoint> breakpoints)
     {
-        Set<Integer> targets = new TreeSet<>();
-        if (breakpointLines == null)
+        Map<Integer, BreakpointSpec> targets = new TreeMap<>();
+        if (breakpoints == null)
         {
             return targets;
         }
-        for (Integer line : breakpointLines)
+        for (LegendDebug.Breakpoint breakpoint : breakpoints)
         {
-            if (line != null && line >= 0 && line < lines.length)
+            int line = breakpoint == null ? -1 : breakpoint.getLine();
+            if (line >= 0 && line < lines.length)
             {
-                targets.add(line + 1);
+                targets.put(line + 1, new BreakpointSpec(
+                        blankToNull(breakpoint.getCondition()),
+                        blankToNull(breakpoint.getLogMessage())));
             }
         }
         return targets;
+    }
+
+    private static String blankToNull(String condition)
+    {
+        return condition == null || condition.trim().isEmpty() ? null : condition.trim();
     }
 
     private static CoreInstance findZeroArgumentFunction(PureRuntime runtime, String functionName)
@@ -655,21 +917,47 @@ class LegendDebugSession
     {
         private final boolean pause;
         private final String reason;
+        /** Console text to surface with this decision (logpoint output, or why a condition failed open). */
+        private final String note;
 
-        private PauseDecision(boolean pause, String reason)
+        private PauseDecision(boolean pause, String reason, String note)
         {
             this.pause = pause;
             this.reason = reason;
+            this.note = note;
         }
 
         private static PauseDecision pause(String reason)
         {
-            return new PauseDecision(true, reason);
+            return new PauseDecision(true, reason, null);
+        }
+
+        private static PauseDecision pause(String reason, String note)
+        {
+            return new PauseDecision(true, reason, note);
         }
 
         private static PauseDecision resume()
         {
-            return new PauseDecision(false, null);
+            return new PauseDecision(false, null, null);
+        }
+
+        private static PauseDecision resume(String note)
+        {
+            return new PauseDecision(false, null, note);
+        }
+    }
+
+    /** Per-line breakpoint settings; a null condition always fires, a non-null logMessage never suspends. */
+    private static class BreakpointSpec
+    {
+        private final String condition;
+        private final String logMessage;
+
+        private BreakpointSpec(String condition, String logMessage)
+        {
+            this.condition = condition;
+            this.logMessage = logMessage;
         }
     }
 
@@ -677,32 +965,52 @@ class LegendDebugSession
     {
         private final DebugExecutionLocation location;
         private final boolean userBreakpoint;
+        private final BreakpointSpec breakpointSpec;
         private final int stackDepth;
 
-        private PauseLocation(DebugExecutionLocation location, boolean userBreakpoint)
+        private PauseLocation(DebugExecutionLocation location, boolean userBreakpoint, BreakpointSpec breakpointSpec)
         {
             this.location = location;
             this.userBreakpoint = userBreakpoint;
+            this.breakpointSpec = breakpointSpec;
             this.stackDepth = location == null ? 0 : location.getStackDepth();
         }
     }
 
+    /**
+     * Line -> settings; presence of a key is what makes a line a breakpoint at all. The map is swapped
+     * as a whole, immutable snapshot so a live breakpoint update (see {@link #updateBreakpoints}) is safe
+     * to race against the interpreter thread's line checks without any extra locking.
+     */
     private static class LineMap
     {
-        private final Set<Integer> userBreakpointOriginalLines = new TreeSet<>();
+        private volatile Map<Integer, BreakpointSpec> breakpointsByLine;
 
-        private LineMap()
+        private LineMap(Map<Integer, BreakpointSpec> breakpointsByLine)
         {
+            this.breakpointsByLine = snapshot(breakpointsByLine);
         }
 
-        private void addUserBreakpoints(Collection<Integer> originalLines)
+        private void replace(Map<Integer, BreakpointSpec> breakpointsByLine)
         {
-            this.userBreakpointOriginalLines.addAll(originalLines);
+            this.breakpointsByLine = snapshot(breakpointsByLine);
         }
 
         private boolean isUserBreakpoint(int originalLineOneBased)
         {
-            return this.userBreakpointOriginalLines.contains(originalLineOneBased);
+            return this.breakpointsByLine.containsKey(originalLineOneBased);
+        }
+
+        private BreakpointSpec specForLine(int originalLineOneBased)
+        {
+            return this.breakpointsByLine.get(originalLineOneBased);
+        }
+
+        private static Map<Integer, BreakpointSpec> snapshot(Map<Integer, BreakpointSpec> source)
+        {
+            return source == null || source.isEmpty()
+                    ? Collections.emptyMap()
+                    : Collections.unmodifiableMap(new TreeMap<>(source));
         }
     }
 }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/debug/LegendDebugState.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/debug/LegendDebugState.java
@@ -738,7 +738,7 @@ class LegendDebugState
         {
             return "Nil";
         }
-        CoreInstance classifier = value.getClassifier();
+        CoreInstance classifier = this.functionExecution.getProcessorSupport().getClassifier(value);
         if (classifier == null)
         {
             return value.getClass().getSimpleName();

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/debug/LegendPureDebugAdapter.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/debug/LegendPureDebugAdapter.java
@@ -86,6 +86,7 @@ class LegendPureDebugAdapter implements IDebugProtocolServer
 
     private volatile IDebugProtocolClient client;
     private volatile String function = DEFAULT_FUNCTION;
+    private volatile LegendDebug.ExecutionMode mode = LegendDebug.ExecutionMode.SHARED;
     private volatile boolean configurationDone;
     private volatile boolean launched;
     private volatile boolean started;
@@ -118,7 +119,8 @@ class LegendPureDebugAdapter implements IDebugProtocolServer
         capabilities.setSupportsEvaluateForHovers(Boolean.TRUE);
         capabilities.setSupportsTerminateRequest(Boolean.TRUE);
         capabilities.setSupportsSteppingGranularity(Boolean.FALSE);
-        capabilities.setSupportsConditionalBreakpoints(Boolean.FALSE);
+        capabilities.setSupportsConditionalBreakpoints(Boolean.TRUE);
+        capabilities.setSupportsLogPoints(Boolean.TRUE);
         capabilities.setSupportsFunctionBreakpoints(Boolean.FALSE);
         capabilities.setSupportsDataBreakpoints(Boolean.FALSE);
         IDebugProtocolClient currentClient = this.client;
@@ -136,8 +138,12 @@ class LegendPureDebugAdapter implements IDebugProtocolServer
         this.function = configuredFunction == null || configuredFunction.toString().trim().isEmpty()
                 ? DEFAULT_FUNCTION
                 : configuredFunction.toString().trim();
+        Object configuredMode = args == null ? null : args.get("mode");
+        this.mode = configuredMode != null && "FORKED".equalsIgnoreCase(configuredMode.toString().trim())
+                ? LegendDebug.ExecutionMode.FORKED
+                : LegendDebug.ExecutionMode.SHARED;
         this.launched = true;
-        LOGGER.info("Legend Pure DAP launch requested for {}", this.function);
+        LOGGER.info("Legend Pure DAP launch requested for {} (mode={})", this.function, this.mode);
         maybeStart();
         return CompletableFuture.completedFuture(null);
     }
@@ -164,10 +170,12 @@ class LegendPureDebugAdapter implements IDebugProtocolServer
         {
             SourceBreakpoint requestedBreakpoint = requested[i];
             int oneBasedLine = requestedBreakpoint == null ? 1 : requestedBreakpoint.getLine();
+            String condition = requestedBreakpoint == null ? null : requestedBreakpoint.getCondition();
+            String logMessage = requestedBreakpoint == null ? null : requestedBreakpoint.getLogMessage();
             boolean verified = uri != null && path != null && path.endsWith(".pure");
             if (verified)
             {
-                accepted.add(new LegendDebug.Breakpoint(uri, Math.max(0, oneBasedLine - 1)));
+                accepted.add(new LegendDebug.Breakpoint(uri, Math.max(0, oneBasedLine - 1), condition, logMessage));
             }
             Breakpoint breakpoint = new Breakpoint();
             breakpoint.setVerified(verified);
@@ -187,6 +195,7 @@ class LegendPureDebugAdapter implements IDebugProtocolServer
         }
         LOGGER.info("Legend Pure DAP registered {} verified breakpoint(s) for {}", accepted.size(), path);
         maybeStart();
+        this.debugService.updateBreakpoints(breakpointsSnapshot());
         SetBreakpointsResponse response = new SetBreakpointsResponse();
         response.setBreakpoints(responseBreakpoints);
         return CompletableFuture.completedFuture(response);
@@ -337,9 +346,10 @@ class LegendPureDebugAdapter implements IDebugProtocolServer
         this.started = true;
         this.state = State.RUNNING;
         LegendDebug.StartParams params = startParams();
-        LOGGER.info("Legend Pure DAP starting {} with {} breakpoint(s)",
+        LOGGER.info("Legend Pure DAP starting {} with {} breakpoint(s) [mode={}]",
                 params.getFunction(),
-                params.getBreakpoints() == null ? 0 : params.getBreakpoints().size());
+                params.getBreakpoints() == null ? 0 : params.getBreakpoints().size(),
+                params.getMode());
         this.runExecutor.submit(() -> handleResponse(this.debugService.start(params)));
     }
 
@@ -347,11 +357,17 @@ class LegendPureDebugAdapter implements IDebugProtocolServer
     {
         LegendDebug.StartParams params = new LegendDebug.StartParams();
         params.setFunction(this.function);
+        params.setMode(this.mode);
+        params.setBreakpoints(breakpointsSnapshot());
+        return params;
+    }
+
+    private List<LegendDebug.Breakpoint> breakpointsSnapshot()
+    {
         synchronized (this.breakpoints)
         {
-            params.setBreakpoints(new ArrayList<>(this.breakpoints));
+            return new ArrayList<>(this.breakpoints);
         }
-        return params;
     }
 
     private void resume(String command, DebugCommand debugCommand)
@@ -421,7 +437,15 @@ class LegendPureDebugAdapter implements IDebugProtocolServer
         {
             return;
         }
-        this.debugService.stop();
+        // debugService.stop() drains and returns whatever console output was captured since the last
+        // drain (e.g. the tail of ExecDebug's verbose trace, or a plain print() call, emitted as the
+        // interpreter unwinds right at the end of execution) - forward it before terminating, or it's
+        // captured server-side and then silently discarded, never reaching the client at all.
+        LegendDebug.Response response = this.debugService.stop();
+        if (response != null && response.getOutput() != null && !response.getOutput().isEmpty())
+        {
+            sendOutput(this.client, response.getOutput(), "console");
+        }
         this.state = State.TERMINATED;
         this.stackFrames = Collections.emptyList();
         sendTerminated(this.client);

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/diagnostics/DiagnosticService.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/diagnostics/DiagnosticService.java
@@ -122,7 +122,10 @@ public class DiagnosticService
     public void clear(String uri)
     {
         this.codeActionsByUri.remove(uri);
-        this.client.publishDiagnostics(new PublishDiagnosticsParams(uri, Collections.emptyList()));
+        if (this.client != null)
+        {
+            this.client.publishDiagnostics(new PublishDiagnosticsParams(uri, Collections.emptyList()));
+        }
     }
 
     public List<Either<org.eclipse.lsp4j.Command, CodeAction>> codeActions(String uri)

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/mutation/SourceMutationService.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/mutation/SourceMutationService.java
@@ -44,13 +44,13 @@ public class SourceMutationService
 
     public LegendPureSession.CompileResult modifyAndCompile(String sourceId, String content)
     {
-        this.session.graphWriteLock().lock();
-        try
+        try (LegendPureSession.LockHandle lockHandle = this.session.acquireGraphWriteLock())
         {
-            if (!this.session.isInitialized())
+            if (!this.session.isInitialized() || sourceId == null)
             {
                 return LegendPureSession.CompileResult.notReady();
             }
+            this.session.markGraphDirty();
             PureRuntime runtime = this.session.getPureRuntime();
             String effectiveSourceId = sourceId;
             SourceSnapshot snapshot = null;
@@ -58,6 +58,17 @@ public class SourceMutationService
             {
                 SourceMutation mutation;
                 String resolvedId = this.session.resolveSourceId(sourceId);
+                // Snapshot BEFORE the loadSourceIfLoadable() below, which - for a source that has never
+                // been loaded this session - is itself the first thing to introduce it into the runtime
+                // (from whatever's currently on disk). Snapshotting after that call would capture the
+                // just-loaded (possibly already-broken) content as the "good" state to restore to; if
+                // this compile then fails, restoreSnapshots() would try to "restore" to that same broken
+                // content, fail its own verification recompile, and get misreported as an internal error
+                // instead of the plain compile error it actually is. Snapshotting first means a source
+                // that didn't exist before this call correctly restores via delete (undoing the load),
+                // not via a self-referential modify-back-to-broken-content.
+                String preLoadSnapshotId = resolvedId == null ? sourceId : resolvedId;
+                snapshot = snapshot(preLoadSnapshotId);
 
                 if (resolvedId == null && sourceId.startsWith("/"))
                 {
@@ -85,7 +96,10 @@ public class SourceMutationService
                     }
                 }
                 effectiveSourceId = resolvedId == null ? sourceId : resolvedId;
-                snapshot = snapshot(effectiveSourceId);
+                if (!effectiveSourceId.equals(preLoadSnapshotId))
+                {
+                    snapshot = snapshot(effectiveSourceId);
+                }
 
                 if (resolvedId != null)
                 {
@@ -93,10 +107,26 @@ public class SourceMutationService
                     if (existingSource != null && existingSource.isImmutable())
                     {
                         LspLog.debug("Skipping modification of immutable source: " + resolvedId);
+                        this.session.markGraphCompiled();
                         return LegendPureSession.CompileResult.success(Collections.emptyList());
                     }
 
-                    runtime.modify(resolvedId, content);
+                    // resolveSourceId() only confirms the path matches a known repo/pattern - it says
+                    // nothing about whether this source has ever actually been loaded. Calling modify()
+                    // on one that hasn't (e.g. a file just created on disk, opened here for the first
+                    // time) leaves the runtime in a state the "missing" snapshot branch of
+                    // restoreSnapshots() can't correctly undo if this compile then fails, which
+                    // surfaces as a genuine PureCompilationException being misreported as an internal
+                    // error (and needlessly triggering full recovery). Mirrors the same
+                    // already-correct create-vs-modify branch in applyBulkChangesAndCompile().
+                    if (existingSource == null)
+                    {
+                        runtime.createInMemorySource(resolvedId, content);
+                    }
+                    else
+                    {
+                        runtime.modify(resolvedId, content);
+                    }
                     mutation = runtime.compile();
                 }
                 else if (isOverlayBackedSource(runtime, sourceId))
@@ -110,6 +140,7 @@ public class SourceMutationService
                     }
                     if (workspaceSource.isImmutable())
                     {
+                        this.session.markGraphCompiled();
                         return LegendPureSession.CompileResult.success(Collections.emptyList());
                     }
                     mutation = runtime.compile();
@@ -121,6 +152,7 @@ public class SourceMutationService
                     snapshot = snapshot(effectiveSourceId);
                     mutation = runtime.createInMemoryAndCompile(Tuples.pair(inMemoryId, content));
                 }
+                this.session.markGraphCompiled();
                 return LegendPureSession.CompileResult.success(mutation.getModifiedFiles());
             }
             catch (Exception e)
@@ -128,21 +160,17 @@ public class SourceMutationService
                 return restoreAfterFailure(Collections.singletonList(snapshot == null ? snapshot(effectiveSourceId) : snapshot), e);
             }
         }
-        finally
-        {
-            this.session.graphWriteLock().unlock();
-        }
     }
 
     public LegendPureSession.CompileResult applyBulkChangesAndCompile(List<LegendPureSession.FileChange> changes)
     {
-        this.session.graphWriteLock().lock();
-        try
+        try (LegendPureSession.LockHandle lockHandle = this.session.acquireGraphWriteLock())
         {
             if (!this.session.isInitialized())
             {
                 return LegendPureSession.CompileResult.notReady();
             }
+            this.session.markGraphDirty();
             PureRuntime runtime = this.session.getPureRuntime();
             List<SourceSnapshot> snapshots = snapshot(changes);
             try
@@ -189,6 +217,7 @@ public class SourceMutationService
                     }
                 }
                 SourceMutation mutation = runtime.compile();
+                this.session.markGraphCompiled();
                 clearOverlayForAcceptedDiskChanges(changes);
                 return LegendPureSession.CompileResult.success(mutation.getModifiedFiles());
             }
@@ -197,21 +226,17 @@ public class SourceMutationService
                 return restoreAfterFailure(snapshots, e);
             }
         }
-        finally
-        {
-            this.session.graphWriteLock().unlock();
-        }
     }
 
     public LegendPureSession.CompileResult restoreFromDisk(String sourceId)
     {
-        this.session.graphWriteLock().lock();
-        try
+        try (LegendPureSession.LockHandle lockHandle = this.session.acquireGraphWriteLock())
         {
             if (!this.session.isInitialized() || sourceId == null)
             {
                 return LegendPureSession.CompileResult.notReady();
             }
+            this.session.markGraphDirty();
             PureRuntime runtime = this.session.getPureRuntime();
             SourceSnapshot snapshot = snapshot(sourceId);
             try
@@ -221,12 +246,14 @@ public class SourceMutationService
                 Source source = resolvedId == null ? null : runtime.getSourceById(resolvedId);
                 if (source != null && source.isImmutable())
                 {
+                    this.session.markGraphCompiled();
                     return LegendPureSession.CompileResult.success(Collections.emptyList());
                 }
                 if (source != null && source.isInMemory())
                 {
                     runtime.delete(effectiveId);
                     SourceMutation mutation = runtime.compile();
+                    this.session.markGraphCompiled();
                     return LegendPureSession.CompileResult.success(mutation.getModifiedFiles());
                 }
 
@@ -243,15 +270,23 @@ public class SourceMutationService
                         runtime.delete(effectiveId);
                     }
                     SourceMutation mutation = runtime.compile();
+                    this.session.markGraphCompiled();
                     return LegendPureSession.CompileResult.success(mutation.getModifiedFiles());
                 }
 
                 if (source == null)
                 {
-                    runtime.loadSourceIfLoadable(effectiveId);
-                    source = runtime.getSourceById(effectiveId);
+                    // Only disk-anchored ids are loadable from storage - a bare/in-memory scratch id
+                    // (e.g. welcome.pure) whose live Source was already removed by a race (such as a
+                    // legend/deleteFile racing this didClose) has nothing to restore from disk.
+                    if (effectiveId.startsWith("/"))
+                    {
+                        runtime.loadSourceIfLoadable(effectiveId);
+                        source = runtime.getSourceById(effectiveId);
+                    }
                     if (source == null)
                     {
+                        this.session.markGraphCompiled();
                         return LegendPureSession.CompileResult.success(Collections.emptyList());
                     }
                 }
@@ -261,6 +296,7 @@ public class SourceMutationService
                     runtime.modify(effectiveId, diskContent);
                 }
                 SourceMutation mutation = runtime.compile();
+                this.session.markGraphCompiled();
                 clearOverlayIfDiskMatches(effectiveId, diskContent);
                 return LegendPureSession.CompileResult.success(mutation.getModifiedFiles());
             }
@@ -269,10 +305,6 @@ public class SourceMutationService
                 LspLog.debug("restoreFromDisk failed for " + sourceId + ": " + e.getMessage());
                 return restoreAfterFailure(Collections.singletonList(snapshot), e);
             }
-        }
-        finally
-        {
-            this.session.graphWriteLock().unlock();
         }
     }
 
@@ -345,10 +377,15 @@ public class SourceMutationService
                 }
             }
             runtime.compile();
+            this.session.markGraphCompiled();
             return true;
         }
         catch (Exception restoreError)
         {
+            // Deliberately do NOT mark the graph compiled here - a genuine "modifyAndCompile AND its
+            // own recovery both failed" leaves graphDirty=true, which is correct: the caller already
+            // treats this as an internal error and triggers a full reinitialize() (which itself clears
+            // graphDirty on success) - see restoreAfterFailure()/CompileResult.error(..., true).
             LOGGER.warn("Failed to restore runtime after bulk compile failure", restoreError);
             return false;
         }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/DriftChangeType.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/DriftChangeType.java
@@ -1,0 +1,34 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+public enum DriftChangeType
+{
+    CREATED("created"),
+    MODIFIED("modified"),
+    DELETED("deleted");
+
+    private final String protocolValue;
+
+    DriftChangeType(String protocolValue)
+    {
+        this.protocolValue = protocolValue;
+    }
+
+    public String getProtocolValue()
+    {
+        return this.protocolValue;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/ExecuteFunctionParams.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/ExecuteFunctionParams.java
@@ -22,11 +22,24 @@ import java.util.List;
  * ("my::pkg::testFoo__Boolean_1_"), or a bare path ("my::pkg::testFoo") in which case common
  * zero-arg return shapes are tried. Optional {@code files} are compiled as one atomic batch before
  * execution (same semantics as ExecuteGoParams.files).
+ * <p>
+ * {@code pctAdapterPath} is optional and only meaningful for a &lt;&lt;PCT.test&gt;&gt; function,
+ * which takes exactly one parameter: the adapter {@code Function} itself. When set, it is the Pure
+ * path of one of the adapters returned by legend/getPCTAdapters; omitting it leaves the zero-argument
+ * behaviour unchanged for every other function.
+ * <p>
+ * {@code beforeFunctionPath}/{@code afterFunctionPath} are optional Pure paths (see
+ * legend/getSetupTeardown) run immediately before/after {@code function}, within the same atomic
+ * call - see {@code LegendPureSession#executeFunction(String, String, String, String)} for the
+ * fail-fast/forgiving semantics of each.
  */
 public class ExecuteFunctionParams
 {
     private String function;
     private List<FileEntry> files;
+    private String pctAdapterPath;
+    private String beforeFunctionPath;
+    private String afterFunctionPath;
 
     public ExecuteFunctionParams()
     {
@@ -50,5 +63,35 @@ public class ExecuteFunctionParams
     public void setFiles(List<FileEntry> files)
     {
         this.files = files;
+    }
+
+    public String getPctAdapterPath()
+    {
+        return this.pctAdapterPath;
+    }
+
+    public void setPctAdapterPath(String pctAdapterPath)
+    {
+        this.pctAdapterPath = pctAdapterPath;
+    }
+
+    public String getBeforeFunctionPath()
+    {
+        return this.beforeFunctionPath;
+    }
+
+    public void setBeforeFunctionPath(String beforeFunctionPath)
+    {
+        this.beforeFunctionPath = beforeFunctionPath;
+    }
+
+    public String getAfterFunctionPath()
+    {
+        return this.afterFunctionPath;
+    }
+
+    public void setAfterFunctionPath(String afterFunctionPath)
+    {
+        this.afterFunctionPath = afterFunctionPath;
     }
 }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/GetSetupTeardownParams.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/GetSetupTeardownParams.java
@@ -1,0 +1,44 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+/**
+ * Params for legend/getSetupTeardown: {@code functionPath} is the Pure path of a test function
+ * (typically {@link TestFunctionInfo#getFunctionPath()}) to find the nearest Before/After-package
+ * functions for.
+ */
+public class GetSetupTeardownParams
+{
+    private String functionPath;
+
+    public GetSetupTeardownParams()
+    {
+    }
+
+    public GetSetupTeardownParams(String functionPath)
+    {
+        this.functionPath = functionPath;
+    }
+
+    public String getFunctionPath()
+    {
+        return this.functionPath;
+    }
+
+    public void setFunctionPath(String functionPath)
+    {
+        this.functionPath = functionPath;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/LegendDebug.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/LegendDebug.java
@@ -27,6 +27,8 @@ public final class LegendDebug
     {
         private String uri;
         private int line;
+        private String condition;
+        private String logMessage;
 
         public Breakpoint()
         {
@@ -34,8 +36,20 @@ public final class LegendDebug
 
         public Breakpoint(String uri, int line)
         {
+            this(uri, line, null);
+        }
+
+        public Breakpoint(String uri, int line, String condition)
+        {
+            this(uri, line, condition, null);
+        }
+
+        public Breakpoint(String uri, int line, String condition, String logMessage)
+        {
             this.uri = uri;
             this.line = line;
+            this.condition = condition;
+            this.logMessage = logMessage;
         }
 
         public String getUri()
@@ -57,12 +71,52 @@ public final class LegendDebug
         {
             this.line = line;
         }
+
+        public String getCondition()
+        {
+            return this.condition;
+        }
+
+        public void setCondition(String condition)
+        {
+            this.condition = condition;
+        }
+
+        /**
+         * DAP logpoint message: when set, hitting this line logs the (interpolated) message and keeps
+         * running instead of suspending. {@code {expression}} segments are evaluated in the paused frame.
+         */
+        public String getLogMessage()
+        {
+            return this.logMessage;
+        }
+
+        public void setLogMessage(String logMessage)
+        {
+            this.logMessage = logMessage;
+        }
+    }
+
+    /**
+     * SHARED (default): debug execution attaches directly to the main session's already-compiled
+     * PureRuntime under its graph read lock - no recompile, but the read lock is held for the whole
+     * paused-at-breakpoint duration, blocking main-session compiles until resume/stop, and only sees
+     * already-compiled (saved and previously-pushed) sources.
+     * FORKED: debug execution runs against its own isolated PureRuntime, compiled fresh from
+     * the current workspace + unsaved-editor-buffer snapshot. Slower to start, but never blocks the main
+     * session's compiles and can debug unsaved edits.
+     */
+    public enum ExecutionMode
+    {
+        FORKED,
+        SHARED
     }
 
     public static class StartParams
     {
         private String function;
         private List<Breakpoint> breakpoints = new ArrayList<>();
+        private ExecutionMode mode = ExecutionMode.SHARED;
 
         public StartParams()
         {
@@ -86,6 +140,16 @@ public final class LegendDebug
         public void setBreakpoints(List<Breakpoint> breakpoints)
         {
             this.breakpoints = breakpoints == null ? new ArrayList<>() : breakpoints;
+        }
+
+        public ExecutionMode getMode()
+        {
+            return this.mode;
+        }
+
+        public void setMode(ExecutionMode mode)
+        {
+            this.mode = mode == null ? ExecutionMode.SHARED : mode;
         }
     }
 

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/LegendLanguageClient.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/LegendLanguageClient.java
@@ -21,4 +21,13 @@ public interface LegendLanguageClient extends LanguageClient
 {
     @JsonNotification("legend/statusChanged")
     void statusChanged(LspStatus status);
+
+    @JsonNotification("legend/logOutput")
+    void logOutput(LegendLogEvent event);
+
+    @JsonNotification("legend/workspaceDriftDetected")
+    void workspaceDriftDetected(WorkspaceDriftEvent event);
+
+    @JsonNotification("legend/lockContention")
+    void lockContention(LockContentionEvent event);
 }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/LegendLogEvent.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/LegendLogEvent.java
@@ -1,0 +1,51 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+public class LegendLogEvent
+{
+    private String level;
+    private String message;
+
+    public LegendLogEvent()
+    {
+    }
+
+    public LegendLogEvent(String level, String message)
+    {
+        this.level = level;
+        this.message = message;
+    }
+
+    public String getLevel()
+    {
+        return this.level;
+    }
+
+    public void setLevel(String level)
+    {
+        this.level = level;
+    }
+
+    public String getMessage()
+    {
+        return this.message;
+    }
+
+    public void setMessage(String message)
+    {
+        this.message = message;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/LockContentionEvent.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/LockContentionEvent.java
@@ -1,0 +1,75 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+public class LockContentionEvent
+{
+    private boolean active;
+    private String lockType;
+    private String reason;
+    private int pendingCount;
+
+    public LockContentionEvent()
+    {
+    }
+
+    public LockContentionEvent(boolean active, String lockType, String reason, int pendingCount)
+    {
+        this.active = active;
+        this.lockType = lockType;
+        this.reason = reason;
+        this.pendingCount = pendingCount;
+    }
+
+    public boolean isActive()
+    {
+        return this.active;
+    }
+
+    public void setActive(boolean active)
+    {
+        this.active = active;
+    }
+
+    public String getLockType()
+    {
+        return this.lockType;
+    }
+
+    public void setLockType(String lockType)
+    {
+        this.lockType = lockType;
+    }
+
+    public String getReason()
+    {
+        return this.reason;
+    }
+
+    public void setReason(String reason)
+    {
+        this.reason = reason;
+    }
+
+    public int getPendingCount()
+    {
+        return this.pendingCount;
+    }
+
+    public void setPendingCount(int pendingCount)
+    {
+        this.pendingCount = pendingCount;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/LogErrorEntry.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/LogErrorEntry.java
@@ -1,0 +1,51 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+public class LogErrorEntry
+{
+    private long timestamp;
+    private String message;
+
+    public LogErrorEntry()
+    {
+    }
+
+    public LogErrorEntry(long timestamp, String message)
+    {
+        this.timestamp = timestamp;
+        this.message = message;
+    }
+
+    public long getTimestamp()
+    {
+        return this.timestamp;
+    }
+
+    public void setTimestamp(long timestamp)
+    {
+        this.timestamp = timestamp;
+    }
+
+    public String getMessage()
+    {
+        return this.message;
+    }
+
+    public void setMessage(String message)
+    {
+        this.message = message;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/LspStatus.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/LspStatus.java
@@ -14,6 +14,9 @@
 
 package org.finos.legend.pure.lsp.protocol;
 
+import java.util.Collections;
+import java.util.List;
+
 public class LspStatus
 {
     private String state;
@@ -24,6 +27,20 @@ public class LspStatus
     private String message;
     private int compiledRepositories;
     private int totalRepositories;
+
+    // Observability fields, filled in by LegendPureLspServer#status() on top of whatever
+    // PureRuntimeManager#currentStatus() already built - see that method for why these live here
+    // rather than being threaded through PureRuntimeManager itself (they describe the server/session,
+    // not compile progress).
+    private int connectedClientCount;
+    private int port = -1;
+    private String transport;
+    private int requestPoolSize;
+    private List<String> repoRoots = Collections.emptyList();
+    private List<String> jvmArgs = Collections.emptyList();
+    private List<LogErrorEntry> recentErrors = Collections.emptyList();
+    private boolean lockContended;
+    private String lockContentionReason;
 
     public LspStatus()
     {
@@ -126,5 +143,95 @@ public class LspStatus
     public void setTotalRepositories(int totalRepositories)
     {
         this.totalRepositories = totalRepositories;
+    }
+
+    public int getConnectedClientCount()
+    {
+        return this.connectedClientCount;
+    }
+
+    public void setConnectedClientCount(int connectedClientCount)
+    {
+        this.connectedClientCount = connectedClientCount;
+    }
+
+    public int getPort()
+    {
+        return this.port;
+    }
+
+    public void setPort(int port)
+    {
+        this.port = port;
+    }
+
+    public String getTransport()
+    {
+        return this.transport;
+    }
+
+    public void setTransport(String transport)
+    {
+        this.transport = transport;
+    }
+
+    public int getRequestPoolSize()
+    {
+        return this.requestPoolSize;
+    }
+
+    public void setRequestPoolSize(int requestPoolSize)
+    {
+        this.requestPoolSize = requestPoolSize;
+    }
+
+    public List<String> getRepoRoots()
+    {
+        return this.repoRoots;
+    }
+
+    public void setRepoRoots(List<String> repoRoots)
+    {
+        this.repoRoots = repoRoots == null ? Collections.emptyList() : repoRoots;
+    }
+
+    public List<String> getJvmArgs()
+    {
+        return this.jvmArgs;
+    }
+
+    public void setJvmArgs(List<String> jvmArgs)
+    {
+        this.jvmArgs = jvmArgs == null ? Collections.emptyList() : jvmArgs;
+    }
+
+    public List<LogErrorEntry> getRecentErrors()
+    {
+        return this.recentErrors;
+    }
+
+    public void setRecentErrors(List<LogErrorEntry> recentErrors)
+    {
+        this.recentErrors = recentErrors == null ? Collections.emptyList() : recentErrors;
+    }
+
+    public boolean isLockContended()
+    {
+        return this.lockContended;
+    }
+
+    public void setLockContended(boolean lockContended)
+    {
+        this.lockContended = lockContended;
+    }
+
+    public String getLockContentionReason()
+    {
+        return this.lockContentionReason;
+    }
+
+    public void setLockContentionReason(String lockContentionReason)
+    {
+        this.lockContentionReason = lockContentionReason;
     }
 }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/PCTAdapterInfo.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/PCTAdapterInfo.java
@@ -1,0 +1,58 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+/**
+ * One adapter found by legend/getPCTAdapters: a Function in the compiled graph carrying the
+ * &lt;&lt;PCT.adapter&gt;&gt; stereotype (see org.finos.legend.pure.m3.pct.shared.PCTTools#PCT_PROFILE).
+ * {@code name} is its 'adapterName' tagged value, falling back to the element's own simple name when
+ * absent; {@code path} is the fully-qualified Pure path, suitable for
+ * ExecuteFunctionParams#pctAdapterPath.
+ */
+public class PCTAdapterInfo
+{
+    private String name;
+    private String path;
+
+    public PCTAdapterInfo()
+    {
+    }
+
+    public PCTAdapterInfo(String name, String path)
+    {
+        this.name = name;
+        this.path = path;
+    }
+
+    public String getName()
+    {
+        return this.name;
+    }
+
+    public void setName(String name)
+    {
+        this.name = name;
+    }
+
+    public String getPath()
+    {
+        return this.path;
+    }
+
+    public void setPath(String path)
+    {
+        this.path = path;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/ResolveSourceUriParams.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/ResolveSourceUriParams.java
@@ -1,0 +1,38 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+/**
+ * Params for legend/resolveSourceUri: resolve a Pure internal sourceId (e.g. embedded in a stack
+ * trace's "resource:..." location reference) to an editor-navigable URI.
+ */
+public class ResolveSourceUriParams
+{
+    private String sourceId;
+
+    public ResolveSourceUriParams()
+    {
+    }
+
+    public String getSourceId()
+    {
+        return this.sourceId;
+    }
+
+    public void setSourceId(String sourceId)
+    {
+        this.sourceId = sourceId;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/ResolveSourceUriResult.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/ResolveSourceUriResult.java
@@ -1,0 +1,37 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+public class ResolveSourceUriResult
+{
+    private String uri;
+
+    public ResolveSourceUriResult()
+    {
+    }
+
+    /**
+     * Null/empty if the sourceId could not be resolved to any navigable URI.
+     */
+    public String getUri()
+    {
+        return this.uri;
+    }
+
+    public void setUri(String uri)
+    {
+        this.uri = uri;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/SetupTeardownInfo.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/SetupTeardownInfo.java
@@ -1,0 +1,84 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+/**
+ * Result of legend/getSetupTeardown: the nearest {@code <<test.BeforePackage>>}/
+ * {@code <<test.AfterPackage>>} functions to the requested test function (see
+ * org.finos.legend.pure.m3.execution.test.TestTools#findNearestBeforePackageFunction), found by
+ * walking up its package chain and stopping at the first match in each direction. Either pair of
+ * fields may be null if no such function exists anywhere up the chain. {@code beforeFunctionPath}/
+ * {@code afterFunctionPath} are suitable for {@link ExecuteFunctionParams#setBeforeFunctionPath}/
+ * {@link ExecuteFunctionParams#setAfterFunctionPath}.
+ */
+public class SetupTeardownInfo
+{
+    private String beforeFunctionPath;
+    private String beforeFunctionName;
+    private String afterFunctionPath;
+    private String afterFunctionName;
+
+    public SetupTeardownInfo()
+    {
+    }
+
+    public SetupTeardownInfo(String beforeFunctionPath, String beforeFunctionName, String afterFunctionPath, String afterFunctionName)
+    {
+        this.beforeFunctionPath = beforeFunctionPath;
+        this.beforeFunctionName = beforeFunctionName;
+        this.afterFunctionPath = afterFunctionPath;
+        this.afterFunctionName = afterFunctionName;
+    }
+
+    public String getBeforeFunctionPath()
+    {
+        return this.beforeFunctionPath;
+    }
+
+    public void setBeforeFunctionPath(String beforeFunctionPath)
+    {
+        this.beforeFunctionPath = beforeFunctionPath;
+    }
+
+    public String getBeforeFunctionName()
+    {
+        return this.beforeFunctionName;
+    }
+
+    public void setBeforeFunctionName(String beforeFunctionName)
+    {
+        this.beforeFunctionName = beforeFunctionName;
+    }
+
+    public String getAfterFunctionPath()
+    {
+        return this.afterFunctionPath;
+    }
+
+    public void setAfterFunctionPath(String afterFunctionPath)
+    {
+        this.afterFunctionPath = afterFunctionPath;
+    }
+
+    public String getAfterFunctionName()
+    {
+        return this.afterFunctionName;
+    }
+
+    public void setAfterFunctionName(String afterFunctionName)
+    {
+        this.afterFunctionName = afterFunctionName;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/SyncWorkspaceParams.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/SyncWorkspaceParams.java
@@ -1,0 +1,46 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+import java.util.List;
+
+/**
+ * {@code uris} null or empty means "sync everything currently known to be dirty" (the watcher's full
+ * accumulated set); a non-empty list syncs only those specific files, letting a client offer the user a
+ * checkbox list rather than an all-or-nothing sync.
+ */
+public class SyncWorkspaceParams
+{
+    private List<String> uris;
+
+    public SyncWorkspaceParams()
+    {
+    }
+
+    public SyncWorkspaceParams(List<String> uris)
+    {
+        this.uris = uris;
+    }
+
+    public List<String> getUris()
+    {
+        return this.uris;
+    }
+
+    public void setUris(List<String> uris)
+    {
+        this.uris = uris;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/SyncWorkspaceResult.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/SyncWorkspaceResult.java
@@ -1,0 +1,97 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+public class SyncWorkspaceResult
+{
+    private boolean success;
+    private int created;
+    private int modified;
+    private int deleted;
+    private String error;
+
+    public SyncWorkspaceResult()
+    {
+    }
+
+    private SyncWorkspaceResult(boolean success, int created, int modified, int deleted, String error)
+    {
+        this.success = success;
+        this.created = created;
+        this.modified = modified;
+        this.deleted = deleted;
+        this.error = error;
+    }
+
+    public static SyncWorkspaceResult success(int created, int modified, int deleted)
+    {
+        return new SyncWorkspaceResult(true, created, modified, deleted, null);
+    }
+
+    public static SyncWorkspaceResult failure(String error)
+    {
+        return new SyncWorkspaceResult(false, 0, 0, 0, error);
+    }
+
+    public boolean isSuccess()
+    {
+        return this.success;
+    }
+
+    public void setSuccess(boolean success)
+    {
+        this.success = success;
+    }
+
+    public int getCreated()
+    {
+        return this.created;
+    }
+
+    public void setCreated(int created)
+    {
+        this.created = created;
+    }
+
+    public int getModified()
+    {
+        return this.modified;
+    }
+
+    public void setModified(int modified)
+    {
+        this.modified = modified;
+    }
+
+    public int getDeleted()
+    {
+        return this.deleted;
+    }
+
+    public void setDeleted(int deleted)
+    {
+        this.deleted = deleted;
+    }
+
+    public String getError()
+    {
+        return this.error;
+    }
+
+    public void setError(String error)
+    {
+        this.error = error;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/TestFunctionInfo.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/TestFunctionInfo.java
@@ -1,0 +1,126 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+/**
+ * One function found by legend/testFunctions: a real compiled function carrying the
+ * meta::pure::profiles::test "Test" stereotype (see
+ * org.finos.legend.pure.m3.execution.test.TestTools#hasTestStereotype) in the requested source.
+ * {@code functionPath} is the fully-qualified Pure path, suitable for execution (e.g. as
+ * PureDebugRunConfiguration.functionName); {@code line} (1-based) is where the client should
+ * anchor a gutter icon. {@code isPCTTest} additionally distinguishes a PCT test (see
+ * org.finos.legend.pure.m3.pct.shared.PCTTools#isPCTTest) - one that must be run with an adapter
+ * path (see ExecuteFunctionParams#pctAdapterPath, legend/getPCTAdapters) - from a plain test, so a
+ * client can decide whether to offer a "Run PCTs" action for it.
+ * <p>
+ * {@code isBeforeFunction}/{@code isAfterFunction} mark a function carrying the
+ * {@code <<test.BeforePackage>>}/{@code <<test.AfterPackage>>} stereotype instead of {@code Test} -
+ * included here (rather than only via legend/getSetupTeardown) so a Before/After function itself
+ * gets its own gutter marker, letting setup/teardown be run/debugged directly. At most one of
+ * isPCTTest/isBeforeFunction/isAfterFunction is ever true for a given entry.
+ */
+public class TestFunctionInfo
+{
+    private String functionPath;
+    private String name;
+    private int line;
+    private boolean isPCTTest;
+    private boolean isBeforeFunction;
+    private boolean isAfterFunction;
+
+    public TestFunctionInfo()
+    {
+    }
+
+    public TestFunctionInfo(String functionPath, String name, int line)
+    {
+        this(functionPath, name, line, false);
+    }
+
+    public TestFunctionInfo(String functionPath, String name, int line, boolean isPCTTest)
+    {
+        this(functionPath, name, line, isPCTTest, false, false);
+    }
+
+    public TestFunctionInfo(String functionPath, String name, int line, boolean isPCTTest, boolean isBeforeFunction, boolean isAfterFunction)
+    {
+        this.functionPath = functionPath;
+        this.name = name;
+        this.line = line;
+        this.isPCTTest = isPCTTest;
+        this.isBeforeFunction = isBeforeFunction;
+        this.isAfterFunction = isAfterFunction;
+    }
+
+    public String getFunctionPath()
+    {
+        return this.functionPath;
+    }
+
+    public void setFunctionPath(String functionPath)
+    {
+        this.functionPath = functionPath;
+    }
+
+    public String getName()
+    {
+        return this.name;
+    }
+
+    public void setName(String name)
+    {
+        this.name = name;
+    }
+
+    public int getLine()
+    {
+        return this.line;
+    }
+
+    public void setLine(int line)
+    {
+        this.line = line;
+    }
+
+    public boolean isPCTTest()
+    {
+        return this.isPCTTest;
+    }
+
+    public void setPCTTest(boolean isPCTTest)
+    {
+        this.isPCTTest = isPCTTest;
+    }
+
+    public boolean isBeforeFunction()
+    {
+        return this.isBeforeFunction;
+    }
+
+    public void setBeforeFunction(boolean isBeforeFunction)
+    {
+        this.isBeforeFunction = isBeforeFunction;
+    }
+
+    public boolean isAfterFunction()
+    {
+        return this.isAfterFunction;
+    }
+
+    public void setAfterFunction(boolean isAfterFunction)
+    {
+        this.isAfterFunction = isAfterFunction;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/TestFunctionsParams.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/TestFunctionsParams.java
@@ -1,0 +1,43 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+/**
+ * Params for legend/testFunctions. {@code uri} may be a file:// uri, a pure:// uri, or a raw
+ * sourceId - the handler resolves whichever form is given the same way documentSymbol does.
+ */
+public class TestFunctionsParams
+{
+    private String uri;
+
+    public TestFunctionsParams()
+    {
+    }
+
+    public TestFunctionsParams(String uri)
+    {
+        this.uri = uri;
+    }
+
+    public String getUri()
+    {
+        return this.uri;
+    }
+
+    public void setUri(String uri)
+    {
+        this.uri = uri;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/WorkspaceDriftEntry.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/WorkspaceDriftEntry.java
@@ -1,0 +1,51 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+public class WorkspaceDriftEntry
+{
+    private String uri;
+    private String changeType;
+
+    public WorkspaceDriftEntry()
+    {
+    }
+
+    public WorkspaceDriftEntry(String uri, DriftChangeType changeType)
+    {
+        this.uri = uri;
+        this.changeType = changeType.getProtocolValue();
+    }
+
+    public String getUri()
+    {
+        return this.uri;
+    }
+
+    public void setUri(String uri)
+    {
+        this.uri = uri;
+    }
+
+    public String getChangeType()
+    {
+        return this.changeType;
+    }
+
+    public void setChangeType(String changeType)
+    {
+        this.changeType = changeType;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/WorkspaceDriftEvent.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/protocol/WorkspaceDriftEvent.java
@@ -1,0 +1,47 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp.protocol;
+
+import java.util.Collections;
+import java.util.List;
+
+public class WorkspaceDriftEvent
+{
+    private List<WorkspaceDriftEntry> entries;
+
+    public WorkspaceDriftEvent()
+    {
+    }
+
+    public WorkspaceDriftEvent(List<WorkspaceDriftEntry> entries)
+    {
+        this.entries = entries;
+    }
+
+    public static WorkspaceDriftEvent empty()
+    {
+        return new WorkspaceDriftEvent(Collections.emptyList());
+    }
+
+    public List<WorkspaceDriftEntry> getEntries()
+    {
+        return this.entries;
+    }
+
+    public void setEntries(List<WorkspaceDriftEntry> entries)
+    {
+        this.entries = entries;
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/runtime/PureRuntimeManager.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/main/java/org/finos/legend/pure/lsp/runtime/PureRuntimeManager.java
@@ -46,6 +46,7 @@ public class PureRuntimeManager
     private final UriMapper uriMapper;
     private final WorkspaceSymbolProvider symbolProvider;
     private final Runnable openDocumentCompiler;
+    private final DiagnosticService diagnosticService;
     private final AtomicBoolean recoveryInProgress = new AtomicBoolean(false);
 
     private volatile LegendLanguageClient client;
@@ -62,12 +63,14 @@ public class PureRuntimeManager
     private final CompileProgressTracker progressTracker = new CompileProgressTracker();
 
     public PureRuntimeManager(RepositoryScanner repositoryScanner, UriMapper uriMapper,
-                              WorkspaceSymbolProvider symbolProvider, Runnable openDocumentCompiler)
+                              WorkspaceSymbolProvider symbolProvider, Runnable openDocumentCompiler,
+                              DiagnosticService diagnosticService)
     {
         this.repositoryScanner = repositoryScanner;
         this.uriMapper = uriMapper;
         this.symbolProvider = symbolProvider;
         this.openDocumentCompiler = openDocumentCompiler;
+        this.diagnosticService = diagnosticService;
     }
 
     public void setClient(LegendLanguageClient client)
@@ -182,6 +185,7 @@ public class PureRuntimeManager
         LegendPureSession nextSession = this.session == null ? new LegendPureSession() : this.session;
         nextSession.setClasspathRepositoryNames(this.classpathRepositoryNames);
         nextSession.setProgressListener(this::onCompileProgress);
+        nextSession.setClient(this.client);
         if (nextSession.isInitialized())
         {
             nextSession.reinitialize();
@@ -242,17 +246,10 @@ public class PureRuntimeManager
         }
         Exception exception = (Exception) e;
 
-        LegendLanguageClient currentClient = this.client;
-        if (currentClient == null)
-        {
-            return;
-        }
-
-        DiagnosticService diagnosticService = new DiagnosticService(currentClient, this.uriMapper);
-        String errorUri = diagnosticService.resolveErrorUri(exception);
+        String errorUri = this.diagnosticService.resolveErrorUri(exception);
         if (errorUri != null)
         {
-            diagnosticService.publishException(errorUri, exception, this.session);
+            this.diagnosticService.publishException(errorUri, exception, this.session);
         }
     }
 
@@ -275,6 +272,11 @@ public class PureRuntimeManager
     public LegendPureSession getSession()
     {
         return this.session;
+    }
+
+    public List<Path> getWorkspaceRoots()
+    {
+        return this.workspaceRoots;
     }
 
     public SourceMutationService getMutationService()

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/ClientBroadcasterTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/ClientBroadcasterTest.java
@@ -1,0 +1,273 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.finos.legend.pure.lsp.protocol.LegendLanguageClient;
+import org.finos.legend.pure.lsp.protocol.LegendLogEvent;
+import org.finos.legend.pure.lsp.protocol.LockContentionEvent;
+import org.finos.legend.pure.lsp.protocol.WorkspaceDriftEvent;
+import org.finos.legend.pure.lsp.protocol.LspState;
+import org.finos.legend.pure.lsp.protocol.LspStatus;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClientBroadcasterTest
+{
+    @Test
+    public void broadcastsToAllRegisteredClients()
+    {
+        ClientBroadcaster broadcaster = new ClientBroadcaster();
+        RecordingClient first = new RecordingClient();
+        RecordingClient second = new RecordingClient();
+        broadcaster.register(first);
+        broadcaster.register(second);
+
+        PublishDiagnosticsParams diagnostics = new PublishDiagnosticsParams("file:///a.pure", Collections.emptyList());
+        broadcaster.publishDiagnostics(diagnostics);
+        Assert.assertEquals(1, first.diagnostics.size());
+        Assert.assertEquals(1, second.diagnostics.size());
+
+        LspStatus status = new LspStatus(LspState.READY, 1, 1, 0, false, "ready", 0, 0);
+        broadcaster.statusChanged(status);
+        Assert.assertEquals(1, first.statuses.size());
+        Assert.assertEquals(1, second.statuses.size());
+
+        broadcaster.showMessage(new MessageParams(MessageType.Info, "hi"));
+        Assert.assertEquals(1, first.messages.size());
+        Assert.assertEquals(1, second.messages.size());
+
+        broadcaster.logOutput(new LegendLogEvent("INFO", "log line"));
+        Assert.assertEquals(1, first.logs.size());
+        Assert.assertEquals(1, second.logs.size());
+
+        broadcaster.lockContention(new LockContentionEvent(true, "write", "read lock(s) held", 1));
+        Assert.assertEquals(1, first.lockContentions.size());
+        Assert.assertEquals(1, second.lockContentions.size());
+    }
+
+    @Test
+    public void oneClientThrowing_doesNotBlockDeliveryToOthers_andIsDeregistered()
+    {
+        ClientBroadcaster broadcaster = new ClientBroadcaster();
+        RecordingClient healthy = new RecordingClient();
+        ThrowingClient broken = new ThrowingClient();
+        broadcaster.register(healthy);
+        broadcaster.register(broken);
+        Assert.assertEquals(2, broadcaster.connectedClientCount());
+
+        broadcaster.publishDiagnostics(new PublishDiagnosticsParams("file:///a.pure", Collections.emptyList()));
+
+        Assert.assertEquals("Healthy client must still receive the broadcast", 1, healthy.diagnostics.size());
+        Assert.assertEquals("Throwing client should have been auto-deregistered",
+                1, broadcaster.connectedClientCount());
+    }
+
+    @Test
+    public void deregister_stopsFurtherBroadcasts()
+    {
+        ClientBroadcaster broadcaster = new ClientBroadcaster();
+        RecordingClient client = new RecordingClient();
+        broadcaster.register(client);
+        broadcaster.deregister(client);
+
+        broadcaster.publishDiagnostics(new PublishDiagnosticsParams("file:///a.pure", Collections.emptyList()));
+        Assert.assertTrue("Deregistered client should receive nothing", client.diagnostics.isEmpty());
+        Assert.assertEquals(0, broadcaster.connectedClientCount());
+    }
+
+    @Test
+    public void broadcastWithNoRegisteredClients_doesNotThrow()
+    {
+        ClientBroadcaster broadcaster = new ClientBroadcaster();
+        broadcaster.publishDiagnostics(new PublishDiagnosticsParams("file:///a.pure", Collections.emptyList()));
+        broadcaster.statusChanged(new LspStatus(LspState.READY, 0, 0, 0, false, "ready", 0, 0));
+        broadcaster.showMessage(new MessageParams(MessageType.Info, "hi"));
+        broadcaster.logOutput(new LegendLogEvent("INFO", "log line"));
+        // No exception is the assertion.
+    }
+
+    @Test
+    public void register_wrapsPlainLanguageClient_soLegendNotificationsAreNoOpsNotErrors()
+    {
+        ClientBroadcaster broadcaster = new ClientBroadcaster();
+        PlainLanguageClient plain = new PlainLanguageClient();
+        broadcaster.register(plain);
+
+        broadcaster.publishDiagnostics(new PublishDiagnosticsParams("file:///a.pure", Collections.emptyList()));
+        Assert.assertEquals(1, plain.diagnostics.size());
+
+        // statusChanged/logOutput have no meaning for a plain LanguageClient; the adapter no-ops them
+        // rather than throwing, and that no-op must not cause deregistration.
+        broadcaster.statusChanged(new LspStatus(LspState.READY, 0, 0, 0, false, "ready", 0, 0));
+        Assert.assertEquals(1, broadcaster.connectedClientCount());
+    }
+
+    private static class RecordingClient implements LegendLanguageClient
+    {
+        final List<PublishDiagnosticsParams> diagnostics = Collections.synchronizedList(new ArrayList<>());
+        final List<LspStatus> statuses = Collections.synchronizedList(new ArrayList<>());
+        final List<MessageParams> messages = Collections.synchronizedList(new ArrayList<>());
+        final List<LegendLogEvent> logs = Collections.synchronizedList(new ArrayList<>());
+        final List<LockContentionEvent> lockContentions = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public void telemetryEvent(Object object)
+        {
+        }
+
+        @Override
+        public void publishDiagnostics(PublishDiagnosticsParams diagnostics)
+        {
+            this.diagnostics.add(diagnostics);
+        }
+
+        @Override
+        public void showMessage(MessageParams messageParams)
+        {
+            this.messages.add(messageParams);
+        }
+
+        @Override
+        public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams)
+        {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public void logMessage(MessageParams message)
+        {
+        }
+
+        @Override
+        public void statusChanged(LspStatus status)
+        {
+            this.statuses.add(status);
+        }
+
+        @Override
+        public void logOutput(LegendLogEvent event)
+        {
+            this.logs.add(event);
+        }
+
+        @Override
+        public void workspaceDriftDetected(WorkspaceDriftEvent event)
+        {
+        }
+
+        @Override
+        public void lockContention(LockContentionEvent event)
+        {
+            this.lockContentions.add(event);
+        }
+    }
+
+    private static class ThrowingClient implements LegendLanguageClient
+    {
+        @Override
+        public void telemetryEvent(Object object)
+        {
+        }
+
+        @Override
+        public void publishDiagnostics(PublishDiagnosticsParams diagnostics)
+        {
+            throw new RuntimeException("simulated dead connection");
+        }
+
+        @Override
+        public void showMessage(MessageParams messageParams)
+        {
+            throw new RuntimeException("simulated dead connection");
+        }
+
+        @Override
+        public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams)
+        {
+            throw new RuntimeException("simulated dead connection");
+        }
+
+        @Override
+        public void logMessage(MessageParams message)
+        {
+            throw new RuntimeException("simulated dead connection");
+        }
+
+        @Override
+        public void statusChanged(LspStatus status)
+        {
+            throw new RuntimeException("simulated dead connection");
+        }
+
+        @Override
+        public void logOutput(LegendLogEvent event)
+        {
+            throw new RuntimeException("simulated dead connection");
+        }
+
+        @Override
+        public void workspaceDriftDetected(WorkspaceDriftEvent event)
+        {
+            throw new RuntimeException("simulated dead connection");
+        }
+
+        @Override
+        public void lockContention(LockContentionEvent event)
+        {
+            throw new RuntimeException("simulated dead connection");
+        }
+    }
+
+    private static class PlainLanguageClient implements org.eclipse.lsp4j.services.LanguageClient
+    {
+        final List<PublishDiagnosticsParams> diagnostics = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public void telemetryEvent(Object object)
+        {
+        }
+
+        @Override
+        public void publishDiagnostics(PublishDiagnosticsParams diagnostics)
+        {
+            this.diagnostics.add(diagnostics);
+        }
+
+        @Override
+        public void showMessage(MessageParams messageParams)
+        {
+        }
+
+        @Override
+        public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams)
+        {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public void logMessage(MessageParams message)
+        {
+        }
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/FixtureFileEditorLifecycleTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/FixtureFileEditorLifecycleTest.java
@@ -1,0 +1,69 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import org.eclipse.lsp4j.DidCloseTextDocumentParams;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Regression test for the LSP daemon crash reproduced by opening and closing a non-module .pure fixture
+ * file in an editor - see UriMapper#deriveSourceId's local-file exclusion. Before that fix, opening such
+ * a file resolved it to a bare-filename scratch id and attempted (and failed) to compile it; closing it
+ * then called SourceMutationService#restoreFromDisk with that same scratch id, which threw
+ * ("'&lt;file&gt;' should not be in memory!") and triggered full session recovery every time.
+ */
+public class FixtureFileEditorLifecycleTest
+{
+    @Test
+    public void openingAndClosingANonModuleFixtureFile_doesNotCrashTheSession() throws Exception
+    {
+        Path workspaceRoot = Files.createTempDirectory("pure-lsp-fixture-lifecycle-test");
+        Path resourcesDir = workspaceRoot.resolve("real-module/src/main/resources");
+        Path repoDir = resourcesDir.resolve("real_repo");
+        Files.createDirectories(repoDir);
+        Files.write(resourcesDir.resolve("real_repo.definition.json"),
+                ("{\"name\":\"real_repo\","
+                        + "\"pattern\":\"(test::reallife)(::.*)?\","
+                        + "\"dependencies\":[\"platform\"]}").getBytes());
+
+        // A fixture file in a *different* module with no definition.json of its own - the exact shape
+        // of the alloy-lakehouse integration-test-compatibility crash.
+        Path fixtureResourcesDir = workspaceRoot.resolve("fixture-module/src/main/resources");
+        Path fixtureFile = fixtureResourcesDir.resolve("data/ingest/matview/catalog/matview.pure");
+        Files.createDirectories(fixtureFile.getParent());
+        String fixtureContent = "###Lakehouse\n<TEST_GROUP>";
+        Files.write(fixtureFile, fixtureContent.getBytes());
+
+        LegendPureLspServer server = new LegendPureLspServer();
+        server.preconfigureAndWarm(Collections.singletonList(workspaceRoot), Collections.emptySet());
+        Assert.assertTrue(server.getSession().isInitialized());
+
+        String uri = fixtureFile.toUri().toString();
+        server.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(
+                new TextDocumentItem(uri, "pure", 1, fixtureContent)));
+        server.getTextDocumentService().didClose(new DidCloseTextDocumentParams(new TextDocumentIdentifier(uri)));
+
+        Assert.assertTrue("Session must stay healthy, not enter recovery", server.getSession().isInitialized());
+        Assert.assertNull("Nothing should ever be registered for the fixture's bare filename",
+                server.getSession().getPureRuntime().getSourceById("matview.pure"));
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/FoldingRangeProviderTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/FoldingRangeProviderTest.java
@@ -1,0 +1,145 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.util.List;
+import org.eclipse.lsp4j.FoldingRange;
+import org.eclipse.lsp4j.FoldingRangeKind;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Verifies FoldingRangeProvider's text-based scan: brace-delimited bodies, multi-line block
+ * comments, and ###-marker section spans - and that braces/markers inside string literals, line
+ * comments, and block comments are correctly skipped rather than mistaken for structural ones.
+ */
+public class FoldingRangeProviderTest
+{
+    private static LegendPureSession session;
+
+    @BeforeClass
+    public static void init()
+    {
+        session = new LegendPureSession();
+        session.initialize();
+    }
+
+    @AfterClass
+    public static void cleanup()
+    {
+        session = null;
+    }
+
+    private static List<FoldingRange> foldingRangesFor(String sourceId, String code)
+    {
+        LegendPureSession.CompileResult result = session.modifyAndCompile(sourceId, code);
+        Assert.assertTrue("Test fixture should compile: "
+                + (result.getError() != null ? result.getError().getMessage() : ""), result.isSuccess());
+        return FoldingRangeProvider.getFoldingRanges(session.getPureRuntime(), sourceId);
+    }
+
+    @Test
+    public void foldsClassBody()
+    {
+        String code = "Class test::folding::Person\n" +   // line 0
+                "{\n" +                                    // line 1 (brace opens)
+                "  name: String[1];\n" +                    // line 2
+                "  age: Integer[1];\n" +                    // line 3
+                "}\n";                                      // line 4 (brace closes)
+
+        List<FoldingRange> ranges = foldingRangesFor("folding_class.pure", code);
+        boolean found = ranges.stream().anyMatch(r ->
+                r.getStartLine() == 1 && r.getEndLine() == 4 && FoldingRangeKind.Region.equals(r.getKind()));
+        Assert.assertTrue("Expected a region fold from the opening brace (line 1) to the closing "
+                + "brace (line 4), found: " + ranges, found);
+    }
+
+    @Test
+    public void ignoresBraceInsideStringLiteral()
+    {
+        // The '{' and '}' inside the string must not be treated as structural braces, and must not
+        // desynchronize the real class-body brace matching that follows.
+        String code = "Class test::folding::WithBraceString\n" +  // 0
+                "{\n" +                                            // 1
+                "  label: String[1] = '{not a brace}';\n" +        // 2
+                "}\n";                                             // 3
+
+        List<FoldingRange> ranges = foldingRangesFor("folding_string_brace.pure", code);
+        boolean found = ranges.stream().anyMatch(r -> r.getStartLine() == 1 && r.getEndLine() == 3);
+        Assert.assertTrue("Real class body fold must still be found despite braces inside a string literal: "
+                + ranges, found);
+        Assert.assertEquals("Only the real class body should fold - the string's braces must not "
+                + "produce extra/incorrect ranges: " + ranges, 1, ranges.size());
+    }
+
+    @Test
+    public void foldsMultiLineBlockComment()
+    {
+        String code = "/*\n" +                 // 0 (comment opens)
+                " * A multi-line\n" +           // 1
+                " * block comment\n" +          // 2
+                " */\n" +                       // 3 (comment closes)
+                "function test::folding::documented(): Boolean[1]\n" +
+                "{\n" +
+                "  true\n" +
+                "}\n";
+
+        List<FoldingRange> ranges = foldingRangesFor("folding_comment.pure", code);
+        boolean found = ranges.stream().anyMatch(r ->
+                r.getStartLine() == 0 && r.getEndLine() == 3 && FoldingRangeKind.Comment.equals(r.getKind()));
+        Assert.assertTrue("Expected a comment fold spanning the block comment's 4 lines, found: " + ranges, found);
+    }
+
+    @Test
+    public void ignoresSingleLineBlockComment()
+    {
+        String code = "/* single line */\n" +
+                "function test::folding::trivial(): Boolean[1]\n" +
+                "{\n" +
+                "  true\n" +
+                "}\n";
+
+        List<FoldingRange> ranges = foldingRangesFor("folding_single_line_comment.pure", code);
+        boolean foundComment = ranges.stream().anyMatch(r -> FoldingRangeKind.Comment.equals(r.getKind()));
+        Assert.assertFalse("A block comment on a single line has nothing to fold and must not be "
+                + "reported: " + ranges, foundComment);
+    }
+
+    @Test
+    public void foldsSectionMarkerSpans()
+    {
+        String code = "###Pure\n" +                                   // 0 (marker)
+                "function test::folding::inPureSection(): Boolean[1]\n" +
+                "{\n" +
+                "  true\n" +
+                "}\n" +
+                "###Pure\n" +                                          // 5 (next marker)
+                "// a trailing, otherwise-empty second Pure section\n";
+
+        List<FoldingRange> ranges = foldingRangesFor("folding_sections.pure", code);
+        boolean found = ranges.stream().anyMatch(r -> r.getStartLine() == 0 && r.getEndLine() == 4);
+        Assert.assertTrue("Expected the ###Pure section to fold from its marker line to the line "
+                + "before the next ### marker: " + ranges, found);
+    }
+
+    @Test
+    public void unknownSource_returnsEmpty()
+    {
+        List<FoldingRange> ranges = FoldingRangeProvider.getFoldingRanges(session.getPureRuntime(), "no_such_source_999.pure");
+        Assert.assertTrue(ranges.isEmpty());
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/LegendPureLspServerTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/LegendPureLspServerTest.java
@@ -130,4 +130,63 @@ public class LegendPureLspServerTest
             }
         }
     }
+
+    @Test
+    public void resolveRequestPoolSize_noPropertySet_returnsDefaultOfTwelve()
+    {
+        withRequestPoolSizeProperty(null, () ->
+                Assert.assertEquals(12, LegendPureLspServer.resolveRequestPoolSize()));
+    }
+
+    @Test
+    public void resolveRequestPoolSize_readsValidPropertyOverride()
+    {
+        withRequestPoolSizeProperty("20", () ->
+                Assert.assertEquals(20, LegendPureLspServer.resolveRequestPoolSize()));
+    }
+
+    @Test
+    public void resolveRequestPoolSize_invalidProperty_fallsBackToDefault()
+    {
+        withRequestPoolSizeProperty("notanumber", () ->
+                Assert.assertEquals(12, LegendPureLspServer.resolveRequestPoolSize()));
+    }
+
+    @Test
+    public void resolveRequestPoolSize_nonPositiveProperty_fallsBackToDefault()
+    {
+        withRequestPoolSizeProperty("0", () ->
+                Assert.assertEquals(12, LegendPureLspServer.resolveRequestPoolSize()));
+        withRequestPoolSizeProperty("-5", () ->
+                Assert.assertEquals(12, LegendPureLspServer.resolveRequestPoolSize()));
+    }
+
+    private static void withRequestPoolSizeProperty(String value, Runnable assertion)
+    {
+        String propertyName = "legend.lsp.requestPoolSize";
+        String saved = System.getProperty(propertyName);
+        if (value == null)
+        {
+            System.clearProperty(propertyName);
+        }
+        else
+        {
+            System.setProperty(propertyName, value);
+        }
+        try
+        {
+            assertion.run();
+        }
+        finally
+        {
+            if (saved == null)
+            {
+                System.clearProperty(propertyName);
+            }
+            else
+            {
+                System.setProperty(propertyName, saved);
+            }
+        }
+    }
 }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/LegendPureSessionGraphDirtyTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/LegendPureSessionGraphDirtyTest.java
@@ -1,0 +1,94 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Verifies the graphDirty contract that lets ensureCompiled() skip the write lock entirely when
+ * nothing is pending: dirty starts false, every successful SourceMutationService mutation (and the
+ * immutable-source no-op branches) leaves it false again, and execute() never leaves it dirty behind
+ * (so a run of executions never forces the next one back onto the slow/write-lock path).
+ */
+public class LegendPureSessionGraphDirtyTest
+{
+    @Test
+    public void freshSessionIsNotDirtyAfterInitialize() throws Exception
+    {
+        LegendPureSession session = new LegendPureSession();
+        session.initialize();
+        Assert.assertFalse(readGraphDirty(session));
+    }
+
+    @Test
+    public void successfulModifyAndCompile_leavesGraphNotDirty() throws Exception
+    {
+        LegendPureSession session = new LegendPureSession();
+        session.initialize();
+
+        LegendPureSession.CompileResult result = session.modifyAndCompile(
+                "graphDirtyTest.pure", "function graphDirtyTestFn():Any[*]\n{\n  print('hi', 1);\n}\n");
+        Assert.assertTrue("compile should succeed, got: "
+                        + (result.getError() != null ? result.getError().getMessage() : ""),
+                result.isSuccess());
+        Assert.assertFalse("graph should be clean immediately after a successful compile", readGraphDirty(session));
+    }
+
+    @Test
+    public void executeNeverLeavesGraphDirty() throws Exception
+    {
+        LegendPureSession session = new LegendPureSession();
+        session.initialize();
+        session.modifyAndCompile("graphDirtyTest2.pure", "function go():Any[*]\n{\n  print('go', 1);\n}\n");
+        Assert.assertFalse(readGraphDirty(session));
+
+        LegendPureSession.ExecuteResult result = session.executeGo();
+        Assert.assertTrue("go() should execute, got: " + result.getError(), result.isSuccess());
+        // ensureCompiled() runs before every execute() - confirm it never leaves dirty=true behind,
+        // so a run of back-to-back executions keeps taking the fast (no-write-lock) path.
+        Assert.assertFalse(readGraphDirty(session));
+    }
+
+    @Test
+    public void markGraphDirtyAndMarkGraphCompiled_roundTrip()
+    {
+        LegendPureSession session = new LegendPureSession();
+        session.initialize();
+        Assert.assertFalse(readGraphDirty(session));
+
+        session.markGraphDirty();
+        Assert.assertTrue(readGraphDirty(session));
+
+        session.markGraphCompiled();
+        Assert.assertFalse(readGraphDirty(session));
+    }
+
+    private static boolean readGraphDirty(LegendPureSession session)
+    {
+        try
+        {
+            Field field = LegendPureSession.class.getDeclaredField("graphDirty");
+            field.setAccessible(true);
+            return ((AtomicBoolean) field.get(session)).get();
+        }
+        catch (ReflectiveOperationException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/LegendPureSessionIntegrationTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/LegendPureSessionIntegrationTest.java
@@ -69,6 +69,16 @@ public class LegendPureSessionIntegrationTest
     }
 
     @Test
+    public void modifyAndCompile_nullSourceId_isSafeNoOp()
+    {
+        // UriMapper.toSourceId() returns null for a .pure file that isn't part of any registered Pure
+        // module (a fixture resource that merely has the extension) - modifyAndCompile must treat that
+        // the same as "not ready" rather than dereferencing the null sourceId.
+        LegendPureSession.CompileResult result = session.modifyAndCompile(null, "irrelevant content");
+        Assert.assertFalse("Null sourceId means nothing to compile", result.isReady());
+    }
+
+    @Test
     public void compile_invalidPureCode_returnsCompileError()
     {
         LegendPureSession.CompileResult result = session.modifyAndCompile(
@@ -152,6 +162,48 @@ public class LegendPureSessionIntegrationTest
         Assert.assertEquals("Invalid background edit must remain on disk", invalidDiskContent, new String(Files.readAllBytes(sourceFile)));
         Assert.assertEquals("Runtime should keep last good source content after failed background compile",
                 originalContent, workspaceSession.getPureRuntime().getSourceById(sourceId).getContent());
+    }
+
+    @Test
+    public void modifyAndCompile_neverBeforeCompiledSourceWithCompileError_isNotInternalAndRuntimeStaysUsable() throws Exception
+    {
+        // Reproduces a source that is on disk, backed by a real workspace repo, but has never been
+        // loaded/compiled this session (e.g. a file the agent just wrote, then immediately pushed via
+        // textDocument/didChange). Its first-ever compile attempt failing used to be misclassified as
+        // an internal error - see SourceMutationService#modifyAndCompile's snapshot-before-load fix.
+        Path workspaceRoot = Files.createTempDirectory("pure-lsp-never-compiled-error-test");
+        Path resourcesDir = workspaceRoot.resolve("new-module/src/main/resources");
+        Path repoDir = resourcesDir.resolve("never_compiled_repo");
+        Files.createDirectories(repoDir);
+
+        String brokenContent = "function test::neverbefore::dummySix():String[1]\n{\n  dummyMissingPiece();\n}\n";
+        Files.write(resourcesDir.resolve("never_compiled_repo.definition.json"),
+                ("{\"name\":\"never_compiled_repo\","
+                        + "\"pattern\":\"(test::neverbefore)(::.*)?\","
+                        + "\"dependencies\":[\"platform\"]}").getBytes());
+        // Deliberately no BrandNew.pure written to disk yet - the whole point is that this source has
+        // never existed anywhere (not on disk, not in the runtime) until the modifyAndCompile call below
+        // introduces it live, matching a freshly-created file pushed via textDocument/didChange before
+        // it's ever been part of a scan.
+
+        RepositoryScanner scanner = new RepositoryScanner();
+        scanner.scan(Collections.singletonList(workspaceRoot));
+
+        LegendPureSession workspaceSession = new LegendPureSession();
+        workspaceSession.initialize(scanner);
+
+        String sourceId = "/never_compiled_repo/BrandNew.pure";
+        LegendPureSession.CompileResult result = workspaceSession.modifyAndCompile(sourceId, brokenContent);
+
+        Assert.assertFalse("A plain unresolved-function error must not be misreported as internal", result.isInternalError());
+        Assert.assertFalse("Compile should be reported as failed", result.isSuccess());
+        Assert.assertNotNull(result.getError());
+
+        String validContent = "function test::neverbefore::workingFunc():Boolean[1]\n{\n  true;\n}\n";
+        LegendPureSession.CompileResult secondResult = workspaceSession.modifyAndCompile(
+                "/never_compiled_repo/Working.pure", validContent);
+        Assert.assertTrue("Runtime must still be healthy for a subsequent, unrelated, valid source: "
+                + (secondResult.getError() == null ? null : secondResult.getError().getMessage()), secondResult.isSuccess());
     }
 
     @Test
@@ -312,6 +364,37 @@ public class LegendPureSessionIntegrationTest
         Assert.assertTrue("Safe class should still compile after immutable source modification attempt, got: "
                 + (r2.getError() != null ? r2.getError().getMessage() : ""),
                 r2.isSuccess());
+    }
+
+    // -- restoreFromDisk race tests --
+
+    @Test
+    public void restoreFromDisk_inMemorySourceAlreadyDeleted_isSafeNoOp()
+    {
+        // Reproduces the didClose/legend-deleteFile race: a bare in-memory scratch source (e.g.
+        // welcome.pure) whose live Source is removed (simulated here via a direct runtime.delete)
+        // before restoreFromDisk runs for the same id. restoreFromDisk must not fall through to a
+        // disk reload for a bare id - that used to throw "'welcome.pure' should not be in memory!"
+        // and get misclassified as an internal error, triggering full session recovery.
+        session.reinitialize();
+
+        LegendPureSession.CompileResult created = session.modifyAndCompile(
+                "welcome.pure",
+                "function go():Any[*]\n{\n  'scratch'\n}\n"
+        );
+        Assert.assertTrue("Scratch source should compile", created.isSuccess());
+
+        session.getPureRuntime().delete("welcome.pure");
+        session.getPureRuntime().compile();
+
+        LegendPureSession.CompileResult result = session.restoreFromDisk("welcome.pure");
+
+        Assert.assertFalse("Restoring an already-deleted in-memory source is not an internal error: "
+                + (result.getError() == null ? null : result.getError().getMessage()),
+                result.isInternalError());
+        Assert.assertTrue("Session must stay healthy, not enter recovery", session.isInitialized());
+        Assert.assertNull("Nothing should be reloaded for the bare in-memory id",
+                session.getPureRuntime().getSourceById("welcome.pure"));
     }
 
     // -- Execute go() tests --

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/LockContentionNotificationTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/LockContentionNotificationTest.java
@@ -1,0 +1,207 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.finos.legend.pure.lsp.protocol.LegendLanguageClient;
+import org.finos.legend.pure.lsp.protocol.LegendLogEvent;
+import org.finos.legend.pure.lsp.protocol.LockContentionEvent;
+import org.finos.legend.pure.lsp.protocol.LspStatus;
+import org.finos.legend.pure.lsp.protocol.WorkspaceDriftEvent;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Exercises LegendPureSession's legend/lockContention notification (see acquireLock()/onBlockStart()/
+ * onBlockEnd()): a caller that is actually forced to wait for the graph lock, for longer than the
+ * notification delay, must produce exactly one active=true event followed by exactly one active=false
+ * event. A caller granted the lock immediately, or one whose wait clears before the delay elapses,
+ * must produce no events at all.
+ */
+public class LockContentionNotificationTest
+{
+    @Test
+    public void blockedReadCallerProducesStartAndEndEvents() throws Exception
+    {
+        LegendPureSession session = new LegendPureSession();
+        session.initialize();
+        // Shrink the debounce delay so this test doesn't have to sleep for the real 5s default.
+        session.setLockContentionNotificationDelayMs(50);
+
+        RecordingClient client = new RecordingClient();
+        session.setClient(client);
+
+        LegendPureSession.LockHandle writeHandle = session.acquireGraphWriteLock();
+        Assert.assertTrue("No contention expected for an immediately-granted lock", client.events.isEmpty());
+
+        Thread reader = new Thread(() ->
+        {
+            try (LegendPureSession.LockHandle ignored = session.acquireGraphReadLock())
+            {
+                // Nothing to do - the point is just acquiring (and promptly releasing) it.
+            }
+        }, "test-blocked-reader");
+        reader.start();
+
+        // The reader can only be blocked (rather than racing ahead) while the write lock above is
+        // still held, so this confirms acquireGraphReadLock() really did have to wait for it.
+        Assert.assertTrue("Expected a lock-contention start event within 5s",
+                client.activeLatch.await(5, TimeUnit.SECONDS));
+        Assert.assertTrue("Session should report itself contended while the reader waits", session.isLockContended());
+        Assert.assertNotNull(session.lockContentionReason());
+
+        writeHandle.close();
+        reader.join(5000);
+        Assert.assertFalse("Reader thread should have finished", reader.isAlive());
+
+        Assert.assertTrue("Expected a lock-contention end event within 5s",
+                client.clearedLatch.await(5, TimeUnit.SECONDS));
+        Assert.assertFalse("Session should no longer report contention once the reader is done", session.isLockContended());
+
+        Assert.assertEquals("Exactly one start + one end event expected", 2, client.events.size());
+        LockContentionEvent start = client.events.get(0);
+        Assert.assertTrue(start.isActive());
+        Assert.assertEquals("read", start.getLockType());
+        LockContentionEvent end = client.events.get(1);
+        Assert.assertFalse(end.isActive());
+        Assert.assertEquals("read", end.getLockType());
+    }
+
+    @Test
+    public void immediatelyGrantedLock_producesNoContentionEvent()
+    {
+        LegendPureSession session = new LegendPureSession();
+        session.initialize();
+
+        RecordingClient client = new RecordingClient();
+        session.setClient(client);
+
+        try (LegendPureSession.LockHandle ignored = session.acquireGraphReadLock())
+        {
+            Assert.assertFalse(session.isLockContended());
+        }
+        Assert.assertTrue("An uncontended acquisition must not publish any event", client.events.isEmpty());
+    }
+
+    @Test
+    public void contentionShorterThanNotificationDelay_producesNoEvent() throws Exception
+    {
+        LegendPureSession session = new LegendPureSession();
+        session.initialize();
+        session.setLockContentionNotificationDelayMs(300);
+
+        RecordingClient client = new RecordingClient();
+        session.setClient(client);
+
+        LegendPureSession.LockHandle writeHandle = session.acquireGraphWriteLock();
+
+        Thread reader = new Thread(() ->
+        {
+            try (LegendPureSession.LockHandle ignored = session.acquireGraphReadLock())
+            {
+                // Nothing to do - the point is just acquiring (and promptly releasing) it.
+            }
+        }, "test-short-blocked-reader");
+        reader.start();
+
+        // Confirm the reader is genuinely blocked (not just "hasn't started yet"), while staying well
+        // under the 300ms debounce delay above so the active notification never gets a chance to fire.
+        long deadline = System.currentTimeMillis() + 200;
+        while (!session.isLockContended() && System.currentTimeMillis() < deadline)
+        {
+            Thread.sleep(5);
+        }
+        Assert.assertTrue("Reader should be blocked on the write lock", session.isLockContended());
+
+        writeHandle.close();
+        reader.join(5000);
+        Assert.assertFalse("Reader thread should have finished", reader.isAlive());
+
+        // Give the (expected-to-be-cancelled) debounce timer a chance to fire if cancellation failed.
+        Thread.sleep(500);
+        Assert.assertTrue("Contention shorter than the debounce delay must not publish any event", client.events.isEmpty());
+    }
+
+    private static class RecordingClient implements LegendLanguageClient
+    {
+        final List<LockContentionEvent> events = Collections.synchronizedList(new ArrayList<>());
+        final CountDownLatch activeLatch = new CountDownLatch(1);
+        final CountDownLatch clearedLatch = new CountDownLatch(1);
+
+        @Override
+        public void lockContention(LockContentionEvent event)
+        {
+            this.events.add(event);
+            if (event.isActive())
+            {
+                this.activeLatch.countDown();
+            }
+            else
+            {
+                this.clearedLatch.countDown();
+            }
+        }
+
+        @Override
+        public void telemetryEvent(Object object)
+        {
+        }
+
+        @Override
+        public void publishDiagnostics(PublishDiagnosticsParams diagnostics)
+        {
+        }
+
+        @Override
+        public void showMessage(MessageParams messageParams)
+        {
+        }
+
+        @Override
+        public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams)
+        {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public void logMessage(MessageParams message)
+        {
+        }
+
+        @Override
+        public void statusChanged(LspStatus status)
+        {
+        }
+
+        @Override
+        public void logOutput(LegendLogEvent event)
+        {
+        }
+
+        @Override
+        public void workspaceDriftDetected(WorkspaceDriftEvent event)
+        {
+        }
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/LspEndToEndTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/LspEndToEndTest.java
@@ -65,6 +65,8 @@ import org.finos.legend.pure.lsp.protocol.FileEntry;
 import org.finos.legend.pure.lsp.protocol.LspStatus;
 import org.finos.legend.pure.lsp.protocol.SetOptionParams;
 import org.finos.legend.pure.lsp.protocol.SetOptionResult;
+import org.finos.legend.pure.lsp.protocol.TestFunctionInfo;
+import org.finos.legend.pure.lsp.protocol.TestFunctionsParams;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -584,6 +586,37 @@ public class LspEndToEndTest
     }
 
     @Test
+    public void testFunctions_rpc_findsOnlyRealTestStereotypedFunction() throws Exception
+    {
+        long ts = System.currentTimeMillis();
+        String uri = "file:///workspace/src/main/resources/e2e_test_functions_" + ts + ".pure";
+        CheckBatchParams compile = new CheckBatchParams();
+        compile.setFiles(Collections.singletonList(new FileEntry(uri,
+                "function <<test.Test>> test::e2e::tf::realTest" + ts + "(): Boolean[1]\n"
+                        + "{\n  assert(true, |'')\n}\n"
+                        + "function test::e2e::tf::plainFn" + ts + "(): Boolean[1]\n"
+                        + "{\n  true\n}\n")));
+        CheckBatchResult compileResult = server.checkBatch(compile).get(30, TimeUnit.SECONDS);
+        Assert.assertTrue("Fixture should compile, got: " + compileResult.getError(), compileResult.isSuccess());
+
+        List<TestFunctionInfo> found = server.testFunctions(new TestFunctionsParams(uri)).get(15, TimeUnit.SECONDS);
+        Assert.assertEquals("Should find exactly the one <<test.Test>>-stereotyped function, found: " + found,
+                1, found.size());
+        Assert.assertEquals("test::e2e::tf::realTest" + ts + "__Boolean_1_", found.get(0).getFunctionPath());
+        Assert.assertEquals("realTest" + ts, found.get(0).getName());
+
+        server.deleteFile(new DeleteFileParams(uri)).get(15, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testFunctions_rpc_uninitializedOrMissingUri_returnsEmpty() throws Exception
+    {
+        List<TestFunctionInfo> result = server.testFunctions(new TestFunctionsParams()).get(10, TimeUnit.SECONDS);
+        Assert.assertNotNull("Should return an (empty) list rather than fail", result);
+        Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
     public void status_rpc_exposesRepositoryProgressFields() throws Exception
     {
         // Plumbing/invariant check that legend/status carries the compiled/total repository fields
@@ -600,6 +633,54 @@ public class LspEndToEndTest
         Assert.assertTrue("Compiled repositories must not exceed total ("
                         + status.getCompiledRepositories() + " > " + status.getTotalRepositories() + ")",
                 status.getCompiledRepositories() <= status.getTotalRepositories());
+    }
+
+    @Test
+    public void twoConnectedClients_bothReceiveDiagnostics_disconnectStopsOnlyOne() throws Exception
+    {
+        // Regression test for the multi-client broadcast bug: a second client connecting (e.g. an
+        // agent/CLI bridge sharing the same warm socket-mode daemon as an IDE session) must not steal
+        // notifications away from the first, already-connected client.
+        MockLanguageClient secondClient = new MockLanguageClient();
+        server.connect(secondClient);
+        try
+        {
+            long ts = System.currentTimeMillis();
+            String uri = "file:///workspace/src/main/resources/e2e_multiclient_" + ts + ".pure";
+            mockClient.clearDiagnostics();
+            secondClient.clearDiagnostics();
+
+            server.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(
+                    new TextDocumentItem(uri, "pure", 1,
+                            "Class test::e2e::MultiClient" + ts + "\n{\n  x: NoSuchType999[1];\n}\n")));
+            Thread.sleep(1500);
+
+            Assert.assertFalse("Original client should still receive diagnostics",
+                    mockClient.getDiagnosticsFor(uri).isEmpty());
+            Assert.assertFalse("Second client should also receive diagnostics",
+                    secondClient.getDiagnosticsFor(uri).isEmpty());
+
+            // Disconnect the second client; the first must keep receiving updates uninterrupted.
+            server.disconnect(secondClient);
+            mockClient.clearDiagnostics();
+            secondClient.clearDiagnostics();
+
+            VersionedTextDocumentIdentifier docId = new VersionedTextDocumentIdentifier(uri, 2);
+            TextDocumentContentChangeEvent fix = new TextDocumentContentChangeEvent(
+                    "Class test::e2e::MultiClient" + ts + "\n{\n  x: String[1];\n}\n");
+            server.getTextDocumentService().didChange(new DidChangeTextDocumentParams(
+                    docId, Collections.singletonList(fix)));
+            Thread.sleep(1500);
+
+            Assert.assertFalse("Still-connected original client should keep receiving diagnostics",
+                    mockClient.getDiagnosticsFor(uri).isEmpty());
+            Assert.assertTrue("Disconnected client must receive nothing further",
+                    secondClient.getDiagnosticsFor(uri).isEmpty());
+        }
+        finally
+        {
+            server.disconnect(secondClient);
+        }
     }
 
     /**

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/OverlayWorkspaceCodeStorageTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/OverlayWorkspaceCodeStorageTest.java
@@ -17,6 +17,9 @@ package org.finos.legend.pure.lsp;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import org.eclipse.collections.api.RichIterable;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
 import org.junit.Assert;
@@ -65,5 +68,62 @@ public class OverlayWorkspaceCodeStorageTest
 
         Assert.assertTrue(storage.exists(createdSourceId));
         Assert.assertFalse("Overlay create must not create a physical file", Files.exists(createdFile));
+    }
+
+    @Test
+    public void getUserFiles_excludesTopLevelDataFixtureDir_butKeepsWelcomePure() throws Exception
+    {
+        // Reproduces the alloy-lakehouse-ingest-integration-test-compatibility layout: a top-level
+        // "data" folder full of runtime test-fixture .pure text (template strings a Java test harness
+        // reads and substitutes, never meant to be parsed by the LSP), plus a real package file and a
+        // welcome.pure entry point that must always be kept even though it sits under "data".
+        Path root = this.tempFolder.getRoot().toPath().resolve("fixture_repo");
+        Path realModelFile = root.resolve("model/Person.pure");
+        Path fixtureFile = root.resolve("data/ingest/matview/catalog/matview.pure");
+        Path welcomeUnderData = root.resolve("data/welcome.pure");
+        Files.createDirectories(realModelFile.getParent());
+        Files.createDirectories(fixtureFile.getParent());
+        Files.write(realModelFile, "Class test::fixture::Person\n{\n  name: String[1];\n}\n".getBytes(StandardCharsets.UTF_8));
+        Files.write(fixtureFile, "###Lakehouse\nnot valid outside a template substitution\n".getBytes(StandardCharsets.UTF_8));
+        Files.write(welcomeUnderData, "function go():Any[*]\n{\n  'hi'\n}\n".getBytes(StandardCharsets.UTF_8));
+
+        CodeRepository repository = new GenericCodeRepository("fixture_repo", "(test::fixture)(::.*)?");
+        OverlayWorkspaceCodeStorage storage = new OverlayWorkspaceCodeStorage(repository, root);
+
+        Set<String> files = toSet(storage.getUserFiles());
+
+        Assert.assertTrue("Real package file should be compilable, got: " + files,
+                files.contains("/fixture_repo/model/Person.pure"));
+        Assert.assertFalse("File under a top-level data/ fixture folder should be excluded, got: " + files,
+                files.contains("/fixture_repo/data/ingest/matview/catalog/matview.pure"));
+        Assert.assertTrue("welcome.pure must always be kept, even under data/, got: " + files,
+                files.contains("/fixture_repo/data/welcome.pure"));
+    }
+
+    @Test
+    public void getUserFiles_keepsDataAsNestedPackageSegment() throws Exception
+    {
+        // Guards against over-broadening the exclusion: a "data" package nested below the repo root
+        // (e.g. legend-engine's real core::pure::data package, at core/pure/data/*.pure) is legitimate
+        // compilable source and must not be swept up by the top-level-only fixture exclusion.
+        Path root = this.tempFolder.getRoot().toPath().resolve("core_repo");
+        Path nestedDataPackageFile = root.resolve("pure/data/data.pure");
+        Files.createDirectories(nestedDataPackageFile.getParent());
+        Files.write(nestedDataPackageFile, "function test::core::data::f(): Any[*] { [] }\n".getBytes(StandardCharsets.UTF_8));
+
+        CodeRepository repository = new GenericCodeRepository("core_repo", "(test::core)(::.*)?");
+        OverlayWorkspaceCodeStorage storage = new OverlayWorkspaceCodeStorage(repository, root);
+
+        Set<String> files = toSet(storage.getUserFiles());
+
+        Assert.assertTrue("Nested data/ package (not at the repo's top level) must still compile, got: " + files,
+                files.contains("/core_repo/pure/data/data.pure"));
+    }
+
+    private static Set<String> toSet(RichIterable<String> files)
+    {
+        Set<String> result = new HashSet<>();
+        files.forEach(result::add);
+        return result;
     }
 }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/PCTAdapterProviderTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/PCTAdapterProviderTest.java
@@ -1,0 +1,115 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.util.List;
+import java.util.Optional;
+import org.finos.legend.pure.lsp.protocol.PCTAdapterInfo;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Verifies PCTAdapterProvider mirrors meta::pure::ide::testing::getPCTAdapters(): every element
+ * carrying the &lt;&lt;PCT.adapter&gt;&gt; stereotype is found, named by its 'adapterName' tagged
+ * value (falling back to the element's own name), keyed by its Pure path.
+ */
+public class PCTAdapterProviderTest
+{
+    private static final String SOURCE_ID = "test_pct_adapter_provider.pure";
+
+    private static LegendPureSession session;
+
+    @BeforeClass
+    public static void init()
+    {
+        session = new LegendPureSession();
+        session.initialize();
+
+        String code = "function <<meta::pure::test::pct::PCT.adapter>> "
+                + "{meta::pure::test::pct::PCT.adapterName='Test-Custom'} "
+                + "test::pct::adapters::myAdapter(f:Function<{->String[1]}>[1]):String[1]\n" +
+                "{\n" +
+                "  $f->eval() + '-adapted';\n" +
+                "}\n" +
+                "\n" +
+                "function <<meta::pure::test::pct::PCT.adapter>> "
+                + "test::pct::adapters::unnamedAdapter(f:Function<{->String[1]}>[1]):String[1]\n" +
+                "{\n" +
+                "  $f->eval();\n" +
+                "}\n" +
+                "\n" +
+                "function test::pct::adapters::plainFunction(): Boolean[1]\n" +
+                "{\n" +
+                "  true\n" +
+                "}\n";
+
+        LegendPureSession.CompileResult result = session.modifyAndCompile(SOURCE_ID, code);
+        Assert.assertTrue("Test fixture should compile: "
+                + (result.getError() != null ? result.getError().getMessage() : ""), result.isSuccess());
+    }
+
+    @AfterClass
+    public static void cleanup()
+    {
+        session = null;
+    }
+
+    @Test
+    public void findsAdapterWithExplicitName()
+    {
+        List<PCTAdapterInfo> found = PCTAdapterProvider.getPCTAdapters(session.getPureRuntime());
+        Optional<PCTAdapterInfo> custom = found.stream()
+                .filter(a -> "test::pct::adapters::myAdapter__Function_1__String_1_".equals(a.getPath())
+                        || a.getPath().startsWith("test::pct::adapters::myAdapter"))
+                .findFirst();
+        Assert.assertTrue("Expected the custom adapter to be found, found: " + found, custom.isPresent());
+        Assert.assertEquals("Test-Custom", custom.get().getName());
+    }
+
+    @Test
+    public void fallsBackToElementNameWhenAdapterNameTagAbsent()
+    {
+        List<PCTAdapterInfo> found = PCTAdapterProvider.getPCTAdapters(session.getPureRuntime());
+        Optional<PCTAdapterInfo> unnamed = found.stream()
+                .filter(a -> a.getPath().startsWith("test::pct::adapters::unnamedAdapter"))
+                .findFirst();
+        Assert.assertTrue("Expected the unnamed adapter to be found, found: " + found, unnamed.isPresent());
+        Assert.assertEquals("unnamedAdapter", unnamed.get().getName());
+    }
+
+    @Test
+    public void ignoresPlainFunction()
+    {
+        List<PCTAdapterInfo> found = PCTAdapterProvider.getPCTAdapters(session.getPureRuntime());
+        boolean containsPlain = found.stream().anyMatch(a -> a.getPath().contains("plainFunction"));
+        Assert.assertFalse("A function without the PCT.adapter stereotype must not be reported", containsPlain);
+    }
+
+    @Test
+    public void includesTheBuiltInPlatformInMemoryAdapter()
+    {
+        // meta::pure::test::pct::testAdapterForInMemoryExecution is defined in the platform itself
+        // (pct_core.pure), always loaded - a real end-to-end sanity check that this isn't only
+        // finding elements from this test's own fixture source.
+        List<PCTAdapterInfo> found = PCTAdapterProvider.getPCTAdapters(session.getPureRuntime());
+        boolean containsBuiltIn = found.stream()
+                .anyMatch(a -> "In-Memory".equals(a.getName())
+                        && a.getPath().startsWith("meta::pure::test::pct::testAdapterForInMemoryExecution"));
+        Assert.assertTrue("Expected the platform's built-in In-Memory PCT adapter to be found, found: " + found,
+                containsBuiltIn);
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/PCTTestExecutionTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/PCTTestExecutionTest.java
@@ -1,0 +1,143 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.util.List;
+import org.finos.legend.pure.lsp.protocol.PCTAdapterInfo;
+import org.finos.legend.pure.lsp.protocol.TestFunctionInfo;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Verifies LegendPureSession#executeFunction(String, String) resolves the given pctAdapterPath and
+ * substitutes it as the sole argument to a &lt;&lt;PCT.test&gt;&gt; function - mirroring, for a single
+ * function invoked by path, the substitution org.finos.legend.pure.m3.execution.test.TestRunner
+ * (legend-pure-core) already performs for a bulk PCT run via _Package.getByUserPath(pctAdapter, ...).
+ */
+public class PCTTestExecutionTest
+{
+    private static final String SOURCE_ID = "test_pct_execution.pure";
+
+    private static LegendPureSession session;
+    private static String pctTestFunctionPath;
+    private static String pctAdapterPath;
+
+    @BeforeClass
+    public static void init()
+    {
+        session = new LegendPureSession();
+        session.initialize();
+
+        String code = "function <<meta::pure::test::pct::PCT.adapter>> "
+                + "{meta::pure::test::pct::PCT.adapterName='Test-Custom'} "
+                + "test::pct::exec::myAdapter(f:Function<{->String[1]}>[1]):String[1]\n" +
+                "{\n" +
+                "  $f->eval() + '-adapted';\n" +
+                "}\n" +
+                "\n" +
+                "function <<meta::pure::test::pct::PCT.test>> "
+                + "test::pct::exec::myPctTest(f:Function<{Function<{->String[1]}>[1]->String[1]}>[1]):Boolean[1]\n" +
+                "{\n" +
+                "  print($f->eval(|'hello'));\n" +
+                "  true;\n" +
+                "}\n" +
+                "\n" +
+                "function test::pct::exec::notAnAdapter(): String[1]\n" +
+                "{\n" +
+                "  'not-an-adapter';\n" +
+                "}\n";
+
+        LegendPureSession.CompileResult result = session.modifyAndCompile(SOURCE_ID, code);
+        Assert.assertTrue("Test fixture should compile: "
+                + (result.getError() != null ? result.getError().getMessage() : ""), result.isSuccess());
+
+        // The precise, execution-ready path (mangled id form) for a non-zero-arg function like a PCT
+        // test isn't guessable from its bare path - it's exactly what legend/testFunctions already
+        // hands back to a client for this purpose (see TestFunctionInfo#getFunctionPath), so resolve
+        // it the same way here instead of hand-guessing Pure's name-mangling scheme.
+        List<TestFunctionInfo> testFunctions = TestFunctionProvider.getTestFunctions(session.getPureRuntime(), SOURCE_ID);
+        pctTestFunctionPath = testFunctions.stream()
+                .filter(f -> f.getName().equals("myPctTest"))
+                .findFirst()
+                .map(TestFunctionInfo::getFunctionPath)
+                .orElseThrow(() -> new AssertionError("myPctTest should be discovered as a test function: " + testFunctions));
+
+        // Likewise, the adapter's precise path (mangled id form, since it's not zero-arg either) is
+        // exactly what legend/getPCTAdapters hands back - resolve it the same way a real client would,
+        // rather than hand-guessing Pure's name-mangling scheme.
+        List<PCTAdapterInfo> adapters = PCTAdapterProvider.getPCTAdapters(session.getPureRuntime());
+        pctAdapterPath = adapters.stream()
+                .filter(a -> a.getPath().startsWith("test::pct::exec::myAdapter"))
+                .findFirst()
+                .map(PCTAdapterInfo::getPath)
+                .orElseThrow(() -> new AssertionError("myAdapter should be discovered as a PCT adapter: " + adapters));
+    }
+
+    @AfterClass
+    public static void cleanup()
+    {
+        session = null;
+    }
+
+    @Test
+    public void discoveredAsPCTTest()
+    {
+        List<TestFunctionInfo> testFunctions = TestFunctionProvider.getTestFunctions(session.getPureRuntime(), SOURCE_ID);
+        TestFunctionInfo info = testFunctions.stream()
+                .filter(f -> f.getName().equals("myPctTest"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("myPctTest should be discovered: " + testFunctions));
+        Assert.assertTrue("A <<PCT.test>> function must be flagged isPCTTest so a client can offer "
+                + "a \"Run PCTs\" action for it", info.isPCTTest());
+    }
+
+    @Test
+    public void executesPCTTestWithResolvedAdapter()
+    {
+        LegendPureSession.ExecuteResult result =
+                session.executeFunction(pctTestFunctionPath, pctAdapterPath);
+
+        Assert.assertTrue("Execution should succeed: " + result.getError(), result.isSuccess());
+        Assert.assertTrue("Adapter should have been invoked, wrapping the test's lambda result: "
+                + result.getOutput(), result.getOutput().contains("hello-adapted"));
+    }
+
+    @Test
+    public void unknownAdapterPathFailsWithClearError()
+    {
+        LegendPureSession.ExecuteResult result =
+                session.executeFunction(pctTestFunctionPath, "test::pct::exec::noSuchAdapter999");
+
+        Assert.assertFalse("Execution should fail for an adapter path that does not resolve", result.isSuccess());
+        Assert.assertTrue("Error should name the missing adapter: " + result.getError(),
+                result.getError().contains("noSuchAdapter999"));
+    }
+
+    @Test
+    public void nullAdapterPathBehavesAsZeroArgumentExecution()
+    {
+        // notAnAdapter() takes no parameters - executeFunction(path) and executeFunction(path, null)
+        // must behave identically for a function that isn't a PCT test.
+        LegendPureSession.ExecuteResult withNullAdapter =
+                session.executeFunction("test::pct::exec::notAnAdapter", null);
+        LegendPureSession.ExecuteResult plain =
+                session.executeFunction("test::pct::exec::notAnAdapter");
+
+        Assert.assertTrue("Execution should succeed: " + withNullAdapter.getError(), withNullAdapter.isSuccess());
+        Assert.assertEquals(plain.getOutput(), withNullAdapter.getOutput());
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/RepositoryScannerTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/RepositoryScannerTest.java
@@ -299,6 +299,112 @@ public class RepositoryScannerTest
         Assert.assertTrue("Resolved file should exist: " + resolved, Files.exists(resolved));
     }
 
+    @Test
+    public void deriveSourceIdFromPath_matchesFileInsideRepoDir() throws IOException
+    {
+        Path resourcesDir = tempFolder.getRoot().toPath()
+                .resolve("mod/src/main/resources");
+        Files.createDirectories(resourcesDir);
+        Files.write(resourcesDir.resolve("my_repo.definition.json"),
+                "{\"name\": \"my_repo\"}".getBytes());
+
+        Path pureFile = resourcesDir.resolve("my_repo/sub/Model.pure");
+        Files.createDirectories(pureFile.getParent());
+        Files.write(pureFile, "Class my::repo::Model {}".getBytes());
+
+        RepositoryScanner scanner = new RepositoryScanner();
+        scanner.scan(Collections.singletonList(tempFolder.getRoot().toPath()));
+
+        Assert.assertEquals("/my_repo/sub/Model.pure", scanner.deriveSourceIdFromPath(pureFile));
+    }
+
+    @Test
+    public void deriveSourceIdFromPath_ignoresSiblingDirectoryWithoutOwnDefinitionFile() throws IOException
+    {
+        // A definition.json for "my_repo" lives directly under src/main/resources, alongside (not
+        // containing) a sibling "data" folder that has no definition.json of its own - that sibling is
+        // not part of the "my_repo" module just because it shares the same src/main/resources parent.
+        Path resourcesDir = tempFolder.getRoot().toPath()
+                .resolve("mod/src/main/resources");
+        Files.createDirectories(resourcesDir);
+        Files.write(resourcesDir.resolve("my_repo.definition.json"),
+                "{\"name\": \"my_repo\"}".getBytes());
+
+        Path fixtureFile = resourcesDir.resolve("data/ingest/fixture.pure");
+        Files.createDirectories(fixtureFile.getParent());
+        Files.write(fixtureFile, "###Lakehouse\n<TEST_GROUP>".getBytes());
+
+        RepositoryScanner scanner = new RepositoryScanner();
+        scanner.scan(Collections.singletonList(tempFolder.getRoot().toPath()));
+
+        Assert.assertNull("Sibling directory without its own definition.json must not resolve",
+                scanner.deriveSourceIdFromPath(fixtureFile));
+    }
+
+    @Test
+    public void deriveSourceIdFromPath_excludesOwnRepoTopLevelDataFolder() throws IOException
+    {
+        // Unlike the sibling-directory case above, this fixture lives INSIDE the registered repo's own
+        // directory (my_repo/data/...) - module membership alone isn't enough to treat it as compilable
+        // source; WorkspaceDriftWatcher relies on this method to make that call for files changed outside
+        // the editor, so a gap here reintroduces the fixture-file compile crash via that path.
+        Path resourcesDir = tempFolder.getRoot().toPath()
+                .resolve("mod/src/main/resources");
+        Files.createDirectories(resourcesDir);
+        Files.write(resourcesDir.resolve("my_repo.definition.json"),
+                "{\"name\": \"my_repo\"}".getBytes());
+
+        Path fixtureFile = resourcesDir.resolve("my_repo/data/ingest/matview/fixture.pure");
+        Files.createDirectories(fixtureFile.getParent());
+        Files.write(fixtureFile, "###Lakehouse\n<TEST_GROUP>".getBytes());
+
+        RepositoryScanner scanner = new RepositoryScanner();
+        scanner.scan(Collections.singletonList(tempFolder.getRoot().toPath()));
+
+        Assert.assertNull("Own repo's top-level data folder must not resolve to a compilable source",
+                scanner.deriveSourceIdFromPath(fixtureFile));
+    }
+
+    @Test
+    public void deriveSourceIdFromPath_stillIncludesWelcomePureInsideDataFolder() throws IOException
+    {
+        Path resourcesDir = tempFolder.getRoot().toPath()
+                .resolve("mod/src/main/resources");
+        Files.createDirectories(resourcesDir);
+        Files.write(resourcesDir.resolve("my_repo.definition.json"),
+                "{\"name\": \"my_repo\"}".getBytes());
+
+        Path welcomeFile = resourcesDir.resolve("my_repo/data/welcome.pure");
+        Files.createDirectories(welcomeFile.getParent());
+        Files.write(welcomeFile, "function go():Any[*] {[]}".getBytes());
+
+        RepositoryScanner scanner = new RepositoryScanner();
+        scanner.scan(Collections.singletonList(tempFolder.getRoot().toPath()));
+
+        Assert.assertEquals("/my_repo/data/welcome.pure", scanner.deriveSourceIdFromPath(welcomeFile));
+    }
+
+    @Test
+    public void deriveSourceIdFromPath_includesNestedDataPackageNotAtRepoTopLevel() throws IOException
+    {
+        // A deeper, non-top-level package that happens to be named "data" (e.g. legend-engine's real
+        // core::pure::data) must not be shadowed by the top-level fixture-folder exclusion.
+        Path resourcesDir = tempFolder.getRoot().toPath()
+                .resolve("mod/src/main/resources");
+        Files.createDirectories(resourcesDir);
+        Files.write(resourcesDir.resolve("my_repo.definition.json"),
+                "{\"name\": \"my_repo\"}".getBytes());
+
+        Path nestedFile = resourcesDir.resolve("my_repo/core/pure/data/Model.pure");
+        Files.createDirectories(nestedFile.getParent());
+        Files.write(nestedFile, "Class my::repo::Model {}".getBytes());
+
+        RepositoryScanner scanner = new RepositoryScanner();
+        scanner.scan(Collections.singletonList(tempFolder.getRoot().toPath()));
+
+        Assert.assertEquals("/my_repo/core/pure/data/Model.pure", scanner.deriveSourceIdFromPath(nestedFile));
+    }
+
     private static Path findLegendPureRoot()
     {
         Path current = java.nio.file.Paths.get(System.getProperty("user.dir")).toAbsolutePath();

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/SemanticTokensProviderTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/SemanticTokensProviderTest.java
@@ -14,7 +14,10 @@
 
 package org.finos.legend.pure.lsp;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -61,6 +64,33 @@ public class SemanticTokensProviderTest
             "  $nm->toUpper();\n" +                                                  // line 4
             "}\n";                                                                   // line 5
 
+    private static final String SNAP_CLS_SOURCE_ID = "sem_test_snap_cls.pure";
+    private static final String SNAP_CLS_CODE =
+            "Class test::snap::Holder\n" +
+            "{\n" +
+            "  someProperty: String[1];\n" +
+            "  decorated(prefix: String[1]) {$prefix + $this.someProperty}: String[1];\n" +
+            "}\n";
+
+    private static final String SNAP_SOURCE_ID = "sem_test_snap.pure";
+    private static final String SNAP_CODE =
+            "function test::snap::deep::myFunction(x: test::snap::Holder[1]): String[1]\n" +  // line 1
+            "{\n" +                                                                           // line 2
+            "  $x.someProperty->toUpper()\n" +                                                // line 3
+            "}\n";                                                                            // line 4
+
+    private static final String LEN_SOURCE_ID = "sem_test_len.pure";
+    private static final String LEN_CODE =
+            "function test::snap::helper(s: String[1]): String[1]\n" +               // line 1
+            "{\n" +                                                                  // line 2
+            "  $s\n" +                                                               // line 3
+            "}\n" +                                                                  // line 4
+            "function test::snap::useQualified(h: test::snap::Holder[1]): String[1]\n" + // line 5
+            "{\n" +                                                                  // line 6
+            "  let a = test::snap::helper($h.someProperty);\n" +                     // line 7
+            "  $h.decorated('p');\n" +                                               // line 8
+            "}\n";                                                                   // line 9
+
     @BeforeClass
     public static void init()
     {
@@ -85,6 +115,17 @@ public class SemanticTokensProviderTest
         LegendPureSession.CompileResult r5 = session.modifyAndCompile(BODY_SOURCE_ID, BODY_CODE);
         Assert.assertTrue("process should compile: " +
                 (r5.getError() != null ? r5.getError().getMessage() : ""), r5.isSuccess());
+
+        LegendPureSession.CompileResult r6 = session.modifyAndCompile(SNAP_CLS_SOURCE_ID, SNAP_CLS_CODE);
+        Assert.assertTrue("Holder should compile: " +
+                (r6.getError() != null ? r6.getError().getMessage() : ""), r6.isSuccess());
+        LegendPureSession.CompileResult r7 = session.modifyAndCompile(SNAP_SOURCE_ID, SNAP_CODE);
+        Assert.assertTrue("myFunction should compile: " +
+                (r7.getError() != null ? r7.getError().getMessage() : ""), r7.isSuccess());
+
+        LegendPureSession.CompileResult r8 = session.modifyAndCompile(LEN_SOURCE_ID, LEN_CODE);
+        Assert.assertTrue("useQualified should compile: " +
+                (r8.getError() != null ? r8.getError().getMessage() : ""), r8.isSuccess());
     }
 
     @AfterClass
@@ -431,5 +472,280 @@ public class SemanticTokensProviderTest
             }
         }
         Assert.assertTrue("Should contain a variable definition token for let binding", foundLetVar);
+    }
+
+    // ── Token start column lands on the identifier, not on preceding punctuation ──
+
+    @Test
+    public void propertyAccessToken_startsAtPropertyName_notAtDot()
+    {
+        // "  $x.someProperty->toUpper()" — the token must cover "someProperty", never start on the '.'
+        String line = SNAP_CODE.split("\\R", -1)[2];
+        int expectedCol = line.indexOf("someProperty");
+
+        int[] token = findToken(decode(snapTokens()), 2, 4, false); // property, not a definition
+        Assert.assertNotNull("Did not find a property access token on line 3", token);
+        Assert.assertEquals("Property token should start at 'someProperty', not at the '.'",
+                expectedCol, token[1]);
+        Assert.assertEquals("Property token should cover the whole identifier",
+                expectedCol + "someProperty".length(), token[1] + token[2]);
+    }
+
+    @Test
+    public void packageQualifiedFunctionDefinitionToken_startsAtSimpleName_notAtPackageSeparator()
+    {
+        // "function test::snap::deep::myFunction(...)" — the token must cover "myFunction",
+        // never start on the '::' that precedes it.
+        String line = SNAP_CODE.split("\\R", -1)[0];
+        int expectedCol = line.indexOf("myFunction");
+
+        int[] token = findToken(decode(snapTokens()), 0, 3, true); // function definition
+        Assert.assertNotNull("Did not find a function definition token on line 1", token);
+        Assert.assertEquals("Function definition token should start at 'myFunction', not at the '::'",
+                expectedCol, token[1]);
+        Assert.assertEquals("Function definition token should cover the whole simple name",
+                expectedCol + "myFunction".length(), token[1] + token[2]);
+    }
+
+    @Test
+    public void unqualifiedFunctionCallToken_startsAtCallName()
+    {
+        // "  $x.someProperty->toUpper()" — an unqualified call already reports the name's own
+        // column; snapping must leave it exactly where it was.
+        String line = SNAP_CODE.split("\\R", -1)[2];
+        int expectedCol = line.indexOf("toUpper");
+
+        int[] token = findToken(decode(snapTokens()), 2, 3, false); // function call, not a definition
+        Assert.assertNotNull("Did not find a function call token on line 3", token);
+        Assert.assertEquals("Function call token should start at 'toUpper'", expectedCol, token[1]);
+        Assert.assertEquals("Function call token should cover the whole call name",
+                expectedCol + "toUpper".length(), token[1] + token[2]);
+    }
+
+    @Test
+    public void variableToken_startsAtVariableName_notAtDollarSign()
+    {
+        // "  $x.someProperty->toUpper()" — the variable token covers "x", not the '$' sigil
+        String line = SNAP_CODE.split("\\R", -1)[2];
+        int expectedCol = line.indexOf("$x") + 1;
+
+        int[] token = findToken(decode(snapTokens()), 2, 10, false); // variable reference
+        Assert.assertNotNull("Did not find a variable token on line 3", token);
+        Assert.assertEquals("Variable token should start at 'x', not at the '$'", expectedCol, token[1]);
+    }
+
+    @Test
+    public void snapToNameColumn_movesPastLeadingPunctuation()
+    {
+        String[] lines = {
+                "  $x.someProperty->toUpper()",
+                "function a::b::c::myFunction():Any[*]"
+        };
+
+        // '.' reported instead of the property name (1-based column 5 is the '.')
+        Assert.assertEquals(6, SemanticTokensProvider.snapToNameColumn(lines, 1, 5, "someProperty"));
+        // '::' reported instead of the simple function name (1-based column 17 starts that "::")
+        Assert.assertEquals(19, SemanticTokensProvider.snapToNameColumn(lines, 2, 17, "myFunction"));
+        // '->' reported instead of the call name
+        Assert.assertEquals(20, SemanticTokensProvider.snapToNameColumn(lines, 1, 18, "toUpper"));
+    }
+
+    @Test
+    public void snapToNameColumn_leavesAlreadyCorrectColumnsUntouched()
+    {
+        String[] lines = {"  $x.someProperty->toUpper()"};
+        Assert.assertEquals(6, SemanticTokensProvider.snapToNameColumn(lines, 1, 6, "someProperty"));
+        Assert.assertEquals(20, SemanticTokensProvider.snapToNameColumn(lines, 1, 20, "toUpper"));
+    }
+
+    @Test
+    public void snapToNameColumn_fallsBackToReportedColumn()
+    {
+        String[] lines = {"  $x.someProperty->toUpper()"};
+
+        // Name not present anywhere near the reported column
+        Assert.assertEquals(6, SemanticTokensProvider.snapToNameColumn(lines, 1, 6, "Absent"));
+        // Name present but beyond the search window
+        Assert.assertEquals(1, SemanticTokensProvider.snapToNameColumn(lines, 1, 1, "toUpper"));
+        // Out-of-range line, missing line array, empty/null name, and degenerate columns
+        Assert.assertEquals(6, SemanticTokensProvider.snapToNameColumn(lines, 9, 6, "someProperty"));
+        Assert.assertEquals(6, SemanticTokensProvider.snapToNameColumn(null, 1, 6, "someProperty"));
+        Assert.assertEquals(6, SemanticTokensProvider.snapToNameColumn(lines, 1, 6, null));
+        Assert.assertEquals(6, SemanticTokensProvider.snapToNameColumn(lines, 1, 6, ""));
+        Assert.assertEquals(1, SemanticTokensProvider.snapToNameColumn(lines, 1, 0, "someProperty"));
+        Assert.assertEquals(99, SemanticTokensProvider.snapToNameColumn(lines, 1, 99, "someProperty"));
+    }
+
+    @Test
+    public void identifierLengthAt_measuresTheIdentifierAtTheColumn()
+    {
+        String[] lines = {"  let a$1 = test::snap::helper($h.decorated('p'));"};
+
+        // Stops at the '(' rather than painting the qualified name's full length
+        Assert.assertEquals(6, SemanticTokensProvider.identifierLengthAt(lines, 1, lines[0].indexOf("helper") + 1, 18));
+        Assert.assertEquals(9, SemanticTokensProvider.identifierLengthAt(lines, 1, lines[0].indexOf("decorated") + 1, 11));
+        // '$' is a valid identifier character after the first one
+        Assert.assertEquals(3, SemanticTokensProvider.identifierLengthAt(lines, 1, lines[0].indexOf("a$1") + 1, 1));
+    }
+
+    @Test
+    public void identifierLengthAt_fallsBackWhenColumnIsNotAnIdentifier()
+    {
+        String[] lines = {"  $h.decorated('p');"};
+
+        // A '$' cannot start an identifier, so a column landing on the sigil keeps the reported length
+        Assert.assertEquals(7, SemanticTokensProvider.identifierLengthAt(lines, 1, lines[0].indexOf('$') + 1, 7));
+        Assert.assertEquals(7, SemanticTokensProvider.identifierLengthAt(lines, 1, lines[0].indexOf('.') + 1, 7));
+        Assert.assertEquals(7, SemanticTokensProvider.identifierLengthAt(lines, 9, 3, 7));
+        Assert.assertEquals(7, SemanticTokensProvider.identifierLengthAt(null, 1, 3, 7));
+        Assert.assertEquals(7, SemanticTokensProvider.identifierLengthAt(lines, 1, 999, 7));
+        // Never returns a length below 1, whatever the caller reported
+        Assert.assertEquals(1, SemanticTokensProvider.identifierLengthAt(lines, 1, 0, 0));
+    }
+
+    // ── Token length spans exactly the identifier at the token's column ──
+
+    @Test
+    public void packageQualifiedCallToken_lengthCoversSimpleNameOnly()
+    {
+        // "  let a = test::snap::helper($h.someProperty);" — the model reports the call name as
+        // "test::snap::helper", but the token starts at "helper" and must stop before the '('.
+        String line = LEN_CODE.split("\\R", -1)[6];
+        int expectedCol = line.indexOf("helper");
+
+        int[] token = findToken(decode(lenTokens()), 6, 3, false); // function call, not a definition
+        Assert.assertNotNull("Did not find a qualified call token on line 7", token);
+        Assert.assertEquals("Call token should start at 'helper'", expectedCol, token[1]);
+        Assert.assertEquals("Call token should be as long as the simple name",
+                "helper".length(), token[2]);
+        Assert.assertEquals("Call token must stop at the '(', not paint into it",
+                line.indexOf('('), token[1] + token[2]);
+    }
+
+    @Test
+    public void qualifiedPropertyToken_lengthCoversPropertyNameOnly()
+    {
+        // "  $h.decorated('p');" — a qualified property's name carries its parameter types,
+        // but the token must cover only the "decorated" identifier.
+        String line = LEN_CODE.split("\\R", -1)[7];
+        int expectedCol = line.indexOf("decorated");
+
+        int[] token = findToken(decode(lenTokens()), 7, 4, false); // property, not a definition
+        Assert.assertNotNull("Did not find a qualified property token on line 8", token);
+        Assert.assertEquals("Property token should start at 'decorated'", expectedCol, token[1]);
+        Assert.assertEquals("Property token should be as long as the property name",
+                "decorated".length(), token[2]);
+        Assert.assertEquals("Property token must stop at the '(', not paint into it",
+                line.indexOf('('), token[1] + token[2]);
+    }
+
+    @Test
+    public void unqualifiedTokens_keepTheirLengths()
+    {
+        List<int[]> tokens = decode(snapTokens());
+
+        Assert.assertEquals("Unqualified call token length unchanged",
+                "toUpper".length(), findToken(tokens, 2, 3, false)[2]);
+        Assert.assertEquals("Function definition token length unchanged",
+                "myFunction".length(), findToken(tokens, 0, 3, true)[2]);
+        Assert.assertEquals("Parameter token length unchanged", "x".length(), findToken(tokens, 0, 7, false)[2]);
+        Assert.assertEquals("Variable token length unchanged", "x".length(), findToken(tokens, 2, 10, false)[2]);
+        Assert.assertEquals("Property token length unchanged",
+                "someProperty".length(), findToken(tokens, 2, 4, false)[2]);
+    }
+
+    @Test
+    public void enumMemberAndClassMemberTokens_keepTheirLengths()
+    {
+        List<int[]> enumTokens = decode(SemanticTokensProvider.getTokens(session.getPureRuntime(), ENUM_SOURCE_ID));
+        Assert.assertEquals("Enum definition token length unchanged", "Color".length(), findToken(enumTokens, 0, 2, true)[2]);
+        Assert.assertEquals("Red token length unchanged", "Red".length(), findToken(enumTokens, 2, 5, false)[2]);
+        Assert.assertEquals("Green token length unchanged", "Green".length(), findToken(enumTokens, 3, 5, false)[2]);
+        Assert.assertEquals("Blue token length unchanged", "Blue".length(), findToken(enumTokens, 4, 5, false)[2]);
+
+        List<int[]> classTokens = decode(SemanticTokensProvider.getTokens(session.getPureRuntime(), CLASS_SOURCE_ID));
+        Assert.assertEquals("Class definition token length unchanged", "Person".length(), findToken(classTokens, 0, 1, true)[2]);
+        Assert.assertEquals("Property definition token length unchanged", "name".length(), findToken(classTokens, 2, 4, true)[2]);
+        Assert.assertEquals("Type reference token length unchanged", "String".length(), findToken(classTokens, 2, 6, false)[2]);
+    }
+
+    @Test
+    public void everyToken_spansExactlyOneIdentifier()
+    {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put(CLASS_SOURCE_ID, CLASS_CODE);
+        sources.put(ENUM_SOURCE_ID, ENUM_CODE);
+        sources.put(FUNC_SOURCE_ID, FUNC_CODE);
+        sources.put(BODY_SOURCE_ID, BODY_CODE);
+        sources.put(SNAP_CLS_SOURCE_ID, SNAP_CLS_CODE);
+        sources.put(SNAP_SOURCE_ID, SNAP_CODE);
+        sources.put(LEN_SOURCE_ID, LEN_CODE);
+
+        for (Map.Entry<String, String> entry : sources.entrySet())
+        {
+            String[] lines = entry.getValue().split("\\R", -1);
+            for (int[] token : decode(SemanticTokensProvider.getTokens(session.getPureRuntime(), entry.getKey())))
+            {
+                String where = entry.getKey() + " line " + token[0] + " col " + token[1];
+                Assert.assertTrue(where + ": line out of range", token[0] < lines.length);
+                String line = lines[token[0]];
+                Assert.assertTrue(where + ": token runs past end of line", token[1] + token[2] <= line.length());
+
+                String text = line.substring(token[1], token[1] + token[2]);
+                Assert.assertTrue(where + ": token text '" + text + "' is not an identifier",
+                        text.matches("[A-Za-z0-9_][A-Za-z0-9_$]*"));
+
+                int after = token[1] + token[2];
+                Assert.assertFalse(where + ": token stops mid-identifier before '" + line.substring(after) + "'",
+                        after < line.length() && isIdentifierChar(line.charAt(after)));
+            }
+        }
+    }
+
+    private static boolean isIdentifierChar(char c)
+    {
+        return Character.toString(c).matches("[A-Za-z0-9_$]");
+    }
+
+    private static List<Integer> lenTokens()
+    {
+        return SemanticTokensProvider.getTokens(session.getPureRuntime(), LEN_SOURCE_ID);
+    }
+
+    private static List<Integer> snapTokens()
+    {
+        return SemanticTokensProvider.getTokens(session.getPureRuntime(), SNAP_SOURCE_ID);
+    }
+
+    /**
+     * Decodes the LSP delta-encoded 5-tuples into absolute {line, column, length, type, modifiers},
+     * with line and column 0-based as the protocol reports them.
+     */
+    private static List<int[]> decode(List<Integer> data)
+    {
+        List<int[]> tokens = new ArrayList<>();
+        int absLine = 0;
+        int absCol = 0;
+        for (int i = 0; i < data.size(); i += 5)
+        {
+            int deltaLine = data.get(i);
+            int deltaCol = data.get(i + 1);
+            absLine += deltaLine;
+            absCol = (deltaLine == 0) ? absCol + deltaCol : deltaCol;
+            tokens.add(new int[]{absLine, absCol, data.get(i + 2), data.get(i + 3), data.get(i + 4)});
+        }
+        return tokens;
+    }
+
+    private static int[] findToken(List<int[]> tokens, int line, int tokenType, boolean definition)
+    {
+        for (int[] token : tokens)
+        {
+            if (token[0] == line && token[3] == tokenType && (((token[4] & 1) != 0) == definition))
+            {
+                return token;
+            }
+        }
+        return null;
     }
 }

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/TestFunctionProviderTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/TestFunctionProviderTest.java
@@ -1,0 +1,131 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.util.List;
+import org.finos.legend.pure.lsp.protocol.TestFunctionInfo;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Verifies legend/testFunctions finds functions by their real compiled &lt;&lt;test.Test&gt;&gt;
+ * stereotype - not by scanning source text for the annotation. The negative cases (a different
+ * stereotype, and the literal annotation text sitting inertly in a comment/string) exist
+ * specifically to prove that: a text/regex scan would wrongly match both.
+ */
+public class TestFunctionProviderTest
+{
+    private static final String SOURCE_ID = "test_function_provider.pure";
+
+    private static LegendPureSession session;
+
+    @BeforeClass
+    public static void init()
+    {
+        session = new LegendPureSession();
+        session.initialize();
+
+        String code = "Profile test::tfp::other::OtherProfile\n" +
+                "{\n" +
+                "  stereotypes: [NotATest];\n" +
+                "}\n" +
+                "\n" +
+                "function <<test.Test>> test::tfp::realTestFunction(): Boolean[1]\n" +
+                "{\n" +
+                "  assert(true, |'')\n" +
+                "}\n" +
+                "\n" +
+                "function test::tfp::plainFunction(): Boolean[1]\n" +
+                "{\n" +
+                "  true\n" +
+                "}\n" +
+                "\n" +
+                "function <<test::tfp::other::OtherProfile.NotATest>> test::tfp::otherStereotypeFunction(): Boolean[1]\n" +
+                "{\n" +
+                "  true\n" +
+                "}\n" +
+                "\n" +
+                "// This one merely mentions <<test.Test>> as text - it must NOT be picked up:\n" +
+                "// a regex/text scan would incorrectly match this comment and the string below.\n" +
+                "function test::tfp::textOnlyFunction(): String[1]\n" +
+                "{\n" +
+                "  '<<test.Test>>'\n" +
+                "}\n";
+
+        LegendPureSession.CompileResult result = session.modifyAndCompile(SOURCE_ID, code);
+        Assert.assertTrue("Test fixture should compile: " +
+                (result.getError() != null ? result.getError().getMessage() : ""), result.isSuccess());
+    }
+
+    @AfterClass
+    public static void cleanup()
+    {
+        session = null;
+    }
+
+    @Test
+    public void getTestFunctions_findsOnlyRealTestStereotypedFunction()
+    {
+        List<TestFunctionInfo> found = TestFunctionProvider.getTestFunctions(session.getPureRuntime(), SOURCE_ID);
+
+        Assert.assertEquals("Exactly one function should carry the real test.Test stereotype, found: " + found,
+                1, found.size());
+
+        TestFunctionInfo info = found.get(0);
+        // Mangled id form (qualified path + signature suffix) - one of the accepted forms for
+        // execution (see ExecuteFunctionParams), and precise even when a name is overloaded.
+        Assert.assertEquals("test::tfp::realTestFunction__Boolean_1_", info.getFunctionPath());
+        Assert.assertEquals("realTestFunction", info.getName());
+        Assert.assertEquals("Function declaration is on line 6", 6, info.getLine());
+    }
+
+    @Test
+    public void getTestFunctions_ignoresPlainFunction()
+    {
+        List<TestFunctionInfo> found = TestFunctionProvider.getTestFunctions(session.getPureRuntime(), SOURCE_ID);
+        boolean containsPlain = found.stream()
+                .anyMatch(f -> f.getName().equals("plainFunction"));
+        Assert.assertFalse("Plain function without any stereotype must not be reported", containsPlain);
+    }
+
+    @Test
+    public void getTestFunctions_ignoresDifferentStereotype()
+    {
+        List<TestFunctionInfo> found = TestFunctionProvider.getTestFunctions(session.getPureRuntime(), SOURCE_ID);
+        boolean containsOther = found.stream()
+                .anyMatch(f -> f.getName().equals("otherStereotypeFunction"));
+        Assert.assertFalse("Function with an unrelated stereotype must not be reported", containsOther);
+    }
+
+    @Test
+    public void getTestFunctions_ignoresLiteralAnnotationTextInCommentsAndStrings()
+    {
+        List<TestFunctionInfo> found = TestFunctionProvider.getTestFunctions(session.getPureRuntime(), SOURCE_ID);
+        boolean containsTextOnly = found.stream()
+                .anyMatch(f -> f.getName().equals("textOnlyFunction"));
+        Assert.assertFalse("A function merely containing the annotation text in a comment/string "
+                + "(no real stereotype) must not be reported - proves this is not text matching", containsTextOnly);
+    }
+
+    @Test
+    public void getTestFunctions_unknownSource_returnsEmpty()
+    {
+        List<TestFunctionInfo> found = TestFunctionProvider.getTestFunctions(
+                session.getPureRuntime(), "no_such_source_999.pure");
+        Assert.assertTrue(found.isEmpty());
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/UriMapperTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/UriMapperTest.java
@@ -148,6 +148,121 @@ public class UriMapperTest
     }
 
     @Test
+    public void deriveSourceId_acceptsResourcesPath_whenScannerConfirmsLeadingSegmentIsARegisteredRepo() throws Exception
+    {
+        java.nio.file.Path tempDir = java.nio.file.Files.createTempDirectory("lsp_test_known_repo");
+        try
+        {
+            java.nio.file.Path resourcesDir = tempDir.resolve("core-module/src/main/resources");
+            java.nio.file.Files.createDirectories(resourcesDir.resolve("core/pure/extensions"));
+            java.nio.file.Files.write(resourcesDir.resolve("core.definition.json"), "{\"name\": \"core\"}".getBytes());
+            java.nio.file.Path pureFile = resourcesDir.resolve("core/pure/extensions/functions.pure");
+            java.nio.file.Files.write(pureFile, "Class X {}".getBytes());
+
+            RepositoryScanner scanner = new RepositoryScanner();
+            scanner.scan(java.util.Collections.singletonList(tempDir));
+
+            UriMapper mapper = new UriMapper();
+            mapper.setRepositoryScanner(scanner);
+
+            Assert.assertEquals("/core/pure/extensions/functions.pure", mapper.deriveSourceId(pureFile.toUri().toString()));
+        }
+        finally
+        {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void deriveSourceId_rejectsResourcesPath_whenLeadingSegmentIsNotARegisteredRepo() throws Exception
+    {
+        java.nio.file.Path tempDir = java.nio.file.Files.createTempDirectory("lsp_test_unknown_repo");
+        try
+        {
+            // "core" is the only registered repo; the fixture module has no definition.json of its own,
+            // so its "data" folder must never be treated as a repo name just because the path happens to
+            // contain a src/main/resources segment (this is the exact shape of the alloy-lakehouse
+            // integration-test-compatibility crash: a ###Lakehouse template .pure fixture, never meant
+            // to be legend-pure-compilable, sitting under some other module's src/main/resources/data).
+            java.nio.file.Path coreResourcesDir = tempDir.resolve("core-module/src/main/resources");
+            java.nio.file.Files.createDirectories(coreResourcesDir.resolve("core"));
+            java.nio.file.Files.write(coreResourcesDir.resolve("core.definition.json"), "{\"name\": \"core\"}".getBytes());
+
+            java.nio.file.Path fixtureResourcesDir = tempDir.resolve("some-other-module/src/main/resources");
+            java.nio.file.Path fixtureFile = fixtureResourcesDir.resolve("data/ingest/matview/catalog/matview.pure");
+            java.nio.file.Files.createDirectories(fixtureFile.getParent());
+            java.nio.file.Files.write(fixtureFile, "###Lakehouse\n<TEST_GROUP>".getBytes());
+
+            RepositoryScanner scanner = new RepositoryScanner();
+            scanner.scan(java.util.Collections.singletonList(tempDir));
+
+            UriMapper mapper = new UriMapper();
+            mapper.setRepositoryScanner(scanner);
+
+            String sourceId = mapper.deriveSourceId(fixtureFile.toUri().toString());
+
+            // Must NOT resolve to "/data/ingest/matview/catalog/matview.pure" (which would imply a bogus
+            // "data" repo and get fed into modifyAndCompile against a real module's grammar). Must also
+            // NOT fall back to an anonymous scratch file ("matview.pure") - unlike a genuinely external/
+            // jar-embedded source, this file really exists on local disk, so treating it as scratch would
+            // still attempt (and fail) to compile it, and leaves a later editor-close's restoreFromDisk
+            // with nothing registered to restore, crashing the session. Must resolve to null: ignored
+            // outright, the same as a .java file would be.
+            Assert.assertNull(sourceId);
+        }
+        finally
+        {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void deriveSourceId_stillScratchFallsBack_forSyntheticPathThatDoesNotExistOnDisk() throws Exception
+    {
+        // Contrast with the test above: a scanner IS configured, but the uri's path does not correspond
+        // to any real file on this disk (e.g. a jar-embedded platform source navigated to via
+        // go-to-definition, whose literal "!"-joined jar-entry-style path never exists as a real file).
+        // This must keep falling back to scratch/in-memory handling - only a file that genuinely exists
+        // on local disk and isn't part of any module gets ignored outright.
+        java.nio.file.Path tempDir = java.nio.file.Files.createTempDirectory("lsp_test_synthetic_path");
+        try
+        {
+            java.nio.file.Path resourcesDir = tempDir.resolve("core-module/src/main/resources");
+            java.nio.file.Files.createDirectories(resourcesDir.resolve("core"));
+            java.nio.file.Files.write(resourcesDir.resolve("core.definition.json"), "{\"name\": \"core\"}".getBytes());
+
+            RepositoryScanner scanner = new RepositoryScanner();
+            scanner.scan(java.util.Collections.singletonList(tempDir));
+
+            UriMapper mapper = new UriMapper();
+            mapper.setRepositoryScanner(scanner);
+
+            String sourceId = mapper.deriveSourceId("file:///nonexistent/synthetic/fail.pure");
+            Assert.assertEquals("fail.pure", sourceId);
+        }
+        finally
+        {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    private static void deleteRecursively(java.nio.file.Path root) throws Exception
+    {
+        java.nio.file.Files.walk(root).sorted(java.util.Comparator.reverseOrder())
+                .forEach(p ->
+                {
+                    try
+                    {
+                        java.nio.file.Files.delete(p);
+                    }
+                    catch (Exception ignored)
+                    {
+                        // Best-effort cleanup for the temporary test workspace.
+                    }
+                });
+    }
+
+    @Test
     public void toUri_returnsPureScheme_forUnknownStorageSourceId()
     {
         UriMapper mapper = new UriMapper();

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/WorkspaceDriftWatcherTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/WorkspaceDriftWatcherTest.java
@@ -1,0 +1,206 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BooleanSupplier;
+import org.finos.legend.pure.lsp.protocol.DriftChangeType;
+import org.finos.legend.pure.lsp.protocol.WorkspaceDriftEntry;
+import org.finos.legend.pure.lsp.protocol.WorkspaceDriftEvent;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class WorkspaceDriftWatcherTest
+{
+    private static final long AWAIT_TIMEOUT_MS = 15_000;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private RepositoryScanner scanner;
+    private UriMapper uriMapper;
+    private Path resourcesRoot;
+    private final CopyOnWriteArrayList<WorkspaceDriftEvent> published = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<String> openUris = new CopyOnWriteArrayList<>();
+    private WorkspaceDriftWatcher watcher;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        // The .definition.json lives directly under src/main/resources (a sibling of the repo-named
+        // directory), NOT inside it - RepositoryScanner maps the repo name to the definition file's
+        // *parent*, and sourceIds are derived relative to that. Getting this one level wrong silently
+        // derives sourceIds without the "/myrepo/" prefix instead of failing loudly.
+        File resourcesDir = tempFolder.newFolder("module", "src", "main", "resources");
+        File repoDir = new File(resourcesDir, "myrepo");
+        Assert.assertTrue(repoDir.mkdirs());
+        try (FileWriter w = new FileWriter(new File(resourcesDir, "myrepo.definition.json")))
+        {
+            w.write("{\"name\": \"myrepo\"}");
+        }
+        this.resourcesRoot = repoDir.toPath();
+
+        this.scanner = new RepositoryScanner();
+        this.scanner.scan(Collections.singletonList(tempFolder.getRoot().toPath()));
+        Assert.assertEquals(resourcesDir.toPath(), this.scanner.getMappings().get("myrepo"));
+
+        this.uriMapper = new UriMapper();
+        this.uriMapper.setRepositoryScanner(this.scanner);
+
+        this.watcher = new WorkspaceDriftWatcher(this.scanner, this.uriMapper,
+                this.openUris::contains, this.published::add);
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (this.watcher != null)
+        {
+            this.watcher.stop();
+        }
+    }
+
+    @Test
+    public void detectsNewFileAsCreated() throws Exception
+    {
+        this.watcher.start(this.scanner.getMappings().values());
+
+        writeFile("New.pure", "Class my::New {}");
+
+        awaitUntil(() -> !this.published.isEmpty(), AWAIT_TIMEOUT_MS);
+        WorkspaceDriftEntry entry = onlyEntry();
+        Assert.assertEquals("created", entry.getChangeType());
+        Assert.assertTrue(entry.getUri().endsWith("New.pure"));
+        Assert.assertTrue(this.watcher.getDirtySourceIds().contains("/myrepo/New.pure"));
+    }
+
+    @Test
+    public void detectsContentChangeAsModified() throws Exception
+    {
+        writeFile("Existing.pure", "Class my::Existing {}");
+        this.watcher.start(this.scanner.getMappings().values());
+
+        writeFile("Existing.pure", "Class my::Existing { prop: String[1]; }");
+
+        awaitUntil(() -> !this.published.isEmpty(), AWAIT_TIMEOUT_MS);
+        WorkspaceDriftEntry entry = onlyEntry();
+        Assert.assertEquals("modified", entry.getChangeType());
+    }
+
+    @Test
+    public void detectsDeletionAsDeleted() throws Exception
+    {
+        File file = writeFile("Gone.pure", "Class my::Gone {}");
+        this.watcher.start(this.scanner.getMappings().values());
+
+        Assert.assertTrue(file.delete());
+
+        awaitUntil(() -> !this.published.isEmpty(), AWAIT_TIMEOUT_MS);
+        WorkspaceDriftEntry entry = onlyEntry();
+        Assert.assertEquals("deleted", entry.getChangeType());
+    }
+
+    @Test
+    public void ignoresNonPureFiles() throws Exception
+    {
+        this.watcher.start(this.scanner.getMappings().values());
+
+        writeFile("readme.txt", "not pure source");
+        // Give the watcher a real chance to (incorrectly) publish before concluding it didn't.
+        Thread.sleep(1_500);
+
+        Assert.assertTrue(this.published.isEmpty());
+    }
+
+    @Test
+    public void excludesOpenDocumentsFromPublishedDriftButKeepsThemTrackedInternally() throws Exception
+    {
+        File file = writeFile("Open.pure", "Class my::Open {}");
+        String uri = file.toURI().toString();
+        this.openUris.add(uri);
+        this.watcher.start(this.scanner.getMappings().values());
+
+        writeFile("Open.pure", "Class my::Open { prop: String[1]; }");
+        // Also touch a second, non-open file so we have a positive signal that publishing did happen
+        // and simply chose to exclude the open one, rather than the watcher having missed everything.
+        writeFile("NotOpen.pure", "Class my::NotOpen {}");
+
+        awaitUntil(() -> !this.published.isEmpty(), AWAIT_TIMEOUT_MS);
+        for (WorkspaceDriftEvent event : this.published)
+        {
+            for (WorkspaceDriftEntry entry : event.getEntries())
+            {
+                Assert.assertNotEquals(uri, entry.getUri());
+            }
+        }
+        Assert.assertTrue(this.watcher.getDirtySourceIds().contains("/myrepo/Open.pure"));
+    }
+
+    @Test
+    public void clearRemovesEntriesFromDirtySet() throws Exception
+    {
+        this.watcher.start(this.scanner.getMappings().values());
+        writeFile("ToClear.pure", "Class my::ToClear {}");
+
+        awaitUntil(() -> this.watcher.getDirtySourceIds().contains("/myrepo/ToClear.pure"), AWAIT_TIMEOUT_MS);
+        this.watcher.clear(Collections.singleton("/myrepo/ToClear.pure"));
+
+        Assert.assertFalse(this.watcher.getDirtySourceIds().contains("/myrepo/ToClear.pure"));
+    }
+
+    private File writeFile(String name, String content) throws IOException
+    {
+        File file = this.resourcesRoot.resolve(name).toFile();
+        try (FileWriter w = new FileWriter(file))
+        {
+            w.write(content);
+        }
+        return file;
+    }
+
+    private WorkspaceDriftEntry onlyEntry()
+    {
+        Assert.assertEquals(1, this.published.size());
+        List<WorkspaceDriftEntry> entries = this.published.get(0).getEntries();
+        Assert.assertEquals(1, entries.size());
+        return entries.get(0);
+    }
+
+    private static void awaitUntil(BooleanSupplier condition, long timeoutMs) throws InterruptedException
+    {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline)
+        {
+            if (condition.getAsBoolean())
+            {
+                return;
+            }
+            Thread.sleep(50);
+        }
+        Assert.assertTrue("Timed out waiting for condition", condition.getAsBoolean());
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/WorkspaceSyncIntegrationTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/WorkspaceSyncIntegrationTest.java
@@ -1,0 +1,155 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.lsp;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.finos.legend.pure.lsp.protocol.SyncWorkspaceParams;
+import org.finos.legend.pure.lsp.protocol.SyncWorkspaceResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Exercises legend/syncWorkspace end to end against a real compiled session. Explicitly passes the uri
+ * to sync in every test rather than relying on {@link WorkspaceDriftWatcher} to have detected the disk
+ * change first - watcher detection/debounce timing is covered separately in
+ * {@link WorkspaceDriftWatcherTest}, so this stays focused on "given a change, does sync apply it and
+ * report it correctly".
+ */
+public class WorkspaceSyncIntegrationTest
+{
+    private static final String DEFINITION = "{\"name\":\"sync_repo\","
+            + "\"pattern\":\"(test::sync)(::.*)?\","
+            + "\"dependencies\":[\"platform\"]}";
+
+    @Test
+    public void syncAppliesModifiedFileAndReportsIt() throws Exception
+    {
+        Path workspaceRoot = Files.createTempDirectory("pure-lsp-sync-modify-test");
+        Path resourcesDir = workspaceRoot.resolve("sync-module/src/main/resources");
+        Path repoDir = resourcesDir.resolve("sync_repo");
+        Path sourceFile = repoDir.resolve("model/SyncPerson.pure");
+        Files.createDirectories(sourceFile.getParent());
+
+        String originalContent = "Class test::sync::SyncPerson\n{\n  name: String[1];\n}\n";
+        Files.write(resourcesDir.resolve("sync_repo.definition.json"), DEFINITION.getBytes());
+        Files.write(sourceFile, originalContent.getBytes());
+
+        LegendPureLspServer server = new LegendPureLspServer();
+        server.preconfigureAndWarm(Collections.singletonList(workspaceRoot), Collections.emptySet());
+        Assert.assertTrue(server.getSession().isInitialized());
+
+        String sourceId = "/sync_repo/model/SyncPerson.pure";
+        String newContent = "Class test::sync::SyncPerson\n{\n  name: String[1];\n  age: Integer[1];\n}\n";
+        Files.write(sourceFile, newContent.getBytes());
+
+        String uri = sourceFile.toUri().toString();
+        SyncWorkspaceResult result = server.syncWorkspace(new SyncWorkspaceParams(Collections.singletonList(uri))).get();
+
+        Assert.assertTrue("Sync should succeed: " + result.getError(), result.isSuccess());
+        Assert.assertEquals(1, result.getModified());
+        Assert.assertEquals(0, result.getCreated());
+        Assert.assertEquals(0, result.getDeleted());
+        Assert.assertEquals(newContent, server.getSession().getPureRuntime().getSourceById(sourceId).getContent());
+    }
+
+    @Test
+    public void syncAppliesNewFileAndReportsItAsCreated() throws Exception
+    {
+        Path workspaceRoot = Files.createTempDirectory("pure-lsp-sync-create-test");
+        Path resourcesDir = workspaceRoot.resolve("sync-module/src/main/resources");
+        Path repoDir = resourcesDir.resolve("sync_repo");
+        Files.createDirectories(repoDir);
+        Files.write(resourcesDir.resolve("sync_repo.definition.json"), DEFINITION.getBytes());
+
+        LegendPureLspServer server = new LegendPureLspServer();
+        server.preconfigureAndWarm(Collections.singletonList(workspaceRoot), Collections.emptySet());
+        Assert.assertTrue(server.getSession().isInitialized());
+
+        Path newFile = repoDir.resolve("model/BrandNew.pure");
+        Files.createDirectories(newFile.getParent());
+        String content = "Class test::sync::BrandNew\n{\n  id: Integer[1];\n}\n";
+        Files.write(newFile, content.getBytes());
+
+        String uri = newFile.toUri().toString();
+        SyncWorkspaceResult result = server.syncWorkspace(new SyncWorkspaceParams(Collections.singletonList(uri))).get();
+
+        Assert.assertTrue("Sync should succeed: " + result.getError(), result.isSuccess());
+        Assert.assertEquals(1, result.getCreated());
+        Assert.assertNotNull(server.getSession().getPureRuntime().getSourceById("/sync_repo/model/BrandNew.pure"));
+    }
+
+    @Test
+    public void syncAppliesDeletionAndReportsIt() throws Exception
+    {
+        Path workspaceRoot = Files.createTempDirectory("pure-lsp-sync-delete-test");
+        Path resourcesDir = workspaceRoot.resolve("sync-module/src/main/resources");
+        Path repoDir = resourcesDir.resolve("sync_repo");
+        Path sourceFile = repoDir.resolve("model/ToDelete.pure");
+        Files.createDirectories(sourceFile.getParent());
+
+        Files.write(resourcesDir.resolve("sync_repo.definition.json"), DEFINITION.getBytes());
+        Files.write(sourceFile, "Class test::sync::ToDelete\n{\n  name: String[1];\n}\n".getBytes());
+
+        LegendPureLspServer server = new LegendPureLspServer();
+        server.preconfigureAndWarm(Collections.singletonList(workspaceRoot), Collections.emptySet());
+        String sourceId = "/sync_repo/model/ToDelete.pure";
+        Assert.assertNotNull(server.getSession().getPureRuntime().getSourceById(sourceId));
+
+        String uri = sourceFile.toUri().toString();
+        Files.delete(sourceFile);
+
+        SyncWorkspaceResult result = server.syncWorkspace(new SyncWorkspaceParams(Collections.singletonList(uri))).get();
+
+        Assert.assertTrue("Sync should succeed: " + result.getError(), result.isSuccess());
+        Assert.assertEquals(1, result.getDeleted());
+        Assert.assertNull(server.getSession().getPureRuntime().getSourceById(sourceId));
+    }
+
+    @Test
+    public void syncSkipsFilesCurrentlyOpenInAnEditor() throws Exception
+    {
+        Path workspaceRoot = Files.createTempDirectory("pure-lsp-sync-open-doc-test");
+        Path resourcesDir = workspaceRoot.resolve("sync-module/src/main/resources");
+        Path repoDir = resourcesDir.resolve("sync_repo");
+        Path sourceFile = repoDir.resolve("model/OpenDoc.pure");
+        Files.createDirectories(sourceFile.getParent());
+
+        String originalContent = "Class test::sync::OpenDoc\n{\n  name: String[1];\n}\n";
+        Files.write(resourcesDir.resolve("sync_repo.definition.json"), DEFINITION.getBytes());
+        Files.write(sourceFile, originalContent.getBytes());
+
+        LegendPureLspServer server = new LegendPureLspServer();
+        server.preconfigureAndWarm(Collections.singletonList(workspaceRoot), Collections.emptySet());
+
+        String uri = sourceFile.toUri().toString();
+        String openBufferContent = "Class test::sync::OpenDoc\n{\n  name: String[1];\n  fromEditor: Boolean[1];\n}\n";
+        server.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(
+                new TextDocumentItem(uri, "pure", 1, openBufferContent)));
+
+        // A conflicting disk change while the document is open in an editor.
+        String diskContent = "Class test::sync::OpenDoc\n{\n  name: String[1];\n  fromDisk: Boolean[1];\n}\n";
+        Files.write(sourceFile, diskContent.getBytes());
+
+        SyncWorkspaceResult result = server.syncWorkspace(new SyncWorkspaceParams(Collections.singletonList(uri))).get();
+
+        Assert.assertTrue("Sync should succeed (as a no-op): " + result.getError(), result.isSuccess());
+        Assert.assertEquals("Open document must not be touched by sync", 0,
+                result.getCreated() + result.getModified() + result.getDeleted());
+    }
+}

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/debug/LegendDebugSessionTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/debug/LegendDebugSessionTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.finos.legend.pure.lsp.LegendPureSession;
@@ -330,6 +331,92 @@ public class LegendDebugSessionTest
     }
 
     @Test(timeout = 60_000)
+    public void sharedModeAttachesToMainRuntimeAndDebugsAlreadyCompiledFunction()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_shared_go.pure";
+        String uri = "file:///workspace/debug_shared_go.pure";
+        String code =
+                "function go():Any[*]\n" +
+                        "{\n" +
+                        "  let x = 'shared';\n" +
+                        "  $x;\n" +
+                        "}\n";
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        LegendDebugSession debug = LegendDebugSession.createShared(
+                session,
+                null,
+                uriMapper,
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, zeroBasedLine(code, "  $x;"))));
+
+        LegendDebug.Response paused = debug.start();
+        Assert.assertTrue(paused.isSuccess());
+        Assert.assertEquals("paused", paused.getState());
+        Assert.assertEquals("breakpoint", paused.getReason());
+        Assert.assertTrue(debug.variables().stream().anyMatch(variable -> "x".equals(variable.getName())));
+
+        LegendDebug.Response completed = debug.continueExecution();
+        Assert.assertTrue(completed.isSuccess());
+        Assert.assertEquals("completed", completed.getState());
+    }
+
+    @Test(timeout = 60_000)
+    public void sharedModeBlocksMainSessionCompileWhilePausedAndReleasesOnStop() throws Exception
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_shared_paused_go.pure";
+        String uri = "file:///workspace/debug_shared_paused_go.pure";
+        String code =
+                "function go():Any[*]\n" +
+                        "{\n" +
+                        "  let x = 'done';\n" +
+                        "  $x;\n" +
+                        "}\n";
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        LegendDebugSession debug = LegendDebugSession.createShared(
+                session,
+                null,
+                uriMapper,
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, zeroBasedLine(code, "  $x;"))));
+        LegendDebug.Response paused = debug.start();
+        Assert.assertEquals("paused", paused.getState());
+
+        java.util.concurrent.CountDownLatch compileFinished = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.atomic.AtomicReference<LegendPureSession.CompileResult> compileResult = new java.util.concurrent.atomic.AtomicReference<>();
+        Thread compileThread = new Thread(() ->
+        {
+            compileResult.set(session.modifyAndCompile(
+                    "debug_shared_main_blocked.pure",
+                    "Class test::debug::SharedBlocked\n{\n  name: String[1];\n}\n"));
+            compileFinished.countDown();
+        });
+        compileThread.start();
+        try
+        {
+            Assert.assertFalse("Main session compile should be blocked while a SHARED debug session is paused",
+                    compileFinished.await(500, java.util.concurrent.TimeUnit.MILLISECONDS));
+
+            debug.stop();
+
+            Assert.assertTrue("Main session compile should complete once the SHARED debug session releases the graph lock",
+                    compileFinished.await(30, java.util.concurrent.TimeUnit.SECONDS));
+            Assert.assertTrue("Expected compile success: " + errorMessage(compileResult.get()), compileResult.get().isSuccess());
+        }
+        finally
+        {
+            compileThread.join(30_000);
+        }
+    }
+
+    @Test(timeout = 60_000)
     public void stepOverStaysInTheCurrentFunction()
     {
         LegendPureSession session = newInitializedSession();
@@ -377,6 +464,93 @@ public class LegendDebugSessionTest
         LegendDebug.Response stepped = debug.stepIn();
         Assert.assertEquals("step", stepped.getReason());
         Assert.assertEquals(3, stepped.getStackFrames().get(0).getLine());
+
+        debug.stop();
+    }
+
+    @Test(timeout = 60_000)
+    public void stepInEntersLambdaBodyPassedToNativeHigherOrderFunction()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_step_in_lambda_go.pure";
+        String uri = "file:///workspace/debug_step_in_lambda_go.pure";
+        String code =
+                "function go():Any[*]\n" +
+                        "{\n" +
+                        "  let x = [1, 2];\n" +
+                        "  let y = $x->map(i |\n" +
+                        "    print('mapping', 1);\n" +
+                        "    $i + 1;);\n" +
+                        "  print($y, 1);\n" +
+                        "}\n";
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        LegendDebugSession debug = LegendDebugSession.create(
+                session,
+                null,
+                uriMapper,
+                Collections.emptyMap(),
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, 3)));
+
+        Assert.assertEquals("let y = ...", 4, debug.start().getStackFrames().get(0).getLine());
+
+        LegendDebug.Response steppedIntoLambda = debug.stepIn();
+        Assert.assertEquals("step", steppedIntoLambda.getReason());
+        Assert.assertEquals("step into map's lambda should stop on its first statement",
+                5, steppedIntoLambda.getStackFrames().get(0).getLine());
+
+        LegendDebug.Response steppedToSecondStatement = debug.stepIn();
+        Assert.assertEquals("step", steppedToSecondStatement.getReason());
+        Assert.assertEquals("stepping again should advance to the lambda's second statement",
+                6, steppedToSecondStatement.getStackFrames().get(0).getLine());
+
+        debug.stop();
+    }
+
+    @Test(timeout = 60_000)
+    public void stepInEntersEachBranchLambdaOfIfAndFollowsLetStatements()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_step_in_if_lambda_go.pure";
+        String uri = "file:///workspace/debug_step_in_if_lambda_go.pure";
+        String code =
+                "function go():Any[*]\n" +
+                        "{\n" +
+                        "  let flag = true;\n" +
+                        "  if($flag,\n" +
+                        "     | let a = 1;\n" +
+                        "       let b = $a + 1;\n" +
+                        "       print($b, 1);,\n" +
+                        "     | print('false', 1););\n" +
+                        "}\n";
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        LegendDebugSession debug = LegendDebugSession.create(
+                session,
+                null,
+                uriMapper,
+                Collections.emptyMap(),
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, 3)));
+
+        Assert.assertEquals(4, debug.start().getStackFrames().get(0).getLine());
+
+        LegendDebug.Response first = debug.stepIn();
+        Assert.assertEquals("step into the true-branch lambda should stop on its first (let) statement",
+                5, first.getStackFrames().get(0).getLine());
+
+        LegendDebug.Response second = debug.stepIn();
+        Assert.assertEquals("stepping should follow subsequent let statements inside the lambda",
+                6, second.getStackFrames().get(0).getLine());
+
+        LegendDebug.Response third = debug.stepIn();
+        Assert.assertEquals("stepping should reach the lambda's final statement",
+                7, third.getStackFrames().get(0).getLine());
 
         debug.stop();
     }
@@ -555,6 +729,54 @@ public class LegendDebugSessionTest
     }
 
     @Test(timeout = 60_000)
+    public void variablesPanelSupportsMultiLevelNestedExpansion()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_multi_level_nested_locals.pure";
+        String uri = "file:///workspace/debug_multi_level_nested_locals.pure";
+        String code =
+                "###Pure\n" +
+                        "Class test::debug::nested::Address\n" +
+                        "{\n" +
+                        "  city: String[1];\n" +
+                        "}\n" +
+                        "Class test::debug::nested::Person\n" +
+                        "{\n" +
+                        "  name: String[1];\n" +
+                        "  address: test::debug::nested::Address[1];\n" +
+                        "}\n" +
+                        "function go():Any[*]\n" +
+                        "{\n" +
+                        "  let address = ^test::debug::nested::Address(city='London');\n" +
+                        "  let person = ^test::debug::nested::Person(name='Ada', address=$address);\n" +
+                        "  $person;\n" +
+                        "}\n";
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        LegendDebugSession debug = debugAtBreakpoint(session, sourceId, uri, code, "  $person;");
+
+        LegendDebug.Response paused = debug.start();
+        Assert.assertTrue(paused.isSuccess());
+        Assert.assertEquals("paused", paused.getState());
+
+        List<LegendDebug.Variable> locals = debug.variables(1);
+        LegendDebug.Variable person = variable(locals, "person");
+        Assert.assertTrue("A Person instance should be expandable", person.getVariablesReference() > 0);
+
+        List<LegendDebug.Variable> personChildren = debug.variables(person.getVariablesReference());
+        Assert.assertEquals("Ada", variable(personChildren, "name").getValue());
+        LegendDebug.Variable address = variable(personChildren, "address");
+        Assert.assertTrue("A nested Address instance should itself be expandable, not flattened to a leaf",
+                address.getVariablesReference() > 0);
+
+        List<LegendDebug.Variable> addressChildren = debug.variables(address.getVariablesReference());
+        Assert.assertEquals("Real grandchild data should be reachable, not just the top level",
+                "London", variable(addressChildren, "city").getValue());
+
+        debug.stop();
+    }
+
+    @Test(timeout = 60_000)
     public void localsAppearOnlyAfterAssignmentHasExecuted()
     {
         LegendPureSession session = newInitializedSession();
@@ -608,6 +830,408 @@ public class LegendDebugSessionTest
         assertCompiled(session.modifyAndCompile(sourceId, code));
 
         assertBreakpointLine(session, sourceId, uri, 3, 4);
+    }
+
+    @Test(timeout = 60_000)
+    public void updatingBreakpointsToRemoveMidSessionStopsFurtherPausesOnThatLine()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_update_breakpoints_remove_go.pure";
+        String uri = "file:///workspace/debug_update_breakpoints_remove_go.pure";
+        String code = mapPrintCode(new int[] {1, 2});
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        int breakpointLine = zeroBasedLine(code, "    print($n, 1);");
+        LegendDebugSession debug = LegendDebugSession.create(
+                session,
+                null,
+                uriMapper,
+                Collections.emptyMap(),
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, breakpointLine)));
+
+        LegendDebug.Response firstPause = debug.start();
+        Assert.assertEquals("paused", firstPause.getState());
+        Assert.assertEquals("breakpoint", firstPause.getReason());
+        Assert.assertEquals("1", variable(debug.variables(), "n").getValue());
+
+        debug.updateBreakpoints(Collections.emptyList());
+
+        LegendDebug.Response completed = debug.continueExecution();
+        Assert.assertTrue(completed.isSuccess());
+        Assert.assertEquals("Second iteration should not re-pause once the breakpoint was removed mid-session",
+                "completed", completed.getState());
+    }
+
+    @Test(timeout = 60_000)
+    public void updatingBreakpointsToAddMidSessionPausesOnTheNewLine()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_update_breakpoints_add_go.pure";
+        String uri = "file:///workspace/debug_update_breakpoints_add_go.pure";
+        String code =
+                "function go():Any[*]\n" +
+                        "{\n" +
+                        "  print('start', 1);\n" +
+                        "  let numbers = [1, 2];\n" +
+                        "  $numbers->map(n |\n" +
+                        "    print($n, 1);\n" +
+                        "    $n;\n" +
+                        "  );\n" +
+                        "}\n";
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        int startBreakpointLine = zeroBasedLine(code, "  print('start', 1);");
+        int loopBreakpointLine = zeroBasedLine(code, "    print($n, 1);");
+        LegendDebugSession debug = LegendDebugSession.create(
+                session,
+                null,
+                uriMapper,
+                Collections.emptyMap(),
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, startBreakpointLine)));
+
+        LegendDebug.Response firstPause = debug.start();
+        Assert.assertEquals("paused", firstPause.getState());
+        Assert.assertEquals(startBreakpointLine + 1, firstPause.getStackFrames().get(0).getLine());
+
+        debug.updateBreakpoints(Arrays.asList(
+                new LegendDebug.Breakpoint(uri, startBreakpointLine),
+                new LegendDebug.Breakpoint(uri, loopBreakpointLine)));
+
+        LegendDebug.Response secondPause = debug.continueExecution();
+        Assert.assertEquals("Newly-added breakpoint should pause once execution reaches it",
+                "paused", secondPause.getState());
+        Assert.assertEquals("breakpoint", secondPause.getReason());
+        Assert.assertEquals(loopBreakpointLine + 1, secondPause.getStackFrames().get(0).getLine());
+
+        debug.stop();
+    }
+
+    @Test(timeout = 60_000)
+    public void conditionalBreakpointOnlyPausesWhenConditionIsTrue()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_conditional_breakpoint_go.pure";
+        String uri = "file:///workspace/debug_conditional_breakpoint_go.pure";
+        String code = mapPrintCode(new int[] {1, 2, 3});
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        int breakpointLine = zeroBasedLine(code, "    print($n, 1);");
+        LegendDebugSession debug = LegendDebugSession.create(
+                session,
+                null,
+                uriMapper,
+                Collections.emptyMap(),
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, breakpointLine, "$n == 2")));
+
+        LegendDebug.Response paused = debug.start();
+        Assert.assertTrue("Expected a conditional pause: " + paused.getMessage(), paused.isSuccess());
+        Assert.assertEquals("paused", paused.getState());
+        Assert.assertEquals("breakpoint", paused.getReason());
+        Assert.assertEquals("2", variable(debug.variables(), "n").getValue());
+
+        LegendDebug.Response completed = debug.continueExecution();
+        Assert.assertTrue(completed.isSuccess());
+        Assert.assertEquals("Only the iteration matching the condition should pause",
+                "completed", completed.getState());
+    }
+
+    @Test(timeout = 60_000)
+    public void conditionalBreakpointThatIsAlwaysFalseNeverPauses()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_conditional_breakpoint_always_false_go.pure";
+        String uri = "file:///workspace/debug_conditional_breakpoint_always_false_go.pure";
+        String code = mapPrintCode(new int[] {1, 2});
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        int breakpointLine = zeroBasedLine(code, "    print($n, 1);");
+        LegendDebugSession debug = LegendDebugSession.create(
+                session,
+                null,
+                uriMapper,
+                Collections.emptyMap(),
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, breakpointLine, "false")));
+
+        LegendDebug.Response result = debug.start();
+        Assert.assertTrue("Expected the run to complete: " + result.getMessage(), result.isSuccess());
+        Assert.assertEquals("A breakpoint with condition `false` should never pause, on either iteration",
+                "completed", result.getState());
+    }
+
+    @Test(timeout = 60_000)
+    public void conditionalBreakpointOnNestedCallLineThatIsAlwaysFalseNeverPauses()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_conditional_breakpoint_nested_go.pure";
+        String uri = "file:///workspace/debug_conditional_breakpoint_nested_go.pure";
+        // Two FunctionExpression nodes on one line (toString, then print) - per Phase 1, each
+        // nested call is its own pause-checkpoint, so this line yields 2 condition evaluations
+        // per loop iteration, not 1.
+        String code = "function go():Any[*]\n" +
+                "{\n" +
+                "  let numbers = [1, 2];\n" +
+                "  $numbers->map(n |\n" +
+                "    print($n->toString(), 1);\n" +
+                "  );\n" +
+                "}\n";
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        int breakpointLine = zeroBasedLine(code, "    print($n->toString(), 1);");
+        LegendDebugSession debug = LegendDebugSession.create(
+                session,
+                null,
+                uriMapper,
+                Collections.emptyMap(),
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, breakpointLine, "false")));
+
+        LegendDebug.Response result = debug.start();
+        Assert.assertTrue("Expected the run to complete: " + result.getMessage(), result.isSuccess());
+        Assert.assertEquals("A breakpoint with condition `false` on a line with nested calls should never pause",
+                "completed", result.getState());
+    }
+
+    @Test(timeout = 60_000)
+    public void conditionalBreakpointWithVariableConditionNeverTrueNeverPauses()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_conditional_breakpoint_never_true_go.pure";
+        String uri = "file:///workspace/debug_conditional_breakpoint_never_true_go.pure";
+        String code = mapPrintCode(new int[] {1, 2, 3, 4, 5});
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        int breakpointLine = zeroBasedLine(code, "    print($n, 1);");
+        LegendDebugSession debug = LegendDebugSession.create(
+                session,
+                null,
+                uriMapper,
+                Collections.emptyMap(),
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, breakpointLine, "$n == 99")));
+
+        LegendDebug.Response result = debug.start();
+        Assert.assertTrue("Expected the run to complete: " + result.getMessage(), result.isSuccess());
+        Assert.assertEquals("A never-true condition must not pause on any of the 5 iterations",
+                "completed", result.getState());
+    }
+
+    @Test(timeout = 60_000)
+    public void conditionalBreakpointInFunctionCalledTwiceNeverPausesWhenFalse()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_conditional_breakpoint_two_calls_go.pure";
+        String uri = "file:///workspace/debug_conditional_breakpoint_two_calls_go.pure";
+        // A line hit twice via two separate calls (two distinct frames), rather than a loop.
+        String code = "function helper(x:Integer[1]):Any[*]\n" +
+                "{\n" +
+                "  print($x, 1);\n" +
+                "}\n" +
+                "\n" +
+                "function go():Any[*]\n" +
+                "{\n" +
+                "  helper(1);\n" +
+                "  helper(2);\n" +
+                "}\n";
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        int breakpointLine = zeroBasedLine(code, "  print($x, 1);");
+        LegendDebugSession debug = LegendDebugSession.create(
+                session,
+                null,
+                uriMapper,
+                Collections.emptyMap(),
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, breakpointLine, "$x == 99")));
+
+        LegendDebug.Response result = debug.start();
+        Assert.assertTrue("Expected the run to complete: " + result.getMessage(), result.isSuccess());
+        Assert.assertEquals("A never-true condition must not pause on either call",
+                "completed", result.getState());
+    }
+
+    @Test(timeout = 60_000)
+    public void sharedModeConditionalBreakpointThatIsAlwaysFalseNeverPauses()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_shared_conditional_false_go.pure";
+        String uri = "file:///workspace/debug_shared_conditional_false_go.pure";
+        String code = mapPrintCode(new int[] {1, 2});
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        int breakpointLine = zeroBasedLine(code, "    print($n, 1);");
+        // SHARED is what the IntelliJ client actually launches with, and unlike FORKED it evaluates
+        // conditions against the live main runtime while holding its graph read lock.
+        LegendDebugSession debug = LegendDebugSession.createShared(
+                session,
+                null,
+                uriMapper,
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, breakpointLine, "false")));
+
+        LegendDebug.Response result = debug.start();
+        Assert.assertTrue("Expected the run to complete: " + result.getMessage(), result.isSuccess());
+        Assert.assertEquals("A `false` condition must not pause on either iteration in SHARED mode",
+                "completed", result.getState());
+    }
+
+    @Test(timeout = 60_000)
+    public void sharedModeConditionalBreakpointWithVariableConditionNeverTrueNeverPauses()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_shared_conditional_never_true_go.pure";
+        String uri = "file:///workspace/debug_shared_conditional_never_true_go.pure";
+        String code = mapPrintCode(new int[] {1, 2, 3});
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        int breakpointLine = zeroBasedLine(code, "    print($n, 1);");
+        LegendDebugSession debug = LegendDebugSession.createShared(
+                session,
+                null,
+                uriMapper,
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, breakpointLine, "$n == 99")));
+
+        LegendDebug.Response result = debug.start();
+        Assert.assertTrue("Expected the run to complete: " + result.getMessage(), result.isSuccess());
+        Assert.assertEquals("A never-true condition must not pause on any iteration in SHARED mode",
+                "completed", result.getState());
+    }
+
+    @Test(timeout = 60_000)
+    public void logpointLogsInterpolatedMessageWithoutPausing()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_logpoint_go.pure";
+        String uri = "file:///workspace/debug_logpoint_go.pure";
+        String code = mapPrintCode(new int[] {1, 2});
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        int breakpointLine = zeroBasedLine(code, "    print($n, 1);");
+        LegendDebug.Breakpoint logpoint = new LegendDebug.Breakpoint(uri, breakpointLine, null, "n is {$n}");
+        LegendDebugSession debug = LegendDebugSession.create(
+                session,
+                null,
+                uriMapper,
+                Collections.emptyMap(),
+                "go():Any[*]",
+                Collections.singletonList(logpoint));
+
+        LegendDebug.Response result = debug.start();
+        Assert.assertTrue("Expected the run to complete: " + result.getMessage(), result.isSuccess());
+        Assert.assertEquals("A logpoint must never suspend", "completed", result.getState());
+        Assert.assertTrue("Expected the interpolated logpoint output, got: " + result.getOutput(),
+                result.getOutput() != null && result.getOutput().contains("n is 1"));
+        Assert.assertTrue("Expected the logpoint to fire on every iteration, got: " + result.getOutput(),
+                result.getOutput().contains("n is 2"));
+    }
+
+    @Test(timeout = 60_000)
+    public void breakpointWithUnevaluableConditionExplainsWhyItPaused()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_condition_failure_note_go.pure";
+        String uri = "file:///workspace/debug_condition_failure_note_go.pure";
+        String code =
+                "function go():Any[*]\n" +
+                        "{\n" +
+                        "  print('value', 1);\n" +
+                        "}\n";
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        int breakpointLine = zeroBasedLine(code, "  print('value', 1);");
+        LegendDebugSession debug = LegendDebugSession.create(
+                session,
+                null,
+                uriMapper,
+                Collections.emptyMap(),
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, breakpointLine, "$nope == 2")));
+
+        LegendDebug.Response paused = debug.start();
+        Assert.assertEquals("paused", paused.getState());
+        Assert.assertTrue("A fail-open pause must say why on the console, got: " + paused.getOutput(),
+                paused.getOutput() != null && paused.getOutput().contains("could not be evaluated"));
+
+        debug.stop();
+    }
+
+    @Test(timeout = 60_000)
+    public void conditionalBreakpointWithMalformedConditionFailsOpenAndPauses()
+    {
+        LegendPureSession session = newInitializedSession();
+        String sourceId = "debug_conditional_breakpoint_malformed_go.pure";
+        String uri = "file:///workspace/debug_conditional_breakpoint_malformed_go.pure";
+        String code =
+                "function go():Any[*]\n" +
+                        "{\n" +
+                        "  print('value', 1);\n" +
+                        "}\n";
+        assertCompiled(session.modifyAndCompile(sourceId, code));
+
+        UriMapper uriMapper = new UriMapper();
+        uriMapper.register(uri, sourceId);
+        int breakpointLine = zeroBasedLine(code, "  print('value', 1);");
+        LegendDebugSession debug = LegendDebugSession.create(
+                session,
+                null,
+                uriMapper,
+                Collections.emptyMap(),
+                "go():Any[*]",
+                Collections.singletonList(new LegendDebug.Breakpoint(uri, breakpointLine, "$undefinedVariable == 2")));
+
+        LegendDebug.Response paused = debug.start();
+        Assert.assertTrue("A broken condition should fail open and still pause: " + paused.getMessage(), paused.isSuccess());
+        Assert.assertEquals("paused", paused.getState());
+        Assert.assertEquals("breakpoint", paused.getReason());
+
+        debug.stop();
+    }
+
+    private static String mapPrintCode(int[] values)
+    {
+        StringBuilder literal = new StringBuilder();
+        for (int i = 0; i < values.length; i++)
+        {
+            if (i > 0)
+            {
+                literal.append(", ");
+            }
+            literal.append(values[i]);
+        }
+        return "function go():Any[*]\n" +
+                "{\n" +
+                "  let numbers = [" + literal + "];\n" +
+                "  $numbers->map(n |\n" +
+                "    print($n, 1);\n" +
+                "    $n;\n" +
+                "  );\n" +
+                "}\n";
     }
 
     private static String steppingCode()

--- a/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/debug/LegendPureDebugAdapterTest.java
+++ b/legend-pure-lsp/legend-pure-lsp-server/src/test/java/org/finos/legend/pure/lsp/debug/LegendPureDebugAdapterTest.java
@@ -77,7 +77,8 @@ public class LegendPureDebugAdapterTest
             Assert.assertEquals(Boolean.TRUE, capabilities.getSupportsConfigurationDoneRequest());
             Assert.assertEquals(Boolean.TRUE, capabilities.getSupportsEvaluateForHovers());
             Assert.assertEquals(Boolean.TRUE, capabilities.getSupportsTerminateRequest());
-            Assert.assertEquals(Boolean.FALSE, capabilities.getSupportsConditionalBreakpoints());
+            Assert.assertEquals(Boolean.TRUE, capabilities.getSupportsConditionalBreakpoints());
+            Assert.assertEquals(Boolean.TRUE, capabilities.getSupportsLogPoints());
 
             Source source = new Source();
             source.setPath("/workspace/debug_dap.pure");


### PR DESCRIPTION
LSP: implement lock contention notification with debounce mechanism and add corresponding tests

LSP: add tests for graphDirty contract and enhance request pool size configuration

LSP: introduce lock contention notifications and enhance observability in status reporting

LSP: enhance support for conditional breakpoints and log points, add setup/teardown function discovery

LSP: enhance breakpoint management with conditional support and fixture file handling

Fix SHARED-mode debug test calling the FORKED create() overload

The prior compile fix for stale createShared(...) call sites swapped them to create(...) instead - the FORKED-mode 6-arg overload - so sharedModeBlocksMainSessionCompileWhilePausedAndReleasesOnStop silently stopped exercising SHARED mode's graph-lock behavior at all, and its "compile should be blocked while paused" assertion started failing once the module could compile again. Restored the correct 5-arg createShared(...) call at both SHARED-mode call sites.

LSP: add legend/testFunctions to power a Run/Debug gutter icon for <<test.Test>> functions

Adds a legend/testFunctions JSON-RPC request that finds real compiled functions carrying the meta::pure::profiles::test "Test" stereotype in a given source, using the same semantic check the Pure test runner itself uses (TestTools#hasTestStereotype) - not a text/regex scan for the "<<test.Test>>" annotation, which would falsely match commented-out or differently-qualified occurrences. This lets the IntelliJ plugin place a go()-style Run/Debug gutter icon on real test functions instead of guessing from source text.

Also fixes a pre-existing test-compile break in LegendDebugSessionTest (stale LegendDebugSession.createShared(...) calls left over from a prior create() signature change) that was blocking this module's test suite entirely.

Co-Authored-By: Claude Code

Fix WorkspaceDriftWatcher/syncWorkspace reintroducing the fixture-file compile crash

RepositoryScanner.deriveSourceIdFromPath() validated only that a changed file's path fell under a registered repo's own directory (module membership), not that it sat outside that repo's own top-level "data" fixture folder - the exclusion OverlayWorkspaceCodeStorage.isCompilableWorkspaceFile() already applies for the bulk workspace scan (except welcome.pure, the go() entry point).

WorkspaceDriftWatcher (a filesystem watcher added after both prior fixes) calls deriveSourceIdFromPath() directly to decide whether an out-of-editor file change (a rebase, a checkout) is worth tracking as drift, and treats any non-null result as a real, compilable source. Because the method didn't know about the fixture convention, editing a fixture .pure file (e.g. a ###Lakehouse template) under a repo's own data/ folder got marked dirty; legend/syncWorkspace then read it off disk and fed it straight into SourceMutationService.applyBulkChangesAndCompile(), reintroducing the exact fixture-file compile crash the original two commits (5426aae48, 185f07ac1) fixed - just via this new watch-and-sync path instead of the initial bulk scan or a direct editor open.

UriMapper's fallback branch calls the same method, so it's fixed too.

Verified the new RepositoryScannerTest cases fail against the pre-fix method (confirmed by temporarily reverting), then pass after the fix; ran UriMapperTest, RepositoryScannerTest, OverlayWorkspaceCodeStorageTest, WorkspaceDriftWatcherTest, and WorkspaceSyncIntegrationTest - all green.

Co-Authored-By: Claude Code

LSP: workspace drift detection, client broadcast, and stale-source resolution

Adds cross-session workspace drift tracking (detect/notify/review external file changes against the live compiled graph), a client broadcaster for multi-client notification fanout, resolveSourceUri for mapping stack-trace source locations back to editor URIs, and richer execution-failure formatting.

Fix UriMapper/RepositoryScanner accepting .pure files not part of any registered Pure module

deriveSourceId's src/main/resources substring-stripping blindly trusted anything after the marker as a real sourceId, so a fixture .pure file in a module with no definition.json (e.g. alloy-lakehouse's data/ingest/matview template) got fed into modifyAndCompile as if its containing folder were a real repo, crashing compilation. Now validated against the actual registered workspace repos (or the live runtime) before being trusted, with the loose fallback preserved only when no scanner is configured. RepositoryScanner.deriveSourceIdFromPath had the same class of bug (matched anything under a repo's resourcesRoot instead of its own repoDir).

Add debug-adapter regression tests for lambda step-in and nested variable expansion

Server-side stepping (LegendDebugFunctionExecution/LegendDebugSession) already routes lambda invocations from if/map/filter through the same instrumented executeFunction path as named function calls, so step-in already descends into lambda bodies (verified empirically for if, map, nested map+filter, multi- statement bodies with let, and SHARED mode). Add regression tests that pin this down so it doesn't silently regress, plus a multi-level (grandchild) nested variable expansion test confirming LegendDebugState's variablesReference recursion isn't just one level deep.

The actual client-visible bugs (IntelliJ "step into" looking like it skips lambda bodies, and the Variables panel never showing nested structure) were both root-caused to the pure-intellij plugin side, not this server: see that repo's uncommitted PureDebugProcess.kt changes.

Fix LSP daemon crash on non-code .pure fixture files under src/main/resources/data

Workspace scanning (RepositoryScanner -> OverlayWorkspaceCodeStorage) recursively registered every *.pure file under a repo's root as compilable source, via FSCodeStorage.getFilesRecursive() with no filtering beyond the extension check. Files like alloy-lakehouse's data/ingest/matview/.../matview.pure are template text (###Lakehouse grammar with <TEST_GROUP> placeholders) read as raw classpath resource strings by a Java test harness - never meant to be parsed by legend-pure's M3 grammar - the same role .legend fixtures play elsewhere. Feeding one to the initial workspace compile threw a parse exception that poisoned the whole all-or-nothing compile, leaving every module (not just the bad file) uncompiled.

- OverlayWorkspaceCodeStorage: exclude .pure files under a repo's own top-level "data" folder from the compilable set, except welcome.pure (the conventional go() entry-point file), which is always kept. Scoped to the repo root only (not any depth) so it can't shadow a legitimate nested "data" package, such as legend-engine's real core::pure::data.
- LegendPureSession.reinitialize(): stop nulling pureRuntime/initialized before attempting the new compile. initialize() only overwrites those fields once the new runtime build actually succeeds, so a failed reindex/recovery now keeps serving the last good session instead of going permanently dark - mirroring SourceMutationService's existing restore-on-failure behavior for incremental edits.

Verified via mvn test -pl legend-pure-lsp/legend-pure-lsp-server with OverlayWorkspaceCodeStorageTest, RepositoryScannerTest, and LegendPureSessionIntegrationTest (all passing).