### PR TITLE
Add sub-second field widths and optional sections to date formats

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -163,7 +163,7 @@ paths are always equivalent from a user's perspective.
 | [Documentation Maintenance](maintenance/maintenance.md) | Keeping docs up to date, ownership, and review cadence |
 | [Module README Template](templates/module-readme-template.md) | Standard template for per-module README files |
 | [Phased Documentation Plan](maintenance/documentation-plan.md) | The phased timeline that produced this documentation set |
-| [Architecture Decision Records](decisions/) | ADR-001 JUnit 4; ADR-002 Eclipse Collections; ADR-003 No mocking; ADR-004 Date difference semantics (proposed) |
+| [Architecture Decision Records](decisions/) | ADR-001 JUnit 4; ADR-002 Eclipse Collections; ADR-003 No mocking; ADR-004 Date difference semantics (proposed); ADR-005 Date format sub-second fields and optional sections |
 
 ---
 

--- a/docs/decisions/ADR-005-date-format-subsecond-and-optional-sections.md
+++ b/docs/decisions/ADR-005-date-format-subsecond-and-optional-sections.md
@@ -1,0 +1,287 @@
+# ADR-005: Sub-Second Fields and Optional Sections in the Date Format Language
+
+**Status:** Accepted. Implemented in `legend-pure-m4` and `legend-pure-m3-core`.
+**Date:** 2026-08-27
+**Deciders:** Legend Pure core team
+
+## Context
+
+`meta::pure::functions::string::format` renders a date from a format string: `%t{yyyy-MM-dd}`,
+optionally opening with a time zone. One method does the work, `DateFormat.format` in
+`legend-pure-m4`, and everything routes through it. `PureDate.format(String)` delegates to it, and
+the Pure native reaches it from both engines by carving the `%t{...}` payload out of the larger
+format string. A change there lands on both engines at once.
+
+Two gaps in that language prompted this work. Both are visible from inside Pure, without reference
+to anything downstream.
+
+### Gap 1: the language cannot describe Pure's own type
+
+A Pure date comes at seven granularities, from a bare year to a sub-second of arbitrary precision. A
+format string could address exactly one of them, because every control character was mandatory:
+`yyyy-MM-dd` was a run-time error for a `Year`, and `yyyy` silently discarded everything a
+`DateWithSubsecond` knew. There was no way to write a format string that renders a collection of
+dates whose granularities differ, which is the ordinary case for data drawn from more than one
+source.
+
+That is a language under-powered for its own type system, and nothing about the design forced it.
+The renderer already knew, per component, whether the date carried it, since that is what it tested
+before throwing. The information was there and could not be reached.
+
+The workaround is visible in shipped Pure. Every SQL literal writer in legend-engine branches on
+granularity and keeps a format string per branch; the Oracle one has five branches and five format
+strings for what is one string under this change.
+
+### Gap 2: the sub-second field's count meant two different things
+
+Repeating a control character is documented as widening the field, and for `S` it did so for one,
+two, or three letters. At four letters the count stopped meaning anything and the field wrote the
+whole stored fraction, however long.
+
+| Field | `.070004235` | `.07` | What the count did |
+|---|---|---|---|
+| `SS` | `07` | `07` | capped the width at 2 |
+| `SSS` | `070` | `07` | capped the width at 3 |
+| `SSSS` | `070004235` | `07` | nothing |
+| `SSSSSSSSS` | `070004235` | `07` | nothing |
+
+So `SSS` and `SSSS` differed in kind rather than in degree, and `SSSS` and `SSSSSSSSS` were the same
+field written two ways. Alongside that, the field could not write a **fixed-width** fraction at all,
+which ISO 8601 and every wire format built on it require.
+
+This was not a theoretical complaint. Of the fourteen sub-second fields written in legend-engine's
+`.pure` sources, **ten are spelled with four letters or more, and not one of them gets the fixed
+width its author plainly meant**. `formatDate`'s "ISO 8601 nanosecond precision" writes nine digits
+only for a date whose fraction already has nine; every SQL literal writer spells its fraction
+`SSSSSS` and means microseconds.
+
+## Decisions
+
+### 1. A sub-second field is a width: a minimum, a maximum, a policy at each end, and a fill
+
+The field says how many digits to write and what to do when the date does not fit:
+
+| Parameter | Range | Meaning |
+|---|---|---|
+| `min` | 0, 1, 2, ... | fewest digits the field will write |
+| `max` | `max(min, 1)` to unbounded | most digits the field will write |
+| `below` | fill or throw | what happens when the stored fraction is shorter than `min` |
+| `above` | truncate or throw | what happens when it is longer than `max` |
+| `fill` | one character | what padding writes, default `0` |
+
+The general form states all of it, `S(min,max)` with `*` for an unbounded maximum, `!` after either
+bound to throw rather than fill or truncate there, and an optional third part naming a fill other
+than zero. Five shorthands cover the cases worth a short spelling: `SN` exactly N, `S<N` at most N,
+`S>N` at least N and everything beyond, `S*` however many the date has, and `S!N` exactly N and
+refusing a shorter fraction.
+
+Rendering applies the maximum before the minimum, so a field can cut a long fraction down and pad a
+short one out without the two ever meeting, and the minimum is tested against what the maximum left,
+which is what makes `S(3,3)` a fixed width rather than a contradiction. Fill goes on the right and
+truncation takes a prefix, because sub-second digits run most significant first: `.07` padded to
+three is `.070`, not `.007`.
+
+### 2. Padding is worth marking. Truncating is not
+
+`S!N` exists and there is no matching short spelling for refusing to truncate. That asymmetry is
+principled rather than arbitrary, and it follows from what a Pure date is.
+
+**A Pure date is a span of time rather than an instant**, and the number of digits it stores is the
+precision of that span. `.07` *contains* `.070`, `.071`, and `.0712`. So:
+
+- **Truncating widens the span.** It loses precision and stays true. There is little reason to want
+  it refused.
+- **Padding narrows it.** It claims a precision the date does not have. Refusing is a real choice,
+  and it deserves a short spelling.
+
+Refusing to truncate is a validation concern rather than a formatting one, and validation concerns
+spell out: `S(N!,N!)` rather than a second `!` prefix, whose reading would be ad hoc and whose use
+case is thin.
+
+The same reasoning is why the fallback that invents a fraction is written out rather than
+abbreviated. `?[.S9|".000000000"]` is four characters longer than a hypothetical `.S=9` and says
+what it does; the nine zeros stay visible, which is the point.
+
+### 3. A sub-second field always fails on a date with no fraction
+
+**Presence is not a field concern.** How many digits to write is the field's business; whether there
+are any to write is not, and belongs to the optional section around it, which is where every other
+control character already leaves the question.
+
+Two readings were rejected, both of which have the field answer for an absent fraction itself:
+
+- **Write the fill out to the minimum width**, so `S3` gives `000`. This makes the field silently
+  claim millisecond precision for a date that has none, and makes the claim invisible at the call
+  site. It is the reading legend-engine's forked implementation took, and it is why that fork and
+  this one cannot be told apart by reading a format string.
+- **Write nothing.** This leaves the decimal point behind, and the point is not the field's to
+  remove. Only a section can take the separator with it.
+
+Beyond taste, the decision earns its place structurally. **With the precondition, every sub-second
+field can fail**, so every one of them composes with an optional section. Without it, a field
+carrying no throwing policy could never fail, so `?[.S3]` would render `.000` forever and
+`?[.S*|".000"]` could never reach its fallback. Both look right and quietly are not. The precondition
+removes that trap entirely rather than documenting it, and collapses an axis out of the parameter
+space: a renderable date has at least one digit, so a minimum of 0 and a minimum of 1 are the same
+field.
+
+A field and a section do not overlap, and the pair that looks as though it might is worth knowing:
+
+| Format | `.070004235` | `.070` | `.07` | no fraction |
+|---|---|---|---|---|
+| `?[SSS\|"000"]` | `070` | `070` | `07` | `000` |
+| `S3` | `070` | `070` | `070` | fails |
+| `?[S3\|"000"]` | `070` | `070` | `070` | `000` |
+
+Nothing a field can say answers for a date with no fraction, and nothing a section can say pads a
+short one. Saying both takes both.
+
+### 4. The repetition form is frozen, and every legacy form gains an exact modern equivalent
+
+`S` through `SSS` are `S<1` through `S<3`. `SSSS` and longer are `S*`. Same semantics, no migration,
+and the discontinuity at four letters becomes visible as the point where `S<N` turns into `S*`. The
+older spelling can therefore be deprecated later without anything losing a way to be said.
+
+Every character the new forms recruit (`<`, `>`, `*`, `!`, `(`, `)`, `?`, `|`, `]`, and a digit after
+`S`) was an error before this change, so **no format string that worked before changes meaning**.
+That claim was checked rather than asserted: the implementation this replaced was run head to head
+with the new one over 4,377,492 pairs of a format string and a date, covering every control character
+at widths one to five, every pair and triple drawn from a pool of runs, separators, and quoted text,
+against seven time zones and twelve dates. Every difference is one deliberate change, `a` now
+consuming its run of repetitions like every other control character, so `aa` writes `PM` rather than
+`PMPM`. A fifty-row table of that comparison is checked in as `TestDateFormat`'s compatibility suite.
+
+`DateFormatPattern.pattern()` writes the modern spelling and never the repetition form, which makes
+reading a format string and writing it back the mechanical half of a migration.
+
+**The one hazard, named rather than buried:** `S3` and `SSS` look like the same field and are not.
+`S3` is exactly three digits; `SSS` is at most three. On `.07` the first gives `070` and the second
+`07`, and the difference is in the unsound direction, since the padded form claims precision the date
+lacks. `S+N` was considered as a spelling that could not be confused with `SSS` and rejected, because
+`+` and `>` would both read as "at least", making `S+3` and `S>3` near-synonyms with different
+meanings: a worse collision, between two new forms rather than between a new form and a deprecated
+one.
+
+### 5. Optional sections are `?[...]`, with full alternation
+
+A run of the format string in `?[...]` is written where the date can carry it and left out where it
+cannot. Within one, `|` separates alternatives: the first alternative every element of which can
+write the date is the one written, and where none can, the section writes nothing.
+
+`?` prefixes the brackets so there is no collision with the leading `[zone]`, and brackets for
+optionality have precedent in Java's `DateTimeFormatter`. Braces were rejected because `%t{...}` is
+bounded by scanning for the first unquoted `}`.
+
+Alternation is full rather than body-plus-default because the viability check is a loop either way,
+and a literal-only alternative is exactly a default.
+
+**Sections nest, and a nested section asks the date for nothing on its own account**, so it adds no
+requirement to the alternative holding it. `?[" at "?[HH:mm]]` on a date with no hour writes `" at "`
+and stops, because the outer alternative holds a literal and a section and both of those can always
+write. Hoisting the literal out, as `?[" at "HH:mm]`, is what makes the two rise and fall together.
+The alternative, letting a nested section refuse on its parent's behalf, was rejected because it
+makes viability depend on a whole subtree and would make `?[X]` and `?[X|""]` mean different things.
+
+An alternative may not be empty. One at the front would make the whole section write nothing whatever
+the date, which is a silent bug; one at the back says what the section without it already says. `""`
+spells an empty alternative where one is meant, and is therefore an element that writes nothing
+rather than nothing at all.
+
+**What a section costs:** it never fails, which is what it is for, and therefore a throwing
+sub-second bound inside one selects the next alternative where outside one it would raise. So
+"refuse over-precise data *and* tolerate coarse data" is not sayable. That is the one place this
+design closes off something a user might reasonably want, and it is the price of a construct that can
+be relied on never to fail. In exchange it makes a new shape of fallback available:
+`?[.S(0,3!)|".(truncated)"]` takes its fallback because the date carries too much rather than too
+little, which nothing else in the language can ask for.
+
+### 6. Validation rejects only the incoherent, never the merely inert
+
+Format strings are frequently built at run time, so a string's validity must not depend on how it was
+authored. A generator that uniformly emits `S(min!,max)` and passes `min = 1` writes a field with a
+dead marker, and it renders rather than failing: the field means something perfectly clear, namely
+the same thing without the marker. Two validation standards, with the compiler stricter than the
+renderer, would make a literal format string fail where the identical computed one succeeds.
+
+So the parse rejects a maximum below one, a minimum above the maximum, a fill that is not exactly one
+character, and syntactic malformation, and nothing else.
+
+The fill is the one place the rule bites, and it shows what the rule actually says. A multi-character
+fill has **two** defensible meanings: write the fill once per missing digit, or write it repeatedly
+until the gap is closed. Nothing in the model prefers either. Admitting the unambiguous does not
+oblige choosing arbitrarily among meanings, so a longer fill is rejected while inert markers are not.
+
+### 7. A literal format string is checked when it is compiled
+
+A format string was only ever found to be wrong by running it. `FormatTools.validate` checks a format
+string against the specifier grammar the two engines implement, and `FormatValidator` calls it from
+`FunctionExpressionValidator` wherever parameter 0 of `format` is a literal.
+
+The check covers the whole string rather than only its date patterns, because a specifier that does
+not exist is as much a property of the string alone as a pattern that could never write a date. It
+does **not** check the specifiers against the arguments, in number or in kind: `args` is an `Any[*]`
+that is frequently computed, so a format string has to be free to be right for arguments the compiler
+cannot see, and getting that wrong would turn a nuisance into an outage.
+
+Only a literal can be checked this way, which is why the run-time check stays. Every SQL literal
+writer in legend-engine splices its time zone into its format string, so none of them is a literal at
+any call site.
+
+## Consequences
+
+**Positive:**
+
+- One format string renders a date at whatever precision it carries, across all seven granularities:
+  `yyyy?[-MM?[-dd?["T"HH?[:mm?[:ss?[.S*]]]]]]`. That closes gap 1.
+- A fixed-width fraction is sayable, so `?[.S9|".000000000"]` replaces a branch, two `format` calls,
+  a concatenation, and a second pass over the date. That closes gap 2.
+- The format string is read once into a `DateFormatPattern` that can be held and reused, and a
+  pattern can be built directly by a caller that has no format string to hand.
+- Resolving the time zone moved to parse time, which makes a zoned pattern **faster** than the loop
+  it replaced: that called `ZoneId.of` on every single call.
+- A malformed literal format string now fails to compile rather than waiting for its line to run.
+
+**Negative:**
+
+- Parsing per call costs about three times the old loop for an unzoned pattern. A pattern hoisted out
+  of a loop is at parity or better, and a zoned one is faster either way.
+- `S3` and `SSS` are confusable, as decision 4 records.
+- A throwing bound inside a section stops throwing, as decision 5 records.
+- `StrictTimeFormat` is now visibly a second implementation of an overlapping language, with the
+  sub-second rule this change replaced. It has no Pure surface, so nothing reaches it except
+  `PureStrictTime.format(String)` from Java, and it was deliberately left alone.
+
+**Mitigation:**
+
+- The confusable pair is documented in `DateFormat`'s javadoc and in `format`'s doc string, and
+  deprecating the repetition form retires it.
+- `pattern()` writes the modern spelling of any field it reads, so the migration is mechanical for
+  every format string whose meaning is already right.
+
+## Rejected
+
+- **Trimming trailing zeros.** Designed as a `#` suffix and cut. It cancels out against the minimum,
+  and which of them wins depends on an ordering nothing in the notation settles: trim before padding
+  and `SN#` means exactly `SN`; trim after and the minimum is dead whenever the fill is a zero. A
+  feature whose two readings differ on every field carrying both parameters is one to take up on its
+  own. It has a real use case, matching PostgreSQL's own timestamp rendering, so it will come back.
+- **`S=N`, "exactly N digits, inventing them when the date has none".** A category error: it is a
+  shorthand for a field *and* a section, and should not wear an `S` spelling that implies otherwise.
+- **Rounding rather than truncating above the maximum.** Recommended against permanently. Rounding
+  does not widen the span a date stands for, it *moves* it, so the rendered value can name a range the
+  date never covered, and `.9999` at width three would carry into the second.
+- **Text fields** (month names, day-of-week names, eras). They drag in locale, which this formatter
+  has never had and which is a design commitment rather than a feature addition. `MMM` writing `003`
+  is the worst behaviour in the language and predates this work; it wants a lint, not a silent fix.
+
+## See also
+
+- `legend-pure-m4/.../primitive/date/DateFormatPattern.java` and its javadoc, which carries the
+  rendering order, the viability rule, and the interval argument.
+- `legend-pure-m4/.../primitive/date/DateFormat.java`, whose `format` javadoc is the user-facing
+  reference for the whole language.
+- `legend-pure-m3-core/.../platform/pure/essential/string/toString/format.pure`, the Pure surface.
+- `TestDateFormat`, whose `LEGACY_COMPATIBILITY` table is the compatibility suite, and
+  `TestDateFormatPattern`, which carries the worked tables of this decision as tests.
+- [ADR-004: Date Difference Semantics](ADR-004-date-difference-semantics.md), which reads a Pure date
+  as a span in the same way and for the same reasons.

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/functionExpression/FormatValidator.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/functionExpression/FormatValidator.java
@@ -1,0 +1,72 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.compiler.validation.functionExpression;
+
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.list.ListIterable;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.FunctionExpression;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.InstanceValue;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.tools.FormatTools;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m4.exception.PureCompilationException;
+
+/**
+ * Checks a literal format string where {@code format} is called with one, so a format string that
+ * could never be used is a compilation error rather than something waiting for the line to be
+ * executed.
+ *
+ * <p>Only a literal can be checked here. A format string that is computed reaches this as something
+ * other than a literal and is left alone, which is why the run-time check stays: the format strings
+ * the relational stores build for their SQL literals are assembled from a time zone and a
+ * granularity, and are never literal at any call site.
+ *
+ * <p>What is checked is what {@link FormatTools#validate} checks, which is the format string alone.
+ * Whether the specifiers and the arguments agree, in number or in kind, is a different question with
+ * a different answer at every call site, and is left to the run time on purpose.
+ */
+public class FormatValidator
+{
+    public static void validateFormat(FunctionExpression instance, ProcessorSupport processorSupport) throws PureCompilationException
+    {
+        ListIterable<? extends ValueSpecification> parametersValues = instance._parametersValues().toList();
+        if (parametersValues.isEmpty() || !(parametersValues.get(0) instanceof InstanceValue))
+        {
+            return;
+        }
+
+        RichIterable<? extends CoreInstance> values = ((InstanceValue) parametersValues.get(0))._valuesCoreInstance();
+        if (values.size() != 1)
+        {
+            return;
+        }
+
+        CoreInstance value = values.getFirst();
+        if ((value != null) && processorSupport.instance_instanceOf(value, M3Paths.String))
+        {
+            try
+            {
+                FormatTools.validate(PrimitiveUtilities.getStringValue(value));
+            }
+            catch (IllegalArgumentException e)
+            {
+                throw new PureCompilationException(instance.getSourceInformation(), e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/validator/FunctionExpressionValidator.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/compiler/validation/validator/FunctionExpressionValidator.java
@@ -22,6 +22,7 @@ import org.finos.legend.pure.m3.compiler.validation.Validator;
 import org.finos.legend.pure.m3.compiler.validation.ValidatorState;
 import org.finos.legend.pure.m3.compiler.validation.functionExpression.CopyValidator;
 import org.finos.legend.pure.m3.compiler.validation.functionExpression.EnumValidator;
+import org.finos.legend.pure.m3.compiler.validation.functionExpression.FormatValidator;
 import org.finos.legend.pure.m3.compiler.validation.functionExpression.GetAllValidator;
 import org.finos.legend.pure.m3.compiler.validation.functionExpression.GetAllVersionsInRangeValidator;
 import org.finos.legend.pure.m3.compiler.validation.functionExpression.GetAllVersionsValidator;
@@ -86,6 +87,10 @@ public class FunctionExpressionValidator implements MatchRunner<FunctionExpressi
         if ("extractEnumValue_Enumeration_1__String_1__T_1_".equals(function.getName()))
         {
             EnumValidator.validateEnum(instance, processorSupport);
+        }
+        if ("format_String_1__Any_MANY__String_1_".equals(function.getName()))
+        {
+            FormatValidator.validateFormat(instance, processorSupport);
         }
         if ("subType_Any_m__T_1__T_m_".equals(function.getName()) || "whenSubType_Any_1__T_1__T_$0_1$_".equals(function.getName()) || "whenSubType_Any_$0_1$__T_1__T_$0_1$_".equals(function.getName()) || "whenSubType_Any_MANY__T_1__T_MANY_".equals(function.getName()))
         {

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/tools/FormatTools.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/tools/FormatTools.java
@@ -134,6 +134,22 @@ public class FormatTools
         return end + 1;
     }
 
+    /**
+     * Find the brace that closes the date pattern of a {@code %t} specifier, so that the pattern
+     * can be carved out and handed to {@link DateFormat}.
+     *
+     * <p>Only quoting is read here, and it is read the way the pattern parser reads it: a
+     * {@code "} opens a run of text, a second one closes it, and inside such a run a backslash
+     * makes text of whatever follows it, the quote and the backslash included. A brace inside a
+     * quoted run therefore does not end the pattern, and neither does a quote a backslash has
+     * escaped. Outside a run of quoted text a backslash is an ordinary character to this scan,
+     * which is what lets the parser report it as the invalid control character it is.
+     *
+     * @param formatString format string
+     * @param start        index of the character just after the {@code t}
+     * @return index of the closing brace, or -1 where no pattern follows the specifier
+     * @throws IllegalArgumentException if a pattern is opened and never closed
+     */
     public static int findEndOfDateFormatString(String formatString, int start)
     {
         int length = formatString.length();
@@ -147,18 +163,21 @@ public class FormatTools
         for (int i = start + 1; i < length; i++)
         {
             char next = formatString.charAt(i);
-            if (inQuotes)
+            if (escaped)
+            {
+                // the character a backslash escapes is text, whatever it is, and escapes nothing
+                // itself
+                escaped = false;
+            }
+            else if (inQuotes)
             {
                 if (next == '"')
                 {
-                    if (!escaped)
-                    {
-                        inQuotes = false;
-                    }
+                    inQuotes = false;
                 }
                 else if (next == '\\')
                 {
-                    escaped = !escaped;
+                    escaped = true;
                 }
             }
             else if (next == '"')

--- a/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/tools/FormatTools.java
+++ b/legend-pure-core/legend-pure-m3-core/src/main/java/org/finos/legend/pure/m3/tools/FormatTools.java
@@ -14,12 +14,126 @@
 
 package org.finos.legend.pure.m3.tools;
 
+import org.finos.legend.pure.m4.coreinstance.primitive.date.DateFormat;
+
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 
 public class FormatTools
 {
+    /**
+     * Check that a format string is one {@code format} can use, and do nothing else. Everything this
+     * reports is a property of the format string alone: that each specifier in it is one that exists
+     * and is written the way that specifier is written, and that each date pattern in it could write
+     * some date.
+     *
+     * <p>What it deliberately does not report is whether the specifiers and the arguments agree, in
+     * number or in kind. The arguments are an {@code Any[*]} that is frequently computed, so a
+     * format string has to be free to be right for arguments this cannot see.
+     *
+     * <p>This is the specifier grammar the two engines implement as they render, in
+     * {@code PureStringFormat} for the compiled engine and {@code Format} for the interpreted one,
+     * written once more so that it can be checked without a date to write or an argument to take.
+     * The two must agree; a format string this accepts and they reject is a fault here.
+     *
+     * @param formatString format string
+     * @throws IllegalArgumentException if the format string holds something that is not a
+     *                                  specifier, a specifier that is not written the way that one
+     *                                  is written, or a date pattern that could never write a date
+     */
+    public static void validate(String formatString)
+    {
+        int length = formatString.length();
+        int index = 0;
+        while (index < length)
+        {
+            if (formatString.charAt(index++) == '%')
+            {
+                index = validateSpecifier(formatString, index);
+            }
+        }
+    }
+
+    /**
+     * Check the specifier beginning at the given index, the {@code %} having been taken.
+     *
+     * @param formatString format string
+     * @param index        index just past the {@code %}
+     * @return index to go on reading the format string from
+     */
+    private static int validateSpecifier(String formatString, int index)
+    {
+        if (index >= formatString.length())
+        {
+            throw new IllegalArgumentException("Format string ends with '%': " + formatString);
+        }
+
+        // the character after the % is taken either way, so the second % of %% cannot begin one
+        char specifier = formatString.charAt(index++);
+        switch (specifier)
+        {
+            case '%':
+            case 's':
+            case 'r':
+            case 'd':
+            case 'f':
+            {
+                return index;
+            }
+            case 't':
+            {
+                int end = findEndOfDateFormatString(formatString, index);
+                if (end == -1)
+                {
+                    // no pattern follows, so the date is written in its canonical form and there is
+                    // nothing here to be wrong
+                    return index;
+                }
+                DateFormat.validate(formatString, index + 1, end);
+                return end + 1;
+            }
+            case '0':
+            {
+                return validateWidth(formatString, index - 1, 'd');
+            }
+            case '.':
+            {
+                return validateWidth(formatString, index - 1, 'f');
+            }
+            default:
+            {
+                throw new IllegalArgumentException("Invalid format specifier: %" + specifier);
+            }
+        }
+    }
+
+    /**
+     * Check the digits and the closing character of a specifier that takes a width, which is
+     * {@code %0<digits>d} and {@code %.<digits>f}. At least one digit is required, since the digits
+     * are read as a number and there is no number to read where there are none.
+     *
+     * @param formatString format string
+     * @param start        index of the character that opened the width, the {@code 0} or the dot
+     * @param closer       character the specifier ends with
+     * @return index to go on reading the format string from
+     */
+    private static int validateWidth(String formatString, int start, char closer)
+    {
+        int length = formatString.length();
+        int end = start + 1;
+        while ((end < length) && Character.isDigit(formatString.charAt(end)))
+        {
+            end++;
+        }
+        if ((end == (start + 1)) || (end >= length) || (formatString.charAt(end) != closer))
+        {
+            int stop = Math.min(end + 1, length);
+            throw new IllegalArgumentException("Invalid format specifier: %" + formatString.substring(start, stop));
+        }
+        return end + 1;
+    }
+
     public static int findEndOfDateFormatString(String formatString, int start)
     {
         int length = formatString.length();

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/format.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/format.pure
@@ -149,34 +149,8 @@ function <<PCT.test>> meta::pure::functions::string::tests::format::testFormatDa
     assertEq('on 2014-03-10 08:07:44.001-0500', $f->eval(|format('on %t{[EST]yyyy-MM-dd HH:mm:ss.SSSZ}', %2014-03-10T13:07:44.001)));
     assertEq('on 2014-03-10 14:07:44.001+0100', $f->eval(|format('on %t{[CET]yyyy-MM-dd HH:mm:ss.SSSZ}', %2014-03-10T13:07:44.001)));
 
-    // A run of four or more S writes the fraction the date stores rather than that many digits,
-    // which is what it has always done here. Any platform that writes 001000000 for this is running
-    // a different implementation of the format language, not this one.
-    assertEq('on 001', $f->eval(|format('on %t{SSSSSSSSS}', %2014-03-10T13:07:44.001)));
-
-    // A sub-second field takes a width of its own, which a run of letters cannot state.
-    assertEq('on 070', $f->eval(|format('on %t{S3}', %2014-03-10T13:07:44.07)));
-    assertEq('on 07', $f->eval(|format('on %t{S<3}', %2014-03-10T13:07:44.07)));
-    assertEq('on 070004235', $f->eval(|format('on %t{S*}', %2014-03-10T13:07:44.070004235)));
-    assertEq('on 2014-03-10T13:07:44.001000000', $f->eval(|format('on %t{yyyy-MM-dd"T"HH:mm:ss.S9}', %2014-03-10T13:07:44.001)));
-
-    // An optional section is written where the date can carry it and left out where it cannot, so
-    // one pattern serves every granularity.
-    assertEq('on 2014', $f->eval(|format('on %t{yyyy?[-MM?[-dd]]}', %2014)));
-    assertEq('on 2014-03', $f->eval(|format('on %t{yyyy?[-MM?[-dd]]}', %2014-03)));
-    assertEq('on 2014-03-10', $f->eval(|format('on %t{yyyy?[-MM?[-dd]]}', %2014-03-10)));
-    assertEq('on 2014-03-10', $f->eval(|format('on %t{yyyy?[-MM?[-dd]]}', %2014-03-10T13:07:44.001)));
-
-    // Alternatives are tried in the order they are written, and the first the date can carry wins.
-    assertEq('on 13:07:44', $f->eval(|format('on %t{?[HH:mm:ss|HH:mm|"--"]}', %2014-03-10T13:07:44)));
-    assertEq('on 13:07', $f->eval(|format('on %t{?[HH:mm:ss|HH:mm|"--"]}', %2014-03-10T13:07)));
-    assertEq('on --', $f->eval(|format('on %t{?[HH:mm:ss|HH:mm|"--"]}', %2014-03-10)));
-
-    // A field says how wide a fraction is and a section says what to do when there is none, so a
-    // fixed width fraction that survives a date without one takes both.
-    assertEq('on 2014-03-10T13:07:44.001000000', $f->eval(|format('on %t{yyyy-MM-dd"T"HH:mm:ss?[.S9|".000000000"]}', %2014-03-10T13:07:44.001)));
-    assertEq('on 2014-03-10T13:07:44.070000000', $f->eval(|format('on %t{yyyy-MM-dd"T"HH:mm:ss?[.S9|".000000000"]}', %2014-03-10T13:07:44.07)));
-    assertEq('on 2014-03-10T13:07:44.000000000', $f->eval(|format('on %t{yyyy-MM-dd"T"HH:mm:ss?[.S9|".000000000"]}', %2014-03-10T13:07:44)));
+    // Sub-second field widths and optional sections are covered by testFormatDateWithSubSecondWidth
+    // and testFormatDateWithOptionalSection, which are not PCT tests yet.
 }
 
 function <<PCT.test>> meta::pure::functions::string::tests::format::testFormatBoolean<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
@@ -219,4 +193,38 @@ function <<test.Test>> meta::pure::functions::string::tests::format::testFormatT
 function <<test.Test>> meta::pure::functions::string::tests::format::testFormatTooManyInputs():Boolean[1]
 {
     assertError(|format('Hello %s %s', ['Catherine', 'Joe', 'Katie']), 'Unused format args. [3] arguments provided to expression "Hello %s %s"');
+}
+
+function <<test.Test>> meta::pure::functions::string::tests::format::testFormatDateWithSubSecondWidth():Boolean[1]
+{
+    // A run of four or more S writes the fraction the date stores rather than that many digits,
+    // which is what it has always done here.
+    assertEq('on 001', format('on %t{SSSSSSSSS}', %2014-03-10T13:07:44.001));
+
+    // A sub-second field takes a width of its own, which a run of letters cannot state.
+    assertEq('on 070', format('on %t{S3}', %2014-03-10T13:07:44.07));
+    assertEq('on 07', format('on %t{S<3}', %2014-03-10T13:07:44.07));
+    assertEq('on 070004235', format('on %t{S*}', %2014-03-10T13:07:44.070004235));
+    assertEq('on 2014-03-10T13:07:44.001000000', format('on %t{yyyy-MM-dd"T"HH:mm:ss.S9}', %2014-03-10T13:07:44.001));
+}
+
+function <<test.Test>> meta::pure::functions::string::tests::format::testFormatDateWithOptionalSection():Boolean[1]
+{
+    // An optional section is written where the date can carry it and left out where it cannot, so
+    // one pattern serves every granularity.
+    assertEq('on 2014', format('on %t{yyyy?[-MM?[-dd]]}', %2014));
+    assertEq('on 2014-03', format('on %t{yyyy?[-MM?[-dd]]}', %2014-03));
+    assertEq('on 2014-03-10', format('on %t{yyyy?[-MM?[-dd]]}', %2014-03-10));
+    assertEq('on 2014-03-10', format('on %t{yyyy?[-MM?[-dd]]}', %2014-03-10T13:07:44.001));
+
+    // Alternatives are tried in the order they are written, and the first the date can carry wins.
+    assertEq('on 13:07:44', format('on %t{?[HH:mm:ss|HH:mm|"--"]}', %2014-03-10T13:07:44));
+    assertEq('on 13:07', format('on %t{?[HH:mm:ss|HH:mm|"--"]}', %2014-03-10T13:07));
+    assertEq('on --', format('on %t{?[HH:mm:ss|HH:mm|"--"]}', %2014-03-10));
+
+    // A field says how wide a fraction is and a section says what to do when there is none, so a
+    // fixed width fraction that survives a date without one takes both.
+    assertEq('on 2014-03-10T13:07:44.001000000', format('on %t{yyyy-MM-dd"T"HH:mm:ss?[.S9|".000000000"]}', %2014-03-10T13:07:44.001));
+    assertEq('on 2014-03-10T13:07:44.070000000', format('on %t{yyyy-MM-dd"T"HH:mm:ss?[.S9|".000000000"]}', %2014-03-10T13:07:44.07));
+    assertEq('on 2014-03-10T13:07:44.000000000', format('on %t{yyyy-MM-dd"T"HH:mm:ss?[.S9|".000000000"]}', %2014-03-10T13:07:44));
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/format.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/format.pure
@@ -149,8 +149,10 @@ function <<PCT.test>> meta::pure::functions::string::tests::format::testFormatDa
     assertEq('on 2014-03-10 08:07:44.001-0500', $f->eval(|format('on %t{[EST]yyyy-MM-dd HH:mm:ss.SSSZ}', %2014-03-10T13:07:44.001)));
     assertEq('on 2014-03-10 14:07:44.001+0100', $f->eval(|format('on %t{[CET]yyyy-MM-dd HH:mm:ss.SSSZ}', %2014-03-10T13:07:44.001)));
 
-    // Sub-second field widths and optional sections are covered by testFormatDateWithSubSecondWidth
-    // and testFormatDateWithOptionalSection, which are not PCT tests yet.
+    // Sub-second field widths, optional sections, and escapes in a quoted run are covered by
+    // testFormatDateWithSubSecondWidth, testFormatDateWithSubSecondGeneralForm,
+    // testFormatDateWithOptionalSection, and testFormatDateWithEscapes, which are not PCT tests
+    // yet.
 }
 
 function <<PCT.test>> meta::pure::functions::string::tests::format::testFormatBoolean<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]
@@ -204,8 +206,65 @@ function <<test.Test>> meta::pure::functions::string::tests::format::testFormatD
     // A sub-second field takes a width of its own, which a run of letters cannot state.
     assertEq('on 070', format('on %t{S3}', %2014-03-10T13:07:44.07));
     assertEq('on 07', format('on %t{S<3}', %2014-03-10T13:07:44.07));
+    assertEq('on 070', format('on %t{S>3}', %2014-03-10T13:07:44.07));
+    assertEq('on 070004235', format('on %t{S>3}', %2014-03-10T13:07:44.070004235));
     assertEq('on 070004235', format('on %t{S*}', %2014-03-10T13:07:44.070004235));
     assertEq('on 2014-03-10T13:07:44.001000000', format('on %t{yyyy-MM-dd"T"HH:mm:ss.S9}', %2014-03-10T13:07:44.001));
+
+    // S!N is the one shorthand that refuses a short fraction rather than padding it, since padding
+    // claims a precision the date does not have where truncating only gives some up. It is the same
+    // field as S3 on a date that fits, and parts from it only on the date that does not: S3 writes
+    // 070 for a two digit fraction where S!3 refuses it.
+    assertEq('on 070', format('on %t{S!3}', %2014-03-10T13:07:44.070));
+    assertError(|format('on %t{S!3}', %2014-03-10T13:07:44.07), 'Date has a 2 digit sub-second, but 3 are required: 2014-03-10T13:07:44.07+0000');
+
+    // Every sub-second field fails on a date with no fraction at all, whatever width it states: how
+    // many digits to write is the field's business, and whether there are any to write is not.
+    assertError(|format('on %t{S*}', %2014-03-10T13:07:44), 'Date has no sub-second: 2014-03-10T13:07:44+0000');
+    assertError(|format('on %t{S3}', %2014-03-10), 'Date has no sub-second: 2014-03-10');
+}
+
+function <<test.Test>> meta::pure::functions::string::tests::format::testFormatDateWithSubSecondGeneralForm():Boolean[1]
+{
+    // The general form states both bounds at once. The maximum is applied first and the minimum is
+    // tested against what it left, so one field cuts a long fraction down and pads a short one out
+    // without the two ever meeting.
+    assertEq('on 070', format('on %t{S(3,6)}', %2014-03-10T13:07:44.07));
+    assertEq('on 0700', format('on %t{S(3,6)}', %2014-03-10T13:07:44.0700));
+    assertEq('on 070004', format('on %t{S(3,6)}', %2014-03-10T13:07:44.070004235));
+
+    // A maximum of * is no maximum at all, which is what S>3 says in two characters.
+    assertEq('on 070', format('on %t{S(3,*)}', %2014-03-10T13:07:44.07));
+    assertEq('on 070004235', format('on %t{S(3,*)}', %2014-03-10T13:07:44.070004235));
+
+    // A ! after either bound refuses rather than padding or truncating there. S!3 spells the marker
+    // on the minimum; the one on the maximum has no shorthand, since truncating widens the span a
+    // date stands for and stays true where padding narrows it.
+    assertEq('on 070', format('on %t{S(3!,3)}', %2014-03-10T13:07:44.070));
+    assertError(|format('on %t{S(3!,3)}', %2014-03-10T13:07:44.07), 'Date has a 2 digit sub-second, but 3 are required: 2014-03-10T13:07:44.07+0000');
+    assertEq('on 070', format('on %t{S(0,3!)}', %2014-03-10T13:07:44.070));
+    assertError(|format('on %t{S(0,3!)}', %2014-03-10T13:07:44.070004235), 'Date has a 9 digit sub-second, but at most 3 may be written: 2014-03-10T13:07:44.070004235+0000');
+
+    // The third part names a fill other than zero, as one quoted character. It goes on the right,
+    // since sub-second digits run most significant first.
+    assertEq('on 07____', format('on %t{S(6,6,"_")}', %2014-03-10T13:07:44.07));
+
+    // All three parts at once: between three and six digits, padded with underscores where the date
+    // is short, and refused rather than cut where it is long.
+    assertEq('on 07_', format('on %t{S(3,6!,"_")}', %2014-03-10T13:07:44.07));
+    assertEq('on 070004', format('on %t{S(3,6!,"_")}', %2014-03-10T13:07:44.070004));
+    assertError(|format('on %t{S(3,6!,"_")}', %2014-03-10T13:07:44.070004235), 'Date has a 9 digit sub-second, but at most 6 may be written: 2014-03-10T13:07:44.070004235+0000');
+
+    // A marker with nothing to act on is legal and does nothing, so a format string built at run
+    // time may spell every field the same way. A date that can be written at all carries at least
+    // one sub-second digit, so a minimum of one is never short.
+    assertEq('on 07', format('on %t{S(1!,3)}', %2014-03-10T13:07:44.07));
+
+    // A section never fails, so a throwing bound inside one selects the next alternative rather
+    // than raising, whichever of the two bounds carries the marker. That is a fallback taken
+    // because the date carries too much rather than too little, which nothing else can ask for.
+    assertEq('on 13:07:44.070', format('on %t{HH:mm:ss?[.S(0,3!)|".(truncated)"]}', %2014-03-10T13:07:44.070));
+    assertEq('on 13:07:44.(truncated)', format('on %t{HH:mm:ss?[.S(0,3!)|".(truncated)"]}', %2014-03-10T13:07:44.070004235));
 }
 
 function <<test.Test>> meta::pure::functions::string::tests::format::testFormatDateWithOptionalSection():Boolean[1]
@@ -227,4 +286,21 @@ function <<test.Test>> meta::pure::functions::string::tests::format::testFormatD
     assertEq('on 2014-03-10T13:07:44.001000000', format('on %t{yyyy-MM-dd"T"HH:mm:ss?[.S9|".000000000"]}', %2014-03-10T13:07:44.001));
     assertEq('on 2014-03-10T13:07:44.070000000', format('on %t{yyyy-MM-dd"T"HH:mm:ss?[.S9|".000000000"]}', %2014-03-10T13:07:44.07));
     assertEq('on 2014-03-10T13:07:44.000000000', format('on %t{yyyy-MM-dd"T"HH:mm:ss?[.S9|".000000000"]}', %2014-03-10T13:07:44));
+}
+
+function <<test.Test>> meta::pure::functions::string::tests::format::testFormatDateWithEscapes():Boolean[1]
+{
+    // Text in double quotes is written without them, so a brace inside a quoted run is text rather
+    // than the end of the pattern.
+    assertEq('on 2014}', format('on %t{yyyy"}"}', %2014-03-10T13:07:44.07));
+
+    // A backslash inside a quoted run makes text of whatever follows it, which is the only way to
+    // write a quote, and the only way to write a backslash before one.
+    assertEq('on 2014a"b', format('on %t{yyyy"a\\"b"}', %2014-03-10T13:07:44.07));
+    assertEq('on 2014a\\b', format('on %t{yyyy"a\\\\b"}', %2014-03-10T13:07:44.07));
+
+    // A sub-second fill is one quoted character and takes the same escape, so it can be either of
+    // them too. The fill goes on the right, so these pad .07 out to four digits.
+    assertEq('on 07""', format('on %t{S(4,4,"\\"")}', %2014-03-10T13:07:44.07));
+    assertEq('on 07\\\\', format('on %t{S(4,4,"\\\\")}', %2014-03-10T13:07:44.07));
 }

--- a/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/format.pure
+++ b/legend-pure-core/legend-pure-m3-core/src/main/resources/platform/pure/essential/string/toString/format.pure
@@ -21,18 +21,44 @@ Builds a string by substituting values into a format template.
 Each specifier in `format` consumes the next value from `args`, in order.
 
 **Specifiers**
-- `%s` — the value as a string.
-- `%d` — an integer; width and zero-padding may be given, as in `%05d`.
-- `%f` — a floating-point number; precision may be given, as in `%.2f`.
-- `%r` — the value's Pure representation, quoting strings as they would be written in source.
-- `%t` — a date. A pattern may follow in braces, as in `%t{yyyy-MM-dd}`, optionally opening with a
-  timezone, as in `%t{[CET]yyyy-MM-dd HH:mm:ss.SSSZ}`.
+- `%s`: the value as a string.
+- `%d`: an integer; width and zero-padding may be given, as in `%05d`.
+- `%f`: a floating-point number; precision may be given, as in `%.2f`.
+- `%r`: the value's Pure representation, quoting strings as they would be written in source.
+- `%t`: a date. A pattern may follow in braces, as in `%t{yyyy-MM-dd}`, optionally opening with a
+  timezone, as in `%t{[CET]yyyy-MM-dd HH:mm:ss.SSSZ}`. See **Date patterns** below.
 
 **Parameters**
-- `format` — the template.
-- `args` — the values to substitute, in the order their specifiers appear.
+- `format`: the template.
+- `args`: the values to substitute, in the order their specifiers appear.
 
 **Returns** the formatted string.
+
+**Date patterns**
+
+`y M d H h a m s S z Z X` stand for the components of a date, the separators `- / : .`, tab, and
+space stand for themselves, and text in double quotes is written without them. Repeating a character
+widens the field it writes, so `d` gives 1 where `dd` gives 01. Every part of a pattern is required,
+so a date that does not carry it is an error.
+
+Two parts of a pattern say more than a run of letters can.
+
+A **sub-second field** takes a width. `S3` writes exactly three digits, padding a shorter fraction;
+`S<3` writes at most three; `S>3` at least three and everything beyond; `S*` however many the date
+has; and `S!3` exactly three, failing rather than padding one that is shorter. `S(m,n)` gives both
+bounds at once, with `*` for no maximum, `!` after either bound to fail rather than pad or truncate
+there, and an optional third part naming a fill other than zero. A run of `S` keeps the meaning it
+has always had: one to three letters are `S<1` to `S<3`, and four or more is `S*`.
+
+An **optional section**, written `?[...]`, is put in where the date can carry it and left out where
+it cannot, with `|` between alternatives: the first alternative the date can carry is the one
+written, and where the date can carry none of them the section writes nothing. Sections nest, and a
+section is what lets one pattern serve dates that do not agree on precision.
+
+A sub-second field says how wide a fraction is, never whether there is one, so what to write for a
+date with no fraction at all is a question for the section around it. That is why the decimal point
+belongs inside the section: `?[.S3]` writes `.070` or nothing, where `.?[S3]` would leave a bare
+point behind.
 
 **Examples**
 ```pure
@@ -40,6 +66,9 @@ format('Hello %s %s', ['John', 'Roe'])                  // 'Hello John Roe'
 format('%s scored %.2f', ['Pierre', 3.14159])           // 'Pierre scored 3.14'
 format('%s has %05d points', ['Pierre', 42])            // 'Pierre has 00042 points'
 format('on %t{yyyy-MM-dd}', %2014-02-27T10:01:35.231)   // 'on 2014-02-27'
+format('%t{yyyy?[-MM?[-dd]]}', %2014-02)                // '2014-02'
+format('%t{HH:mm:ss?[.S3]}', %2014-02-27T10:01:35.2)    // '10:01:35.200'
+format('%t{HH:mm:ss?[.S3]}', %2014-02-27T10:01:35)      // '10:01:35'
 ```
 
 **See also** `meta::pure::functions::string::toString(Any[1]):String[1]`,
@@ -119,6 +148,35 @@ function <<PCT.test>> meta::pure::functions::string::tests::format::testFormatDa
     assertEq('on 2014-03-10 13:07:44.001Z', $f->eval(|format('on %t{yyyy-MM-dd HH:mm:ss.SSSX}', %2014-03-10T13:07:44.001)));
     assertEq('on 2014-03-10 08:07:44.001-0500', $f->eval(|format('on %t{[EST]yyyy-MM-dd HH:mm:ss.SSSZ}', %2014-03-10T13:07:44.001)));
     assertEq('on 2014-03-10 14:07:44.001+0100', $f->eval(|format('on %t{[CET]yyyy-MM-dd HH:mm:ss.SSSZ}', %2014-03-10T13:07:44.001)));
+
+    // A run of four or more S writes the fraction the date stores rather than that many digits,
+    // which is what it has always done here. Any platform that writes 001000000 for this is running
+    // a different implementation of the format language, not this one.
+    assertEq('on 001', $f->eval(|format('on %t{SSSSSSSSS}', %2014-03-10T13:07:44.001)));
+
+    // A sub-second field takes a width of its own, which a run of letters cannot state.
+    assertEq('on 070', $f->eval(|format('on %t{S3}', %2014-03-10T13:07:44.07)));
+    assertEq('on 07', $f->eval(|format('on %t{S<3}', %2014-03-10T13:07:44.07)));
+    assertEq('on 070004235', $f->eval(|format('on %t{S*}', %2014-03-10T13:07:44.070004235)));
+    assertEq('on 2014-03-10T13:07:44.001000000', $f->eval(|format('on %t{yyyy-MM-dd"T"HH:mm:ss.S9}', %2014-03-10T13:07:44.001)));
+
+    // An optional section is written where the date can carry it and left out where it cannot, so
+    // one pattern serves every granularity.
+    assertEq('on 2014', $f->eval(|format('on %t{yyyy?[-MM?[-dd]]}', %2014)));
+    assertEq('on 2014-03', $f->eval(|format('on %t{yyyy?[-MM?[-dd]]}', %2014-03)));
+    assertEq('on 2014-03-10', $f->eval(|format('on %t{yyyy?[-MM?[-dd]]}', %2014-03-10)));
+    assertEq('on 2014-03-10', $f->eval(|format('on %t{yyyy?[-MM?[-dd]]}', %2014-03-10T13:07:44.001)));
+
+    // Alternatives are tried in the order they are written, and the first the date can carry wins.
+    assertEq('on 13:07:44', $f->eval(|format('on %t{?[HH:mm:ss|HH:mm|"--"]}', %2014-03-10T13:07:44)));
+    assertEq('on 13:07', $f->eval(|format('on %t{?[HH:mm:ss|HH:mm|"--"]}', %2014-03-10T13:07)));
+    assertEq('on --', $f->eval(|format('on %t{?[HH:mm:ss|HH:mm|"--"]}', %2014-03-10)));
+
+    // A field says how wide a fraction is and a section says what to do when there is none, so a
+    // fixed width fraction that survives a date without one takes both.
+    assertEq('on 2014-03-10T13:07:44.001000000', $f->eval(|format('on %t{yyyy-MM-dd"T"HH:mm:ss?[.S9|".000000000"]}', %2014-03-10T13:07:44.001)));
+    assertEq('on 2014-03-10T13:07:44.070000000', $f->eval(|format('on %t{yyyy-MM-dd"T"HH:mm:ss?[.S9|".000000000"]}', %2014-03-10T13:07:44.07)));
+    assertEq('on 2014-03-10T13:07:44.000000000', $f->eval(|format('on %t{yyyy-MM-dd"T"HH:mm:ss?[.S9|".000000000"]}', %2014-03-10T13:07:44)));
 }
 
 function <<PCT.test>> meta::pure::functions::string::tests::format::testFormatBoolean<Z|y>(f:Function<{Function<{->Z[y]}>[1]->Z[y]}>[1]):Boolean[1]

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/tools/TestFormatTools.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/tools/TestFormatTools.java
@@ -20,6 +20,88 @@ import org.junit.Test;
 
 public class TestFormatTools
 {
+    /**
+     * Every specifier the two engines render, and nothing else.
+     */
+    @Test
+    public void testValidateSpecifiers()
+    {
+        FormatTools.validate("");
+        FormatTools.validate("no specifiers at all");
+        FormatTools.validate("%s %d %f %r %t");
+        FormatTools.validate("%05d %.2f %00d %.0f");
+        FormatTools.validate("100%% and %s");
+        FormatTools.validate("%s%s%s");
+
+        // the second % of %% cannot open a specifier, so what follows it is text
+        FormatTools.validate("%%q");
+        FormatTools.validate("%%t{not a pattern}");
+
+        assertInvalid("Invalid format specifier: %q", "%q");
+        assertInvalid("Invalid format specifier: %S", "a %S b");
+        assertInvalid("Invalid format specifier: % ", "% s");
+        assertInvalid("Format string ends with '%': ends with %", "ends with %");
+    }
+
+    /**
+     * A width is written between the character that opens it and the one that closes it, and there
+     * has to be one: the digits are read as a number, and there is no number in none of them.
+     */
+    @Test
+    public void testValidateWidths()
+    {
+        FormatTools.validate("%0100d");
+        FormatTools.validate("%.11f");
+
+        assertInvalid("Invalid format specifier: %0d", "%0d");
+        assertInvalid("Invalid format specifier: %.f", "%.f");
+        assertInvalid("Invalid format specifier: %05x", "%05x");
+        assertInvalid("Invalid format specifier: %.2d", "%.2d");
+        assertInvalid("Invalid format specifier: %05", "%05");
+        assertInvalid("Invalid format specifier: %.", "%.");
+    }
+
+    /**
+     * A date pattern is checked where one is written, and every pattern in the string is.
+     */
+    @Test
+    public void testValidateDatePatterns()
+    {
+        FormatTools.validate("%t");
+        FormatTools.validate("%t and %t");
+        FormatTools.validate("on %t{yyyy-MM-dd} at %t{HH:mm:ss?[.S3]}");
+        FormatTools.validate("%t{[America/New_York]yyyy-MM-dd\"T\"HH:mm:ssX}");
+        FormatTools.validate("%t{S(3!,9,\"_\")}");
+
+        assertInvalid("Invalid format control character 'Q' in format string: yyyy-Q", "%t{yyyy-Q}");
+        assertInvalid("Invalid format control character 'Q' in format string: yyyy-Q", "%t{yyyy-MM-dd} %t{yyyy-Q}");
+        assertInvalid("Unknown time zone: Europe/Lissabon", "%t{[Europe/Lissabon]yyyy}");
+        assertInvalid("Sub-second minimum 5 exceeds maximum 3 in format string: S(5,3)", "%t{S(5,3)}");
+        assertInvalid("Empty alternative in optional section in format string: ?[|HH]", "%t{?[|HH]}");
+        assertInvalid("Could not find end of date format starting at index 2 of: %t{yyyy-MM-dd", "%t{yyyy-MM-dd");
+    }
+
+    /**
+     * How many arguments a format string wants, and of what kind, is not this check's business: the
+     * arguments are often computed, so a format string has to be free to be right for arguments
+     * this cannot see.
+     */
+    @Test
+    public void testValidateSaysNothingAboutArguments()
+    {
+        FormatTools.validate("%s %s %s %s");
+        FormatTools.validate("no arguments wanted");
+        FormatTools.validate("%d");
+    }
+
+    private static void assertInvalid(String expectedMessage, String formatString)
+    {
+        Assert.assertEquals(
+                formatString,
+                expectedMessage,
+                Assert.assertThrows(formatString, IllegalArgumentException.class, () -> FormatTools.validate(formatString)).getMessage());
+    }
+
     @Test
     public void testIntegerZeroPadding()
     {

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/tools/TestFormatTools.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/tools/TestFormatTools.java
@@ -73,12 +73,53 @@ public class TestFormatTools
         FormatTools.validate("%t{[America/New_York]yyyy-MM-dd\"T\"HH:mm:ssX}");
         FormatTools.validate("%t{S(3!,9,\"_\")}");
 
+        // a quote and a brace can be written where the pattern parser accepts them, which takes an
+        // escape inside quoted text for the first and only quoting for the second
+        FormatTools.validate("%t{yyyy\"a\\\"b\"}");
+        FormatTools.validate("%t{S(4,4,\"\\\"\")}");
+        FormatTools.validate("%t{yyyy\"}\"}");
+
         assertInvalid("Invalid format control character 'Q' in format string: yyyy-Q", "%t{yyyy-Q}");
         assertInvalid("Invalid format control character 'Q' in format string: yyyy-Q", "%t{yyyy-MM-dd} %t{yyyy-Q}");
         assertInvalid("Unknown time zone: Europe/Lissabon", "%t{[Europe/Lissabon]yyyy}");
         assertInvalid("Sub-second minimum 5 exceeds maximum 3 in format string: S(5,3)", "%t{S(5,3)}");
         assertInvalid("Empty alternative in optional section in format string: ?[|HH]", "%t{?[|HH]}");
         assertInvalid("Could not find end of date format starting at index 2 of: %t{yyyy-MM-dd", "%t{yyyy-MM-dd");
+    }
+
+    /**
+     * The scan that carves a date pattern out of a format string reads quoting, and reads it the
+     * way the pattern parser does. A brace inside a quoted run is text rather than the end of the
+     * pattern, and so is a quote a backslash has escaped.
+     */
+    @Test
+    public void testFindEndOfDateFormatString()
+    {
+        // a specifier with no pattern after it, which is a date written in its canonical form
+        assertEndOfDateFormat(-1, "%t", 2);
+        assertEndOfDateFormat(-1, "%t and text", 2);
+
+        assertEndOfDateFormat(16, "on %t{yyyy-MM-dd}", 5);
+        assertEndOfDateFormat(3, "%t{}", 2);
+
+        // quoted text runs to its closing quote, and a brace inside it is text
+        assertEndOfDateFormat(18, "%t{yyyy\"T\"HH:mm:ss}", 2);
+        assertEndOfDateFormat(12, "%t{yyyy\"a}b\"}", 2);
+
+        // a backslash inside quoted text makes text of the character after it, so an escaped quote
+        // leaves the run open and escapes nothing itself
+        assertEndOfDateFormat(13, "%t{yyyy\"a\\\"b\"}", 2);
+        assertEndOfDateFormat(13, "%t{yyyy\"a\\\\b\"}", 2);
+        assertEndOfDateFormat(12, "%t{yyyy\"a\\b\"}", 2);
+        assertEndOfDateFormat(14, "%t{S(4,4,\"\\\"\")}", 2);
+        assertEndOfDateFormat(14, "%t{S(4,4,\"\\}\")}", 2);
+
+        // the first unquoted brace ends the pattern, whatever follows it
+        assertEndOfDateFormat(16, "on %t{yyyy-MM-dd} at %t{HH:mm}", 5);
+
+        assertNoEndOfDateFormat("Could not find end of date format starting at index 2 of: %t{yyyy-MM-dd", "%t{yyyy-MM-dd", 2);
+        assertNoEndOfDateFormat("Could not find end of date format starting at index 2 of: %t{yyyy\"unclosed}", "%t{yyyy\"unclosed}", 2);
+        assertNoEndOfDateFormat("Could not find end of date format starting at index 2 of: %t{yyyy\"a\\\"}", "%t{yyyy\"a\\\"}", 2);
     }
 
     /**
@@ -92,6 +133,19 @@ public class TestFormatTools
         FormatTools.validate("%s %s %s %s");
         FormatTools.validate("no arguments wanted");
         FormatTools.validate("%d");
+    }
+
+    private static void assertEndOfDateFormat(int expectedEnd, String formatString, int start)
+    {
+        Assert.assertEquals(formatString, expectedEnd, FormatTools.findEndOfDateFormatString(formatString, start));
+    }
+
+    private static void assertNoEndOfDateFormat(String expectedMessage, String formatString, int start)
+    {
+        Assert.assertEquals(
+                formatString,
+                expectedMessage,
+                Assert.assertThrows(formatString, IllegalArgumentException.class, () -> FormatTools.findEndOfDateFormatString(formatString, start)).getMessage());
     }
 
     private static void assertInvalid(String expectedMessage, String formatString)

--- a/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/validation/TestFormat.java
+++ b/legend-pure-core/legend-pure-m3-core/src/test/java/org/finos/legend/pure/m3/tests/validation/TestFormat.java
@@ -1,0 +1,249 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m3.tests.validation;
+
+import org.finos.legend.pure.m3.tests.AbstractPureTestWithCoreCompiledPlatform;
+import org.finos.legend.pure.m4.exception.PureCompilationException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * A date pattern written into a literal format string is checked where it is written, so a pattern
+ * that could never write any date is a compilation error rather than something waiting for the line
+ * to be executed.
+ */
+public class TestFormat extends AbstractPureTestWithCoreCompiledPlatform
+{
+    @BeforeClass
+    public static void setUp()
+    {
+        setUpRuntime();
+    }
+
+    @After
+    public void cleanRuntime()
+    {
+        runtime.delete("testFunc.pure");
+        runtime.compile();
+    }
+
+    /**
+     * A specifier that does not exist, or one that is not written the way that specifier is written,
+     * is caught where it is written rather than where it runs.
+     */
+    @Test
+    public void testSpecifierThatIsNotOne()
+    {
+        assertFormatFailsToCompile("Invalid format specifier: %q", "'%q'");
+        assertFormatFailsToCompile("Invalid format specifier: %S", "'a %S b'");
+        assertFormatFailsToCompile("Format string ends with '%': ends with %", "'ends with %'");
+        assertFormatFailsToCompile("Invalid format specifier: %05x", "'%05x'");
+        assertFormatFailsToCompile("Invalid format specifier: %0d", "'%0d'");
+        assertFormatFailsToCompile("Invalid format specifier: %.f", "'%.f'");
+    }
+
+    /**
+     * How many arguments a format string wants, and of what kind, stays a run-time question. The
+     * arguments are an Any[*] that is often computed, so a format string has to be free to be right
+     * for arguments the compiler cannot see.
+     */
+    @Test
+    public void testArgumentsAreNotTheCompilersBusiness()
+    {
+        assertFormatCompiles("'%s %s %s'");
+        assertFormatCompiles("'no specifiers at all'");
+        assertFormatCompiles("'%d'");
+    }
+
+    @Test
+    public void testPatternThatMeansNothing()
+    {
+        assertFormatFailsToCompile(
+                "Invalid format control character 'Q' in format string: yyyy-Q",
+                "'%t{yyyy-Q}'");
+        assertFormatFailsToCompile(
+                "Unknown time zone: Europe/Lissabon",
+                "'%t{[Europe/Lissabon]yyyy}'");
+        assertFormatFailsToCompile(
+                "Time zone can only be set at the beginning of the format string",
+                "'%t{yyyy[EST]}'");
+    }
+
+    @Test
+    public void testSubsecondFieldThatMeansNothing()
+    {
+        assertFormatFailsToCompile(
+                "Sub-second minimum 5 exceeds maximum 3 in format string: S(5,3)",
+                "'%t{S(5,3)}'");
+        assertFormatFailsToCompile(
+                "Sub-second maximum must be at least 1: 0 in format string: S<0",
+                "'%t{S<0}'");
+        assertFormatFailsToCompile(
+                "Expected a digit count after 'S<' in format string: S<",
+                "'%t{S<}'");
+        assertFormatFailsToCompile(
+                "Missing closing parenthesis in format string: S(3,3",
+                "'%t{S(3,3}'");
+    }
+
+    @Test
+    public void testOptionalSectionThatMeansNothing()
+    {
+        assertFormatFailsToCompile(
+                "Missing closing bracket for optional section in format string: ?[HH:mm",
+                "'%t{?[HH:mm}'");
+        assertFormatFailsToCompile(
+                "Unmatched ']' in format string: HH]",
+                "'%t{HH]}'");
+        assertFormatFailsToCompile(
+                "'|' outside an optional section in format string: HH|mm",
+                "'%t{HH|mm}'");
+        assertFormatFailsToCompile(
+                "Empty alternative in optional section in format string: ?[|HH]",
+                "'%t{?[|HH]}'");
+    }
+
+    /**
+     * A brace that has been opened and not closed is the format string's fault rather than the
+     * pattern's, and is reported where the pattern would have been.
+     *
+     * <p>An unterminated quote inside a pattern arrives the same way, and can only arrive that way:
+     * the scan that finds the closing brace tracks quotes as the pattern parser does, so a quote
+     * left open swallows the brace that would have ended the pattern. A pattern reached through
+     * {@code %t} therefore never reports the pattern parser's own missing-quote error, and one that
+     * closes its quotes has no missing quote left to report.
+     */
+    @Test
+    public void testPatternWithNoEnd()
+    {
+        assertFormatFailsToCompile(
+                "Could not find end of date format starting at index 2 of: %t{yyyy-MM-dd",
+                "'%t{yyyy-MM-dd'");
+        assertFormatFailsToCompile(
+                "Could not find end of date format starting at index 2 of: %t{yyyy \"abc}",
+                "'%t{yyyy \"abc}'");
+
+        // and where the quotes do close, the brace outside them ends the pattern as it should
+        assertFormatCompiles("'%t{yyyy \"abc}\"}'");
+    }
+
+    /**
+     * Every date pattern in the string is checked, not only the first.
+     */
+    @Test
+    public void testEveryPatternInTheString()
+    {
+        assertFormatFailsToCompile(
+                "Invalid format control character 'Q' in format string: yyyy-Q",
+                "'%t{yyyy-MM-dd} to %t{yyyy-Q}'");
+    }
+
+    /**
+     * What is valid compiles, including the forms this work added and the ones it did not touch.
+     */
+    @Test
+    public void testPatternsThatMeanSomething()
+    {
+        assertFormatCompiles("'%t{yyyy-MM-dd}'");
+        assertFormatCompiles("'%t{[America/New_York]yyyy-MM-dd\"T\"HH:mm:ssX}'");
+        assertFormatCompiles("'%t{SSSS}'");
+        assertFormatCompiles("'%t{S<6}'");
+        assertFormatCompiles("'%t{S(3!,9,\"_\")}'");
+        assertFormatCompiles("'%t{yyyy?[-MM?[-dd?[\"T\"HH:mm:ss?[.S*]]]]}'");
+        assertFormatCompiles("'%t{?[HH:mm:ss|HH:mm|\"--\"]}'");
+
+        // a bare %t writes the date in its canonical form, and has no pattern to be wrong
+        assertFormatCompiles("'%t'");
+        assertFormatCompiles("'%t and %t'");
+
+        // and the second % of %% cannot open a pattern
+        assertFormatCompiles("'100%%t{not a pattern}'");
+    }
+
+    /**
+     * Only a literal format string can be checked here. One that is computed reaches the validator
+     * as something other than a literal, and is left to the run-time check, which is why that check
+     * stays.
+     */
+    @Test
+    public void testAComputedFormatStringIsLeftAlone()
+    {
+        compileTestSource("testFunc.pure",
+                "function testFunc(zone:String[1]):String[1]\n" +
+                        "{\n" +
+                        "    format('%t{[' + $zone + ']yyyy-Q}', %2014-03-10);\n" +
+                        "}");
+    }
+
+    /**
+     * The failure names the line and column the call was written at, since a model with more than
+     * one format string in it is otherwise a search.
+     */
+    @Test
+    public void testTheFailureSaysWhereItIs()
+    {
+        PureCompilationException e = Assert.assertThrows(PureCompilationException.class, () -> compileTestSource(
+                "testFunc.pure",
+                "function testFunc():String[1]\n" +
+                        "{\n" +
+                        "    let a = 'x';\n" +
+                        "    format('%t{yyyy-Q}', %2014-03-10);\n" +
+                        "}"));
+        assertPureException(
+                PureCompilationException.class,
+                "Invalid format control character 'Q' in format string: yyyy-Q",
+                "testFunc.pure",
+                4,
+                5,
+                e);
+    }
+
+    private static void assertFormatCompiles(String formatString)
+    {
+        compileTestSource("testFunc.pure", functionUsing(formatString));
+        discardTestSource();
+    }
+
+    private void assertFormatFailsToCompile(String expectedMessage, String formatString)
+    {
+        PureCompilationException e = Assert.assertThrows(
+                formatString,
+                PureCompilationException.class,
+                () -> compileTestSource("testFunc.pure", functionUsing(formatString)));
+        assertPureException(PureCompilationException.class, expectedMessage, e);
+        discardTestSource();
+    }
+
+    /**
+     * Take the source back out of the runtime. A compile that failed leaves it registered all the
+     * same, so without this the next one in the same test is refused for the name rather than for
+     * the format string it was written to check.
+     */
+    private static void discardTestSource()
+    {
+        runtime.delete("testFunc.pure");
+        runtime.compile();
+    }
+
+    private static String functionUsing(String formatString)
+    {
+        return "function testFunc():String[1]\n" +
+                "{\n" +
+                "    format(" + formatString + ", %2014-03-10T13:07:44.070004235);\n" +
+                "}";
+    }
+}

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -38,6 +38,9 @@ public class DateFormat
      * a backslash escapes the character after it, so a quote may be written {@code \"}; a backslash
      * outside quotes is an error, as is any other character with no meaning here. Repeating a
      * control character widens the field it writes: {@code d} gives 1 where {@code dd} gives 01.
+     * Two things are not control characters at all: a sub-second field takes a width instead of a
+     * run of letters, and {@code ?[}, {@code |}, and {@code ]} open, divide, and close an optional
+     * section. Both are described below.
      *
      * <table border="1">
      * <caption>Control characters</caption>
@@ -98,6 +101,42 @@ public class DateFormat
      * {@code .07} contains {@code .070}, {@code .071}, and {@code .0712}. Truncating widens the
      * span, which loses precision but stays true; padding narrows it, which claims a precision the
      * date does not have. That is why only padding has a short spelling for refusing it.
+     *
+     * <p>A run of the format string in {@code ?[...]} is an optional section, written where the date
+     * can carry it and left out where it cannot. Within one, {@code |} separates alternatives: the
+     * first alternative every element of which can write the date is the one written, and where none
+     * of them can, the section writes nothing. So {@code yyyy-MM-dd?[" at "HH:mm]} writes the time
+     * where the date has one and the date alone where it does not, and
+     * {@code ?[HH:mm:ss|HH:mm|HH|"--"]} writes as much of the time as the date carries. A section
+     * never fails, so a pattern whose date-dependent parts all sit inside one writes any date at
+     * all.
+     *
+     * <p>Sections nest, and there is one thing to know about nesting: a section asks the date for
+     * nothing on its own account, so it adds no requirement to the alternative holding it.
+     *
+     * <pre>
+     * ?[HH:mm?[:ss]]        on 13:07 writes 13:07     -- inner writes nothing, outer unaffected
+     * ?[" at "?[HH:mm]]     on a date with no hour writes " at "
+     * ?[" at "HH:mm]        on a date with no hour writes nothing
+     * </pre>
+     *
+     * <p>The second line is the one that surprises. The outer alternative holds a literal and a
+     * section, both of which can always write, so the outer section writes and the inner one does
+     * not. Hoisting the literal out, as the third line does, is what makes the two rise and fall
+     * together.
+     *
+     * <p>Sections are also how a date with no fraction of a second is written, since a sub-second
+     * field says only how wide a fraction is and never whether there is one:
+     * {@code HH:mm:ss?[.S3]} writes {@code 13:07:44.070} or {@code 13:07:44}, and the decimal point
+     * goes with the digits because the section carries both. {@code ?[.S3|".000"]} invents the
+     * fraction instead, which is worth writing out rather than abbreviating, since it claims a
+     * precision the date does not have.
+     *
+     * <p>An alternative may not be empty: {@code ?[|HH]} and {@code ?[HH|]} are errors, the first
+     * because it would write nothing whatever the date, and the second because it says what
+     * {@code ?[HH]} already says. {@code ""} spells an empty alternative where one is meant.
+     * A throwing sub-second bound inside a section selects the next alternative rather than raising,
+     * which is the one thing a section takes away.
      *
      * <p>A format string may open with a time zone in square brackets, as in
      * {@code [America/New_York]yyyy-MM-dd HH:mm:ss}, and only open with one: a zone appearing after

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -18,7 +18,6 @@ import org.finos.legend.pure.m4.tools.SafeAppendable;
 import org.finos.legend.pure.m4.tools.TextTools;
 
 import java.io.IOException;
-import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -35,20 +34,22 @@ public class DateFormat
      *
      * <p>Each character of the format string is a control character standing for one component of
      * the date, except for the separators {@code - / : . }, tab and space, which are written out as
-     * they appear, and text in double quotes, which is written out without them. A backslash escapes
-     * the character after it. Repeating a control character widens the field it writes: {@code d}
-     * gives 1 where {@code dd} gives 01.
+     * they appear, and text in double quotes, which is written out without them. Within quoted text
+     * a backslash escapes the character after it, so a quote may be written {@code \"}; a backslash
+     * outside quotes is an error, as is any other character with no meaning here. Repeating a
+     * control character widens the field it writes: {@code d} gives 1 where {@code dd} gives 01.
      *
      * <table border="1">
      * <caption>Control characters</caption>
      * <tr><th>Character</th><th>Component</th><th>Example</th></tr>
-     * <tr><td>{@code y}</td><td>year; one or two of them write the last two digits, three or more
+     * <tr><td>{@code y}</td><td>year; one to three of them write the last two digits, four or more
      * the whole year</td><td>{@code yy} 14, {@code yyyy} 2014</td></tr>
      * <tr><td>{@code M}</td><td>month</td><td>{@code MM} 03</td></tr>
      * <tr><td>{@code d}</td><td>day of the month</td><td>{@code dd} 10</td></tr>
      * <tr><td>{@code H}</td><td>hour, 0 to 23</td><td>{@code HH} 16</td></tr>
      * <tr><td>{@code h}</td><td>hour, 1 to 12</td><td>{@code hh} 04</td></tr>
-     * <tr><td>{@code a}</td><td>AM or PM</td><td>PM</td></tr>
+     * <tr><td>{@code a}</td><td>AM or PM; repeating it makes no difference, as there is no width to
+     * widen</td><td>PM</td></tr>
      * <tr><td>{@code m}</td><td>minute</td><td>{@code mm} 12</td></tr>
      * <tr><td>{@code s}</td><td>second</td><td>{@code ss} 35</td></tr>
      * <tr><td>{@code S}</td><td>sub-second; up to three of them truncate the date's own digits,
@@ -76,6 +77,14 @@ public class DateFormat
      * was asked for, but {@code Z} and {@code X} are an error, since an offset belongs to an
      * instant and a zone can be keeping more than one over a date that broad.
      *
+     * <p>The format string is read in full before anything is written, so a malformed one leaves
+     * the appendable as it found it. A component the date does not have is a fault of the pair
+     * rather than of the format string, and is found where it is reached, so a date short of what
+     * the string asks for may have part of itself written before the error.
+     *
+     * <p>{@link DateFormatPattern} is this method's working: it holds a format string already read,
+     * and can be built directly by a caller with no format string to hand.
+     *
      * @param appendable   appendable to write to
      * @param formatString format string
      * @param date         date to write
@@ -87,303 +96,60 @@ public class DateFormat
      */
     public static <T extends Appendable> T format(T appendable, String formatString, PureDate date)
     {
-        SafeAppendable safeAppendable = SafeAppendable.wrap(appendable);
-        int length = formatString.length();
-        ZonedDateTime zoned = null;
-        String timeZoneId = null;
-        int i = 0;
-        while (i < length)
-        {
-            char character = formatString.charAt(i++);
-            switch (character)
-            {
-                // Timezone conversion
-                case '[':
-                {
-                    if (i > 1)
-                    {
-                        throw new IllegalArgumentException("Time zone can only be set at the beginning of the format string");
-                    }
+        return format(appendable, formatString, 0, formatString.length(), date);
+    }
 
-                    StringBuilder tzBuilder = new StringBuilder();
-                    boolean done = false;
-                    boolean escaped = false;
-                    boolean inQuotes = false;
-                    while (!done && (i < length))
-                    {
-                        char next = formatString.charAt(i++);
-                        if (escaped)
-                        {
-                            tzBuilder.append(next);
-                            escaped = false;
-                        }
-                        else if (next == '"')
-                        {
-                            inQuotes = !inQuotes;
-                        }
-                        else if ((next == ']') && !inQuotes)
-                        {
-                            done = true;
-                        }
-                        else if (next == '\\')
-                        {
-                            escaped = true;
-                        }
-                        else
-                        {
-                            tzBuilder.append(next);
-                        }
-                    }
-                    if (inQuotes)
-                    {
-                        throw new IllegalArgumentException("Missing closing quotes in time zone definition: " + formatString);
-                    }
-                    if (!done)
-                    {
-                        throw new IllegalArgumentException("Missing closing bracket in format string: " + formatString);
-                    }
-                    timeZoneId = tzBuilder.toString();
-                    ZoneId timeZone;
-                    try
-                    {
-                        timeZone = ZoneId.of(timeZoneId, ZoneId.SHORT_IDS);
-                    }
-                    catch (DateTimeException e)
-                    {
-                        throw new IllegalArgumentException("Unknown time zone: " + timeZoneId, e);
-                    }
+    /**
+     * Write a Pure date to an appendable in the form a portion of a string describes, which is how
+     * a format string held inside a larger one is used without first cutting it out.
+     *
+     * @param appendable   appendable to write to
+     * @param formatString string holding the format string
+     * @param start        start index of the format string (inclusive)
+     * @param end          end index of the format string (exclusive)
+     * @param date         date to write
+     * @param <T>          appendable type
+     * @return the appendable
+     * @throws IllegalArgumentException if the format string is malformed, names a time zone that
+     *                                  cannot be resolved, sets a time zone anywhere but at the
+     *                                  start, or asks for a component the date does not have
+     * @see #format(Appendable, String, PureDate)
+     */
+    public static <T extends Appendable> T format(T appendable, String formatString, int start, int end, PureDate date)
+    {
+        return DateFormatPattern.parse(formatString, start, end).render(appendable, date);
+    }
 
-                    if (date.hasHour())
-                    {
-                        // A Pure date is always understood as UTC, so the instant it starts at
-                        // is what the requested zone renders.
-                        zoned = PureDateToJava.start().toInstant(date).atZone(timeZone);
-                    }
-                    break;
-                }
-                // Year
-                case 'y':
-                {
-                    int displayYear = (zoned == null) ? date.getYear() : zoned.getYear();
-                    int count = getCharCountFrom(character, formatString, i);
-                    if (count < 3)
-                    {
-                        // The two digit form is the last two digits of the year, which a year
-                        // before the era has as much as one after it: it drops the sign along with
-                        // the century, as it already drops the difference between 1914 and 2014.
-                        appendNonNegTwoDigitInt(safeAppendable, Math.abs(displayYear % 100));
-                    }
-                    else
-                    {
-                        safeAppendable.append(displayYear);
-                    }
-                    i += count;
-                    break;
-                }
-                // Month
-                case 'M':
-                {
-                    if (!date.hasMonth())
-                    {
-                        throw new IllegalArgumentException("Date has no month: " + date);
-                    }
-                    int displayMonth = (zoned == null) ? date.getMonth() : zoned.getMonthValue();
-                    int count = getCharCountFrom(character, formatString, i);
-                    appendZeroPaddedInt(safeAppendable, displayMonth, count + 1);
-                    i += count;
-                    break;
-                }
-                // Day
-                case 'd':
-                {
-                    if (!date.hasDay())
-                    {
-                        throw new IllegalArgumentException("Date has no day: " + date);
-                    }
-                    int displayDay = (zoned == null) ? date.getDay() : zoned.getDayOfMonth();
-                    int count = getCharCountFrom(character, formatString, i);
-                    appendZeroPaddedInt(safeAppendable, displayDay, count + 1);
-                    i += count;
-                    break;
-                }
-                // Hour (1-12)
-                case 'h':
-                {
-                    if (!date.hasHour())
-                    {
-                        throw new IllegalArgumentException("Date has no hour: " + date);
-                    }
-                    int preDisplayHour = (zoned == null) ? date.getHour() : zoned.getHour();
-                    int displayHour = (preDisplayHour == 0) ? 12 : ((preDisplayHour > 12) ? (preDisplayHour - 12) : preDisplayHour);
-                    int count = getCharCountFrom(character, formatString, i);
-                    appendZeroPaddedInt(safeAppendable, displayHour, count + 1);
-                    i += count;
-                    break;
-                }
-                // Hour (0-23)
-                case 'H':
-                {
-                    if (!date.hasHour())
-                    {
-                        throw new IllegalArgumentException("Date has no hour: " + date);
-                    }
-                    int displayHour = (zoned == null) ? date.getHour() : zoned.getHour();
-                    int count = getCharCountFrom(character, formatString, i);
-                    appendZeroPaddedInt(safeAppendable, displayHour, count + 1);
-                    i += count;
-                    break;
-                }
-                // AM/PM
-                case 'a':
-                {
-                    if (!date.hasHour())
-                    {
-                        throw new IllegalArgumentException("Date has no hour: " + date);
-                    }
-                    int displayHour = (zoned == null) ? date.getHour() : zoned.getHour();
-                    safeAppendable.append((displayHour < 12) ? "AM" : "PM");
-                    break;
-                }
-                // Minute
-                case 'm':
-                {
-                    if (!date.hasMinute())
-                    {
-                        throw new IllegalArgumentException("Date has no minute: " + date);
-                    }
-                    int displayMinute = (zoned == null) ? date.getMinute() : zoned.getMinute();
-                    int count = getCharCountFrom(character, formatString, i);
-                    appendZeroPaddedInt(safeAppendable, displayMinute, count + 1);
-                    i += count;
-                    break;
-                }
-                // Second
-                case 's':
-                {
-                    if (!date.hasSecond())
-                    {
-                        throw new IllegalArgumentException("Date has no second: " + date);
-                    }
-                    int displaySecond = (zoned == null) ? date.getSecond() : zoned.getSecond();
-                    int count = getCharCountFrom(character, formatString, i);
-                    appendZeroPaddedInt(safeAppendable, displaySecond, count + 1);
-                    i += count;
-                    break;
-                }
-                // Subsecond
-                case 'S':
-                {
-                    if (!date.hasSubsecond())
-                    {
-                        throw new IllegalArgumentException("Date has no sub-second: " + date);
-                    }
-                    int count = getCharCountFrom(character, formatString, i);
-                    if (count < 3)
-                    {
-                        int maxLen = count + 1;
-                        int len = date.getSubsecond().length();
-                        if (len <= maxLen)
-                        {
-                            safeAppendable.append(date.getSubsecond());
-                        }
-                        else
-                        {
-                            int j = 0;
-                            while (j < maxLen)
-                            {
-                                safeAppendable.append(date.getSubsecond().charAt(j++));
-                            }
-                        }
-                    }
-                    else
-                    {
-                        safeAppendable.append(date.getSubsecond());
-                    }
-                    i += count;
-                    break;
-                }
-                // General time zone
-                case 'z':
-                {
-                    int count = getCharCountFrom(character, formatString, i);
-                    safeAppendable.append((timeZoneId == null) ? "GMT" : timeZoneId);
-                    i += count;
-                    break;
-                }
-                // RFC 822 time zone
-                case 'Z':
-                {
-                    if (!date.hasHour())
-                    {
-                        throw new IllegalArgumentException("Date has no hour (required for Z): " + date);
-                    }
-                    int count = getCharCountFrom(character, formatString, i);
-                    appendRFC822TimeZone(safeAppendable, getOffsetInMinutes(zoned));
-                    i += count;
-                    break;
-                }
-                // ISO 8601 time zone
-                case 'X':
-                {
-                    if (!date.hasHour())
-                    {
-                        throw new IllegalArgumentException("Date has no hour (required for X): " + date);
-                    }
-                    int count = getCharCountFrom(character, formatString, i);
-                    appendISO8601TimeZone(safeAppendable, getOffsetInMinutes(zoned));
-                    i += count;
-                    break;
-                }
-                // Separator
-                case '-':
-                case '/':
-                case ':':
-                case '.':
-                case ' ':
-                case '\t':
-                {
-                    safeAppendable.append(character);
-                    break;
-                }
-                // Quote
-                case '"':
-                {
-                    boolean done = false;
-                    boolean escaped = false;
-                    while (!done && (i < length))
-                    {
-                        char next = formatString.charAt(i++);
-                        if (escaped)
-                        {
-                            safeAppendable.append(next);
-                            escaped = false;
-                        }
-                        else if (next == '"')
-                        {
-                            done = true;
-                        }
-                        else if (next == '\\')
-                        {
-                            escaped = true;
-                        }
-                        else
-                        {
-                            safeAppendable.append(next);
-                        }
-                    }
-                    if (!done)
-                    {
-                        throw new IllegalArgumentException("Missing closing quote in format string: " + formatString);
-                    }
-                    break;
-                }
-                default:
-                {
-                    throw new IllegalArgumentException("Invalid format control character '" + character + "' in format string: " + formatString);
-                }
-            }
-        }
-        return appendable;
+    /**
+     * Check that a format string is one {@link #format} can use, and do nothing else. Everything
+     * this reports is a property of the format string alone, so a string that passes will render
+     * any date carrying the components it names.
+     *
+     * @param formatString format string
+     * @throws IllegalArgumentException if the format string is malformed, names a time zone that
+     *                                  cannot be resolved, or sets a time zone anywhere but at the
+     *                                  start
+     */
+    public static void validate(String formatString)
+    {
+        validate(formatString, 0, formatString.length());
+    }
+
+    /**
+     * Check that a portion of a string is a format string {@link #format} can use, and do nothing
+     * else.
+     *
+     * @param formatString string holding the format string
+     * @param start        start index of the format string (inclusive)
+     * @param end          end index of the format string (exclusive)
+     * @throws IllegalArgumentException if the format string is malformed, names a time zone that
+     *                                  cannot be resolved, or sets a time zone anywhere but at the
+     *                                  start
+     * @see #validate(String)
+     */
+    public static void validate(String formatString, int start, int end)
+    {
+        DateFormatPattern.parse(formatString, start, end);
     }
 
     @Deprecated
@@ -690,7 +456,7 @@ public class DateFormat
      * @param zoned date and time being rendered, or null for UTC
      * @return offset from UTC in minutes
      */
-    private static int getOffsetInMinutes(ZonedDateTime zoned)
+    static int getOffsetInMinutes(ZonedDateTime zoned)
     {
         return (zoned == null) ? 0 : (zoned.getOffset().getTotalSeconds() / 60);
     }
@@ -702,7 +468,7 @@ public class DateFormat
      * @param appendable      appendable to write to
      * @param offsetInMinutes offset from UTC in minutes
      */
-    private static void appendRFC822TimeZone(SafeAppendable appendable, int offsetInMinutes)
+    static void appendRFC822TimeZone(SafeAppendable appendable, int offsetInMinutes)
     {
         int absolute = Math.abs(offsetInMinutes);
         appendable.append((offsetInMinutes < 0) ? '-' : '+');
@@ -718,7 +484,7 @@ public class DateFormat
      * @param appendable      appendable to write to
      * @param offsetInMinutes offset from UTC in minutes
      */
-    private static void appendISO8601TimeZone(SafeAppendable appendable, int offsetInMinutes)
+    static void appendISO8601TimeZone(SafeAppendable appendable, int offsetInMinutes)
     {
         if (offsetInMinutes == 0)
         {
@@ -736,7 +502,7 @@ public class DateFormat
         }
     }
 
-    private static void appendNonNegTwoDigitInt(SafeAppendable appendable, int integer)
+    static void appendNonNegTwoDigitInt(SafeAppendable appendable, int integer)
     {
         char c1;
         char c2;
@@ -753,7 +519,7 @@ public class DateFormat
         appendable.append(c1).append(c2);
     }
 
-    private static void appendZeroPaddedInt(SafeAppendable appendable, int integer, int minLength)
+    static void appendZeroPaddedInt(SafeAppendable appendable, int integer, int minLength)
     {
         String string = Integer.toString(integer);
         for (int fill = minLength - string.length(); fill > 0; fill--)
@@ -761,16 +527,6 @@ public class DateFormat
             appendable.append('0');
         }
         appendable.append(string);
-    }
-
-    private static int getCharCountFrom(char character, String string, int start)
-    {
-        int count = 0;
-        for (int i = start, length = string.length(); (i < length) && (string.charAt(i) == character); i++)
-        {
-            count++;
-        }
-        return count;
     }
 
     /**

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormat.java
@@ -52,8 +52,8 @@ public class DateFormat
      * widen</td><td>PM</td></tr>
      * <tr><td>{@code m}</td><td>minute</td><td>{@code mm} 12</td></tr>
      * <tr><td>{@code s}</td><td>second</td><td>{@code ss} 35</td></tr>
-     * <tr><td>{@code S}</td><td>sub-second; up to three of them truncate the date's own digits,
-     * more write them all</td><td>{@code SSS} 070</td></tr>
+     * <tr><td>{@code S}</td><td>sub-second; this one takes a width rather than a run of letters,
+     * and the forms it takes are below</td><td>{@code S3} 070</td></tr>
      * <tr><td>{@code z}</td><td>general time zone: the zone as written in the format string, or GMT
      * if none was</td><td>{@code z} EST</td></tr>
      * <tr><td>{@code Z}</td><td>RFC 822 time zone: always a sign, two digits of hours and two of
@@ -61,6 +61,43 @@ public class DateFormat
      * <tr><td>{@code X}</td><td>ISO 8601 time zone: Z for UTC, otherwise a sign, hours, and minutes
      * only when the offset has them; requires an hour</td><td>{@code X} -05</td></tr>
      * </table>
+     *
+     * <p>A sub-second field says how many digits of the fraction of a second to write, which is
+     * the one place the format language says more than a run of letters can. Every form of it fails
+     * on a date with no fraction at all: how many digits to write is the field's business, and
+     * whether there are any to write is not.
+     *
+     * <table border="1">
+     * <caption>Sub-second widths</caption>
+     * <tr><th>Field</th><th>Digits written</th><th>{@code .070004235}</th><th>{@code .07}</th></tr>
+     * <tr><td>{@code SN}</td><td>exactly N, padding a shorter fraction</td><td>{@code S3} 070</td>
+     * <td>{@code S3} 070</td></tr>
+     * <tr><td>{@code S<N}</td><td>at most N, and fewer where that is all there is</td>
+     * <td>{@code S<3} 070</td><td>{@code S<3} 07</td></tr>
+     * <tr><td>{@code S>N}</td><td>at least N, padding a shorter fraction, and everything beyond</td>
+     * <td>{@code S>3} 070004235</td><td>{@code S>3} 070</td></tr>
+     * <tr><td>{@code S*}</td><td>however many the date has</td><td>{@code S*} 070004235</td>
+     * <td>{@code S*} 07</td></tr>
+     * <tr><td>{@code S!N}</td><td>exactly N, failing rather than padding a shorter fraction</td>
+     * <td>{@code S!3} 070</td><td>{@code S!3} fails</td></tr>
+     * <tr><td>{@code S} to {@code SSS}</td><td>at most one, two, or three; the same fields as
+     * {@code S<1} to {@code S<3}</td><td>{@code SSS} 070</td><td>{@code SSS} 07</td></tr>
+     * <tr><td>{@code SSSS} and longer</td><td>however many the date has; the same field as
+     * {@code S*}</td><td>{@code SSSS} 070004235</td><td>{@code SSSS} 07</td></tr>
+     * </table>
+     *
+     * <p>The general form, {@code S(min,max)}, says both bounds at once: {@code *} for an unbounded
+     * maximum, {@code !} after either bound to fail rather than pad or truncate there, and an
+     * optional third part naming a fill character other than the zero padding otherwise uses. So
+     * {@code S(3!,9,"_")} writes between three and nine digits, refuses a fraction shorter than
+     * three rather than padding it, and pads with underscores. A marker with nothing to act on is
+     * legal and does nothing.
+     *
+     * <p>Truncating and padding are not two sides of one thing. A Pure date is a span of time rather
+     * than an instant, and the number of digits it stores is the precision of that span, so
+     * {@code .07} contains {@code .070}, {@code .071}, and {@code .0712}. Truncating widens the
+     * span, which loses precision but stays true; padding narrows it, which claims a precision the
+     * date does not have. That is why only padding has a short spelling for refusing it.
      *
      * <p>A format string may open with a time zone in square brackets, as in
      * {@code [America/New_York]yyyy-MM-dd HH:mm:ss}, and only open with one: a zone appearing after

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormatPattern.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormatPattern.java
@@ -46,9 +46,9 @@ import java.util.function.ToIntFunction;
  * </pre>
  *
  * <p>The builder reaches everything a format string reaches and a little it does not: a literal may
- * hold any text at all, where a format string has to quote it and escape the quotes within it, and
- * a sub-second field may take any width and policy {@link SubsecondBuilder} describes, where the
- * format string spells only some of them.
+ * hold any text at all, where a format string has to quote it and escape the quotes within it. Every
+ * sub-second field {@link SubsecondBuilder} describes has a spelling in the format string, so the
+ * two reach the same fields by different routes.
  *
  * <p>{@link #pattern()} goes the other way, writing the format string a pattern stands for. Every
  * pattern {@link #parse} produces writes a string {@code parse} takes back, and reading that back
@@ -124,12 +124,13 @@ public final class DateFormatPattern
     /**
      * Write the format string this pattern stands for, which {@link #parse} reads back into an
      * equal pattern. Where a pattern can be spelled in more than one way this writes one of them,
-     * so the string need not be the one the pattern came from: {@code SSS} and {@code yyyy} come
-     * back as they went in, but {@code "a"" b"} comes back as {@code "a" "b"}.
+     * so the string need not be the one the pattern came from: {@code yyyy} comes back as it went
+     * in, but {@code "a"" b"} comes back as {@code "a" "b"}.
      *
-     * <p>A pattern the builder made can hold a sub-second field the format string has no spelling
-     * for. Those write the spelling the format string is to gain, which is not yet one it takes
-     * back.
+     * <p>A sub-second field is never written as a run of letters, since every field that run can
+     * spell has a width form meaning precisely the same thing: {@code SSS} comes back as
+     * {@code S<3} and {@code SSSS} as {@code S*}. Reading a format string and writing it back is
+     * therefore the rewrite from the older spelling to the newer one.
      *
      * @param appendable appendable to write to
      * @param <T>        appendable type
@@ -770,21 +771,41 @@ public final class DateFormatPattern
         @Override
         void appendPattern(SafeAppendable appendable)
         {
-            // the repetition form is all the format string spells today, so it is what a field it
-            // covers exactly is written as; the shorthands should be preferred once they parse
-            if (!this.failBelow && !this.failAbove && (this.fill == DEFAULT_FILL) && (this.minimum == 0))
+            // a shorthand says in two or three characters what the general form spells out, so a
+            // field one of them covers exactly is written that way; the repetition form is never
+            // written, since every field it can spell has a shorthand that means precisely the same
+            // thing and it is the form to be deprecated
+            if (this.fill == DEFAULT_FILL)
             {
-                if (this.maximum == UNBOUNDED)
+                if (!this.failBelow && !this.failAbove)
                 {
-                    appendable.append("SSSS");
-                    return;
-                }
-                if (this.maximum <= 3)
-                {
-                    for (int i = 0; i < this.maximum; i++)
+                    if (this.minimum == 0)
                     {
                         appendable.append('S');
+                        if (this.maximum == UNBOUNDED)
+                        {
+                            appendable.append('*');
+                        }
+                        else
+                        {
+                            appendable.append('<').append(this.maximum);
+                        }
+                        return;
                     }
+                    if (this.maximum == UNBOUNDED)
+                    {
+                        appendable.append("S>").append(this.minimum);
+                        return;
+                    }
+                    if (this.minimum == this.maximum)
+                    {
+                        appendable.append('S').append(this.minimum);
+                        return;
+                    }
+                }
+                else if (this.failBelow && !this.failAbove && (this.minimum == this.maximum))
+                {
+                    appendable.append("S!").append(this.minimum);
                     return;
                 }
             }
@@ -809,7 +830,12 @@ public final class DateFormatPattern
             }
             if (this.fill != DEFAULT_FILL)
             {
-                appendable.append(",\"").append(this.fill).append('"');
+                appendable.append(",\"");
+                if ((this.fill == '"') || (this.fill == '\\'))
+                {
+                    appendable.append('\\');
+                }
+                appendable.append(this.fill).append('"');
             }
             appendable.append(')');
         }
@@ -872,26 +898,44 @@ public final class DateFormatPattern
         }
 
         /**
-         * Check that some width satisfies both bounds, which is where a field is rejected: the
-         * policies and the fill are markers rather than requirements, and cannot make a field
-         * that means nothing.
+         * Return what is wrong with a pair of bounds, or null where some width satisfies both. This
+         * is the only thing a field is rejected for: the policies and the fill are markers rather
+         * than requirements, and cannot make a field that means nothing.
+         *
+         * @param minimum fewest digits to write
+         * @param maximum most digits to write
+         * @return what is wrong with the bounds, or null
+         */
+        static String widthProblem(int minimum, int maximum)
+        {
+            if (minimum < 0)
+            {
+                return "Sub-second minimum may not be negative: " + minimum;
+            }
+            if (maximum < 1)
+            {
+                return "Sub-second maximum must be at least 1: " + maximum;
+            }
+            if (minimum > maximum)
+            {
+                return "Sub-second minimum " + minimum + " exceeds maximum " + maximum;
+            }
+            return null;
+        }
+
+        /**
+         * Check that some width satisfies both bounds, which is what a caller with nothing further
+         * to say about where the bounds came from does.
          *
          * @param minimum fewest digits to write
          * @param maximum most digits to write
          */
         static void checkWidth(int minimum, int maximum)
         {
-            if (minimum < 0)
+            String problem = widthProblem(minimum, maximum);
+            if (problem != null)
             {
-                throw new IllegalArgumentException("Sub-second minimum may not be negative: " + minimum);
-            }
-            if (maximum < 1)
-            {
-                throw new IllegalArgumentException("Sub-second maximum must be at least 1: " + maximum);
-            }
-            if (minimum > maximum)
-            {
-                throw new IllegalArgumentException("Sub-second minimum " + minimum + " exceeds maximum " + maximum);
+                throw new IllegalArgumentException(problem);
             }
         }
     }
@@ -1589,10 +1633,7 @@ public final class DateFormatPattern
                     }
                     case 'S':
                     {
-                        // up to three letters cut the fraction down to that many digits; from four
-                        // on the count stops meaning anything and the whole fraction is written
-                        int count = runLength(character);
-                        this.builder.subsecond().atMost((count < 4) ? count : Subsecond.UNBOUNDED).endSubsecond();
+                        parseSubsecond();
                         break;
                     }
                     case 'z':
@@ -1653,6 +1694,211 @@ public final class DateFormatPattern
                 count++;
             }
             return count;
+        }
+
+        /**
+         * Read a sub-second field, the {@code S} having been taken. What follows it decides which of
+         * the three spellings this is: a bracket opens the general form, one of the bound characters
+         * opens a shorthand, and anything else - another {@code S} included - is the run of letters
+         * the language has always had.
+         */
+        private void parseSubsecond()
+        {
+            if (this.index < this.end)
+            {
+                switch (this.formatString.charAt(this.index))
+                {
+                    case '(':
+                    {
+                        this.index++;
+                        parseSubsecondGeneralForm();
+                        return;
+                    }
+                    case '*':
+                    {
+                        this.index++;
+                        addSubsecond(0, Subsecond.UNBOUNDED, false, false, Subsecond.DEFAULT_FILL);
+                        return;
+                    }
+                    case '<':
+                    {
+                        this.index++;
+                        addSubsecond(0, parseDigits("S<"), false, false, Subsecond.DEFAULT_FILL);
+                        return;
+                    }
+                    case '>':
+                    {
+                        this.index++;
+                        addSubsecond(parseDigits("S>"), Subsecond.UNBOUNDED, false, false, Subsecond.DEFAULT_FILL);
+                        return;
+                    }
+                    case '!':
+                    {
+                        this.index++;
+                        int digits = parseDigits("S!");
+                        addSubsecond(digits, digits, true, false, Subsecond.DEFAULT_FILL);
+                        return;
+                    }
+                    default:
+                    {
+                        if (isDigit(this.formatString.charAt(this.index)))
+                        {
+                            int digits = parseDigits("S");
+                            addSubsecond(digits, digits, false, false, Subsecond.DEFAULT_FILL);
+                            return;
+                        }
+                        break;
+                    }
+                }
+            }
+
+            // up to three letters cut the fraction down to that many digits; from four on the count
+            // stops meaning anything and the whole fraction is written
+            int count = runLength('S');
+            addSubsecond(0, (count < 4) ? count : Subsecond.UNBOUNDED, false, false, Subsecond.DEFAULT_FILL);
+        }
+
+        /**
+         * Read the body of a general form sub-second field, {@code S(} having been taken.
+         */
+        private void parseSubsecondGeneralForm()
+        {
+            int minimum = parseDigits("S(");
+            boolean failBelow = takeIf('!');
+            if (!takeIf(','))
+            {
+                throw new IllegalArgumentException("Expected ',' after the sub-second minimum in format string: " + text());
+            }
+
+            int maximum;
+            if (takeIf('*'))
+            {
+                maximum = Subsecond.UNBOUNDED;
+            }
+            else if ((this.index < this.end) && isDigit(this.formatString.charAt(this.index)))
+            {
+                maximum = parseDigits(",");
+            }
+            else
+            {
+                throw new IllegalArgumentException("Expected a digit count or '*' for the sub-second maximum in format string: " + text());
+            }
+            boolean failAbove = takeIf('!');
+
+            char fill = takeIf(',') ? parseSubsecondFill() : Subsecond.DEFAULT_FILL;
+            if (!takeIf(')'))
+            {
+                throw new IllegalArgumentException("Missing closing parenthesis in format string: " + text());
+            }
+            addSubsecond(minimum, maximum, failBelow, failAbove, fill);
+        }
+
+        /**
+         * Read the quoted fill character of a general form sub-second field. A backslash escapes the
+         * character after it, so every character can be a fill, the quote and the backslash
+         * included.
+         *
+         * @return fill character
+         */
+        private char parseSubsecondFill()
+        {
+            if (!takeIf('"'))
+            {
+                throw new IllegalArgumentException("Expected a quoted sub-second fill character in format string: " + text());
+            }
+
+            char fill = Subsecond.DEFAULT_FILL;
+            int count = 0;
+            boolean done = false;
+            while (!done && (this.index < this.end))
+            {
+                char next = this.formatString.charAt(this.index++);
+                if (next == '"')
+                {
+                    done = true;
+                }
+                else
+                {
+                    if ((next == '\\') && (this.index < this.end))
+                    {
+                        next = this.formatString.charAt(this.index++);
+                    }
+                    fill = next;
+                    count++;
+                }
+            }
+            if (!done)
+            {
+                throw new IllegalArgumentException("Missing closing quote in format string: " + text());
+            }
+            if (count != 1)
+            {
+                throw new IllegalArgumentException("Sub-second fill must be a single character in format string: " + text());
+            }
+            return fill;
+        }
+
+        /**
+         * Read a run of digits as a count.
+         *
+         * @param after what the count was expected after, for the error where there is none
+         * @return the count
+         */
+        private int parseDigits(String after)
+        {
+            if ((this.index >= this.end) || !isDigit(this.formatString.charAt(this.index)))
+            {
+                throw new IllegalArgumentException("Expected a digit count after '" + after + "' in format string: " + text());
+            }
+
+            long count = 0;
+            while ((this.index < this.end) && isDigit(this.formatString.charAt(this.index)))
+            {
+                count = (count * 10) + (this.formatString.charAt(this.index++) - '0');
+                if (count >= Subsecond.UNBOUNDED)
+                {
+                    // a bound of its own is what an unbounded maximum is written as, so a count that
+                    // reaches the number standing for one cannot be told apart from it
+                    throw new IllegalArgumentException("Sub-second digit count is too large in format string: " + text());
+                }
+            }
+            return (int) count;
+        }
+
+        /**
+         * Add a sub-second field, having read one, checking the bounds here so that the error names
+         * the format string the caller wrote rather than the numbers it was read as.
+         *
+         * @param minimum   fewest digits to write
+         * @param maximum   most digits to write
+         * @param failBelow whether to fail rather than pad below the minimum
+         * @param failAbove whether to fail rather than truncate above the maximum
+         * @param fill      character to pad with
+         */
+        private void addSubsecond(int minimum, int maximum, boolean failBelow, boolean failAbove, char fill)
+        {
+            String problem = Subsecond.widthProblem(minimum, maximum);
+            if (problem != null)
+            {
+                throw new IllegalArgumentException(problem + " in format string: " + text());
+            }
+            this.builder.element(new Subsecond(minimum, maximum, failBelow, failAbove, fill));
+        }
+
+        /**
+         * Take the given character where it is the next one, and say whether it was.
+         *
+         * @param character character to take
+         * @return whether it was there
+         */
+        private boolean takeIf(char character)
+        {
+            if ((this.index < this.end) && (this.formatString.charAt(this.index) == character))
+            {
+                this.index++;
+                return true;
+            }
+            return false;
         }
 
         private void parseTimeZone()
@@ -1764,6 +2010,11 @@ public final class DateFormatPattern
      * @param character character to test
      * @return whether the character is a separator
      */
+    private static boolean isDigit(char character)
+    {
+        return (character >= '0') && (character <= '9');
+    }
+
     private static boolean isSeparator(char character)
     {
         return (character == '-') || (character == '/') || (character == ':') ||

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormatPattern.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormatPattern.java
@@ -1,0 +1,1806 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m4.coreinstance.primitive.date;
+
+import org.finos.legend.pure.m4.tools.SafeAppendable;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.function.ToIntFunction;
+
+/**
+ * A date format string, parsed into the sequence of elements it describes. Rendering a date is then
+ * a walk of that sequence, with nothing left to work out about the format string itself.
+ *
+ * <p>A pattern can be had in either of two ways, and they build the same thing. {@link
+ * #parse(String)} reads one out of a format string, which is what {@link DateFormat#format} does on
+ * every call. {@link #builder()} assembles one directly, for a caller that knows what it wants
+ * written and has no reason to spell it as a string first:
+ *
+ * <pre>
+ * DateFormatPattern.builder()
+ *         .year().literal('-').month().literal('-').day()
+ *         .literal('T')
+ *         .hour24().literal(':').minute().literal(':').second()
+ *         .literal('.').subsecond().exactly(3).endSubsecond()
+ *         .iso8601TimeZoneOffset()
+ *         .build();
+ * </pre>
+ *
+ * <p>The builder reaches everything a format string reaches and a little it does not: a literal may
+ * hold any text at all, where a format string has to quote it and escape the quotes within it, and
+ * a sub-second field may take any width and policy {@link SubsecondBuilder} describes, where the
+ * format string spells only some of them.
+ *
+ * <p>{@link #pattern()} goes the other way, writing the format string a pattern stands for. Every
+ * pattern {@link #parse} produces writes a string {@code parse} takes back, and reading that back
+ * gives an equal pattern.
+ *
+ * <p>A pattern is immutable and holds nothing across renderings, so one may be built once and used
+ * from any number of threads.
+ */
+public final class DateFormatPattern
+{
+    private final Element[] elements;
+    private final ZoneId timeZone;
+    private final String timeZoneId;
+
+    private DateFormatPattern(Element[] elements, ZoneId timeZone, String timeZoneId)
+    {
+        this.elements = elements;
+        this.timeZone = timeZone;
+        this.timeZoneId = timeZoneId;
+    }
+
+    /**
+     * Write a date to an appendable in the form this pattern describes.
+     *
+     * @param appendable appendable to write to
+     * @param date       date to write
+     * @param <T>        appendable type
+     * @return the appendable
+     * @throws IllegalArgumentException if the pattern asks for something the date does not have
+     */
+    public <T extends Appendable> T render(T appendable, PureDate date)
+    {
+        SafeAppendable safeAppendable = SafeAppendable.wrap(appendable);
+        ZonedDateTime zoned = shift(date);
+        for (Element element : this.elements)
+        {
+            element.render(safeAppendable, date, zoned, this.timeZoneId);
+        }
+        return appendable;
+    }
+
+    /**
+     * Write a date to a new string in the form this pattern describes.
+     *
+     * @param date date to write
+     * @return the date written out
+     * @throws IllegalArgumentException if the pattern asks for something the date does not have
+     */
+    public String render(PureDate date)
+    {
+        return render(new StringBuilder(32), date).toString();
+    }
+
+    /**
+     * Return whether every element of this pattern can write the given date, which is whether
+     * {@link #render} will succeed on it. The two ask the same question of each element.
+     *
+     * @param date date to test
+     * @return whether the date can be written
+     */
+    public boolean canRender(PureDate date)
+    {
+        for (Element element : this.elements)
+        {
+            if (!element.canRender(date))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Write the format string this pattern stands for, which {@link #parse} reads back into an
+     * equal pattern. Where a pattern can be spelled in more than one way this writes one of them,
+     * so the string need not be the one the pattern came from: {@code SSS} and {@code yyyy} come
+     * back as they went in, but {@code "a"" b"} comes back as {@code "a" "b"}.
+     *
+     * <p>A pattern the builder made can hold a sub-second field the format string has no spelling
+     * for. Those write the spelling the format string is to gain, which is not yet one it takes
+     * back.
+     *
+     * @param appendable appendable to write to
+     * @param <T>        appendable type
+     * @return the appendable
+     */
+    public <T extends Appendable> T appendPattern(T appendable)
+    {
+        SafeAppendable safeAppendable = SafeAppendable.wrap(appendable);
+        if (this.timeZoneId != null)
+        {
+            appendTimeZoneId(safeAppendable, this.timeZoneId);
+        }
+        for (Element element : this.elements)
+        {
+            element.appendPattern(safeAppendable);
+        }
+        return appendable;
+    }
+
+    /**
+     * Get the format string this pattern stands for.
+     *
+     * @return format string
+     * @see #appendPattern(Appendable)
+     */
+    public String pattern()
+    {
+        return appendPattern(new StringBuilder(32)).toString();
+    }
+
+    /**
+     * Get the time zone this pattern renders in, or null if it renders dates as the UTC times they
+     * are.
+     *
+     * @return time zone, or null
+     */
+    public ZoneId getTimeZone()
+    {
+        return this.timeZone;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (this == other)
+        {
+            return true;
+        }
+        if (!(other instanceof DateFormatPattern))
+        {
+            return false;
+        }
+        DateFormatPattern that = (DateFormatPattern) other;
+        return Arrays.equals(this.elements, that.elements) && Objects.equals(this.timeZoneId, that.timeZoneId);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return (31 * Arrays.hashCode(this.elements)) + Objects.hash(this.timeZoneId);
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder("DateFormatPattern{");
+        if (this.timeZoneId != null)
+        {
+            builder.append('[').append(this.timeZoneId).append("] ");
+        }
+        for (int i = 0; i < this.elements.length; i++)
+        {
+            if (i > 0)
+            {
+                builder.append(", ");
+            }
+            builder.append(this.elements[i]);
+        }
+        return builder.append('}').toString();
+    }
+
+    /**
+     * A Pure date is always understood as UTC, so a zone shifts it to the instant it stands for as
+     * that zone reads it. A date with no hour is not an instant and so is never shifted.
+     *
+     * @param date date being rendered
+     * @return the date as this pattern's zone reads it, or null if there is nothing to shift
+     */
+    private ZonedDateTime shift(PureDate date)
+    {
+        return ((this.timeZone == null) || !date.hasHour()) ? null : PureDateToJava.start().toInstant(date).atZone(this.timeZone);
+    }
+
+    /**
+     * Parse a format string into a pattern.
+     *
+     * @param formatString format string
+     * @return pattern
+     * @throws IllegalArgumentException if the format string is malformed, names a time zone that
+     *                                  cannot be resolved, or sets a time zone anywhere but at the
+     *                                  start
+     */
+    public static DateFormatPattern parse(String formatString)
+    {
+        return parse(formatString, 0, formatString.length());
+    }
+
+    /**
+     * Parse a portion of a string into a pattern, which is how a format string held inside a larger
+     * one is read without first cutting it out.
+     *
+     * @param formatString string holding the format string
+     * @param start        start index of the format string (inclusive)
+     * @param end          end index of the format string (exclusive)
+     * @return pattern
+     * @throws IllegalArgumentException if the format string is malformed, names a time zone that
+     *                                  cannot be resolved, or sets a time zone anywhere but at the
+     *                                  start
+     */
+    public static DateFormatPattern parse(String formatString, int start, int end)
+    {
+        return new Parser(formatString, start, end).parse();
+    }
+
+    /**
+     * Get a builder for assembling a pattern element by element.
+     *
+     * @return builder
+     */
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    /**
+     * One thing a pattern writes. An element either always writes - a literal does - or writes only
+     * a date carrying what it asks for, which is what {@link #canRender} answers.
+     */
+    private abstract static class Element
+    {
+        /**
+         * Return whether this element can write the given date.
+         *
+         * @param date date to test
+         * @return whether the date can be written
+         */
+        abstract boolean canRender(PureDate date);
+
+        /**
+         * Write the given date.
+         *
+         * @param appendable appendable to write to
+         * @param date       date to write
+         * @param zoned      the date as the pattern's time zone reads it, or null if it is not
+         *                   shifted
+         * @param timeZoneId the pattern's time zone as it was named, or null if none was
+         */
+        abstract void render(SafeAppendable appendable, PureDate date, ZonedDateTime zoned, String timeZoneId);
+
+        /**
+         * Write the part of a format string this element stands for.
+         *
+         * @param appendable appendable to write to
+         */
+        abstract void appendPattern(SafeAppendable appendable);
+    }
+
+    /**
+     * Text written out as it stands: a separator, a quoted run of a format string, or anything at
+     * all where the pattern was built rather than parsed.
+     */
+    private static final class Literal extends Element
+    {
+        private final String text;
+
+        Literal(String text)
+        {
+            this.text = text;
+        }
+
+        @Override
+        boolean canRender(PureDate date)
+        {
+            return true;
+        }
+
+        @Override
+        void render(SafeAppendable appendable, PureDate date, ZonedDateTime zoned, String timeZoneId)
+        {
+            appendable.append(this.text);
+        }
+
+        @Override
+        void appendPattern(SafeAppendable appendable)
+        {
+            // a separator stands for itself and anything else has to be quoted, so a literal
+            // holding both is written as runs of each
+            int length = this.text.length();
+            int index = 0;
+            while (index < length)
+            {
+                boolean separators = isSeparator(this.text.charAt(index));
+                int runEnd = index + 1;
+                while ((runEnd < length) && (isSeparator(this.text.charAt(runEnd)) == separators))
+                {
+                    runEnd++;
+                }
+                if (separators)
+                {
+                    appendable.append(this.text, index, runEnd);
+                }
+                else
+                {
+                    appendable.append('"');
+                    for (int i = index; i < runEnd; i++)
+                    {
+                        char character = this.text.charAt(i);
+                        if ((character == '"') || (character == '\\'))
+                        {
+                            appendable.append('\\');
+                        }
+                        appendable.append(character);
+                    }
+                    appendable.append('"');
+                }
+                index = runEnd;
+            }
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            return (this == other) || ((other instanceof Literal) && this.text.equals(((Literal) other).text));
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return this.text.hashCode();
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Literal(\"" + this.text + "\")";
+        }
+    }
+
+    /**
+     * The year in full, however many digits it takes, with a minus sign before the era. A date
+     * always has one, so this always writes.
+     */
+    private static final class Year extends Element
+    {
+        static final Year INSTANCE = new Year();
+
+        private Year()
+        {
+        }
+
+        @Override
+        boolean canRender(PureDate date)
+        {
+            return true;
+        }
+
+        @Override
+        void render(SafeAppendable appendable, PureDate date, ZonedDateTime zoned, String timeZoneId)
+        {
+            appendable.append((zoned == null) ? date.getYear() : zoned.getYear());
+        }
+
+        @Override
+        void appendPattern(SafeAppendable appendable)
+        {
+            appendable.append("yyyy");
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Year";
+        }
+    }
+
+    /**
+     * The last two digits of the year, which a year before the era has as much as one after it: it
+     * drops the sign along with the century, as it already drops the difference between 1914 and
+     * 2014.
+     */
+    private static final class TwoDigitYear extends Element
+    {
+        static final TwoDigitYear INSTANCE = new TwoDigitYear();
+
+        private TwoDigitYear()
+        {
+        }
+
+        @Override
+        boolean canRender(PureDate date)
+        {
+            return true;
+        }
+
+        @Override
+        void render(SafeAppendable appendable, PureDate date, ZonedDateTime zoned, String timeZoneId)
+        {
+            int year = (zoned == null) ? date.getYear() : zoned.getYear();
+            DateFormat.appendNonNegTwoDigitInt(appendable, Math.abs(year % 100));
+        }
+
+        @Override
+        void appendPattern(SafeAppendable appendable)
+        {
+            appendable.append("yy");
+        }
+
+        @Override
+        public String toString()
+        {
+            return "TwoDigitYear";
+        }
+    }
+
+    /**
+     * A component the date carries as a number, written zero padded to a minimum width.
+     */
+    private static final class NumericComponent extends Element
+    {
+        private final Component component;
+        private final int minDigits;
+
+        NumericComponent(Component component, int minDigits)
+        {
+            this.component = component;
+            this.minDigits = minDigits;
+        }
+
+        @Override
+        boolean canRender(PureDate date)
+        {
+            return this.component.has(date);
+        }
+
+        @Override
+        void render(SafeAppendable appendable, PureDate date, ZonedDateTime zoned, String timeZoneId)
+        {
+            this.component.requireOf(date);
+            DateFormat.appendZeroPaddedInt(appendable, this.component.get(date, zoned), this.minDigits);
+        }
+
+        @Override
+        void appendPattern(SafeAppendable appendable)
+        {
+            for (int i = 0; i < this.minDigits; i++)
+            {
+                appendable.append(this.component.getControlCharacter());
+            }
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (this == other)
+            {
+                return true;
+            }
+            if (!(other instanceof NumericComponent))
+            {
+                return false;
+            }
+            NumericComponent that = (NumericComponent) other;
+            return (this.component == that.component) && (this.minDigits == that.minDigits);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return (31 * this.component.hashCode()) + this.minDigits;
+        }
+
+        @Override
+        public String toString()
+        {
+            return this.component + "(" + this.minDigits + ")";
+        }
+    }
+
+    /**
+     * Whether the hour is before or after noon.
+     */
+    private static final class AmPm extends Element
+    {
+        static final AmPm INSTANCE = new AmPm();
+
+        private AmPm()
+        {
+        }
+
+        @Override
+        boolean canRender(PureDate date)
+        {
+            return Component.HOUR_24.has(date);
+        }
+
+        @Override
+        void render(SafeAppendable appendable, PureDate date, ZonedDateTime zoned, String timeZoneId)
+        {
+            Component.HOUR_24.requireOf(date);
+            appendable.append((Component.HOUR_24.get(date, zoned) < 12) ? "AM" : "PM");
+        }
+
+        @Override
+        void appendPattern(SafeAppendable appendable)
+        {
+            appendable.append('a');
+        }
+
+        @Override
+        public String toString()
+        {
+            return "AmPm";
+        }
+    }
+
+    /**
+     * The name of the pattern's time zone, as the pattern was given it, or {@code GMT} where no
+     * zone was named. The pattern already holds that name, so this reads it from the rendering
+     * rather than keeping a copy, and one of these is like every other.
+     */
+    private static final class TimeZoneName extends Element
+    {
+        static final TimeZoneName INSTANCE = new TimeZoneName();
+
+        private TimeZoneName()
+        {
+        }
+
+        @Override
+        boolean canRender(PureDate date)
+        {
+            return true;
+        }
+
+        @Override
+        void render(SafeAppendable appendable, PureDate date, ZonedDateTime zoned, String timeZoneId)
+        {
+            appendable.append((timeZoneId == null) ? "GMT" : timeZoneId);
+        }
+
+        @Override
+        void appendPattern(SafeAppendable appendable)
+        {
+            appendable.append('z');
+        }
+
+        @Override
+        public String toString()
+        {
+            return "TimeZoneName";
+        }
+    }
+
+    /**
+     * The offset from UTC the date is at, in the RFC 822 notation, which is a sign, two digits of
+     * hours, and two of minutes, with nothing left out: UTC is written {@code +0000}. An offset
+     * belongs to an instant, so a date with no hour has none to write.
+     */
+    private static final class RFC822TimeZoneOffset extends Element
+    {
+        static final RFC822TimeZoneOffset INSTANCE = new RFC822TimeZoneOffset();
+
+        private RFC822TimeZoneOffset()
+        {
+        }
+
+        @Override
+        boolean canRender(PureDate date)
+        {
+            return date.hasHour();
+        }
+
+        @Override
+        void render(SafeAppendable appendable, PureDate date, ZonedDateTime zoned, String timeZoneId)
+        {
+            requireHourForOffset(date, 'Z');
+            DateFormat.appendRFC822TimeZone(appendable, DateFormat.getOffsetInMinutes(zoned));
+        }
+
+        @Override
+        void appendPattern(SafeAppendable appendable)
+        {
+            appendable.append('Z');
+        }
+
+        @Override
+        public String toString()
+        {
+            return "RFC822TimeZoneOffset";
+        }
+    }
+
+    /**
+     * The offset from UTC the date is at, in the ISO 8601 notation, which writes UTC as {@code Z}
+     * and leaves out the minutes of an offset that has none. An offset belongs to an instant, so a
+     * date with no hour has none to write.
+     */
+    private static final class ISO8601TimeZoneOffset extends Element
+    {
+        static final ISO8601TimeZoneOffset INSTANCE = new ISO8601TimeZoneOffset();
+
+        private ISO8601TimeZoneOffset()
+        {
+        }
+
+        @Override
+        boolean canRender(PureDate date)
+        {
+            return date.hasHour();
+        }
+
+        @Override
+        void render(SafeAppendable appendable, PureDate date, ZonedDateTime zoned, String timeZoneId)
+        {
+            requireHourForOffset(date, 'X');
+            DateFormat.appendISO8601TimeZone(appendable, DateFormat.getOffsetInMinutes(zoned));
+        }
+
+        @Override
+        void appendPattern(SafeAppendable appendable)
+        {
+            appendable.append('X');
+        }
+
+        @Override
+        public String toString()
+        {
+            return "ISO8601TimeZoneOffset";
+        }
+    }
+
+    /**
+     * The fraction of a second the date carries, written at a width this describes.
+     * {@link SubsecondBuilder} is how one is asked for.
+     *
+     * <p>A sub-second field is a <em>width</em>, and says nothing about whether the date has a
+     * fraction at all: it always fails on a date that has none, exactly as asking for the month
+     * fails on a date with no month. What to write for a date with no fraction is a question for
+     * whatever surrounds the field rather than for the field.
+     *
+     * <p>Given the digits the date stores, the field writes, in this order:
+     *
+     * <ol>
+     * <li>nothing, failing, where the date has no fraction at all;</li>
+     * <li>the first maximum digits, where there are more than that, or nothing, failing, where the
+     * field fails above its maximum;</li>
+     * <li>followed by enough of the fill character to reach the minimum, where it falls short of
+     * it, or nothing, failing, where the field fails below its minimum.</li>
+     * </ol>
+     *
+     * <p>Truncating and padding are not two sides of one thing. A Pure date is a span of time
+     * rather than an instant, and its stored digit count is the precision of that span, so
+     * {@code .07} <em>contains</em> {@code .070}, {@code .071}, and {@code .0712}. Truncating
+     * widens the span, which loses precision but stays true; padding narrows it, which claims a
+     * precision the date does not have. Both are worth having, and only one is worth being careful
+     * with.
+     */
+    private static final class Subsecond extends Element
+    {
+        static final int UNBOUNDED = Integer.MAX_VALUE;
+
+        private static final char DEFAULT_FILL = '0';
+
+        private final int minimum;
+        private final int maximum;
+        private final boolean failBelow;
+        private final boolean failAbove;
+        private final char fill;
+
+        Subsecond(int minimum, int maximum, boolean failBelow, boolean failAbove, char fill)
+        {
+            this.minimum = minimum;
+            this.maximum = maximum;
+            this.failBelow = failBelow;
+            this.failAbove = failAbove;
+            this.fill = fill;
+        }
+
+        @Override
+        boolean canRender(PureDate date)
+        {
+            if (!date.hasSubsecond())
+            {
+                return false;
+            }
+            int length = date.getSubsecond().length();
+            return !(this.failAbove && (length > this.maximum)) &&
+                    !(this.failBelow && (Math.min(length, this.maximum) < this.minimum));
+        }
+
+        @Override
+        void render(SafeAppendable appendable, PureDate date, ZonedDateTime zoned, String timeZoneId)
+        {
+            if (!date.hasSubsecond())
+            {
+                throw new IllegalArgumentException("Date has no sub-second: " + date);
+            }
+
+            String subsecond = date.getSubsecond();
+            int length = subsecond.length();
+            if (length > this.maximum)
+            {
+                if (this.failAbove)
+                {
+                    throw new IllegalArgumentException("Date has a " + length + " digit sub-second, but at most " + this.maximum + " may be written: " + date);
+                }
+                length = this.maximum;
+            }
+            // fill goes on the right, since sub-second digits run most significant first: .07
+            // padded to three digits is .070, not .007
+            int padding = 0;
+            if (length < this.minimum)
+            {
+                if (this.failBelow)
+                {
+                    throw new IllegalArgumentException("Date has a " + length + " digit sub-second, but " + this.minimum + " are required: " + date);
+                }
+                padding = this.minimum - length;
+            }
+
+            appendable.append(subsecond, 0, length);
+            for (int i = 0; i < padding; i++)
+            {
+                appendable.append(this.fill);
+            }
+        }
+
+        @Override
+        void appendPattern(SafeAppendable appendable)
+        {
+            // the repetition form is all the format string spells today, so it is what a field it
+            // covers exactly is written as; the shorthands should be preferred once they parse
+            if (!this.failBelow && !this.failAbove && (this.fill == DEFAULT_FILL) && (this.minimum == 0))
+            {
+                if (this.maximum == UNBOUNDED)
+                {
+                    appendable.append("SSSS");
+                    return;
+                }
+                if (this.maximum <= 3)
+                {
+                    for (int i = 0; i < this.maximum; i++)
+                    {
+                        appendable.append('S');
+                    }
+                    return;
+                }
+            }
+
+            appendable.append("S(").append(this.minimum);
+            if (this.failBelow)
+            {
+                appendable.append('!');
+            }
+            appendable.append(',');
+            if (this.maximum == UNBOUNDED)
+            {
+                appendable.append('*');
+            }
+            else
+            {
+                appendable.append(this.maximum);
+            }
+            if (this.failAbove)
+            {
+                appendable.append('!');
+            }
+            if (this.fill != DEFAULT_FILL)
+            {
+                appendable.append(",\"").append(this.fill).append('"');
+            }
+            appendable.append(')');
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (this == other)
+            {
+                return true;
+            }
+            if (!(other instanceof Subsecond))
+            {
+                return false;
+            }
+            Subsecond that = (Subsecond) other;
+            return (this.minimum == that.minimum) &&
+                    (this.maximum == that.maximum) &&
+                    (this.failBelow == that.failBelow) &&
+                    (this.failAbove == that.failAbove) &&
+                    (this.fill == that.fill);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int hashCode = this.minimum;
+            hashCode = (31 * hashCode) + this.maximum;
+            hashCode = (31 * hashCode) + (this.failBelow ? 1 : 0);
+            hashCode = (31 * hashCode) + (this.failAbove ? 1 : 0);
+            return (31 * hashCode) + this.fill;
+        }
+
+        @Override
+        public String toString()
+        {
+            StringBuilder builder = new StringBuilder("Subsecond(").append(this.minimum);
+            if (this.failBelow)
+            {
+                builder.append('!');
+            }
+            builder.append(", ");
+            if (this.maximum == UNBOUNDED)
+            {
+                builder.append('*');
+            }
+            else
+            {
+                builder.append(this.maximum);
+            }
+            if (this.failAbove)
+            {
+                builder.append('!');
+            }
+            if (this.fill != DEFAULT_FILL)
+            {
+                builder.append(", '").append(this.fill).append('\'');
+            }
+            return builder.append(')').toString();
+        }
+
+        /**
+         * Check that some width satisfies both bounds, which is where a field is rejected: the
+         * policies and the fill are markers rather than requirements, and cannot make a field
+         * that means nothing.
+         *
+         * @param minimum fewest digits to write
+         * @param maximum most digits to write
+         */
+        static void checkWidth(int minimum, int maximum)
+        {
+            if (minimum < 0)
+            {
+                throw new IllegalArgumentException("Sub-second minimum may not be negative: " + minimum);
+            }
+            if (maximum < 1)
+            {
+                throw new IllegalArgumentException("Sub-second maximum must be at least 1: " + maximum);
+            }
+            if (minimum > maximum)
+            {
+                throw new IllegalArgumentException("Sub-second minimum " + minimum + " exceeds maximum " + maximum);
+            }
+        }
+    }
+
+    /**
+     * Assembles a pattern element by element. A builder may be built from more than once, and each
+     * pattern it gives out stands on its own.
+     *
+     * <p>A sub-second field is described by a builder of its own, which {@link #subsecond()} gives
+     * out and {@link SubsecondBuilder#endSubsecond()} hands back. Nothing reaches the pattern until
+     * the field is finished, so a field is either wholly described or not there at all, and a
+     * pattern may hold as many of them as it likes.
+     */
+    public static final class Builder
+    {
+        private static final int DEFAULT_DIGITS = 2;
+
+        private final List<Element> elements = new ArrayList<>();
+        private final StringBuilder pendingLiteral = new StringBuilder();
+        private SubsecondBuilder openSubsecond;
+        private String timeZoneId;
+        private ZoneId timeZone;
+
+        private Builder()
+        {
+        }
+
+        /**
+         * Render dates in the given time zone, rather than as the UTC times they are. A date with
+         * no hour is not an instant and is never shifted, whatever zone is named here.
+         *
+         * <p>The zone may be named in any form {@link ZoneId#of(String, java.util.Map)} takes
+         * against {@link ZoneId#SHORT_IDS} - a region such as {@code America/New_York}, one of the
+         * three letter abbreviations such as {@code EST}, or an offset such as {@code GMT+5} - and
+         * the name as given here is what {@link #timeZoneName} writes. Naming a zone twice keeps
+         * the second, and the name is resolved when the pattern is built.
+         *
+         * @param timeZoneId time zone name
+         * @return this builder
+         */
+        public Builder timeZone(String timeZoneId)
+        {
+            requireNoOpenSubsecond();
+            this.timeZoneId = timeZoneId;
+            if (timeZoneId == null)
+            {
+                this.timeZone = null;
+            }
+            else if ((this.timeZone != null) && !timeZoneId.equals(this.timeZone.getId()))
+            {
+                this.timeZone = null;
+            }
+            return this;
+        }
+
+        /**
+         * Render dates in the given time zone, rather than as the UTC times they are.
+         *
+         * @param timeZone time zone
+         * @return this builder
+         */
+        public Builder timeZone(ZoneId timeZone)
+        {
+            requireNoOpenSubsecond();
+            if (timeZone == null)
+            {
+                this.timeZone = null;
+                this.timeZoneId = null;
+            }
+            else
+            {
+                this.timeZone = timeZone;
+                this.timeZoneId = timeZone.getId();
+            }
+            return this;
+        }
+
+        /**
+         * Write the year in full, however many digits it takes, with a minus sign before the era.
+         *
+         * @return this builder
+         */
+        public Builder year()
+        {
+            return element(Year.INSTANCE);
+        }
+
+        /**
+         * Write the last two digits of the year, which drop the sign along with the century.
+         *
+         * @return this builder
+         */
+        public Builder twoDigitYear()
+        {
+            return element(TwoDigitYear.INSTANCE);
+        }
+
+        /**
+         * Write the month, zero padded to two digits.
+         *
+         * @return this builder
+         */
+        public Builder month()
+        {
+            return month(DEFAULT_DIGITS);
+        }
+
+        /**
+         * Write the month, zero padded to the given width.
+         *
+         * @param minDigits fewest digits to write
+         * @return this builder
+         */
+        public Builder month(int minDigits)
+        {
+            return component(Component.MONTH, minDigits);
+        }
+
+        /**
+         * Write the day of the month, zero padded to two digits.
+         *
+         * @return this builder
+         */
+        public Builder day()
+        {
+            return day(DEFAULT_DIGITS);
+        }
+
+        /**
+         * Write the day of the month, zero padded to the given width.
+         *
+         * @param minDigits fewest digits to write
+         * @return this builder
+         */
+        public Builder day(int minDigits)
+        {
+            return component(Component.DAY, minDigits);
+        }
+
+        /**
+         * Write the hour on the 24 hour clock, zero padded to two digits.
+         *
+         * @return this builder
+         */
+        public Builder hour24()
+        {
+            return hour24(DEFAULT_DIGITS);
+        }
+
+        /**
+         * Write the hour on the 24 hour clock, zero padded to the given width.
+         *
+         * @param minDigits fewest digits to write
+         * @return this builder
+         */
+        public Builder hour24(int minDigits)
+        {
+            return component(Component.HOUR_24, minDigits);
+        }
+
+        /**
+         * Write the hour on the 12 hour clock, zero padded to two digits, with midnight and noon
+         * both written as 12.
+         *
+         * @return this builder
+         */
+        public Builder hour12()
+        {
+            return hour12(DEFAULT_DIGITS);
+        }
+
+        /**
+         * Write the hour on the 12 hour clock, zero padded to the given width, with midnight and
+         * noon both written as 12.
+         *
+         * @param minDigits fewest digits to write
+         * @return this builder
+         */
+        public Builder hour12(int minDigits)
+        {
+            return component(Component.HOUR_12, minDigits);
+        }
+
+        /**
+         * Write whether the hour is before or after noon, as {@code AM} or {@code PM}.
+         *
+         * @return this builder
+         */
+        public Builder amPm()
+        {
+            return element(AmPm.INSTANCE);
+        }
+
+        /**
+         * Write the minute, zero padded to two digits.
+         *
+         * @return this builder
+         */
+        public Builder minute()
+        {
+            return minute(DEFAULT_DIGITS);
+        }
+
+        /**
+         * Write the minute, zero padded to the given width.
+         *
+         * @param minDigits fewest digits to write
+         * @return this builder
+         */
+        public Builder minute(int minDigits)
+        {
+            return component(Component.MINUTE, minDigits);
+        }
+
+        /**
+         * Write the second, zero padded to two digits.
+         *
+         * @return this builder
+         */
+        public Builder second()
+        {
+            return second(DEFAULT_DIGITS);
+        }
+
+        /**
+         * Write the second, zero padded to the given width.
+         *
+         * @param minDigits fewest digits to write
+         * @return this builder
+         */
+        public Builder second(int minDigits)
+        {
+            return component(Component.SECOND, minDigits);
+        }
+
+        /**
+         * Begin a sub-second field, which the builder this gives out describes and its
+         * {@link SubsecondBuilder#endSubsecond()} adds. Nothing reaches the pattern until then, so
+         * a field is either wholly described or not there at all.
+         *
+         * <p>As every sub-second field does, the field this begins fails on a date carrying no
+         * fraction at all, whatever width it ends up with.
+         *
+         * @return builder for the field
+         */
+        public SubsecondBuilder subsecond()
+        {
+            requireNoOpenSubsecond();
+            this.openSubsecond = new SubsecondBuilder(this);
+            return this.openSubsecond;
+        }
+
+        /**
+         * Write the name of the pattern's time zone, as {@link #timeZone} was given it, or
+         * {@code GMT} where no zone was named. The zone may be named before or after this.
+         *
+         * @return this builder
+         */
+        public Builder timeZoneName()
+        {
+            return element(TimeZoneName.INSTANCE);
+        }
+
+        /**
+         * Write the offset from UTC in the RFC 822 notation, which is a sign, two digits of hours,
+         * and two of minutes, with nothing left out: UTC is written {@code +0000}. An offset
+         * belongs to an instant, so this fails on a date with no hour.
+         *
+         * @return this builder
+         */
+        public Builder rfc822TimeZoneOffset()
+        {
+            return element(RFC822TimeZoneOffset.INSTANCE);
+        }
+
+        /**
+         * Write the offset from UTC in the ISO 8601 notation, which writes UTC as {@code Z} and
+         * leaves out the minutes of an offset that has none. An offset belongs to an instant, so
+         * this fails on a date with no hour.
+         *
+         * @return this builder
+         */
+        public Builder iso8601TimeZoneOffset()
+        {
+            return element(ISO8601TimeZoneOffset.INSTANCE);
+        }
+
+        /**
+         * Write the given character as it stands.
+         *
+         * @param character character to write
+         * @return this builder
+         */
+        public Builder literal(char character)
+        {
+            requireNoOpenSubsecond();
+            this.pendingLiteral.append(character);
+            return this;
+        }
+
+        /**
+         * Write the given text as it stands. Unlike a format string, which has to quote text and
+         * escape the quotes within it, this takes any text at all.
+         *
+         * @param text text to write
+         * @return this builder
+         */
+        public Builder literal(String text)
+        {
+            requireNoOpenSubsecond();
+            this.pendingLiteral.append(text);
+            return this;
+        }
+
+        /**
+         * Build the pattern.
+         *
+         * @return pattern
+         * @throws IllegalArgumentException if a time zone was named that cannot be resolved
+         */
+        public DateFormatPattern build()
+        {
+            requireNoOpenSubsecond();
+            flushLiteral();
+            if ((this.timeZoneId != null) && (this.timeZone == null))
+            {
+                this.timeZone = resolveTimeZone(this.timeZoneId);
+            }
+            return new DateFormatPattern(this.elements.toArray(new Element[0]), this.timeZone, this.timeZoneId);
+        }
+
+        private Builder component(Component component, int minDigits)
+        {
+            if (minDigits < 1)
+            {
+                throw new IllegalArgumentException("Width must be at least 1 digit: " + minDigits);
+            }
+            return element(new NumericComponent(component, minDigits));
+        }
+
+        private Builder element(Element element)
+        {
+            requireNoOpenSubsecond();
+            return add(element);
+        }
+
+        /**
+         * Add an element without asking whether a sub-second field is open, which is how the one
+         * call that ends such a field adds it.
+         *
+         * @param element element to add
+         * @return this builder
+         */
+        private Builder add(Element element)
+        {
+            flushLiteral();
+            this.elements.add(element);
+            return this;
+        }
+
+        /**
+         * Refuse to do anything else while a sub-second field is part way through being described.
+         * Quietly ending it would commit a field its author may not have finished writing, and
+         * there is no reading of the half-written chain that says which they meant.
+         */
+        private void requireNoOpenSubsecond()
+        {
+            if (this.openSubsecond != null)
+            {
+                throw new IllegalStateException("A sub-second field is still open: call endSubsecond() before anything else");
+            }
+        }
+
+        private void flushLiteral()
+        {
+            if (this.pendingLiteral.length() > 0)
+            {
+                this.elements.add(new Literal(this.pendingLiteral.toString()));
+                this.pendingLiteral.setLength(0);
+            }
+        }
+    }
+
+    /**
+     * Describes one sub-second field, and adds it to the pattern it came from when
+     * {@link #endSubsecond()} is called. Nothing it is told reaches that pattern before then, so a
+     * field is either wholly described or not there at all.
+     *
+     * <p>A field with nothing said about its width writes however many digits the date has, which
+     * is what {@link #asStored()} says outright. One of {@link #asStored()}, {@link #exactly},
+     * {@link #atMost}, {@link #atLeast} and {@link #between} sets the width, the last such call
+     * winning; {@link #failBelowMinimum()}, {@link #failAboveMaximum()} and {@link #padWith} then
+     * say what to do about a date the width does not fit.
+     *
+     * <p>While a field is open the pattern it belongs to will do nothing else, so the two cannot be
+     * interleaved, and a field cannot be ended twice.
+     *
+     * <pre>
+     * builder.literal('.').subsecond().between(3, 9).failBelowMinimum().endSubsecond()
+     * </pre>
+     */
+    public static final class SubsecondBuilder
+    {
+        private final Builder parent;
+        private int minimum;
+        private int maximum;
+        private boolean failBelow;
+        private boolean failAbove;
+        private char fill;
+        private boolean ended;
+
+        private SubsecondBuilder(Builder parent)
+        {
+            this.parent = parent;
+            this.minimum = 0;
+            this.maximum = Subsecond.UNBOUNDED;
+            this.fill = Subsecond.DEFAULT_FILL;
+        }
+
+        /**
+         * Write however many digits of the fraction of a second the date has, which is what a field
+         * writes where nothing is said about its width.
+         *
+         * @return this builder
+         * @throws IllegalStateException if the field has already been ended
+         */
+        public SubsecondBuilder asStored()
+        {
+            return between(0, Subsecond.UNBOUNDED);
+        }
+
+        /**
+         * Write exactly the given number of digits, cutting down a date carrying more and padding
+         * out one carrying fewer.
+         *
+         * @param digits digits to write
+         * @return this builder
+         * @throws IllegalStateException if the field has already been ended
+         */
+        public SubsecondBuilder exactly(int digits)
+        {
+            return between(digits, digits);
+        }
+
+        /**
+         * Write at most the given number of digits, and fewer where that is all the date has.
+         *
+         * @param maximum most digits to write
+         * @return this builder
+         * @throws IllegalStateException if the field has already been ended
+         */
+        public SubsecondBuilder atMost(int maximum)
+        {
+            return between(0, maximum);
+        }
+
+        /**
+         * Write at least the given number of digits, padding out a date carrying fewer, and however
+         * many more the date has.
+         *
+         * @param minimum fewest digits to write
+         * @return this builder
+         * @throws IllegalStateException if the field has already been ended
+         */
+        public SubsecondBuilder atLeast(int minimum)
+        {
+            return between(minimum, Subsecond.UNBOUNDED);
+        }
+
+        /**
+         * Write between the given numbers of digits, cutting down a date carrying more and padding
+         * out one carrying fewer.
+         *
+         * @param minimum fewest digits to write
+         * @param maximum most digits to write
+         * @return this builder
+         * @throws IllegalArgumentException if no width satisfies both bounds
+         * @throws IllegalStateException if the field has already been ended
+         */
+        public SubsecondBuilder between(int minimum, int maximum)
+        {
+            requireNotEnded();
+            Subsecond.checkWidth(minimum, maximum);
+            this.minimum = minimum;
+            this.maximum = maximum;
+            return this;
+        }
+
+        /**
+         * Fail rather than pad out a fraction shorter than the minimum. A field with no minimum has
+         * nothing to fail on.
+         *
+         * @return this builder
+         * @throws IllegalStateException if the field has already been ended
+         */
+        public SubsecondBuilder failBelowMinimum()
+        {
+            requireNotEnded();
+            this.failBelow = true;
+            return this;
+        }
+
+        /**
+         * Fail rather than cut down a fraction longer than the maximum. A field with no maximum has
+         * nothing to fail on.
+         *
+         * @return this builder
+         * @throws IllegalStateException if the field has already been ended
+         */
+        public SubsecondBuilder failAboveMaximum()
+        {
+            requireNotEnded();
+            this.failAbove = true;
+            return this;
+        }
+
+        /**
+         * Pad a fraction shorter than the minimum with the given character rather than with zeros.
+         *
+         * @param fill fill character
+         * @return this builder
+         * @throws IllegalStateException if the field has already been ended
+         */
+        public SubsecondBuilder padWith(char fill)
+        {
+            requireNotEnded();
+            this.fill = fill;
+            return this;
+        }
+
+        /**
+         * Add the field to the pattern, and give back the builder it belongs to. The field is
+         * finished with, and nothing more may be said about it.
+         *
+         * @return the builder this field was begun from
+         * @throws IllegalStateException if the field has already been ended
+         */
+        public Builder endSubsecond()
+        {
+            requireNotEnded();
+            this.ended = true;
+            this.parent.openSubsecond = null;
+            return this.parent.add(new Subsecond(this.minimum, this.maximum, this.failBelow, this.failAbove, this.fill));
+        }
+
+        private void requireNotEnded()
+        {
+            if (this.ended)
+            {
+                throw new IllegalStateException("This sub-second field has already been ended");
+            }
+        }
+    }
+
+    /**
+     * A component the date carries as a number, with the two ways of reading it - from the date as
+     * it stands, and from the date as a time zone reads it - what to say where the date does not
+     * carry it at all, and the character a format string asks for it by.
+     */
+    private enum Component
+    {
+        MONTH("Month", "month", 'M', PureDate::hasMonth, PureDate::getMonth, ZonedDateTime::getMonthValue),
+        DAY("Day", "day", 'd', PureDate::hasDay, PureDate::getDay, ZonedDateTime::getDayOfMonth),
+        HOUR_24("Hour24", "hour", 'H', PureDate::hasHour, PureDate::getHour, ZonedDateTime::getHour),
+        HOUR_12("Hour12", "hour", 'h', PureDate::hasHour, date -> onTwelveHourClock(date.getHour()), zoned -> onTwelveHourClock(zoned.getHour())),
+        MINUTE("Minute", "minute", 'm', PureDate::hasMinute, PureDate::getMinute, ZonedDateTime::getMinute),
+        SECOND("Second", "second", 's', PureDate::hasSecond, PureDate::getSecond, ZonedDateTime::getSecond);
+
+        private final String label;
+        private final String name;
+        private final char controlCharacter;
+        private final Predicate<PureDate> present;
+        private final ToIntFunction<PureDate> fromDate;
+        private final ToIntFunction<ZonedDateTime> fromZoned;
+
+        Component(String label, String name, char controlCharacter, Predicate<PureDate> present, ToIntFunction<PureDate> fromDate, ToIntFunction<ZonedDateTime> fromZoned)
+        {
+            this.label = label;
+            this.name = name;
+            this.controlCharacter = controlCharacter;
+            this.present = present;
+            this.fromDate = fromDate;
+            this.fromZoned = fromZoned;
+        }
+
+        boolean has(PureDate date)
+        {
+            return this.present.test(date);
+        }
+
+        void requireOf(PureDate date)
+        {
+            if (!this.present.test(date))
+            {
+                throw new IllegalArgumentException("Date has no " + this.name + ": " + date);
+            }
+        }
+
+        int get(PureDate date, ZonedDateTime zoned)
+        {
+            return (zoned == null) ? this.fromDate.applyAsInt(date) : this.fromZoned.applyAsInt(zoned);
+        }
+
+        char getControlCharacter()
+        {
+            return this.controlCharacter;
+        }
+
+        @Override
+        public String toString()
+        {
+            return this.label;
+        }
+
+        private static int onTwelveHourClock(int hour)
+        {
+            return (hour == 0) ? 12 : ((hour > 12) ? (hour - 12) : hour);
+        }
+    }
+
+    /**
+     * Reads a format string, or a portion of one, into a pattern. Everything the parser reports is
+     * a property of the format string alone, so a string that parses will render any date carrying
+     * the components it names.
+     */
+    private static final class Parser
+    {
+        private final String formatString;
+        private final int start;
+        private final int end;
+        private final Builder builder = new Builder();
+        private int index;
+
+        Parser(String formatString, int start, int end)
+        {
+            this.formatString = formatString;
+            this.start = start;
+            this.end = end;
+            this.index = start;
+        }
+
+        DateFormatPattern parse()
+        {
+            while (this.index < this.end)
+            {
+                char character = this.formatString.charAt(this.index++);
+                switch (character)
+                {
+                    case '[':
+                    {
+                        parseTimeZone();
+                        break;
+                    }
+                    case 'y':
+                    {
+                        // the year is written in full only from four letters on, and is not padded
+                        this.builder.element((runLength(character) < 4) ? TwoDigitYear.INSTANCE : Year.INSTANCE);
+                        break;
+                    }
+                    case 'M':
+                    {
+                        this.builder.component(Component.MONTH, runLength(character));
+                        break;
+                    }
+                    case 'd':
+                    {
+                        this.builder.component(Component.DAY, runLength(character));
+                        break;
+                    }
+                    case 'h':
+                    {
+                        this.builder.component(Component.HOUR_12, runLength(character));
+                        break;
+                    }
+                    case 'H':
+                    {
+                        this.builder.component(Component.HOUR_24, runLength(character));
+                        break;
+                    }
+                    case 'm':
+                    {
+                        this.builder.component(Component.MINUTE, runLength(character));
+                        break;
+                    }
+                    case 's':
+                    {
+                        this.builder.component(Component.SECOND, runLength(character));
+                        break;
+                    }
+                    case 'a':
+                    {
+                        runLength(character);
+                        this.builder.amPm();
+                        break;
+                    }
+                    case 'S':
+                    {
+                        // up to three letters cut the fraction down to that many digits; from four
+                        // on the count stops meaning anything and the whole fraction is written
+                        int count = runLength(character);
+                        this.builder.subsecond().atMost((count < 4) ? count : Subsecond.UNBOUNDED).endSubsecond();
+                        break;
+                    }
+                    case 'z':
+                    {
+                        runLength(character);
+                        this.builder.timeZoneName();
+                        break;
+                    }
+                    case 'Z':
+                    {
+                        runLength(character);
+                        this.builder.rfc822TimeZoneOffset();
+                        break;
+                    }
+                    case 'X':
+                    {
+                        runLength(character);
+                        this.builder.iso8601TimeZoneOffset();
+                        break;
+                    }
+                    case '-':
+                    case '/':
+                    case ':':
+                    case '.':
+                    case ' ':
+                    case '\t':
+                    {
+                        this.builder.literal(character);
+                        break;
+                    }
+                    case '"':
+                    {
+                        parseQuotedText();
+                        break;
+                    }
+                    default:
+                    {
+                        throw new IllegalArgumentException("Invalid format control character '" + character + "' in format string: " + text());
+                    }
+                }
+            }
+            return this.builder.build();
+        }
+
+        /**
+         * Consume the run of the given character from the current index, one of them having already
+         * been taken, and return how many there were in all.
+         *
+         * @param character character being repeated
+         * @return length of the run, counting the one already taken
+         */
+        private int runLength(char character)
+        {
+            int count = 1;
+            while ((this.index < this.end) && (this.formatString.charAt(this.index) == character))
+            {
+                this.index++;
+                count++;
+            }
+            return count;
+        }
+
+        private void parseTimeZone()
+        {
+            if (this.index > (this.start + 1))
+            {
+                throw new IllegalArgumentException("Time zone can only be set at the beginning of the format string");
+            }
+
+            StringBuilder timeZoneId = new StringBuilder();
+            boolean done = false;
+            boolean escaped = false;
+            boolean inQuotes = false;
+            while (!done && (this.index < this.end))
+            {
+                char next = this.formatString.charAt(this.index++);
+                if (escaped)
+                {
+                    timeZoneId.append(next);
+                    escaped = false;
+                }
+                else if (next == '"')
+                {
+                    inQuotes = !inQuotes;
+                }
+                else if ((next == ']') && !inQuotes)
+                {
+                    done = true;
+                }
+                else if (next == '\\')
+                {
+                    escaped = true;
+                }
+                else
+                {
+                    timeZoneId.append(next);
+                }
+            }
+            if (inQuotes)
+            {
+                throw new IllegalArgumentException("Missing closing quotes in time zone definition: " + text());
+            }
+            if (!done)
+            {
+                throw new IllegalArgumentException("Missing closing bracket in format string: " + text());
+            }
+            this.builder.timeZone(timeZoneId.toString());
+        }
+
+        private void parseQuotedText()
+        {
+            StringBuilder literal = new StringBuilder();
+            boolean done = false;
+            boolean escaped = false;
+            while (!done && (this.index < this.end))
+            {
+                char next = this.formatString.charAt(this.index++);
+                if (escaped)
+                {
+                    literal.append(next);
+                    escaped = false;
+                }
+                else if (next == '"')
+                {
+                    done = true;
+                }
+                else if (next == '\\')
+                {
+                    escaped = true;
+                }
+                else
+                {
+                    literal.append(next);
+                }
+            }
+            if (!done)
+            {
+                throw new IllegalArgumentException("Missing closing quote in format string: " + text());
+            }
+            this.builder.literal(literal.toString());
+        }
+
+        private String text()
+        {
+            return this.formatString.substring(this.start, this.end);
+        }
+    }
+
+    /**
+     * Refuse to write an offset for a date that has no hour. An offset belongs to an instant, and a
+     * zone can be keeping more than one over a date that broad, so which one it is keeping is just
+     * what knowing the time would have told us.
+     *
+     * @param date             date being rendered
+     * @param controlCharacter character the offset was asked for by
+     */
+    private static void requireHourForOffset(PureDate date, char controlCharacter)
+    {
+        if (!date.hasHour())
+        {
+            throw new IllegalArgumentException("Date has no hour (required for " + controlCharacter + "): " + date);
+        }
+    }
+
+    /**
+     * Return whether a character stands for itself in a format string, rather than having to be
+     * quoted.
+     *
+     * @param character character to test
+     * @return whether the character is a separator
+     */
+    private static boolean isSeparator(char character)
+    {
+        return (character == '-') || (character == '/') || (character == ':') ||
+                (character == '.') || (character == ' ') || (character == '\t');
+    }
+
+    /**
+     * Write a time zone name in the square brackets a format string opens with, escaping what would
+     * otherwise close them.
+     *
+     * @param appendable appendable to write to
+     * @param timeZoneId time zone name
+     */
+    private static void appendTimeZoneId(SafeAppendable appendable, String timeZoneId)
+    {
+        appendable.append('[');
+        for (int i = 0; i < timeZoneId.length(); i++)
+        {
+            char character = timeZoneId.charAt(i);
+            if ((character == ']') || (character == '"') || (character == '\\'))
+            {
+                appendable.append('\\');
+            }
+            appendable.append(character);
+        }
+        appendable.append(']');
+    }
+
+    private static ZoneId resolveTimeZone(String timeZoneId)
+    {
+        try
+        {
+            return ZoneId.of(timeZoneId, ZoneId.SHORT_IDS);
+        }
+        catch (DateTimeException e)
+        {
+            throw new IllegalArgumentException("Unknown time zone: " + timeZoneId, e);
+        }
+    }
+}

--- a/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormatPattern.java
+++ b/legend-pure-core/legend-pure-m4/src/main/java/org/finos/legend/pure/m4/coreinstance/primitive/date/DateFormatPattern.java
@@ -326,38 +326,43 @@ public final class DateFormatPattern
         @Override
         void appendPattern(SafeAppendable appendable)
         {
-            // a separator stands for itself and anything else has to be quoted, so a literal
-            // holding both is written as runs of each
-            int length = this.text.length();
-            int index = 0;
-            while (index < length)
+            if (this.text.isEmpty())
             {
-                boolean separators = isSeparator(this.text.charAt(index));
-                int runEnd = index + 1;
-                while ((runEnd < length) && (isSeparator(this.text.charAt(runEnd)) == separators))
-                {
-                    runEnd++;
-                }
-                if (separators)
-                {
-                    appendable.append(this.text, index, runEnd);
-                }
-                else
-                {
-                    appendable.append('"');
-                    for (int i = index; i < runEnd; i++)
-                    {
-                        char character = this.text.charAt(i);
-                        if ((character == '"') || (character == '\\'))
-                        {
-                            appendable.append('\\');
-                        }
-                        appendable.append(character);
-                    }
-                    appendable.append('"');
-                }
-                index = runEnd;
+                // an empty literal writes nothing, and still has to be written: it is how an
+                // alternative that renders nothing is spelled, and writing nothing for it would
+                // leave an alternative with no elements, which is not a format string at all
+                appendable.append("\"\"");
+                return;
             }
+
+            // separators stand for themselves, so text made only of them is written bare; anything
+            // else is quoted whole rather than split into runs, which would turn " at " into the
+            // three pieces " "at" " and make a literal harder to read the more ordinary it is
+            int length = this.text.length();
+            for (int i = 0; i < length; i++)
+            {
+                if (!isSeparator(this.text.charAt(i)))
+                {
+                    appendQuoted(appendable);
+                    return;
+                }
+            }
+            appendable.append(this.text);
+        }
+
+        private void appendQuoted(SafeAppendable appendable)
+        {
+            appendable.append('"');
+            for (int i = 0; i < this.text.length(); i++)
+            {
+                char character = this.text.charAt(i);
+                if ((character == '"') || (character == '\\'))
+                {
+                    appendable.append('\\');
+                }
+                appendable.append(character);
+            }
+            appendable.append('"');
         }
 
         @Override
@@ -941,6 +946,130 @@ public final class DateFormatPattern
     }
 
     /**
+     * A run of the pattern written where the date can carry it and left out where it cannot, with
+     * alternatives to choose between.
+     *
+     * <p>A section writes the first of its alternatives every element of which can write the date,
+     * and writes nothing at all where none of them can. It therefore never fails, whatever it holds:
+     * a section is the one construct that turns a date the pattern cannot carry into silence rather
+     * than into an error. That is also what it costs - a throwing sub-second bound inside a section
+     * selects the next alternative where outside one it would raise.
+     *
+     * <p>A section nested inside another asks the date for nothing on its own account, since it can
+     * always write. {@code ?[" at "?[HH:mm]]} on a date with no hour therefore writes {@code " at "}
+     * and stops: the outer alternative holds a literal and a section, and both of those can always
+     * write. Hoisting the literal out, as {@code ?[" at "HH:mm]}, is what makes the two rise and
+     * fall together. The alternative - letting a nested section refuse on its parent's behalf -
+     * would make viability depend on a whole subtree, and would make {@code ?[X]} and
+     * {@code ?[X|""]} mean different things.
+     */
+    private static final class OptionalSection extends Element
+    {
+        private final Element[][] alternatives;
+
+        OptionalSection(Element[][] alternatives)
+        {
+            this.alternatives = alternatives;
+        }
+
+        @Override
+        boolean canRender(PureDate date)
+        {
+            return true;
+        }
+
+        @Override
+        void render(SafeAppendable appendable, PureDate date, ZonedDateTime zoned, String timeZoneId)
+        {
+            for (Element[] alternative : this.alternatives)
+            {
+                if (canRenderAll(alternative, date))
+                {
+                    for (Element element : alternative)
+                    {
+                        element.render(appendable, date, zoned, timeZoneId);
+                    }
+                    return;
+                }
+            }
+        }
+
+        @Override
+        void appendPattern(SafeAppendable appendable)
+        {
+            appendable.append("?[");
+            for (int i = 0; i < this.alternatives.length; i++)
+            {
+                if (i > 0)
+                {
+                    appendable.append('|');
+                }
+                for (Element element : this.alternatives[i])
+                {
+                    element.appendPattern(appendable);
+                }
+            }
+            appendable.append(']');
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            return (this == other) ||
+                    ((other instanceof OptionalSection) &&
+                            Arrays.deepEquals(this.alternatives, ((OptionalSection) other).alternatives));
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Arrays.deepHashCode(this.alternatives);
+        }
+
+        @Override
+        public String toString()
+        {
+            StringBuilder builder = new StringBuilder("OptionalSection(");
+            for (int i = 0; i < this.alternatives.length; i++)
+            {
+                if (i > 0)
+                {
+                    builder.append(" | ");
+                }
+                for (int j = 0; j < this.alternatives[i].length; j++)
+                {
+                    if (j > 0)
+                    {
+                        builder.append(", ");
+                    }
+                    builder.append(this.alternatives[i][j]);
+                }
+            }
+            return builder.append(')').toString();
+        }
+
+        /**
+         * Return whether every element of an alternative can write the given date, which is what
+         * makes the alternative the one to write.
+         *
+         * @param elements elements of the alternative
+         * @param date     date to write
+         * @return whether the alternative can be written
+         */
+        private static boolean canRenderAll(Element[] elements, PureDate date)
+        {
+            for (Element element : elements)
+            {
+                if (!element.canRender(date))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    /**
      * Assembles a pattern element by element. A builder may be built from more than once, and each
      * pattern it gives out stands on its own.
      *
@@ -948,12 +1077,18 @@ public final class DateFormatPattern
      * out and {@link SubsecondBuilder#endSubsecond()} hands back. Nothing reaches the pattern until
      * the field is finished, so a field is either wholly described or not there at all, and a
      * pattern may hold as many of them as it likes.
+     *
+     * <p>An optional section is described in place instead, since everything it can hold is what
+     * the builder already writes: {@link #optional()} opens one, {@link #or()} begins its next
+     * alternative, and {@link #endOptional()} closes it. Elements added while a section is open
+     * belong to the alternative being described, and sections may be nested.
      */
     public static final class Builder
     {
         private static final int DEFAULT_DIGITS = 2;
 
         private final List<Element> elements = new ArrayList<>();
+        private final List<OpenSection> openSections = new ArrayList<>();
         private final StringBuilder pendingLiteral = new StringBuilder();
         private SubsecondBuilder openSubsecond;
         private String timeZoneId;
@@ -1251,14 +1386,70 @@ public final class DateFormatPattern
         }
 
         /**
+         * Open an optional section, which writes the first of its alternatives the date can carry
+         * and nothing at all where the date can carry none of them. Elements added from here on
+         * belong to the section's first alternative, {@link #or()} begins the next one, and
+         * {@link #endOptional()} closes the section. Sections may be nested.
+         *
+         * <pre>
+         * builder.year().optional().literal('-').month().endOptional()
+         * </pre>
+         *
+         * @return this builder
+         * @throws IllegalStateException if a sub-second field is still open
+         */
+        public Builder optional()
+        {
+            requireNoOpenSubsecond();
+            flushLiteral();
+            this.openSections.add(new OpenSection());
+            return this;
+        }
+
+        /**
+         * End the alternative being described and begin the next one.
+         *
+         * @return this builder
+         * @throws IllegalStateException if a sub-second field is still open, if no optional section
+         *                               is open, or if the alternative being ended holds nothing
+         */
+        public Builder or()
+        {
+            requireNoOpenSubsecond();
+            endAlternative(requireOpenSection("or()"));
+            return this;
+        }
+
+        /**
+         * Close the optional section being described, adding it to whatever surrounds it.
+         *
+         * @return this builder
+         * @throws IllegalStateException if a sub-second field is still open, if no optional section
+         *                               is open, or if the alternative being ended holds nothing
+         */
+        public Builder endOptional()
+        {
+            requireNoOpenSubsecond();
+            OpenSection section = requireOpenSection("endOptional()");
+            endAlternative(section);
+            this.openSections.remove(this.openSections.size() - 1);
+            return add(new OptionalSection(section.alternatives.toArray(new Element[0][])));
+        }
+
+        /**
          * Build the pattern.
          *
          * @return pattern
          * @throws IllegalArgumentException if a time zone was named that cannot be resolved
+         * @throws IllegalStateException if a sub-second field or an optional section is still open
          */
         public DateFormatPattern build()
         {
             requireNoOpenSubsecond();
+            if (!this.openSections.isEmpty())
+            {
+                throw new IllegalStateException("An optional section is still open: call endOptional() before anything else");
+            }
             flushLiteral();
             if ((this.timeZoneId != null) && (this.timeZone == null))
             {
@@ -1292,7 +1483,7 @@ public final class DateFormatPattern
         private Builder add(Element element)
         {
             flushLiteral();
-            this.elements.add(element);
+            currentElements().add(element);
             return this;
         }
 
@@ -1309,14 +1500,69 @@ public final class DateFormatPattern
             }
         }
 
+        private OpenSection requireOpenSection(String call)
+        {
+            if (this.openSections.isEmpty())
+            {
+                throw new IllegalStateException("No optional section is open: call optional() before " + call);
+            }
+            return this.openSections.get(this.openSections.size() - 1);
+        }
+
+        /**
+         * End the alternative a section is describing. An alternative holding nothing is refused
+         * rather than dropped: one at the front would make the whole section write nothing, which
+         * is a silent bug, and one at the back says what the section without it already says.
+         *
+         * @param section section being described
+         */
+        private void endAlternative(OpenSection section)
+        {
+            flushLiteral();
+            if (section.current.isEmpty())
+            {
+                throw new IllegalStateException("An optional section may not hold an alternative with nothing in it");
+            }
+            section.alternatives.add(section.current.toArray(new Element[0]));
+            section.current.clear();
+        }
+
+        /**
+         * Return the elements being added to, which is the alternative of the innermost open
+         * section, or the pattern itself where no section is open.
+         *
+         * @return elements being added to
+         */
+        private List<Element> currentElements()
+        {
+            return this.openSections.isEmpty()
+                    ? this.elements
+                    : this.openSections.get(this.openSections.size() - 1).current;
+        }
+
+        private boolean currentAlternativeIsEmpty()
+        {
+            return (this.pendingLiteral.length() == 0) && currentElements().isEmpty();
+        }
+
         private void flushLiteral()
         {
             if (this.pendingLiteral.length() > 0)
             {
-                this.elements.add(new Literal(this.pendingLiteral.toString()));
+                currentElements().add(new Literal(this.pendingLiteral.toString()));
                 this.pendingLiteral.setLength(0);
             }
         }
+    }
+
+    /**
+     * An optional section part way through being described: the alternatives already ended, and the
+     * elements of the one being described now.
+     */
+    private static final class OpenSection
+    {
+        private final List<Element[]> alternatives = new ArrayList<>();
+        private final List<Element> current = new ArrayList<>();
     }
 
     /**
@@ -1568,6 +1814,7 @@ public final class DateFormatPattern
         private final int end;
         private final Builder builder = new Builder();
         private int index;
+        private int sectionDepth;
 
         Parser(String formatString, int start, int end)
         {
@@ -1669,13 +1916,60 @@ public final class DateFormatPattern
                         parseQuotedText();
                         break;
                     }
+                    case '?':
+                    {
+                        if (!takeIf('['))
+                        {
+                            throw new IllegalArgumentException("Expected '[' after '?' in format string: " + text());
+                        }
+                        this.builder.optional();
+                        this.sectionDepth++;
+                        break;
+                    }
+                    case '|':
+                    {
+                        if (this.sectionDepth == 0)
+                        {
+                            throw new IllegalArgumentException("'|' outside an optional section in format string: " + text());
+                        }
+                        requireNonEmptyAlternative();
+                        this.builder.or();
+                        break;
+                    }
+                    case ']':
+                    {
+                        if (this.sectionDepth == 0)
+                        {
+                            throw new IllegalArgumentException("Unmatched ']' in format string: " + text());
+                        }
+                        requireNonEmptyAlternative();
+                        this.builder.endOptional();
+                        this.sectionDepth--;
+                        break;
+                    }
                     default:
                     {
                         throw new IllegalArgumentException("Invalid format control character '" + character + "' in format string: " + text());
                     }
                 }
             }
+            if (this.sectionDepth > 0)
+            {
+                throw new IllegalArgumentException("Missing closing bracket for optional section in format string: " + text());
+            }
             return this.builder.build();
+        }
+
+        /**
+         * Refuse an alternative with nothing in it, which the builder would refuse too, so that the
+         * error names the format string rather than the half-built pattern.
+         */
+        private void requireNonEmptyAlternative()
+        {
+            if (this.builder.currentAlternativeIsEmpty())
+            {
+                throw new IllegalArgumentException("Empty alternative in optional section in format string: " + text());
+            }
         }
 
         /**
@@ -1978,7 +2272,16 @@ public final class DateFormatPattern
             {
                 throw new IllegalArgumentException("Missing closing quote in format string: " + text());
             }
-            this.builder.literal(literal.toString());
+            if (literal.length() == 0)
+            {
+                // an empty literal writes nothing and is an element all the same, since it is how an
+                // alternative that renders nothing is spelled
+                this.builder.element(new Literal(""));
+            }
+            else
+            {
+                this.builder.literal(literal.toString());
+            }
         }
 
         private String text()

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -201,6 +201,53 @@ public class TestDateFormat
         Assert.assertEquals("07", format("SSSS", hundredths));
     }
 
+    /**
+     * A sub-second field takes a width, which is the one place the format language says more than a
+     * run of letters can. The run of letters is two of these widths: one to three letters is
+     * {@code S<N}, and four or more is {@code S*}.
+     */
+    @Test
+    public void testFormatSubsecondWidths()
+    {
+        PureDate hundredths = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "07");
+
+        Assert.assertEquals("070", format("S3", DATE));
+        Assert.assertEquals("070", format("S3", hundredths));
+        Assert.assertEquals("070004235", format("S9", DATE));
+        Assert.assertEquals("070000000", format("S9", hundredths));
+
+        Assert.assertEquals("070", format("S<3", DATE));
+        Assert.assertEquals("07", format("S<3", hundredths));
+        Assert.assertEquals("070004235", format("S>3", DATE));
+        Assert.assertEquals("070", format("S>3", hundredths));
+        Assert.assertEquals("070004235", format("S*", DATE));
+        Assert.assertEquals("07", format("S*", hundredths));
+
+        Assert.assertEquals("2014-03-10 16:12:35.070004", format("yyyy-MM-dd HH:mm:ss.S<6", DATE));
+        Assert.assertEquals("2014-03-10 16:12:35.070000", format("yyyy-MM-dd HH:mm:ss.S6", hundredths));
+        Assert.assertEquals("2014-03-10T16:12:35.070004235", format("yyyy-MM-dd\"T\"HH:mm:ss.S9", DATE));
+
+        // and refusing to pad is a field of its own, since padding claims a precision the date lacks
+        Assert.assertEquals("070", format("S!3", DATE));
+        assertFormatFails(
+                "Date has a 2 digit sub-second, but 3 are required: 2014-03-10T16:12:35.07+0000",
+                "S!3",
+                hundredths);
+        assertFormatFails(
+                "Date has a 9 digit sub-second, but at most 3 may be written: 2014-03-10T16:12:35.070004235+0000",
+                "S(0,3!)",
+                DATE);
+
+        // every form fails on a date with no fraction, whatever width it asks for
+        for (String formatString : new String[]{"S", "SSSS", "S3", "S<3", "S>3", "S*", "S!3", "S(3!,9!,\"_\")"})
+        {
+            assertFormatFails(
+                    "Date has no sub-second: 2014-03-10T16:12:35+0000",
+                    formatString,
+                    DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35));
+        }
+    }
+
     // Format: literals
 
     @Test

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -248,6 +248,55 @@ public class TestDateFormat
         }
     }
 
+    // Format: optional sections
+
+    /**
+     * A section is written where the date can carry it and left out where it cannot, so one format
+     * string serves a collection whose dates do not agree on precision.
+     */
+    @Test
+    public void testFormatOptionalSections()
+    {
+        String everything = "yyyy?[-MM?[-dd?[\"T\"HH?[:mm?[:ss?[.S*]]]]]]";
+        Assert.assertEquals("2014", format(everything, DateFunctions.newPureDate(2014)));
+        Assert.assertEquals("2014-03", format(everything, DateFunctions.newPureDate(2014, 3)));
+        Assert.assertEquals("2014-03-10", format(everything, DateFunctions.newPureDate(2014, 3, 10)));
+        Assert.assertEquals("2014-03-10T16", format(everything, DateFunctions.newPureDate(2014, 3, 10, 16)));
+        Assert.assertEquals("2014-03-10T16:12", format(everything, DateFunctions.newPureDate(2014, 3, 10, 16, 12)));
+        Assert.assertEquals("2014-03-10T16:12:35", format(everything, DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35)));
+        Assert.assertEquals("2014-03-10T16:12:35.070004235", format(everything, DATE));
+
+        // alternatives are tried in the order they are written, and the first the date can carry wins
+        String time = "?[HH:mm:ss|HH:mm|HH|\"--\"]";
+        Assert.assertEquals("16:12:35", format(time, DATE));
+        Assert.assertEquals("16:12", format(time, DateFunctions.newPureDate(2014, 3, 10, 16, 12)));
+        Assert.assertEquals("16", format(time, DateFunctions.newPureDate(2014, 3, 10, 16)));
+        Assert.assertEquals("--", format(time, DateFunctions.newPureDate(2014, 3, 10)));
+
+        // a fraction and the point that goes with it are the section's business, not the field's
+        Assert.assertEquals("16:12:35.070", format("HH:mm:ss?[.S3]", DATE));
+        Assert.assertEquals("16:12:35", format("HH:mm:ss?[.S3]", DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35)));
+        Assert.assertEquals("16:12:35.000", format("HH:mm:ss?[.S3|\".000\"]", DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35)));
+
+        // an offset inside a section is what lets a zoned format string take a date with no hour
+        Assert.assertEquals(
+                "2014-03-10T12:12:35-04",
+                format("[America/New_York]yyyy-MM-dd?[\"T\"HH:mm:ssX]", DATE));
+        Assert.assertEquals(
+                "2014-03-10",
+                format("[America/New_York]yyyy-MM-dd?[\"T\"HH:mm:ssX]", DateFunctions.newPureDate(2014, 3, 10)));
+    }
+
+    @Test
+    public void testFormatWithAMalformedOptionalSection()
+    {
+        assertFormatFails("Expected '[' after '?' in format string: yyyy?", "yyyy?", DATE);
+        assertFormatFails("Missing closing bracket for optional section in format string: ?[HH:mm", "?[HH:mm", DATE);
+        assertFormatFails("Unmatched ']' in format string: HH]", "HH]", DATE);
+        assertFormatFails("'|' outside an optional section in format string: HH|mm", "HH|mm", DATE);
+        assertFormatFails("Empty alternative in optional section in format string: ?[|HH]", "?[|HH]", DATE);
+    }
+
     // Format: literals
 
     @Test

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -60,6 +60,69 @@ public class TestDateFormat
             "2014-03-10T16:12:35.070004235+0000"
     };
 
+    /**
+     * The compatibility suite: every expectation here was produced by the single pass loop this
+     * replaced, so a row that changes is a format string whose meaning changed. A null is a date the
+     * format string cannot write, whose wording
+     * {@link #testFormatOfAComponentTheDateDoesNotHave} covers.
+     *
+     * <p>One shape is deliberately absent. A run of {@code a} now writes PM once rather than once
+     * per letter, which is the one behavior this work changed on purpose, and
+     * {@link #testFormatRepeatingAControlCharacterWithNoWidth} pins it instead.
+     */
+    private static final String[][] LEGACY_COMPATIBILITY = {
+            {"y", "14", "14", "14", "14", "14", "14", "14"},
+            {"yy", "14", "14", "14", "14", "14", "14", "14"},
+            {"yyy", "14", "14", "14", "14", "14", "14", "14"},
+            {"yyyy", "2014", "2014", "2014", "2014", "2014", "2014", "2014"},
+            {"yyyyy", "2014", "2014", "2014", "2014", "2014", "2014", "2014"},
+            {"M", null, "3", "3", "3", "3", "3", "3"},
+            {"MM", null, "03", "03", "03", "03", "03", "03"},
+            {"MMM", null, "003", "003", "003", "003", "003", "003"},
+            {"d", null, null, "10", "10", "10", "10", "10"},
+            {"dd", null, null, "10", "10", "10", "10", "10"},
+            {"ddd", null, null, "010", "010", "010", "010", "010"},
+            {"H", null, null, null, "16", "16", "16", "16"},
+            {"HH", null, null, null, "16", "16", "16", "16"},
+            {"h", null, null, null, "4", "4", "4", "4"},
+            {"hh", null, null, null, "04", "04", "04", "04"},
+            {"a", null, null, null, "PM", "PM", "PM", "PM"},
+            {"m", null, null, null, null, "12", "12", "12"},
+            {"mm", null, null, null, null, "12", "12", "12"},
+            {"s", null, null, null, null, null, "35", "35"},
+            {"ss", null, null, null, null, null, "35", "35"},
+            {"S", null, null, null, null, null, null, "0"},
+            {"SS", null, null, null, null, null, null, "07"},
+            {"SSS", null, null, null, null, null, null, "070"},
+            {"SSSS", null, null, null, null, null, null, "070004235"},
+            {"SSSSSSSSS", null, null, null, null, null, null, "070004235"},
+            {"z", "GMT", "GMT", "GMT", "GMT", "GMT", "GMT", "GMT"},
+            {"Z", null, null, null, "+0000", "+0000", "+0000", "+0000"},
+            {"X", null, null, null, "Z", "Z", "Z", "Z"},
+            {"yyyy-MM-dd", null, null, "2014-03-10", "2014-03-10", "2014-03-10", "2014-03-10", "2014-03-10"},
+            {"yyyy-MM-dd HH:mm:ss", null, null, null, null, null, "2014-03-10 16:12:35", "2014-03-10 16:12:35"},
+            {"yyyy-MM-dd HH:mm:ss.SSS", null, null, null, null, null, null, "2014-03-10 16:12:35.070"},
+            {"yyyy-MM-dd HH:mm:ss.SSSSSS", null, null, null, null, null, null, "2014-03-10 16:12:35.070004235"},
+            {"yyyy-MM-dd\"T\"HH:mm:ss", null, null, null, null, null, "2014-03-10T16:12:35", "2014-03-10T16:12:35"},
+            {"yyyy-MM-dd\"T\"HH:mm:ss.SSSSSSSSSZ", null, null, null, null, null, null, "2014-03-10T16:12:35.070004235+0000"},
+            {"yyyyMMdd\"T\"HHmmssX", null, null, null, null, null, "20140310T161235Z", "20140310T161235Z"},
+            {"M/d/yyyy h:mm a", null, null, null, null, "3/10/2014 4:12 PM", "3/10/2014 4:12 PM", "3/10/2014 4:12 PM"},
+            {"dd/MM/yyyy", null, null, "10/03/2014", "10/03/2014", "10/03/2014", "10/03/2014", "10/03/2014"},
+            {"dd.MM.yyyy", null, null, "10.03.2014", "10.03.2014", "10.03.2014", "10.03.2014", "10.03.2014"},
+            {"MMM d\", \"yyyy", null, null, "003 10, 2014", "003 10, 2014", "003 10, 2014", "003 10, 2014", "003 10, 2014"},
+            {"yy/MM/dd hh:mm a z Z X", null, null, null, null, "14/03/10 04:12 PM GMT +0000 Z", "14/03/10 04:12 PM GMT +0000 Z", "14/03/10 04:12 PM GMT +0000 Z"},
+            {"\"at\" HH:mm", null, null, null, null, "at 16:12", "at 16:12", "at 16:12"},
+            {"\"a\\\"b\" HH", null, null, null, "a\"b 16", "a\"b 16", "a\"b 16", "a\"b 16"},
+            {"yyyy-.-", "2014-.-", "2014-.-", "2014-.-", "2014-.-", "2014-.-", "2014-.-", "2014-.-"},
+            {"yyyy\t MM", null, "2014\t 03", "2014\t 03", "2014\t 03", "2014\t 03", "2014\t 03", "2014\t 03"},
+            {"[EST]yyyy-MM-dd HH:mm:ss z Z", null, null, null, null, null, "2014-03-10 11:12:35 EST -0500", "2014-03-10 11:12:35 EST -0500"},
+            {"[America/New_York]yyyy-MM-dd\"T\"HH:mm:ssX", null, null, null, null, null, "2014-03-10T12:12:35-04", "2014-03-10T12:12:35-04"},
+            {"[+05:30]yyyy-MM-dd HH:mmZ", null, null, null, null, "2014-03-10 21:42+0530", "2014-03-10 21:42+0530", "2014-03-10 21:42+0530"},
+            {"[CET]HH:mm:ss.SSSZ", null, null, null, null, null, null, "17:12:35.070+0100"},
+            {"[GMT]yyyy-MM-dd HH:mm:ss.SSSSSS", null, null, null, null, null, null, "2014-03-10 16:12:35.070004235"},
+            {"[UTC]yyyy-MM-dd", null, null, "2014-03-10", "2014-03-10", "2014-03-10", "2014-03-10", "2014-03-10"},
+    };
+
     // Format: date components
 
     /**
@@ -610,6 +673,91 @@ public class TestDateFormat
         assertFormatFails("Missing closing quotes in time zone definition: [\"EST]yyyy", "[\"EST]yyyy", DATE);
         assertFormatFails("Time zone can only be set at the beginning of the format string", "yyyy[EST]", DATE);
         assertFormatFails("Time zone can only be set at the beginning of the format string", "[EST]yyyy[EST]", DATE);
+    }
+
+    // Compatibility
+
+    /**
+     * Every legacy format string still says what it said, at every granularity, which is the claim
+     * the whole of this work rests on. The table is the evidence rather than the argument: its
+     * expectations came from the implementation this replaced.
+     */
+    @Test
+    public void testEveryLegacyFormatStringStillSaysWhatItSaid()
+    {
+        for (String[] row : LEGACY_COMPATIBILITY)
+        {
+            String formatString = row[0];
+            Assert.assertEquals(formatString, DATES.length + 1, row.length);
+            DateFormat.validate(formatString);
+            for (int i = 0; i < DATES.length; i++)
+            {
+                PureDate date = DATES[i];
+                String context = formatString + " on " + date;
+                if (row[i + 1] == null)
+                {
+                    Assert.assertThrows(context, IllegalArgumentException.class, () -> format(formatString, date));
+                }
+                else
+                {
+                    Assert.assertEquals(context, row[i + 1], format(formatString, date));
+                }
+            }
+        }
+    }
+
+    /**
+     * Each run of {@code S} has a width form that means precisely the same thing, at every
+     * granularity and including the granularities where both refuse the date. That equivalence is
+     * what lets the older spelling be deprecated later without anything losing a way to be said.
+     */
+    @Test
+    public void testTheModernSubsecondSpellingsMeanWhatTheLegacyRunsMeant()
+    {
+        assertSameOnEveryDate("S", "S<1");
+        assertSameOnEveryDate("SS", "S<2");
+        assertSameOnEveryDate("SSS", "S<3");
+        assertSameOnEveryDate("SSSS", "S*");
+        assertSameOnEveryDate("SSSSS", "S*");
+        assertSameOnEveryDate("SSSSSSSSS", "S*");
+
+        assertSameOnEveryDate("yyyy-MM-dd HH:mm:ss.SSS", "yyyy-MM-dd HH:mm:ss.S<3");
+        assertSameOnEveryDate("yyyy-MM-dd HH:mm:ss.SSSSSS", "yyyy-MM-dd HH:mm:ss.S*");
+        assertSameOnEveryDate("[EST]HH:mm:ss.SSSZ", "[EST]HH:mm:ss.S<3Z");
+
+        // and the discontinuity the width forms make visible: the count stops meaning a width at
+        // four letters, which is where S<3 turns into S*
+        Assert.assertEquals("070", format("SSS", DATE));
+        Assert.assertEquals("070004235", format("SSSS", DATE));
+    }
+
+    /**
+     * Assert that two format strings say the same thing at every granularity, whether that is a
+     * string they both write or an error they both raise.
+     *
+     * @param legacy format string in the older spelling
+     * @param modern format string in the spelling that replaces it
+     */
+    private static void assertSameOnEveryDate(String legacy, String modern)
+    {
+        for (PureDate date : DATES)
+        {
+            String context = legacy + " and " + modern + " on " + date;
+            String expected;
+            try
+            {
+                expected = format(legacy, date);
+            }
+            catch (IllegalArgumentException e)
+            {
+                Assert.assertEquals(
+                        context,
+                        e.getMessage(),
+                        Assert.assertThrows(context, IllegalArgumentException.class, () -> format(modern, date)).getMessage());
+                continue;
+            }
+            Assert.assertEquals(context, expected, format(modern, date));
+        }
     }
 
     /**

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormat.java
@@ -160,6 +160,27 @@ public class TestDateFormat
     }
 
     /**
+     * Every control character consumes the run of itself that follows it, whether or not the count
+     * means anything to it: a field with no width to widen, and the three time zone notations,
+     * write the same thing however many times the letter is repeated.
+     */
+    @Test
+    public void testFormatRepeatingAControlCharacterWithNoWidth()
+    {
+        Assert.assertEquals("PM", format("a", DATE));
+        Assert.assertEquals("PM", format("aa", DATE));
+        Assert.assertEquals("PM", format("aaaa", DATE));
+        Assert.assertEquals("16 PM", format("HH aaa", DATE));
+
+        Assert.assertEquals("GMT", format("z", DATE));
+        Assert.assertEquals("GMT", format("zzzz", DATE));
+        Assert.assertEquals("+0000", format("Z", DATE));
+        Assert.assertEquals("+0000", format("ZZZZ", DATE));
+        Assert.assertEquals("Z", format("X", DATE));
+        Assert.assertEquals("Z", format("XXXX", DATE));
+    }
+
+    /**
      * The subsecond is cut to one more digit than the format string repeats the letter, but from
      * four letters on it is written in full however many digits it has. It is never padded, so a
      * date with fewer digits than were asked for gives all it has and no more.

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormatPattern.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormatPattern.java
@@ -35,6 +35,7 @@ public class TestDateFormatPattern
 {
     private static final PureDate NANO = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070004235");
     private static final PureDate MILLI = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070");
+    private static final PureDate ONE_MILLI = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "001");
     private static final PureDate HUNDREDTH = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "07");
     private static final PureDate ZERO = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "000");
     private static final PureDate SECOND = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35);
@@ -67,6 +68,13 @@ public class TestDateFormatPattern
             "z",
             "yyyy-MM-dd HH:mm:ss.SSS yy/MM/dd hh:mm a z Z X",
             "SSS.S",
+            "HH:mm:ss.S*",
+            "HH:mm:ss.S<6",
+            "HH:mm:ss.S>3",
+            "HH:mm:ss.S9",
+            "HH:mm:ss.S!3",
+            "HH:mm:ss.S(3!,9!,\"_\")",
+            "S<3.S*",
             "yyyy yyyy yy",
             "z z Z Z X X",
             "\"one\" HH \"two\" HH \"three\""
@@ -433,8 +441,6 @@ public class TestDateFormatPattern
     public void testPatternNormalizesWhatSaysTheSameThing()
     {
         Assert.assertEquals("yyyy-MM-dd", DateFormatPattern.parse("yyyy-MM-dd").pattern());
-        Assert.assertEquals("SSS", DateFormatPattern.parse("SSS").pattern());
-        Assert.assertEquals("SSSS", DateFormatPattern.parse("SSSS").pattern());
 
         // a year of three letters or fewer is the two digit form, and four or more is the whole one
         Assert.assertEquals("yy", DateFormatPattern.parse("y").pattern());
@@ -442,7 +448,6 @@ public class TestDateFormatPattern
         Assert.assertEquals("yyyy", DateFormatPattern.parse("yyyyy").pattern());
 
         // a repeated character with no width to widen writes itself once
-        Assert.assertEquals("SSSS", DateFormatPattern.parse("SSSSSSSSS").pattern());
         Assert.assertEquals("a", DateFormatPattern.parse("aaa").pattern());
         Assert.assertEquals("z", DateFormatPattern.parse("zzz").pattern());
         Assert.assertEquals("Z", DateFormatPattern.parse("ZZ").pattern());
@@ -469,28 +474,37 @@ public class TestDateFormatPattern
     }
 
     /**
-     * A sub-second field the format string spells writes itself that way; one only the builder can
-     * ask for writes the general form, which the format string is to gain and does not yet take
-     * back.
+     * A sub-second field a shorthand covers exactly writes itself that way, and everything else
+     * writes the general form. The repetition form is never written: every field it can spell has a
+     * shorthand meaning precisely the same thing, so a pattern read from a legacy string writes the
+     * modern spelling of what it already meant.
      */
     @Test
     public void testPatternWritesSubsecondFields()
     {
-        Assert.assertEquals("S", builder().subsecond().atMost(1).endSubsecond().build().pattern());
-        Assert.assertEquals("SSS", builder().subsecond().atMost(3).endSubsecond().build().pattern());
-        Assert.assertEquals("SSSS", builder().subsecond().asStored().endSubsecond().build().pattern());
-        Assert.assertEquals("SSSS", builder().subsecond().endSubsecond().build().pattern());
+        Assert.assertEquals("S*", builder().subsecond().asStored().endSubsecond().build().pattern());
+        Assert.assertEquals("S*", builder().subsecond().endSubsecond().build().pattern());
+        Assert.assertEquals("S<1", builder().subsecond().atMost(1).endSubsecond().build().pattern());
+        Assert.assertEquals("S<3", builder().subsecond().atMost(3).endSubsecond().build().pattern());
+        Assert.assertEquals("S<6", builder().subsecond().atMost(6).endSubsecond().build().pattern());
+        Assert.assertEquals("S>3", builder().subsecond().atLeast(3).endSubsecond().build().pattern());
+        Assert.assertEquals("S3", builder().subsecond().exactly(3).endSubsecond().build().pattern());
+        Assert.assertEquals("S!3", builder().subsecond().exactly(3).failBelowMinimum().endSubsecond().build().pattern());
 
-        Assert.assertEquals("S(0,6)", builder().subsecond().atMost(6).endSubsecond().build().pattern());
-        Assert.assertEquals("S(3,3)", builder().subsecond().exactly(3).endSubsecond().build().pattern());
-        Assert.assertEquals("S(3,*)", builder().subsecond().atLeast(3).endSubsecond().build().pattern());
+        // and the general form carries what no shorthand can say
         Assert.assertEquals("S(2,4)", builder().subsecond().between(2, 4).endSubsecond().build().pattern());
-        Assert.assertEquals("S(3!,3)", builder().subsecond().exactly(3).failBelowMinimum().endSubsecond().build().pattern());
         Assert.assertEquals("S(0,3!)", builder().subsecond().atMost(3).failAboveMaximum().endSubsecond().build().pattern());
+        Assert.assertEquals("S(3!,*)", builder().subsecond().atLeast(3).failBelowMinimum().endSubsecond().build().pattern());
         Assert.assertEquals("S(4,4,\"_\")", builder().subsecond().exactly(4).padWith('_').endSubsecond().build().pattern());
         Assert.assertEquals(
                 "S(3!,9!,\"_\")",
                 builder().subsecond().between(3, 9).failBelowMinimum().failAboveMaximum().padWith('_').endSubsecond().build().pattern());
+
+        // a marker with nothing to act on is kept rather than erased, so the field says what it was
+        // asked for even where a shorter spelling would render the same
+        Assert.assertEquals("S(0!,3)", builder().subsecond().atMost(3).failBelowMinimum().endSubsecond().build().pattern());
+        Assert.assertEquals("S(0,*!)", builder().subsecond().asStored().failAboveMaximum().endSubsecond().build().pattern());
+        Assert.assertEquals("S(0,3,\"_\")", builder().subsecond().atMost(3).padWith('_').endSubsecond().build().pattern());
     }
 
     @Test
@@ -624,6 +638,199 @@ public class TestDateFormatPattern
         Assert.assertEquals("S(2,4)", builder().subsecond().exactly(9).between(2, 4).endSubsecond().build().pattern());
     }
 
