### PR TITLE
Build the release deploy from clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,8 +233,9 @@ jobs:
       - name: Build release
         # Tests are skipped here because the `verify` job already ran the
         # whole suite on every supported JDK against this exact commit; this
-        # build only needs to compile, sign and package.
-        run: mvn -B -e -T 3 -DskipTests -Drevision="${RELEASE_VERSION}" install -P release
+        # build only needs to compile, sign and package. `clean` because
+        # several Pure Maven plugins fail over a pre-existing target dir.
+        run: mvn -B -e -T 3 -DskipTests -Drevision="${RELEASE_VERSION}" clean install -P release
         env:
           MAVEN_OPTS: -XX:MaxRAMPercentage=90.0
 
@@ -282,15 +283,18 @@ jobs:
           fi
 
       - name: Deploy release
-        # No -T here: central-publishing-maven-plugin (extensions=true, from the
-        # org.finos:finos parent) defers every module's artifacts and uploads
-        # one bundle for the whole reactor at the end. Under Maven's parallel
-        # builder that aggregation deadlocks -- every thread ends up stuck on
-        # "Waiting for other projects build to finish..." indefinitely. The
-        # build is already done and installed by the step above; deploy only
-        # signs what is missing and uploads, so parallelism buys nothing.
+        # `clean`: several Pure Maven plugins fail over a populated target
+        # directory ("The code repository ... already exists"), so this cannot
+        # build on top of the `Build release` output -- it is a fresh build
+        # that also deploys. That step stays as the gate that a release build
+        # works before the tag is pushed.
+        # No -T: central-publishing-maven-plugin (extensions=true, from the
+        # org.finos:finos parent) aggregates the whole reactor into one bundle
+        # at the end of the build, and that deadlocks under Maven's parallel
+        # builder -- every thread ends up stuck on "Waiting for other projects
+        # build to finish..." indefinitely.
         if: ${{ !inputs.dryRun }}
-        run: mvn -B -e -DskipTests -Drevision="${RELEASE_VERSION}" deploy -P release
+        run: mvn -B -e -DskipTests -Drevision="${RELEASE_VERSION}" clean deploy -P release
         env:
           MAVEN_OPTS: -XX:MaxRAMPercentage=90.0
 


### PR DESCRIPTION
## What

- `Deploy release`: `mvn ... deploy` -> `mvn ... clean deploy`
- `Build release`: `mvn ... install` -> `mvn ... clean install` (consistency; it only works today because the runner checkout is fresh)

## Why

Follow-up to #1334. With the `-T` deadlock gone, the 5.99.0 release ([run 34239781484](https://github.com/finos/legend-pure/actions/runs/34239781484/job/102125182983)) got further and then failed in `Deploy release`, immediately after the tag was pushed:

```
[ERROR] Failed to execute goal org.finos.legend.pure:legend-pure-maven-generation-par:5.99.0:build-pure-jar
        (default) on project legend-pure-m3-precisePrimitives:
        Error serializing Pure PAR: The code repository platform_precise_primitives already exists!
Caused by: java.lang.IllegalStateException: The code repository platform_precise_primitives already exists!
    at CodeRepositorySet$Builder.addCodeRepository (CodeRepositorySet.java:192)
```

`Deploy release` builds on top of the `target/` directories that `Build release` (`mvn ... install`) just populated. `deploy` re-runs the `package` phase, and the Pure PAR generator refuses to regenerate a repository that is already present in `target/`. This is the known "always pass `clean` for lifecycle builds" issue (`CLAUDE.md`) — several Pure Maven plugins don't tolerate a pre-existing target dir. The old `release:perform` never hit it because it built in a fresh checkout.

`clean deploy` makes the deploy a fresh build. `Build release` + `Verify the release artifacts…` stay as the gate that a release build works before the tag is pushed; the deploy step then rebuilds from clean and publishes.

## Testing

Not run (release path). The failure and its cause are visible in the linked run; `clean` is what every green build of this repo uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)