### PR TITLE
Add NullOrder to SortInfo and relational OrderBy/SortByInfo metamodel

### DIFF
--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/meta/type/relation/window/sort.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/grammar/functions/meta/type/relation/window/sort.pure
@@ -19,8 +19,14 @@ Enum meta::pure::functions::relation::SortType
     ASC, DESC
 }
 
+Enum meta::pure::functions::relation::NullOrder
+{
+    FIRST, LAST
+}
+
 Class meta::pure::functions::relation::SortInfo<T>
 {
    column : ColSpec<T>[1];
    direction : SortType[1];
+   nullOrder : meta::pure::functions::relation::NullOrder[0..1];
 }

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/grammar/relational.pure
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/grammar/relational.pure
@@ -535,11 +535,17 @@ Class meta::relational::metamodel::OrderBy
 {
     column : RelationalOperationElement[1];
     direction : meta::relational::metamodel::SortDirection[1];
+    nullOrder : meta::relational::metamodel::NullOrder[0..1];
 }
 
 Enum meta::relational::metamodel::SortDirection
 {
     ASC, DESC
+}
+
+Enum meta::relational::metamodel::NullOrder
+{
+    FIRST, LAST
 }
 
 Class meta::relational::metamodel::Pivot
@@ -573,6 +579,7 @@ Class meta::relational::metamodel::SortByInfo extends meta::relational::metamode
 
    sortByElement: RelationalOperationElement [1];
    sortDirection: meta::relational::metamodel::SortDirection[0..1] ;
+   nullOrder: meta::relational::metamodel::NullOrder[0..1] ;
 }
 
 Enum meta::relational::metamodel::FrameType


### PR DESCRIPTION
## Purpose

Adds an optional null-ordering slot to the sort metamodel so the Relation API and the relational SQL renderer can express SQL `NULLS FIRST` / `NULLS LAST`. This is the metamodel-only half of the feature; the consuming implementation (new `nullsFirst`/`nullsLast` functions, in-memory semantics, SQL generation) lands in a companion **legend-engine** PR.

## Changes

- `meta::pure::functions::relation::NullOrder { FIRST, LAST }` enum, and `SortInfo.nullOrder [0..1]` (empty = the engine's canonical order — nulls sort high).
- `meta::relational::metamodel::NullOrder { FIRST, LAST }` enum, and `nullOrder [0..1]` on both `OrderBy` and `SortByInfo`.

## Compatibility

All new fields are `[0..1]` and default empty, so existing graphs, serialization, and the M3 bootstrap are unaffected. No parser or grammar change (`SortInfo` is constructed inside lambdas, never serialized as a protocol class).

## Testing

Built locally (`mvn clean install -DskipTests`, 56 modules) against a patched 5.96.0; the companion legend-engine branch builds and passes the in-memory Relation PCT suites (compiled + interpreted, 459/459) on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)