+    // The sub-second syntax
+
+    /**
+     * Each shorthand is the field the builder describes the same way, reached through the format
+     * string rather than through Java.
+     */
+    @Test
+    public void testTheSubsecondShorthands()
+    {
+        assertSameAs("S*", builder().subsecond().asStored().endSubsecond());
+        assertSameAs("S<3", builder().subsecond().atMost(3).endSubsecond());
+        assertSameAs("S>3", builder().subsecond().atLeast(3).endSubsecond());
+        assertSameAs("S3", builder().subsecond().exactly(3).endSubsecond());
+        assertSameAs("S!3", builder().subsecond().exactly(3).failBelowMinimum().endSubsecond());
+
+        // a width is a number rather than a digit, and a field is an element like any other
+        assertSameAs("S12", builder().subsecond().exactly(12).endSubsecond());
+        assertSameAs("S<10", builder().subsecond().atMost(10).endSubsecond());
+        assertSameAs("HH:mm:ss.S<6", builder()
+                .hour24().literal(':').minute().literal(':').second()
+                .literal('.').subsecond().atMost(6).endSubsecond());
+        assertSameAs("S<3.S*", builder()
+                .subsecond().atMost(3).endSubsecond()
+                .literal('.').subsecond().asStored().endSubsecond());
+    }
+
+    /**
+     * The general form says both bounds, both policies, and the fill at once, which is the whole of
+     * the model and the nine fields it makes.
+     */
+    @Test
+    public void testTheSubsecondGeneralForm()
+    {
+        assertSameAs("S(0,*)", builder().subsecond().asStored().endSubsecond());
+        assertSameAs("S(0,3)", builder().subsecond().atMost(3).endSubsecond());
+        assertSameAs("S(0,3!)", builder().subsecond().atMost(3).failAboveMaximum().endSubsecond());
+        assertSameAs("S(3,*)", builder().subsecond().atLeast(3).endSubsecond());
+        assertSameAs("S(3!,*)", builder().subsecond().atLeast(3).failBelowMinimum().endSubsecond());
+        assertSameAs("S(3,9)", builder().subsecond().between(3, 9).endSubsecond());
+        assertSameAs("S(3,9!)", builder().subsecond().between(3, 9).failAboveMaximum().endSubsecond());
+        assertSameAs("S(3!,9)", builder().subsecond().between(3, 9).failBelowMinimum().endSubsecond());
+        assertSameAs("S(3!,9!)", builder().subsecond().between(3, 9).failBelowMinimum().failAboveMaximum().endSubsecond());
+
+        // a marker with nothing to act on is legal and does nothing, since a format string may be
+        // built at run time and its validity must not turn on how it was written
+        assertSameAs("S(1!,3)", builder().subsecond().between(1, 3).failBelowMinimum().endSubsecond());
+        assertSameAs("S(3,*!)", builder().subsecond().atLeast(3).failAboveMaximum().endSubsecond());
+        assertSameAs("S(0,3,\"_\")", builder().subsecond().atMost(3).padWith('_').endSubsecond());
+    }
+
+    /**
+     * The fill is one character, which a backslash escapes, so every character can be a fill -
+     * including the quote that ends it and the parenthesis that ends the field.
+     */
+    @Test
+    public void testTheSubsecondFill()
+    {
+        assertSameAs("S(3,3,\"_\")", builder().subsecond().exactly(3).padWith('_').endSubsecond());
+        assertSameAs("S(3,3,\" \")", builder().subsecond().exactly(3).padWith(' ').endSubsecond());
+        assertSameAs("S(3,3,\")\")", builder().subsecond().exactly(3).padWith(')').endSubsecond());
+        assertSameAs("S(3,3,\",\")", builder().subsecond().exactly(3).padWith(',').endSubsecond());
+        assertSameAs("S(3,3,\"\\\"\")", builder().subsecond().exactly(3).padWith('"').endSubsecond());
+        assertSameAs("S(3,3,\"\\\\\")", builder().subsecond().exactly(3).padWith('\\').endSubsecond());
+
+        Assert.assertEquals("07_", DateFormatPattern.parse("S(3,3,\"_\")").render(HUNDREDTH));
+        Assert.assertEquals("07\"", DateFormatPattern.parse("S(3,3,\"\\\"\")").render(HUNDREDTH));
+
+        // an escape is only needed for the two characters that would otherwise end it
+        Assert.assertEquals("07_", DateFormatPattern.parse("S(3,3,\"\\_\")").render(HUNDREDTH));
+    }
+
+    /**
+     * Every field of the worked table in the design, against the fractions it works. The last column
+     * of that table is left out because it is uniform: no field decides for itself what a date with
+     * no fraction at all looks like, which {@link #assertWorkedRow} asserts of every row.
+     */
+    @Test
+    public void testEverySubsecondFieldOfTheWorkedTable()
+    {
+        assertWorkedRow("S3", "070", "001", "070");
+        assertWorkedRow("S9", "070004235", "001000000", "070000000");
+        assertWorkedRow("S!3", "070", "001", null);
+        assertWorkedRow("S<3", "070", "001", "07");
+        assertWorkedRow("S>3", "070004235", "001", "070");
+        assertWorkedRow("S*", "070004235", "001", "07");
+        assertWorkedRow("S(0,3!)", null, "001", "07");
+        assertWorkedRow("S(3!,*)", "070004235", "001", null);
+        assertWorkedRow("S(3,3!)", null, "001", "070");
+        assertWorkedRow("S(3!,3!)", null, "001", null);
+        assertWorkedRow("SSS", "070", "001", "07");
+        assertWorkedRow("SSSSSSSSS", "070004235", "001", "07");
+    }
+
+    /**
+     * Every form the repetition spelling can take has a shorthand that means precisely the same
+     * thing, so the older form can be deprecated without anything losing a way to be said. That
+     * equivalence is also what makes {@code pattern()} a migration: it writes the modern spelling of
+     * a field it read from a legacy one.
+     */
+    @Test
+    public void testEveryLegacySubsecondFormHasAModernSpellingThatMeansTheSame()
+    {
+        assertSameField("S", "S<1");
+        assertSameField("SS", "S<2");
+        assertSameField("SSS", "S<3");
+        assertSameField("SSSS", "S*");
+        assertSameField("SSSSS", "S*");
+        assertSameField("SSSSSSSSS", "S*");
+
+        // the discontinuity the modern spellings make visible: the count stops meaning a width at
+        // four letters, where S<3 turns into S*
+        Assert.assertNotEquals(DateFormatPattern.parse("SSS"), DateFormatPattern.parse("SSSS"));
+
+        // and the hazard the design names: S3 is exactly three digits where SSS is at most three
+        Assert.assertNotEquals(DateFormatPattern.parse("S3"), DateFormatPattern.parse("SSS"));
+        Assert.assertEquals("070", DateFormatPattern.parse("S3").render(HUNDREDTH));
+        Assert.assertEquals("07", DateFormatPattern.parse("SSS").render(HUNDREDTH));
+    }
+
+    /**
+     * A sub-second field is rejected where it is incoherent or ambiguous, and nowhere else.
+     */
+    @Test
+    public void testSubsecondSyntaxErrors()
+    {
+        assertValidationFails("Expected a digit count after 'S<' in format string: S<", "S<");
+        assertValidationFails("Expected a digit count after 'S>' in format string: S>", "S>");
+        assertValidationFails("Expected a digit count after 'S!' in format string: S!", "S!");
+        assertValidationFails("Expected a digit count after 'S!' in format string: S!x", "S!x");
+        assertValidationFails("Expected a digit count after 'S(' in format string: S(", "S(");
+        assertValidationFails("Expected a digit count after 'S(' in format string: S(-1,3)", "S(-1,3)");
+        assertValidationFails("Expected ',' after the sub-second minimum in format string: S(3", "S(3");
+        assertValidationFails("Expected ',' after the sub-second minimum in format string: S(3)", "S(3)");
+        assertValidationFails("Expected a digit count or '*' for the sub-second maximum in format string: S(3,", "S(3,");
+        assertValidationFails("Expected a digit count or '*' for the sub-second maximum in format string: S(3,x)", "S(3,x)");
+        assertValidationFails("Missing closing parenthesis in format string: S(3,3", "S(3,3");
+        assertValidationFails("Missing closing parenthesis in format string: S(3,3,\"_\"", "S(3,3,\"_\"");
+        assertValidationFails("Expected a quoted sub-second fill character in format string: S(3,3,x)", "S(3,3,x)");
+        assertValidationFails("Missing closing quote in format string: S(3,3,\"_", "S(3,3,\"_");
+        assertValidationFails("Sub-second fill must be a single character in format string: S(3,3,\"\")", "S(3,3,\"\")");
+        assertValidationFails("Sub-second fill must be a single character in format string: S(3,3,\"ab\")", "S(3,3,\"ab\")");
+
+        // a width nothing satisfies, named against the string the caller wrote
+        assertValidationFails("Sub-second minimum 5 exceeds maximum 3 in format string: S(5,3)", "S(5,3)");
+        assertValidationFails("Sub-second maximum must be at least 1: 0 in format string: S<0", "S<0");
+        assertValidationFails("Sub-second maximum must be at least 1: 0 in format string: S0", "S0");
+        assertValidationFails("Sub-second maximum must be at least 1: 0 in format string: S(0,0)", "S(0,0)");
+        assertValidationFails("Sub-second maximum must be at least 1: 0 in format string: S!0", "S!0");
+
+        // a count too large to tell from the number standing for an unbounded maximum
+        assertValidationFails("Sub-second digit count is too large in format string: S99999999999", "S99999999999");
+        assertValidationFails("Sub-second digit count is too large in format string: S<2147483647", "S<2147483647");
+        DateFormat.validate("S<2147483646");
+
+        // a width follows the S rather than a run of them, so a run and then a width is neither
+        assertValidationFails("Invalid format control character '3' in format string: SS3", "SS3");
+    }
+
+    /**
+     * Every sub-second field the builder can reach writes a format string the parser takes back as
+     * the same field, and writing that field again gives the same string. This is the round trip the
+     * sub-second syntax exists to close: before it, the builder could describe fields no format
+     * string could spell.
+     */
+    @Test
+    public void testEverySubsecondFieldTheBuilderCanReachRoundTrips()
+    {
+        int[] widths = {0, 1, 2, 3, 9, 12};
+        char[] fills = {'0', '_', ' ', '"', '\\', ')', '(', ',', '*', '!', 'S', '\t', '\n', '3'};
+        int round = 0;
+        for (int minimum : widths)
+        {
+            for (int maximum : widths)
+            {
+                if ((maximum >= 1) && (minimum <= maximum))
+                {
+                    for (boolean failBelow : new boolean[]{false, true})
+                    {
+                        for (boolean failAbove : new boolean[]{false, true})
+                        {
+                            char fill = fills[round++ % fills.length];
+                            assertRoundTrips(field(minimum, maximum, failBelow, failAbove, fill));
+                            assertRoundTrips(field(minimum, -1, failBelow, failAbove, fill));
+                        }
+                    }
+                }
+            }
+        }
+
+        // sub-second precision is unbounded, so a width is capped only by what a number can carry
+        assertRoundTrips(field(0, Integer.MAX_VALUE - 1, false, false, '0'));
+    }
+
     // Equality and description
 
     @Test
