### PR TITLE
Set default NULL ordering to HIGH for H2 test database connections

### DIFF
--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-shared-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/shared/connectionManager/TestDatabaseConnect.java
@@ -111,11 +111,11 @@ public class TestDatabaseConnect extends PerThreadPoolableConnectionProvider
         if (getMajorVersion() == 2)
         {
             defaultH2Properties = System.getProperty("legend.test.h2.properties",
-                    ";NON_KEYWORDS=ANY,ASYMMETRIC,AUTHORIZATION,CAST,CURRENT_PATH,CURRENT_ROLE,DAY,DEFAULT,ELSE,END,HOUR,KEY,MINUTE,MONTH,SECOND,SESSION_USER,SET,SOME,SYMMETRIC,SYSTEM_USER,TO,UESCAPE,USER,VALUE,WHEN,YEAR;MODE=LEGACY");
+                    ";NON_KEYWORDS=ANY,ASYMMETRIC,AUTHORIZATION,CAST,CURRENT_PATH,CURRENT_ROLE,DAY,DEFAULT,ELSE,END,HOUR,KEY,MINUTE,MONTH,SECOND,SESSION_USER,SET,SOME,SYMMETRIC,SYSTEM_USER,TO,UESCAPE,USER,VALUE,WHEN,YEAR;MODE=LEGACY;DEFAULT_NULL_ORDERING=HIGH");
         }
         else
         {
-            defaultH2Properties = ";ALIAS_COLUMN_NAME=TRUE";
+            defaultH2Properties = ";ALIAS_COLUMN_NAME=TRUE;DEFAULT_NULL_ORDERING=HIGH";
         }
 
         String port = System.getProperty("legend.test.h2.port");


### PR DESCRIPTION
## Summary

`TestDatabaseConnect` builds the H2 in-memory connection URL used across Pure's relational store tests. This change appends `DEFAULT_NULL_ORDERING=HIGH` to the connection properties for both H2 major versions, so NULLs sort last by default — aligning the test database's ordering semantics with common production databases.

## Changes

- Append `;DEFAULT_NULL_ORDERING=HIGH` to the H2 v2 (`MODE=LEGACY`) property string
- Append `;DEFAULT_NULL_ORDERING=HIGH` to the H2 v1 (`ALIAS_COLUMN_NAME=TRUE`) property string

🤖 Generated with [Claude Code](https://claude.com/claude-code)