### PR TITLE
Do not run the release deploy with -T (parallel builds)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,8 +282,15 @@ jobs:
           fi
 
       - name: Deploy release
+        # No -T here: central-publishing-maven-plugin (extensions=true, from the
+        # org.finos:finos parent) defers every module's artifacts and uploads
+        # one bundle for the whole reactor at the end. Under Maven's parallel
+        # builder that aggregation deadlocks -- every thread ends up stuck on
+        # "Waiting for other projects build to finish..." indefinitely. The
+        # build is already done and installed by the step above; deploy only
+        # signs what is missing and uploads, so parallelism buys nothing.
         if: ${{ !inputs.dryRun }}
-        run: mvn -B -e -T 3 -DskipTests -Drevision="${RELEASE_VERSION}" deploy -P release
+        run: mvn -B -e -DskipTests -Drevision="${RELEASE_VERSION}" deploy -P release
         env:
           MAVEN_OPTS: -XX:MaxRAMPercentage=90.0
 


### PR DESCRIPTION
## What

The `Deploy release` step in `release.yml` ran `mvn -B -e -T 3 -DskipTests -Drevision=… deploy -P release`. This drops the `-T 3`.

## Why

`central-publishing-maven-plugin` (`extensions=true`, inherited from the `org.finos:finos` parent, `autoPublish=true`) is a deferred/aggregating deployer: it collects every reactor module's artifacts and uploads **one** bundle for the whole build at the end. That end-of-reactor aggregation deadlocks under Maven's multi-threaded builder.

The release dispatched for **5.99.1** ([run 34222496885](https://github.com/finos/legend-pure/actions/runs/34222496885/job/102064252390)) sat in `Deploy release` for **over an hour** with every reactor thread stuck on:

```
[INFO] Waiting for other projects build to finish...
```

It published nothing to Maven Central (latest there is still 5.98.0) and never reached the version bump.

### Why now

This never happened before because `release:perform` (removed in #1333) forks a **single-threaded** `deploy`. #1333 replaced it with a direct `mvn -T 3 … deploy`, introducing parallelism into the deploy for the first time.

`Build release` immediately above still uses `-T 3` — that's fine, it runs `install` and `central-publishing:publish` only binds to `deploy`. The deploy step now only signs and uploads already-built artifacts, so it gains nothing from parallelism. `legend-stack-release.yml` already deploys without `-T`.

## Follow-up for the stuck 5.99.1 release

- Cancel run 34222496885 (deadlocked, will otherwise hang to the 6h timeout).
- Delete the `legend-pure-5.99.1` tag (pushed before the deadlock; nothing was published) via `git push --delete origin legend-pure-5.99.1` or the *Clean repo after failed release* workflow.
- Re-dispatch the release once this is merged.

## Testing

Not run (release path). Verified by reading: the deadlock is reproducible in the linked run, and the change matches the single-threaded deploy that every release through 5.98.0 used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)