@@ -719,6 +926,102 @@ public class TestDateFormatPattern
         // and no field decides for itself what a date with no fraction at all looks like
         assertSubsecond(pattern, SECOND, null);
         assertSubsecond(pattern, DAY, null);
+    }
+
+    /**
+     * Assert that a format string holding one sub-second field writes what the design's worked
+     * table says of it, a null standing for a field that refuses the date rather than writing it.
+     * The table's last column is not a parameter because it is uniform: no field decides for itself
+     * what a date with no fraction at all looks like.
+     *
+     * @param formatString format string holding the field
+     * @param nano         what it writes for {@code .070004235}
+     * @param oneMilli     what it writes for {@code .001}
+     * @param hundredth    what it writes for {@code .07}
+     */
+    private static void assertWorkedRow(String formatString, String nano, String oneMilli, String hundredth)
+    {
+        DateFormatPattern pattern = DateFormatPattern.parse(formatString);
+        assertSubsecond(pattern, NANO, nano);
+        assertSubsecond(pattern, ONE_MILLI, oneMilli);
+        assertSubsecond(pattern, HUNDREDTH, hundredth);
+        assertSubsecond(pattern, SECOND, null);
+        assertSubsecond(pattern, DAY, null);
+    }
+
+    /**
+     * Assert that two format strings hold the same field, and that the second is the spelling the
+     * pattern writes for it.
+     *
+     * @param legacy format string in the repetition form
+     * @param modern format string in the form that replaces it
+     */
+    private static void assertSameField(String legacy, String modern)
+    {
+        DateFormatPattern read = DateFormatPattern.parse(legacy);
+        Assert.assertEquals(legacy, DateFormatPattern.parse(modern), read);
+        Assert.assertEquals(legacy, DateFormatPattern.parse(modern).hashCode(), read.hashCode());
+        Assert.assertEquals(legacy, modern, read.pattern());
+    }
+
+    /**
+     * Build a pattern holding one sub-second field.
+     *
+     * @param minimum   fewest digits to write
+     * @param maximum   most digits to write, or a negative number for an unbounded maximum
+     * @param failBelow whether to fail rather than pad below the minimum
+     * @param failAbove whether to fail rather than truncate above the maximum
+     * @param fill      character to pad with
+     * @return pattern holding the field
+     */
+    private static DateFormatPattern field(int minimum, int maximum, boolean failBelow, boolean failAbove, char fill)
+    {
+        SubsecondBuilder field = builder().subsecond();
+        if (maximum < 0)
+        {
+            field.atLeast(minimum);
+        }
+        else
+        {
+            field.between(minimum, maximum);
+        }
+        if (failBelow)
+        {
+            field.failBelowMinimum();
+        }
+        if (failAbove)
+        {
+            field.failAboveMaximum();
+        }
+        return field.padWith(fill).endSubsecond().build();
+    }
+
+    /**
+     * Assert that a pattern writes a format string the parser takes back as the same pattern, that
+     * writing it again gives the same string, and that the string renders through {@code format}
+     * what the pattern renders directly.
+     *
+     * @param pattern pattern to round trip
+     */
+    private static void assertRoundTrips(DateFormatPattern pattern)
+    {
+        String written = pattern.pattern();
+        DateFormatPattern read = DateFormatPattern.parse(written);
+        Assert.assertEquals(written, pattern, read);
+        Assert.assertEquals(written, pattern.hashCode(), read.hashCode());
+        Assert.assertEquals(written, written, read.pattern());
+        for (PureDate date : new PureDate[]{NANO, MILLI, ONE_MILLI, HUNDREDTH, ZERO, SECOND})
+        {
+            String context = written + " on " + date;
+            Assert.assertEquals(context, pattern.canRender(date), read.canRender(date));
+            if (pattern.canRender(date))
+            {
+                Assert.assertEquals(
+                        context,
+                        pattern.render(date),
+                        DateFormat.format(new StringBuilder(), written, date).toString());
+            }
+        }
     }
 
     private static void assertSubsecond(DateFormatPattern pattern, PureDate date, String expected)

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormatPattern.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormatPattern.java
@@ -39,6 +39,7 @@ public class TestDateFormatPattern
     private static final PureDate HUNDREDTH = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "07");
     private static final PureDate ZERO = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "000");
     private static final PureDate SECOND = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35);
+    private static final PureDate MINUTE = DateFunctions.newPureDate(2014, 3, 10, 16, 12);
     private static final PureDate DAY = DateFunctions.newPureDate(2014, 3, 10);
     private static final PureDate YEAR = DateFunctions.newPureDate(2014);
 
@@ -75,6 +76,15 @@ public class TestDateFormatPattern
             "HH:mm:ss.S!3",
             "HH:mm:ss.S(3!,9!,\"_\")",
             "S<3.S*",
+            "yyyy?[-MM?[-dd?[\"T\"HH:mm:ss]]]",
+            "?[HH:mm:ss|HH:mm|HH|--]",
+            "yyyy-MM-dd?[\" at \"HH:mm]",
+            "yyyy?[-MM?[-dd?[\"T\"HH?[:mm?[:ss?[.S*]]]]]]",
+            "?[yyyy-MM-dd|\"(no day)\"]",
+            "?[HH|\"\"]",
+            "?[\"\"|HH]",
+            "?[?[HH]|\"x\"]",
+            "[America/New_York]yyyy-MM-dd?[\"T\"HH:mm:ssX]",
             "yyyy yyyy yy",
             "z z Z Z X X",
             "\"one\" HH \"two\" HH \"three\""
@@ -231,6 +241,9 @@ public class TestDateFormatPattern
         assertOpenSubsecondRefuses(Builder::rfc822TimeZoneOffset);
         assertOpenSubsecondRefuses(Builder::iso8601TimeZoneOffset);
         assertOpenSubsecondRefuses(Builder::subsecond);
+        assertOpenSubsecondRefuses(Builder::optional);
+        assertOpenSubsecondRefuses(Builder::or);
+        assertOpenSubsecondRefuses(Builder::endOptional);
         assertOpenSubsecondRefuses(Builder::build);
     }
 
@@ -453,10 +466,13 @@ public class TestDateFormatPattern
         Assert.assertEquals("Z", DateFormatPattern.parse("ZZ").pattern());
         Assert.assertEquals("X", DateFormatPattern.parse("XX").pattern());
 
-        // a separator stands for itself, quoted or not, and adjacent text is one run
+        // a separator stands for itself, quoted or not, and adjacent text is one run, quoted whole
         Assert.assertEquals("-", DateFormatPattern.parse("\"-\"").pattern());
-        Assert.assertEquals("\"at\" \"T\" HH", DateFormatPattern.parse("\"at\" \"T\" HH").pattern());
+        Assert.assertEquals("--", DateFormatPattern.parse("\"--\"").pattern());
+        Assert.assertEquals("\"at T \"HH", DateFormatPattern.parse("\"at\" \"T\" HH").pattern());
         Assert.assertEquals("\"abc\"", builder().literal('a').literal("b").literal('c').build().pattern());
+        Assert.assertEquals("\" at \"", builder().literal(" at ").build().pattern());
+        Assert.assertEquals("\".000\"", builder().literal(".000").build().pattern());
     }
 
     /**
@@ -831,6 +847,202 @@ public class TestDateFormatPattern
         assertRoundTrips(field(0, Integer.MAX_VALUE - 1, false, false, '0'));
     }
 
+    // Optional sections
+
+    /**
+     * A section writes the first alternative the date can carry, and nothing at all where the date
+     * can carry none of them.
+     */
+    @Test
+    public void testOptionalSections()
+    {
+        assertSection("yyyy?[-MM?[-dd?[\"T\"HH:mm:ss]]]",
+                "2014-03-10T16:12:35", "2014-03-10T16:12:35", "2014-03-10", "2014");
+        assertSection("?[HH:mm:ss|HH:mm|HH|--]",
+                "16:12:35", "16:12:35", "--", "--");
+        assertSection("yyyy-MM-dd?[\" at \"HH:mm]",
+                "2014-03-10 at 16:12", "2014-03-10 at 16:12", "2014-03-10", null);
+        assertSection("yyyy-MM-dd\"T\"HH:mm:ss?[.S*]",
+                "2014-03-10T16:12:35.070004235", "2014-03-10T16:12:35", null, null);
+
+        // nested to the full depth of the type, this writes a date at whatever precision it carries,
+        // which is the shape a format string could not previously take
+        assertSection("yyyy?[-MM?[-dd?[\"T\"HH?[:mm?[:ss?[.S*]]]]]]",
+                "2014-03-10T16:12:35.070004235", "2014-03-10T16:12:35", "2014-03-10", "2014");
+    }
+
+    /**
+     * A section asks the date for nothing on its own account, so one nested inside another adds no
+     * requirement to the alternative holding it. That is the one surprise in nesting, and hoisting
+     * the literal out of the inner section is what makes the two rise and fall together.
+     */
+    @Test
+    public void testANestedSectionAddsNoRequirementToTheOneHoldingIt()
+    {
+        Assert.assertEquals("16:12", DateFormatPattern.parse("?[HH:mm?[:ss]]").render(MINUTE));
+        Assert.assertEquals("16:12:00", DateFormatPattern.parse("?[HH:mm?[:ss|\":00\"]]").render(MINUTE));
+        Assert.assertEquals("16:12:35", DateFormatPattern.parse("?[HH:mm?[:ss]]").render(SECOND));
+
+        Assert.assertEquals(" at ", DateFormatPattern.parse("?[\" at \"?[HH:mm]]").render(DAY));
+        Assert.assertEquals("", DateFormatPattern.parse("?[\" at \"HH:mm]").render(DAY));
+        Assert.assertEquals(" at 16:12", DateFormatPattern.parse("?[\" at \"?[HH:mm]]").render(SECOND));
+
+        // and an alternative that is only a nested section can always write, so what follows it is
+        // dead
+        Assert.assertEquals("16", DateFormatPattern.parse("?[?[HH]|\"x\"]").render(SECOND));
+        Assert.assertEquals("", DateFormatPattern.parse("?[?[HH]|\"x\"]").render(DAY));
+    }
+
+    /**
+     * A section never fails, whatever it holds, so a pattern whose date-dependent parts all sit
+     * inside one writes any date at all.
+     */
+    @Test
+    public void testASectionNeverFails()
+    {
+        assertCanRender("?[HH:mm:ss]", true, true, true, true);
+        assertCanRender("?[HH:mm:ss|\"--\"]", true, true, true, true);
+        assertCanRender("?[.S!9]", true, true, true, true);
+        assertCanRender("yyyy?[-MM-dd]", true, true, true, true);
+
+        // what is outside a section still fails, section or no section
+        assertCanRender("yyyy-MM-dd?[\" at \"HH:mm]", false, true, true, true);
+    }
+
+    /**
+     * A throwing sub-second bound inside a section selects the next alternative where outside one it
+     * would raise, which makes a section that falls back because the date carries too much rather
+     * than too little. That is a new kind of conditionality and worth pinning rather than
+     * discovering.
+     */
+    @Test
+    public void testAThrowingSubsecondBoundInsideASectionSelectsRatherThanRaises()
+    {
+        DateFormatPattern pattern = DateFormatPattern.parse("?[.S(0,3!)|\".(truncated)\"]");
+        Assert.assertEquals(".(truncated)", pattern.render(NANO));
+        Assert.assertEquals(".070", pattern.render(MILLI));
+        Assert.assertEquals(".07", pattern.render(HUNDREDTH));
+        Assert.assertEquals(".(truncated)", pattern.render(SECOND));
+
+        // outside a section the same field raises rather than selecting
+        Assert.assertThrows(IllegalArgumentException.class, () -> DateFormatPattern.parse(".S(0,3!)").render(NANO));
+
+        // and the same holds of the lower bound
+        DateFormatPattern atLeastMillis = DateFormatPattern.parse("?[.S!3|\".000\"]");
+        Assert.assertEquals(".070", atLeastMillis.render(MILLI));
+        Assert.assertEquals(".000", atLeastMillis.render(HUNDREDTH));
+        Assert.assertEquals(".000", atLeastMillis.render(SECOND));
+    }
+
+    /**
+     * An alternative that writes nothing has to be spelled out, since an empty one is refused. It
+     * says what the section without it already says at the back, and short-circuits the whole
+     * section at the front.
+     */
+    @Test
+    public void testAnAlternativeThatWritesNothingIsSpelledOut()
+    {
+        Assert.assertEquals("16", DateFormatPattern.parse("?[HH|\"\"]").render(SECOND));
+        Assert.assertEquals("", DateFormatPattern.parse("?[HH|\"\"]").render(DAY));
+
+        // at the front it wins outright, which is what writing it rather than leaving a gap admits
+        Assert.assertEquals("", DateFormatPattern.parse("?[\"\"|HH]").render(SECOND));
+
+        // and an empty literal is an element, so it is written back rather than vanishing
+        Assert.assertEquals("?[HH|\"\"]", DateFormatPattern.parse("?[HH|\"\"]").pattern());
+        Assert.assertEquals("\"\"", DateFormatPattern.parse("\"\"").pattern());
+        Assert.assertNotEquals(DateFormatPattern.parse("\"\""), DateFormatPattern.parse(""));
+    }
+
+    /**
+     * A section built element by element is the section the same format string parses into.
+     */
+    @Test
+    public void testTheBuilderAndTheParserAgreeOnSections()
+    {
+        assertSameAs("yyyy-MM-dd?[\" at \"HH:mm]", builder()
+                .year().literal('-').month().literal('-').day()
+                .optional().literal(" at ").hour24().literal(':').minute().endOptional());
+
+        assertSameAs("?[HH:mm:ss|HH:mm|HH|--]", builder()
+                .optional()
+                .hour24().literal(':').minute().literal(':').second()
+                .or().hour24().literal(':').minute()
+                .or().hour24()
+                .or().literal("--")
+                .endOptional());
+
+        assertSameAs("yyyy?[-MM?[-dd?[\"T\"HH:mm:ss]]]", builder()
+                .year()
+                .optional().literal('-').month()
+                .optional().literal('-').day()
+                .optional().literal('T').hour24().literal(':').minute().literal(':').second()
+                .endOptional()
+                .endOptional()
+                .endOptional());
+
+        assertSameAs("[America/New_York]yyyy-MM-dd?[\"T\"HH:mm:ssX]", builder()
+                .timeZone("America/New_York")
+                .year().literal('-').month().literal('-').day()
+                .optional().literal('T').hour24().literal(':').minute().literal(':').second()
+                .iso8601TimeZoneOffset().endOptional());
+
+        assertSameAs("HH:mm?[.S3]", builder()
+                .hour24().literal(':').minute()
+                .optional().literal('.').subsecond().exactly(3).endSubsecond().endOptional());
+    }
+
+    /**
+     * A section is refused where it is not closed, not opened, or holds an alternative with nothing
+     * in it.
+     */
+    @Test
+    public void testSectionSyntaxErrors()
+    {
+        assertValidationFails("Expected '[' after '?' in format string: yyyy?", "yyyy?");
+        assertValidationFails("Expected '[' after '?' in format string: yyyy?x", "yyyy?x");
+        assertValidationFails("Missing closing bracket for optional section in format string: ?[HH:mm", "?[HH:mm");
+        assertValidationFails("Missing closing bracket for optional section in format string: ?[HH:mm?[:ss]", "?[HH:mm?[:ss]");
+        assertValidationFails("Unmatched ']' in format string: HH]", "HH]");
+        assertValidationFails("Unmatched ']' in format string: ?[HH]]", "?[HH]]");
+        assertValidationFails("'|' outside an optional section in format string: HH|mm", "HH|mm");
+        assertValidationFails("Empty alternative in optional section in format string: ?[|HH]", "?[|HH]");
+        assertValidationFails("Empty alternative in optional section in format string: ?[HH|]", "?[HH|]");
+        assertValidationFails("Empty alternative in optional section in format string: ?[]", "?[]");
+
+        // a zone still opens the whole string and nothing else, which a section does not change
+        assertValidationFails("Time zone can only be set at the beginning of the format string", "?[[EST]HH]");
+    }
+
+    /**
+     * A section is closed by the builder that opened it, and an alternative reaches the pattern only
+     * with something in it.
+     */
+    @Test
+    public void testTheBuilderRefusesASectionItCannotBuild()
+    {
+        assertBuilderFailsWithState("No optional section is open: call optional() before or()", () -> builder().or());
+        assertBuilderFailsWithState("No optional section is open: call optional() before endOptional()", () -> builder().endOptional());
+        assertBuilderFailsWithState(
+                "No optional section is open: call optional() before endOptional()",
+                () -> builder().optional().hour24().endOptional().endOptional());
+        assertBuilderFailsWithState(
+                "An optional section is still open: call endOptional() before anything else",
+                () -> builder().optional().hour24().build());
+        assertBuilderFailsWithState(
+                "An optional section may not hold an alternative with nothing in it",
+                () -> builder().optional().or());
+        assertBuilderFailsWithState(
+                "An optional section may not hold an alternative with nothing in it",
+                () -> builder().optional().endOptional());
+        assertBuilderFailsWithState(
+                "An optional section may not hold an alternative with nothing in it",
+                () -> builder().optional().hour24().or().endOptional());
+
+        // and a builder that closed its sections builds as it always did
+        Assert.assertEquals("16", builder().optional().hour24().endOptional().build().render(SECOND));
+    }
+
     // Equality and description
 
     @Test
@@ -1110,6 +1322,32 @@ public class TestDateFormatPattern
         Assert.assertEquals(
                 "This sub-second field has already been ended",
                 Assert.assertThrows(IllegalStateException.class, () -> call.accept(field)).getMessage());
+    }
+
+    /**
+     * Assert that a pattern holding one optional section writes what is expected of each of the
+     * four granularities the tests use, a null standing for a pattern that refuses the date.
+     *
+     * @param formatString format string holding the section
+     * @param nano         what it writes for a date with a nine digit fraction
+     * @param second       what it writes for a date to the second
+     * @param day          what it writes for a date to the day
+     * @param year         what it writes for a date to the year
+     */
+    private static void assertSection(String formatString, String nano, String second, String day, String year)
+    {
+        DateFormatPattern pattern = DateFormatPattern.parse(formatString);
+        assertSubsecond(pattern, NANO, nano);
+        assertSubsecond(pattern, SECOND, second);
+        assertSubsecond(pattern, DAY, day);
+        assertSubsecond(pattern, YEAR, year);
+    }
+
+    private static void assertBuilderFailsWithState(String expectedMessage, Runnable builderCall)
+    {
+        Assert.assertEquals(
+                expectedMessage,
+                Assert.assertThrows(expectedMessage, IllegalStateException.class, builderCall::run).getMessage());
     }
 
     private static void assertBuilderFails(String expectedMessage, Runnable builderCall)

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormatPattern.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormatPattern.java
@@ -955,6 +955,35 @@ public class TestDateFormatPattern
     }
 
     /**
+     * A section and a sub-second field do not do each other's work, and the two spellings that look
+     * as though they might are the ones to be careful of. Nothing a field can say answers for a date
+     * with no fraction, and nothing a section can say pads a short one, so saying both takes both.
+     */
+    @Test
+    public void testASectionAndASubsecondFieldDoNotDoEachOthersWork()
+    {
+        DateFormatPattern section = DateFormatPattern.parse("?[SSS|\"000\"]");
+        DateFormatPattern field = DateFormatPattern.parse("S3");
+
+        // they agree only where the date carries exactly what both ask for
+        Assert.assertEquals("070", section.render(MILLI));
+        Assert.assertEquals("070", field.render(MILLI));
+
+        // on a short fraction only the field pads
+        Assert.assertEquals("07", section.render(HUNDREDTH));
+        Assert.assertEquals("070", field.render(HUNDREDTH));
+
+        // and on no fraction at all only the section has anything to say
+        Assert.assertEquals("000", section.render(SECOND));
+        Assert.assertFalse(field.canRender(SECOND));
+
+        DateFormatPattern both = DateFormatPattern.parse("?[S3|\"000\"]");
+        Assert.assertEquals("070", both.render(MILLI));
+        Assert.assertEquals("070", both.render(HUNDREDTH));
+        Assert.assertEquals("000", both.render(SECOND));
+    }
+
+    /**
      * A section built element by element is the section the same format string parses into.
      */
     @Test

--- a/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormatPattern.java
+++ b/legend-pure-core/legend-pure-m4/src/test/java/org/finos/legend/pure/m4/coreinstance/primitive/date/TestDateFormatPattern.java
@@ -1,0 +1,826 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.m4.coreinstance.primitive.date;
+
+import org.finos.legend.pure.m4.coreinstance.primitive.date.DateFormatPattern.Builder;
+import org.finos.legend.pure.m4.coreinstance.primitive.date.DateFormatPattern.SubsecondBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.ZoneId;
+import java.util.function.Consumer;
+
+/**
+ * Tests for {@link DateFormatPattern}: the two ways of getting one, the way back to the format
+ * string, and what each element does with a date.
+ *
+ * <p>{@link TestDateFormat} covers what a format string means, which is the same question asked
+ * through {@link DateFormat#format}. These tests go at the pattern itself, so they can reach the
+ * builder, the range overload, and the sub-second widths and policies that no format string spells
+ * yet.
+ */
+public class TestDateFormatPattern
+{
+    private static final PureDate NANO = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070004235");
+    private static final PureDate MILLI = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "070");
+    private static final PureDate HUNDREDTH = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "07");
+    private static final PureDate ZERO = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35, "000");
+    private static final PureDate SECOND = DateFunctions.newPureDate(2014, 3, 10, 16, 12, 35);
+    private static final PureDate DAY = DateFunctions.newPureDate(2014, 3, 10);
+    private static final PureDate YEAR = DateFunctions.newPureDate(2014);
+
+    /**
+     * Format strings covering every element, and every element more than once, for the tests that
+     * hold over all of them.
+     */
+    private static final String[] FORMAT_STRINGS = {
+            "",
+            "yyyy",
+            "yy",
+            "yyyy-MM-dd",
+            "yyyy-MM-dd\"T\"HH:mm:ss.SSSZ",
+            "yyyyMMdd\"T\"HHmmssX",
+            "M/d/yyyy h:mm a",
+            "HH:mm:ss.S",
+            "HH:mm:ss.SS",
+            "HH:mm:ss.SSSS",
+            "MMMM/dddd",
+            "[EST]yyyy-MM-dd HH:mm:ss z Z",
+            "[America/New_York]HH:mm X",
+            "[+05:30]HH:mmZ",
+            "\"at\" \"T\" HH",
+            "\"a\\\"b\" HH",
+            "yyyy-.-",
+            "yyyy\t MM",
+            "z",
+            "yyyy-MM-dd HH:mm:ss.SSS yy/MM/dd hh:mm a z Z X",
+            "SSS.S",
+            "yyyy yyyy yy",
+            "z z Z Z X X",
+            "\"one\" HH \"two\" HH \"three\""
+    };
+
+    // Building a pattern
+
+    /**
+     * A pattern built element by element renders what the same format string renders, and is equal
+     * to the pattern that string parses into. The builder is the same model reached another way,
+     * not a second one.
+     */
+    @Test
+    public void testTheBuilderAndTheParserAgree()
+    {
+        assertSameAs("yyyy-MM-dd", builder()
+                .year().literal('-').month().literal('-').day());
+
+        assertSameAs("yyyy-MM-dd\"T\"HH:mm:ss.SSSX", builder()
+                .year().literal('-').month().literal('-').day()
+                .literal('T')
+                .hour24().literal(':').minute().literal(':').second()
+                .literal('.').subsecond().atMost(3).endSubsecond()
+                .iso8601TimeZoneOffset());
+
+        assertSameAs("yy/M/d h:mm a", builder()
+                .twoDigitYear().literal('/').month(1).literal('/').day(1)
+                .literal(' ').hour12(1).literal(':').minute().literal(' ').amPm());
+
+        assertSameAs("[America/New_York]yyyy-MM-dd HH:mm:ss z Z", builder()
+                .timeZone("America/New_York")
+                .year().literal('-').month().literal('-').day()
+                .literal(' ').hour24().literal(':').minute().literal(':').second()
+                .literal(' ').timeZoneName().literal(' ').rfc822TimeZoneOffset());
+
+        assertSameAs("", builder());
+    }
+
+    /**
+     * The builder writes text a format string would have to quote, or could not carry at all.
+     */
+    @Test
+    public void testTheBuilderTakesAnyLiteralText()
+    {
+        Assert.assertEquals(
+                "on 2014-03-10 at 16:12 (\"local\")",
+                builder()
+                        .literal("on ").year().literal('-').month().literal('-').day()
+                        .literal(" at ").hour24().literal(':').minute()
+                        .literal(" (\"local\")")
+                        .build()
+                        .render(NANO));
+
+        // including the characters a format string reads as control characters
+        Assert.assertEquals("yyyy=2014", builder().literal("yyyy=").year().build().render(NANO));
+    }
+
+    /**
+     * A builder may be built from more than once, and each pattern it gives out stands on its own.
+     */
+    @Test
+    public void testABuilderCanBeBuiltFromTwice()
+    {
+        Builder builder = builder().year().literal('-').month();
+        DateFormatPattern first = builder.build();
+        DateFormatPattern second = builder.literal('-').day().build();
+
+        Assert.assertEquals("2014-03", first.render(NANO));
+        Assert.assertEquals("2014-03-10", second.render(NANO));
+        Assert.assertEquals("2014-03", first.render(NANO));
+    }
+
+    /**
+     * The time zone belongs to the pattern rather than to a position within it, so it may be named
+     * after the element that writes its name.
+     */
+    @Test
+    public void testTheTimeZoneMayBeNamedAtAnyPoint()
+    {
+        Assert.assertEquals(
+                "11:12 EST",
+                builder()
+                        .hour24().literal(':').minute().literal(' ').timeZoneName()
+                        .timeZone("EST")
+                        .build()
+                        .render(NANO));
+
+        // with no zone named, the general notation still answers, and says UTC
+        Assert.assertEquals(
+                "16:12 GMT",
+                builder()
+                        .hour24().literal(':').minute().literal(' ').timeZoneName()
+                        .build()
+                        .render(NANO));
+
+        // naming one twice keeps the second
+        Assert.assertEquals(
+                "17:12 CET",
+                builder()
+                        .timeZone("EST")
+                        .hour24().literal(':').minute().literal(' ').timeZoneName()
+                        .timeZone("CET")
+                        .build()
+                        .render(NANO));
+    }
+
+    @Test
+    public void testTheBuilderTakesAZoneIdAsWellAsAName()
+    {
+        DateFormatPattern pattern = builder()
+                .timeZone(ZoneId.of("America/New_York"))
+                .hour24().literal(':').minute()
+                .build();
+        Assert.assertEquals("12:12", pattern.render(NANO));
+        Assert.assertEquals(ZoneId.of("America/New_York"), pattern.getTimeZone());
+        Assert.assertNull(DateFormatPattern.parse("HH:mm").getTimeZone());
+    }
+
+    @Test
+    public void testTheBuilderRejectsWhatItCannotBuild()
+    {
+        assertBuilderFails("Width must be at least 1 digit: 0", () -> builder().month(0));
+        assertBuilderFails("Width must be at least 1 digit: -1", () -> builder().second(-1));
+        assertBuilderFails("Unknown time zone: Europe/Lissabon", () -> builder().timeZone("Europe/Lissabon").build());
+    }
+
+    /**
+     * A sub-second field reaches the pattern when it is ended and not before, and until then the
+     * builder it belongs to will do nothing else at all. Ending it quietly, at the next call or at
+     * {@code build}, would commit a field its author may not have finished writing, and nothing in
+     * the half-written chain says which they meant.
+     */
+    @Test
+    public void testABuilderRefusesToWorkAroundAnOpenSubsecondField()
+    {
+        Assert.assertEquals(
+                "2014.070",
+                builder().year().literal('.').subsecond().exactly(3).endSubsecond().build().render(NANO));
+
+        assertOpenSubsecondRefuses(Builder::year);
+        assertOpenSubsecondRefuses(Builder::twoDigitYear);
+        assertOpenSubsecondRefuses(Builder::month);
+        assertOpenSubsecondRefuses(builder -> builder.day(1));
+        assertOpenSubsecondRefuses(Builder::hour24);
+        assertOpenSubsecondRefuses(Builder::hour12);
+        assertOpenSubsecondRefuses(Builder::amPm);
+        assertOpenSubsecondRefuses(Builder::minute);
+        assertOpenSubsecondRefuses(Builder::second);
+        assertOpenSubsecondRefuses(builder -> builder.literal('x'));
+        assertOpenSubsecondRefuses(builder -> builder.literal("x"));
+        assertOpenSubsecondRefuses(builder -> builder.timeZone("EST"));
+        assertOpenSubsecondRefuses(builder -> builder.timeZone(ZoneId.of("America/New_York")));
+        assertOpenSubsecondRefuses(Builder::timeZoneName);
+        assertOpenSubsecondRefuses(Builder::rfc822TimeZoneOffset);
+        assertOpenSubsecondRefuses(Builder::iso8601TimeZoneOffset);
+        assertOpenSubsecondRefuses(Builder::subsecond);
+        assertOpenSubsecondRefuses(Builder::build);
+    }
+
+    /**
+     * A field is finished with once it has been ended, so it can neither be told anything more nor
+     * added to the pattern a second time.
+     */
+    @Test
+    public void testASubsecondFieldCannotBeUsedAfterItIsEnded()
+    {
+        assertEndedSubsecondRefuses(SubsecondBuilder::asStored);
+        assertEndedSubsecondRefuses(field -> field.exactly(6));
+        assertEndedSubsecondRefuses(field -> field.atMost(6));
+        assertEndedSubsecondRefuses(field -> field.atLeast(6));
+        assertEndedSubsecondRefuses(field -> field.between(2, 6));
+        assertEndedSubsecondRefuses(SubsecondBuilder::failBelowMinimum);
+        assertEndedSubsecondRefuses(SubsecondBuilder::failAboveMaximum);
+        assertEndedSubsecondRefuses(field -> field.padWith('_'));
+        assertEndedSubsecondRefuses(SubsecondBuilder::endSubsecond);
+
+        // and the pattern holds the one field the one time it was ended
+        Builder builder = builder().year();
+        SubsecondBuilder field = builder.subsecond().exactly(3);
+        field.endSubsecond();
+        Assert.assertEquals("2014070", builder.build().render(NANO));
+    }
+
+    // Elements appearing more than once
+
+    /**
+     * Everything but the time zone name may be asked for as often as a pattern likes, and each
+     * asking is answered on its own terms. The time zone itself is the one thing a pattern has only
+     * one of, since it is a property of the pattern rather than of a position in it.
+     */
+    @Test
+    public void testAnElementMayAppearMoreThanOnce()
+    {
+        Assert.assertEquals(
+                "2014-03-10 16:12:35.070 14/03/10 04:12 PM GMT +0000 Z",
+                DateFormat.format(new StringBuilder(), "yyyy-MM-dd HH:mm:ss.SSS yy/MM/dd hh:mm a z Z X", NANO).toString());
+
+        // and in a zone, where each asking sees the same shifted reading
+        Assert.assertEquals(
+                "2014-03-10 11:12:35.070 14/03/10 11:12 AM EST -0500 -05",
+                DateFormat.format(new StringBuilder(), "[EST]yyyy-MM-dd HH:mm:ss.SSS yy/MM/dd hh:mm a z Z X", NANO).toString());
+
+        // sub-second fields of different widths, side by side
+        Assert.assertEquals("070.0", DateFormat.format(new StringBuilder(), "SSS.S", NANO).toString());
+        Assert.assertEquals("07.070004235", DateFormat.format(new StringBuilder(), "SS.SSSS", NANO).toString());
+    }
+
+    /**
+     * The same holds of a pattern the builder made, where the sub-second fields need not agree on
+     * anything at all.
+     */
+    @Test
+    public void testTheBuilderTakesAnElementMoreThanOnce()
+    {
+        Assert.assertEquals(
+                "070|070004235|07",
+                builder()
+                        .subsecond().exactly(3).endSubsecond()
+                        .literal('|')
+                        .subsecond().asStored().endSubsecond()
+                        .literal('|')
+                        .subsecond().atMost(2).endSubsecond()
+                        .build()
+                        .render(NANO));
+
+        // one field failing is the whole pattern failing, wherever it sits
+        DateFormatPattern pattern = builder()
+                .subsecond().atMost(3).endSubsecond()
+                .literal('|')
+                .subsecond().exactly(3).failBelowMinimum().endSubsecond()
+                .build();
+        Assert.assertTrue(pattern.canRender(MILLI));
+        Assert.assertFalse(pattern.canRender(HUNDREDTH));
+
+        // and the time zone name may be written as often as a pattern likes, however late the zone
+        // it names is settled
+        Assert.assertEquals(
+                "EST 11:12 EST",
+                builder()
+                        .timeZoneName().literal(' ').hour24().literal(':').minute().literal(' ').timeZoneName()
+                        .timeZone("EST")
+                        .build()
+                        .render(NANO));
+    }
+
+    // Parsing a portion of a string
+
+    /**
+     * The overload taking a range parses a format string out of the middle of a larger one, which
+     * is how the payload of a {@code %t{...}} specifier is read without first cutting it out.
+     */
+    @Test
+    public void testParseWithinALargerString()
+    {
+        String string = "on %t{yyyy-MM-dd} at %t{HH:mm}";
+        Assert.assertEquals("2014-03-10", DateFormatPattern.parse(string, 6, 16).render(NANO));
+        Assert.assertEquals("16:12", DateFormatPattern.parse(string, 24, 29).render(NANO));
+
+        // the range decides what is parsed, not the string
+        Assert.assertEquals("2014", DateFormatPattern.parse("yyyy-MM-dd", 0, 4).render(NANO));
+        Assert.assertEquals("03-10", DateFormatPattern.parse("yyyy-MM-dd", 5, 10).render(NANO));
+        Assert.assertEquals("", DateFormatPattern.parse("yyyy", 2, 2).render(NANO));
+
+        // the whole string and its full range are the same thing
+        Assert.assertEquals(DateFormatPattern.parse("yyyy-MM-dd"), DateFormatPattern.parse("yyyy-MM-dd", 0, 10));
+    }
+
+    /**
+     * A time zone opens the range it is parsed from, not the string that range came out of, and the
+     * error names the range rather than the string around it.
+     */
+    @Test
+    public void testParseWithinALargerStringPositionsAndReportsAgainstTheRange()
+    {
+        String string = "xx[EST]yyyy-MM-ddxx";
+        Assert.assertEquals("2014-03-10", DateFormatPattern.parse(string, 2, 17).render(DAY));
+
+        // the same zone one character further in is no longer at the start of the format string
+        Assert.assertEquals(
+                "Time zone can only be set at the beginning of the format string",
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateFormatPattern.parse("y[EST]yyyy", 0, 10)).getMessage());
+
+        // and an error quotes what it was given to parse
+        Assert.assertEquals(
+                "Invalid format control character 'Q' in format string: MM-Q",
+                Assert.assertThrows(IllegalArgumentException.class, () -> DateFormatPattern.parse("yyyy-MM-Q-dd", 5, 9)).getMessage());
+    }
+
+    @Test
+    public void testFormatWithinALargerString()
+    {
+        String string = "on %t{yyyy-MM-dd} at %t{HH:mm}";
+        Assert.assertEquals("2014-03-10", DateFormat.format(new StringBuilder(), string, 6, 16, NANO).toString());
+        Assert.assertEquals("16:12", DateFormat.format(new StringBuilder(), string, 24, 29, NANO).toString());
+
+        StringBuilder builder = new StringBuilder("date: ");
+        Assert.assertSame(builder, DateFormat.format(builder, string, 6, 16, NANO));
+        Assert.assertEquals("date: 2014-03-10", builder.toString());
+    }
+
+    // Validation
+
+    /**
+     * Validation asks only what the format string is, so it takes no date and passes anything a
+     * date of the right granularity could be written by.
+     */
+    @Test
+    public void testValidate()
+    {
+        for (String formatString : FORMAT_STRINGS)
+        {
+            DateFormat.validate(formatString);
+        }
+        DateFormat.validate("on %t{yyyy-MM-dd} at", 6, 16);
+
+        assertValidationFails("Invalid format control character 'Q' in format string: yyyy-Q", "yyyy-Q");
+        assertValidationFails("Missing closing quote in format string: \"abc", "\"abc");
+        assertValidationFails("Missing closing bracket in format string: [EST", "[EST");
+        assertValidationFails("Missing closing quotes in time zone definition: [\"EST]yyyy", "[\"EST]yyyy");
+        assertValidationFails("Time zone can only be set at the beginning of the format string", "yyyy[EST]");
+        assertValidationFails("Unknown time zone: Europe/Lissabon", "[Europe/Lissabon]yyyy");
+    }
+
+    /**
+     * A structural error is found before anything is written, so a caller passing its own appendable
+     * gets it back untouched. A component the date does not have is not structural, and is found
+     * where it is reached.
+     */
+    @Test
+    public void testAStructuralErrorLeavesTheAppendableAlone()
+    {
+        StringBuilder builder = new StringBuilder("date: ");
+        Assert.assertThrows(IllegalArgumentException.class, () -> DateFormat.format(builder, "yyyy-Q", NANO));
+        Assert.assertEquals("date: ", builder.toString());
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> DateFormat.format(builder, "yyyy-MM", YEAR));
+        Assert.assertEquals("date: 2014-", builder.toString());
+    }
+
+    // Writing the format string back out
+
+    /**
+     * A pattern writes the format string it stands for, and reading that back gives an equal
+     * pattern. Writing it again gives the same string, so the spelling a pattern chooses is settled
+     * rather than merely one of several.
+     */
+    @Test
+    public void testPatternRoundTrips()
+    {
+        for (String formatString : FORMAT_STRINGS)
+        {
+            DateFormatPattern pattern = DateFormatPattern.parse(formatString);
+            String written = pattern.pattern();
+            Assert.assertEquals(formatString, pattern, DateFormatPattern.parse(written));
+            Assert.assertEquals(formatString, written, DateFormatPattern.parse(written).pattern());
+        }
+    }
+
+    /**
+     * Where a format string can be written in more than one way, the pattern picks one, so a
+     * spelling that says nothing extra comes back in its plainest form.
+     */
+    @Test
+    public void testPatternNormalizesWhatSaysTheSameThing()
+    {
+        Assert.assertEquals("yyyy-MM-dd", DateFormatPattern.parse("yyyy-MM-dd").pattern());
+        Assert.assertEquals("SSS", DateFormatPattern.parse("SSS").pattern());
+        Assert.assertEquals("SSSS", DateFormatPattern.parse("SSSS").pattern());
+
+        // a year of three letters or fewer is the two digit form, and four or more is the whole one
+        Assert.assertEquals("yy", DateFormatPattern.parse("y").pattern());
+        Assert.assertEquals("yy", DateFormatPattern.parse("yyy").pattern());
+        Assert.assertEquals("yyyy", DateFormatPattern.parse("yyyyy").pattern());
+
+        // a repeated character with no width to widen writes itself once
+        Assert.assertEquals("SSSS", DateFormatPattern.parse("SSSSSSSSS").pattern());
+        Assert.assertEquals("a", DateFormatPattern.parse("aaa").pattern());
+        Assert.assertEquals("z", DateFormatPattern.parse("zzz").pattern());
+        Assert.assertEquals("Z", DateFormatPattern.parse("ZZ").pattern());
+        Assert.assertEquals("X", DateFormatPattern.parse("XX").pattern());
+
+        // a separator stands for itself, quoted or not, and adjacent text is one run
+        Assert.assertEquals("-", DateFormatPattern.parse("\"-\"").pattern());
+        Assert.assertEquals("\"at\" \"T\" HH", DateFormatPattern.parse("\"at\" \"T\" HH").pattern());
+        Assert.assertEquals("\"abc\"", builder().literal('a').literal("b").literal('c').build().pattern());
+    }
+
+    /**
+     * A time zone is written back into the brackets a format string opens with, escaping whatever
+     * would otherwise close them, and a quoted name comes back unquoted.
+     */
+    @Test
+    public void testPatternWritesTheTimeZoneBack()
+    {
+        Assert.assertEquals("[EST]HH:mm z", DateFormatPattern.parse("[EST]HH:mm z").pattern());
+        Assert.assertEquals("[EST]HH:mm z", DateFormatPattern.parse("[\"EST\"]HH:mm z").pattern());
+        Assert.assertEquals("[EST]HH:mm z", DateFormatPattern.parse("[E\\ST]HH:mm z").pattern());
+        Assert.assertEquals("[+05:30]HH:mm", DateFormatPattern.parse("[+05:30]HH:mm").pattern());
+        Assert.assertEquals("[America/New_York]X", DateFormatPattern.parse("[America/New_York]X").pattern());
+    }
+
+    /**
+     * A sub-second field the format string spells writes itself that way; one only the builder can
+     * ask for writes the general form, which the format string is to gain and does not yet take
+     * back.
+     */
+    @Test
+    public void testPatternWritesSubsecondFields()
+    {
+        Assert.assertEquals("S", builder().subsecond().atMost(1).endSubsecond().build().pattern());
+        Assert.assertEquals("SSS", builder().subsecond().atMost(3).endSubsecond().build().pattern());
+        Assert.assertEquals("SSSS", builder().subsecond().asStored().endSubsecond().build().pattern());
+        Assert.assertEquals("SSSS", builder().subsecond().endSubsecond().build().pattern());
+
+        Assert.assertEquals("S(0,6)", builder().subsecond().atMost(6).endSubsecond().build().pattern());
+        Assert.assertEquals("S(3,3)", builder().subsecond().exactly(3).endSubsecond().build().pattern());
+        Assert.assertEquals("S(3,*)", builder().subsecond().atLeast(3).endSubsecond().build().pattern());
+        Assert.assertEquals("S(2,4)", builder().subsecond().between(2, 4).endSubsecond().build().pattern());
+        Assert.assertEquals("S(3!,3)", builder().subsecond().exactly(3).failBelowMinimum().endSubsecond().build().pattern());
+        Assert.assertEquals("S(0,3!)", builder().subsecond().atMost(3).failAboveMaximum().endSubsecond().build().pattern());
+        Assert.assertEquals("S(4,4,\"_\")", builder().subsecond().exactly(4).padWith('_').endSubsecond().build().pattern());
+        Assert.assertEquals(
+                "S(3!,9!,\"_\")",
+                builder().subsecond().between(3, 9).failBelowMinimum().failAboveMaximum().padWith('_').endSubsecond().build().pattern());
+    }
+
+    @Test
+    public void testAppendPatternReturnsTheAppendableItWasGiven()
+    {
+        StringBuilder builder = new StringBuilder("format: ");
+        Assert.assertSame(builder, DateFormatPattern.parse("yyyy-MM-dd").appendPattern(builder));
+        Assert.assertEquals("format: yyyy-MM-dd", builder.toString());
+    }
+
+    // canRender
+
+    /**
+     * A pattern can write a date exactly when every element of it can, which is exactly when
+     * rendering succeeds.
+     */
+    @Test
+    public void testCanRender()
+    {
+        assertCanRender("yyyy", true, true, true, true);
+        assertCanRender("yyyy-MM", false, true, true, true);
+        assertCanRender("yyyy-MM-dd", false, true, true, true);
+        assertCanRender("yyyy-MM-dd HH:mm:ss", false, false, true, true);
+        assertCanRender("HH:mm:ss.SSS", false, false, false, true);
+        assertCanRender("a", false, false, true, true);
+        assertCanRender("Z", false, false, true, true);
+        assertCanRender("X", false, false, true, true);
+
+        // a literal, and the general time zone notation, ask the date for nothing
+        assertCanRender("\"any date at all\"", true, true, true, true);
+        assertCanRender("[EST]z", true, true, true, true);
+    }
+
+    // Sub-second widths and policies
+
+    /**
+     * The widths a format string spells today: at most N digits for one to three letters, and
+     * however many the date has from four on. Neither pads.
+     */
+    @Test
+    public void testSubsecondWidthsAFormatStringSpells()
+    {
+        assertSubsecond(builder().subsecond().atMost(1).endSubsecond(), "0", "0", "0", "0");
+        assertSubsecond(builder().subsecond().atMost(2).endSubsecond(), "07", "07", "07", "00");
+        assertSubsecond(builder().subsecond().atMost(3).endSubsecond(), "070", "070", "07", "000");
+        assertSubsecond(builder().subsecond().asStored().endSubsecond(), "070004235", "070", "07", "000");
+
+        // which is what the parser builds them into
+        Assert.assertEquals(builder().subsecond().atMost(1).endSubsecond().build(), DateFormatPattern.parse("S"));
+        Assert.assertEquals(builder().subsecond().atMost(3).endSubsecond().build(), DateFormatPattern.parse("SSS"));
+        Assert.assertEquals(builder().subsecond().asStored().endSubsecond().build(), DateFormatPattern.parse("SSSS"));
+        Assert.assertEquals(builder().subsecond().asStored().endSubsecond().build(), DateFormatPattern.parse("SSSSSSSSS"));
+    }
+
+    /**
+     * A minimum pads a fraction the date has too few digits for. Padding narrows the span of time
+     * the date stands for, so it claims a precision the date does not have, which is why it has to
+     * be asked for rather than being what a width means.
+     */
+    @Test
+    public void testSubsecondMinimum()
+    {
+        assertSubsecond(builder().subsecond().exactly(3).endSubsecond(), "070", "070", "070", "000");
+        assertSubsecond(builder().subsecond().exactly(9).endSubsecond(), "070004235", "070000000", "070000000", "000000000");
+        assertSubsecond(builder().subsecond().atLeast(3).endSubsecond(), "070004235", "070", "070", "000");
+        assertSubsecond(builder().subsecond().between(2, 4).endSubsecond(), "0700", "070", "07", "000");
+
+        // the fill need not be a zero
+        assertSubsecond(builder().subsecond().exactly(4).padWith('_').endSubsecond(), "0700", "070_", "07__", "000_");
+    }
+
+    /**
+     * A field may refuse a fraction outside its width rather than making one fit. Refusing below
+     * the minimum is refusing to invent precision; refusing above the maximum is refusing to be
+     * given more than was asked for.
+     */
+    @Test
+    public void testSubsecondPolicies()
+    {
+        assertSubsecond(builder().subsecond().exactly(3).failBelowMinimum().endSubsecond(), "070", "070", null, "000");
+        assertSubsecond(builder().subsecond().atMost(3).failAboveMaximum().endSubsecond(), null, "070", "07", "000");
+        assertSubsecond(builder().subsecond().exactly(3).failBelowMinimum().failAboveMaximum().endSubsecond(), null, "070", null, "000");
+        assertSubsecond(builder().subsecond().atLeast(3).failBelowMinimum().endSubsecond(), "070004235", "070", null, "000");
+
+        Assert.assertEquals(
+                "Date has a 2 digit sub-second, but 3 are required: 2014-03-10T16:12:35.07+0000",
+                Assert.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> builder().subsecond().exactly(3).failBelowMinimum().endSubsecond().build().render(HUNDREDTH)).getMessage());
+        Assert.assertEquals(
+                "Date has a 9 digit sub-second, but at most 3 may be written: 2014-03-10T16:12:35.070004235+0000",
+                Assert.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> builder().subsecond().atMost(3).failAboveMaximum().endSubsecond().build().render(NANO)).getMessage());
+    }
+
+    /**
+     * Whether a sub-second field can write a date is the same question rendering it asks, including
+     * where the answer turns on how many digits the date has rather than on whether it has any.
+     */
+    @Test
+    public void testSubsecondCanRender()
+    {
+        Assert.assertFalse(builder().subsecond().endSubsecond().build().canRender(SECOND));
+        Assert.assertFalse(builder().subsecond().exactly(3).endSubsecond().build().canRender(DAY));
+        Assert.assertTrue(builder().subsecond().endSubsecond().build().canRender(HUNDREDTH));
+
+        Assert.assertTrue(builder().subsecond().exactly(3).endSubsecond().build().canRender(HUNDREDTH));
+        Assert.assertFalse(builder().subsecond().exactly(3).failBelowMinimum().endSubsecond().build().canRender(HUNDREDTH));
+        Assert.assertTrue(builder().subsecond().exactly(3).failBelowMinimum().endSubsecond().build().canRender(MILLI));
+
+        Assert.assertTrue(builder().subsecond().atMost(3).endSubsecond().build().canRender(NANO));
+        Assert.assertFalse(builder().subsecond().atMost(3).failAboveMaximum().endSubsecond().build().canRender(NANO));
+        Assert.assertTrue(builder().subsecond().atMost(3).failAboveMaximum().endSubsecond().build().canRender(MILLI));
+    }
+
+    /**
+     * A width nothing satisfies is rejected where it is asked for, which is the only thing a
+     * sub-second field is rejected for: the policies and the fill are markers rather than
+     * requirements, and cannot make a field that means nothing.
+     */
+    @Test
+    public void testSubsecondRejectsWidthsNothingSatisfies()
+    {
+        assertBuilderFails("Sub-second minimum 5 exceeds maximum 3", () -> builder().subsecond().between(5, 3));
+        assertBuilderFails("Sub-second maximum must be at least 1: 0", () -> builder().subsecond().between(3, 0));
+        assertBuilderFails("Sub-second maximum must be at least 1: 0", () -> builder().subsecond().atMost(0));
+        assertBuilderFails("Sub-second minimum may not be negative: -1", () -> builder().subsecond().atLeast(-1));
+
+        // and the last width asked for is the one the field takes
+        Assert.assertEquals("S(2,4)", builder().subsecond().exactly(9).between(2, 4).endSubsecond().build().pattern());
+    }
+
+    // Equality and description
+
+    @Test
+    public void testPatternIsAValue()
+    {
+        Assert.assertEquals(DateFormatPattern.parse("yyyy-MM-dd"), DateFormatPattern.parse("yyyy-MM-dd"));
+        Assert.assertEquals(DateFormatPattern.parse("yyyy-MM-dd").hashCode(), DateFormatPattern.parse("yyyy-MM-dd").hashCode());
+        Assert.assertNotEquals(DateFormatPattern.parse("yyyy-MM-dd"), DateFormatPattern.parse("yyyy/MM/dd"));
+        Assert.assertNotEquals(DateFormatPattern.parse("yyyy"), DateFormatPattern.parse("yy"));
+        Assert.assertNotEquals(DateFormatPattern.parse("HH"), DateFormatPattern.parse("hh"));
+
+        // the zone is part of the pattern, and the two numeric notations are not the same element
+        Assert.assertNotEquals(DateFormatPattern.parse("[EST]HH"), DateFormatPattern.parse("[CET]HH"));
+        Assert.assertNotEquals(DateFormatPattern.parse("[EST]z"), DateFormatPattern.parse("[CET]z"));
+        Assert.assertNotEquals(DateFormatPattern.parse("[EST]z"), DateFormatPattern.parse("z"));
+        Assert.assertNotEquals(DateFormatPattern.parse("Z"), DateFormatPattern.parse("X"));
+
+        // a quoted GMT is text that happens to read like the general notation, and is not it
+        Assert.assertNotEquals(DateFormatPattern.parse("z"), DateFormatPattern.parse("\"GMT\""));
+
+        // and every marker a sub-second field carries tells one from another
+        Assert.assertEquals(builder().subsecond().exactly(3).endSubsecond().build(), builder().subsecond().between(3, 3).endSubsecond().build());
+        Assert.assertNotEquals(builder().subsecond().exactly(3).endSubsecond().build(), builder().subsecond().atMost(3).endSubsecond().build());
+        Assert.assertNotEquals(
+                builder().subsecond().exactly(3).endSubsecond().build(),
+                builder().subsecond().exactly(3).failBelowMinimum().endSubsecond().build());
+        Assert.assertNotEquals(
+                builder().subsecond().exactly(3).endSubsecond().build(),
+                builder().subsecond().exactly(3).padWith('_').endSubsecond().build());
+    }
+
+    @Test
+    public void testToStringDescribesTheElements()
+    {
+        Assert.assertEquals(
+                "DateFormatPattern{Year, Literal(\"-\"), Month(2), Literal(\"-\"), Day(2)}",
+                DateFormatPattern.parse("yyyy-MM-dd").toString());
+        Assert.assertEquals(
+                "DateFormatPattern{[EST] Hour24(2), Literal(\":\"), Minute(2), Literal(\" \"), TimeZoneName}",
+                DateFormatPattern.parse("[EST]HH:mm z").toString());
+        Assert.assertEquals(
+                "DateFormatPattern{TwoDigitYear, Literal(\"-\"), RFC822TimeZoneOffset, Literal(\"-\"), ISO8601TimeZoneOffset, Literal(\"-\"), AmPm}",
+                DateFormatPattern.parse("yy-Z-X-a").toString());
+        Assert.assertEquals(
+                "DateFormatPattern{Subsecond(3!, 9!, '_')}",
+                builder().subsecond().between(3, 9).failBelowMinimum().failAboveMaximum().padWith('_').endSubsecond().build().toString());
+    }
+
+    /**
+     * Runs of separators and quoted text collapse into one element, so a pattern holds no more
+     * elements than it has things to write.
+     */
+    @Test
+    public void testAdjacentLiteralsAreOneElement()
+    {
+        Assert.assertEquals(
+                "DateFormatPattern{Year, Literal(\"-.-\")}",
+                DateFormatPattern.parse("yyyy-.-").toString());
+        Assert.assertEquals(
+                "DateFormatPattern{Literal(\"at T \"), Hour24(2)}",
+                DateFormatPattern.parse("\"at\" \"T\" HH").toString());
+        Assert.assertEquals(
+                "DateFormatPattern{Literal(\"abc\")}",
+                builder().literal('a').literal("b").literal('c').build().toString());
+    }
+
+    // Helpers
+
+    private static Builder builder()
+    {
+        return DateFormatPattern.builder();
+    }
+
+    /**
+     * Assert that a pattern holding one sub-second field writes what is expected of each of the
+     * four fractions the tests use, a null standing for a field that refuses the date rather than
+     * writing it.
+     *
+     * @param field     builder holding the field to render
+     * @param nano      what it writes for a nine digit fraction
+     * @param milli     what it writes for {@code .070}
+     * @param hundredth what it writes for {@code .07}
+     * @param zero      what it writes for {@code .000}
+     */
+    private static void assertSubsecond(Builder field, String nano, String milli, String hundredth, String zero)
+    {
+        DateFormatPattern pattern = field.build();
+        assertSubsecond(pattern, NANO, nano);
+        assertSubsecond(pattern, MILLI, milli);
+        assertSubsecond(pattern, HUNDREDTH, hundredth);
+        assertSubsecond(pattern, ZERO, zero);
+
+        // and no field decides for itself what a date with no fraction at all looks like
+        assertSubsecond(pattern, SECOND, null);
+        assertSubsecond(pattern, DAY, null);
+    }
+
+    private static void assertSubsecond(DateFormatPattern pattern, PureDate date, String expected)
+    {
+        String context = pattern.pattern() + " on " + date;
+        if (expected == null)
+        {
+            Assert.assertFalse(context, pattern.canRender(date));
+            Assert.assertThrows(context, IllegalArgumentException.class, () -> pattern.render(date));
+        }
+        else
+        {
+            Assert.assertTrue(context, pattern.canRender(date));
+            Assert.assertEquals(context, expected, pattern.render(date));
+        }
+    }
+
+    private static void assertSameAs(String formatString, Builder builder)
+    {
+        DateFormatPattern parsed = DateFormatPattern.parse(formatString);
+        DateFormatPattern built = builder.build();
+        Assert.assertEquals(formatString, parsed, built);
+        Assert.assertEquals(formatString, parsed.hashCode(), built.hashCode());
+        Assert.assertEquals(formatString, parsed.pattern(), built.pattern());
+        for (PureDate date : new PureDate[]{NANO, MILLI, HUNDREDTH, SECOND, DAY, YEAR})
+        {
+            String context = formatString + " on " + date;
+            if (parsed.canRender(date))
+            {
+                Assert.assertEquals(context, DateFormat.format(new StringBuilder(), formatString, date).toString(), built.render(date));
+            }
+            else
+            {
+                Assert.assertFalse(context, built.canRender(date));
+                Assert.assertThrows(context, IllegalArgumentException.class, () -> built.render(date));
+            }
+        }
+    }
+
+    private static void assertCanRender(String formatString, boolean year, boolean day, boolean second, boolean subsecond)
+    {
+        DateFormatPattern pattern = DateFormatPattern.parse(formatString);
+        assertCanRender(pattern, YEAR, year);
+        assertCanRender(pattern, DAY, day);
+        assertCanRender(pattern, SECOND, second);
+        assertCanRender(pattern, NANO, subsecond);
+    }
+
+    private static void assertCanRender(DateFormatPattern pattern, PureDate date, boolean expected)
+    {
+        String context = pattern + " on " + date;
+        Assert.assertEquals(context, expected, pattern.canRender(date));
+        if (expected)
+        {
+            pattern.render(date);
+        }
+        else
+        {
+            Assert.assertThrows(context, IllegalArgumentException.class, () -> pattern.render(date));
+        }
+    }
+
+    /**
+     * Assert that a builder with a sub-second field part way through refuses the given call.
+     *
+     * @param call call to make on the builder
+     */
+    private static void assertOpenSubsecondRefuses(Consumer<Builder> call)
+    {
+        Builder builder = builder().year();
+        builder.subsecond().exactly(3);
+        Assert.assertEquals(
+                "A sub-second field is still open: call endSubsecond() before anything else",
+                Assert.assertThrows(IllegalStateException.class, () -> call.accept(builder)).getMessage());
+    }
+
+    /**
+     * Assert that a sub-second field that has been ended refuses the given call.
+     *
+     * @param call call to make on the field
+     */
+    private static void assertEndedSubsecondRefuses(Consumer<SubsecondBuilder> call)
+    {
+        SubsecondBuilder field = builder().subsecond();
+        field.endSubsecond();
+        Assert.assertEquals(
+                "This sub-second field has already been ended",
+                Assert.assertThrows(IllegalStateException.class, () -> call.accept(field)).getMessage());
+    }
+
+    private static void assertBuilderFails(String expectedMessage, Runnable builderCall)
+    {
+        Assert.assertEquals(
+                expectedMessage,
+                Assert.assertThrows(expectedMessage, IllegalArgumentException.class, builderCall::run).getMessage());
+    }
+
+    private static void assertValidationFails(String expectedMessage, String formatString)
+    {
+        Assert.assertEquals(
+                formatString,
+                expectedMessage,
+                Assert.assertThrows(formatString, IllegalArgumentException.class, () -> DateFormat.validate(formatString)).getMessage());
+    }
+}

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/PureStringFormat.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/main/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/PureStringFormat.java
@@ -14,12 +14,12 @@
 
 package org.finos.legend.pure.runtime.java.compiled.generation.processors.support;
 
-import org.eclipse.collections.api.factory.Stacks;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.pure.m3.exception.PureExecutionException;
 import org.finos.legend.pure.m3.execution.ExecutionSupport;
 import org.finos.legend.pure.m3.tools.FormatTools;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
+import org.finos.legend.pure.m4.exception.PureException;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -168,11 +168,21 @@ public class PureStringFormat
         }
         catch (NoSuchElementException e)
         {
-            throw new PureExecutionException("Too few arguments passed to format function. Format expression \"" + formatString + "\", number of arguments [" + Iterate.sizeOf(formatArgs) + "]", Stacks.mutable.empty());
+            throw new PureExecutionException("Too few arguments passed to format function. Format expression \"" + formatString + "\", number of arguments [" + Iterate.sizeOf(formatArgs) + "]");
+        }
+        catch (PureException e)
+        {
+            // an error raised writing one of the arguments is already an error Pure code can catch,
+            // and already says where it came from
+            throw e;
+        }
+        catch (RuntimeException e)
+        {
+            throw new PureExecutionException((e.getMessage() == null) ? "Error formatting: " + formatString : e.getMessage(), e);
         }
         if (argIterator.hasNext())
         {
-            throw new PureExecutionException("Unused format args. [" + Iterate.sizeOf(formatArgs) + "] arguments provided to expression \"" + formatString + "\"", Stacks.mutable.empty());
+            throw new PureExecutionException("Unused format args. [" + Iterate.sizeOf(formatArgs) + "] arguments provided to expression \"" + formatString + "\"");
         }
         return builder.toString();
     }

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/TestPureStringFormat.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-compiled/src/test/java/org/finos/legend/pure/runtime/java/compiled/generation/processors/support/TestPureStringFormat.java
@@ -1,0 +1,111 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.compiled.generation.processors.support;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.pure.m3.exception.PureExecutionException;
+import org.finos.legend.pure.m3.execution.ExecutionSupport;
+import org.finos.legend.pure.m4.coreinstance.primitive.date.DateFunctions;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.BiFunction;
+
+public class TestPureStringFormat
+{
+    /**
+     * Only the paths that need no execution support are exercised here, which is every path that
+     * can fail on the format string or on the argument rather than inside a nested Pure call.
+     */
+    private static final BiFunction<Object, ? super ExecutionSupport, ? extends String> TO_REPRESENTATION = (value, es) ->
+    {
+        throw new AssertionError("toRepresentation should not have been reached");
+    };
+
+    @Test
+    public void testFormatWrites()
+    {
+        Assert.assertEquals("on 2014-03-10", format("on %t{yyyy-MM-dd}", date("2014-03-10T13:07:44.07")));
+        Assert.assertEquals("on 070", format("on %t{S3}", date("2014-03-10T13:07:44.07")));
+        Assert.assertEquals("00042", format("%05d", 42L));
+    }
+
+    /**
+     * A date pattern that cannot write the date it was handed is a fault of the pair rather than of
+     * the format string, so it is only ever found while writing. It has to reach Pure as an error
+     * Pure can catch, since nothing above the native turns a Java exception into one.
+     */
+    @Test
+    public void testDateThatCannotBeWritten()
+    {
+        assertFormatError(
+                "Date has a 2 digit sub-second, but 3 are required: 2014-03-10T13:07:44.07+0000",
+                "on %t{S!3}", date("2014-03-10T13:07:44.07"));
+        assertFormatError(
+                "Date has no hour: 2014-03-10",
+                "on %t{HH:mm}", date("2014-03-10"));
+    }
+
+    /**
+     * A format string that is wrong is caught where it is written when it is a literal, and here
+     * when it was computed.
+     */
+    @Test
+    public void testMalformedFormatString()
+    {
+        assertFormatError("Invalid format control character 'Q' in format string: yyyy-Q", "%t{yyyy-Q}", date("2014-03-10"));
+        assertFormatError("Sub-second minimum 5 exceeds maximum 3 in format string: S(5,3)", "%t{S(5,3)}", date("2014-03-10T13:07:44.07"));
+        assertFormatError("Invalid format specifier: %q", "%q", "anything");
+    }
+
+    @Test
+    public void testArgumentOfTheWrongType()
+    {
+        assertFormatError("Expected Integer, got: not an integer", "%d", "not an integer");
+        assertFormatError("Expected Date, got: not a date", "%t{yyyy}", "not a date");
+        assertFormatError("Expected Float, got: 3", "%.2f", 3L);
+    }
+
+    /**
+     * The two argument count errors were already reported as Pure errors, and still are.
+     */
+    @Test
+    public void testArgumentCount()
+    {
+        Assert.assertEquals(
+                "Too few arguments passed to format function. Format expression \"%s %s\", number of arguments [1]",
+                Assert.assertThrows(PureExecutionException.class, () -> format("%s %s", "one")).getInfo());
+        Assert.assertEquals(
+                "Unused format args. [2] arguments provided to expression \"%d\"",
+                Assert.assertThrows(PureExecutionException.class, () -> format("%d", 1L, 2L)).getInfo());
+    }
+
+    private static void assertFormatError(String expectedMessage, String formatString, Object... formatArgs)
+    {
+        PureExecutionException e = Assert.assertThrows(formatString, PureExecutionException.class, () -> format(formatString, formatArgs));
+        Assert.assertEquals(formatString, expectedMessage, e.getInfo());
+        Assert.assertNotNull(formatString, e.getCause());
+    }
+
+    private static String format(String formatString, Object... formatArgs)
+    {
+        return PureStringFormat.format(formatString, Lists.mutable.with(formatArgs), TO_REPRESENTATION, null);
+    }
+
+    private static Object date(String date)
+    {
+        return DateFunctions.parsePureDate(date);
+    }
+}

--- a/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/essentials/string/toString/Format.java
+++ b/legend-pure-runtime/legend-pure-runtime-java-engine-interpreted/src/main/java/org/finos/legend/pure/runtime/java/interpreted/natives/essentials/string/toString/Format.java
@@ -14,22 +14,23 @@
 
 package org.finos.legend.pure.runtime.java.interpreted.natives.essentials.string.toString;
 
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.stack.MutableStack;
-import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.pure.m3.compiler.Context;
+import org.finos.legend.pure.m3.exception.PureExecutionException;
+import org.finos.legend.pure.m3.navigation.Instance;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.finos.legend.pure.m3.navigation.M3Properties;
-import org.finos.legend.pure.m3.exception.PureExecutionException;
-import org.finos.legend.pure.m3.compiler.Context;
-import org.finos.legend.pure.m3.navigation.Instance;
-import org.finos.legend.pure.m3.navigation.ValueSpecificationBootstrap;
-import org.finos.legend.pure.m3.navigation.ProcessorSupport;
-import org.finos.legend.pure.m3.tools.FormatTools;
 import org.finos.legend.pure.m3.navigation.PrimitiveUtilities;
-import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m3.navigation.ValueSpecificationBootstrap;
+import org.finos.legend.pure.m3.tools.FormatTools;
 import org.finos.legend.pure.m4.ModelRepository;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
+import org.finos.legend.pure.m4.exception.PureException;
 import org.finos.legend.pure.runtime.java.interpreted.ExecutionSupport;
 import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
 import org.finos.legend.pure.runtime.java.interpreted.VariableContext;
@@ -140,7 +141,7 @@ public class Format extends NativeFunction
                             {
                                 throw new IllegalArgumentException("Invalid format specifier: %" + formatString.substring(index, j + 1));
                             }
-                            int zeroPad = Integer.valueOf(formatString.substring(index, j));
+                            int zeroPad = Integer.parseInt(formatString.substring(index, j));
                             CoreInstance arg = formatArgs.get(argCounter++);
                             if (!Instance.instanceOf(arg, M3Paths.Integer, processorSupport))
                             {
@@ -171,7 +172,7 @@ public class Format extends NativeFunction
                             {
                                 throw new IllegalArgumentException("Invalid format specifier: %" + formatString.substring(index, j + 1));
                             }
-                            int precision = Integer.valueOf(formatString.substring(index, j));
+                            int precision = Integer.parseInt(formatString.substring(index, j));
                             CoreInstance arg = formatArgs.get(argCounter++);
                             if (!Instance.instanceOf(arg, M3Paths.Float, processorSupport))
                             {
@@ -196,6 +197,16 @@ public class Format extends NativeFunction
         catch (IndexOutOfBoundsException e)
         {
             throw new PureExecutionException(functionExpressionCallStack.peek().getSourceInformation(), "Too few arguments passed to format function. Format expression \"" + formatString + "\", number of arguments [" + formatArgs.size() + "]", functionExpressionCallStack);
+        }
+        catch (PureException e)
+        {
+            // an error raised writing one of the arguments is already an error Pure code can catch,
+            // and already says where it came from
+            throw e;
+        }
+        catch (RuntimeException e)
+        {
+            throw new PureExecutionException(functionExpressionCallStack.peek().getSourceInformation(), (e.getMessage() == null) ? "Error formatting: " + formatString : e.getMessage(), e, functionExpressionCallStack);
         }
         if (argCounter < formatArgs.size())
         {


### PR DESCRIPTION
## What

`meta::pure::functions::string::format` renders a date from a format string — `%t{yyyy-MM-dd}`, optionally opening with a time zone. This adds two things to that language, closing the two gaps that prompted the work. `DateFormat.format` in `legend-pure-m4` does the work for both engines, so the change lands on both at once.

**A sub-second field now takes a width.** Repeating `S` widened the field for one, two, or three letters; at four the count stopped meaning anything and the field wrote the whole stored fraction. So `SSS` and `SSSS` differed in kind rather than in degree, and a *fixed-width* fraction — what ISO 8601 and every wire format built on it require — could not be said at all. Of the fourteen sub-second fields written in legend-engine's `.pure` sources, ten are spelled with four letters or more, and not one of them gets the fixed width its author plainly meant.

| Form | Meaning |
|---|---|
| `S3` | exactly 3 digits, padding a shorter fraction |
| `S<3` | at most 3 |
| `S>3` | at least 3, and everything beyond |
| `S*` | however many the date has |
| `S!3` | exactly 3, failing rather than padding a shorter one |
| `S(min,max)` | the general form: `*` for no maximum, `!` after either bound to fail rather than pad or truncate there, and an optional third part naming a fill other than zero — `S(3!,9,"_")` |

**An optional section, `?[...]`, is written where the date can carry it and left out where it cannot,** with `|` between alternatives. A Pure date comes at seven granularities and every control character used to be mandatory, so one format string could address exactly one of them: `yyyy-MM-dd` was a run-time error for a `Year`, and `yyyy` silently discarded everything a `DateWithSubsecond` knew. Now `yyyy?[-MM?[-dd?["T"HH?[:mm?[:ss?[.S*]]]]]]` renders all seven.

The two compose, and each answers a different question: a field says how wide a fraction is, a section says what to do when there is none. `?[.S9|".000000000"]` replaces a branch, two `format` calls, a concatenation, and a second pass over the date.

## Compatibility

Every character the new forms recruit (`<`, `>`, `*`, `!`, `(`, `)`, `?`, `|`, `]`, and a digit after `S`) was an error before, so **no format string that worked before changes meaning**. That was checked rather than asserted: the implementation this replaces was run head to head with the new one over 4,377,492 pairs of a format string and a date, covering every control character at widths one to five against seven time zones and twelve dates. The one difference is deliberate — `a` now consumes its run of repetitions like every other control character, so `aa` writes `PM` rather than `PMPM`. A fifty-row table of that comparison is checked in as `TestDateFormat`'s compatibility suite.

The repetition form is frozen and every legacy spelling has an exact modern equivalent (`S` through `SSS` are `S<1` through `S<3`; `SSSS` and longer is `S*`), so it can be deprecated later without anything losing a way to be said. `DateFormatPattern.pattern()` writes the modern spelling and never the repetition form, which makes reading a format string and writing it back the mechanical half of a migration.

## Also in here

- **A format string is read once.** `DateFormat.format` is now built on `DateFormatPattern`, a parsed pattern a caller can hold and reuse, or build directly with no format string to hand. Resolving the time zone moved to parse time, so a zoned pattern is *faster* than the loop it replaced, which called `ZoneId.of` on every single call. An unzoned parse-per-call costs about three times the old loop; hoisted out of a loop it is at parity or better.
- **A literal format string is checked when it is compiled.** `FormatValidator` calls `FormatTools.validate` wherever parameter 0 of `format` is a literal, so `%q`, a trailing `%`, `%0d`, and `%t{yyyy-Q}` now fail to compile rather than waiting for their line to run. It deliberately says nothing about whether the specifiers and the arguments agree, in number or in kind — `args` is an `Any[*]` that is frequently computed, and getting that wrong would turn a nuisance into an outage. Nothing stops compiling: across 3,520 `.pure` sources in legend-pure and legend-engine, 312 literal format strings pass and 23 more are assembled from pieces and skipped.
- **Fix: `FormatTools.findEndOfDateFormatString` mishandled backslash escapes** (pre-existing, unchanged since at least March 2024). The flag it set was cleared only by another backslash and never by the character the backslash escaped, so after any `\X` where X is not itself a backslash the scan stayed escaped for the rest of the string and never found the closing brace. `%t{yyyy"a\"b"}` and `%t{S(4,4,"\"")}` are patterns `DateFormat` renders correctly and that no call site could write.
- **Fix: both `format` natives now wrap non-Pure exceptions in `PureExecutionException`.** The interpreted engine wraps every `RuntimeException` a native throws; the compiled engine does not. Since `assertError` catches `PureExecutionException` and nothing else, the one kind of format failure that can only be found by running — a date short of a component its pattern asks for — was the one kind no Pure test could assert on in the compiled engine.

## Tests

| Suite | Covers |
|---|---|
| `TestDateFormatPattern` | the worked tables of the design, as tests |
| `TestDateFormat` | the user-facing surface, plus the `LEGACY_COMPATIBILITY` differential |
| `TestFormat`, `TestFormatTools` | the compile-time check and the specifier grammar |
| `TestPureStringFormat` | the compiled native's error wrapping |
| `format.pure` | the Pure surface, on both engines |

## Notes for reviewers

- **The new-syntax assertions in `format.pure` are `<<test.Test>>` rather than `<<PCT.test>>`, deliberately.** legend-engine carries a second implementation of this format language, used by generated Java execution plans, which writes one digit per `S` whatever the count — `001000000` where this one writes `001`. A PCT test is the contract every platform has to pass, so those assertions sit outside `testFormatDate` until that fork is uplifted. `testFormatDate` carries a note saying where they went, and they move back into it when the two agree.
- **`StrictTimeFormat` is now visibly a second implementation of an overlapping language**, carrying the sub-second rule this change replaces. It has no Pure surface — nothing reaches it except `PureStrictTime.format(String)` from Java — and it was deliberately left alone.
- The motivating downstream case is untouched here but worth knowing: every SQL literal writer in legend-engine branches on granularity and keeps a format string per branch (the Oracle one has five), which is one string under this change.

## Design record

[ADR-005](docs/decisions/ADR-005-date-format-subsecond-and-optional-sections.md) records the decisions, what they cost, and what was rejected — trailing-zero trimming, an `S=N` that invents a fraction, rounding rather than truncating above the maximum, and text fields.