### PR TITLE
Fix release workflow problems from the CI-friendly versions migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,15 @@
 
 name: Build CI
 
-on: [push, pull_request]
+on:
+  push:
+    # Branch pushes only. A release tag lands on a commit this workflow already
+    # built when it went onto the branch, so building it again on the tag push
+    # spends a second full matrix on it and hands `Publish Test Results` a
+    # duplicate set of results for the same commit.
+    tags-ignore:
+      - '**'
+  pull_request:
 
 jobs:
   verify:

--- a/.github/workflows/legend-stack-release.yml
+++ b/.github/workflows/legend-stack-release.yml
@@ -38,6 +38,21 @@ jobs:
           git config --global user.email "37706051+finos-admin@users.noreply.github.com"
           git config --global user.name "FINOS Administrator"
 
+      - name: Verify nothing landed since this run was dispatched
+        run: |
+          set -euo pipefail
+          # The version bump at the end of this run commits onto the commit
+          # built here, so a branch that has moved turns that push into a
+          # non-fast-forward. Fail now, before anything is deployed or tagged,
+          # rather than after. This is not the only guard: that push is plain
+          # and never forced, so git still rejects it if the branch moves
+          # between this check and the bump.
+          tip="$(git ls-remote origin "refs/heads/${GITHUB_REF_NAME}" | cut -f1)"
+          if [ "${tip}" != "${GITHUB_SHA}" ]; then
+            echo "::error::${GITHUB_REF_NAME} moved from ${GITHUB_SHA} to ${tip} after this run was dispatched. Nothing has been deployed or tagged; dispatch the release again."
+            exit 1
+          fi
+
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -93,9 +108,17 @@ jobs:
           set -euo pipefail
           IFS=. read -r major minor patch <<< "${RELEASE_VERSION}"
           nextSnapshot="${major}.${minor}.$((patch + 1))-SNAPSHOT"
-          git fetch origin "${GITHUB_REF_NAME}"
-          git checkout -B "${GITHUB_REF_NAME}" "origin/${GITHUB_REF_NAME}"
+          # Committed onto the commit that was built, deployed and tagged,
+          # never onto whatever the remote tip has become, so the push below is
+          # a plain fast-forward: if anything landed on the branch after the
+          # check above, git rejects it rather than reverting a <revision>
+          # somebody else changed.
+          git checkout -B "${GITHUB_REF_NAME}" "${GITHUB_SHA}"
           sed -i "s|<revision>.*</revision>|<revision>${nextSnapshot}</revision>|" pom.xml
+          if git diff --quiet -- pom.xml; then
+            echo "::error::sed left pom.xml unchanged; set <revision> to ${nextSnapshot} by hand on ${GITHUB_REF_NAME}."
+            exit 1
+          fi
           git add pom.xml
           git commit -m "Bump version to ${nextSnapshot}"
           git push origin "${GITHUB_REF_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@
 # The whole workflow releases one commit, pinned by the `prepare` job and
 # checked out by SHA everywhere else. Nothing reaches the remote -- no commit,
 # no tag, nothing published -- until every JDK in the matrix has gone green
-# against that exact commit.
+# against that exact commit, and the branch is proven not to have moved since.
 name: Release
 
 env:
@@ -186,9 +186,21 @@ jobs:
           git config --global user.email "37706051+finos-admin@users.noreply.github.com"
           git config --global user.name "FINOS Administrator"
 
-      - name: Verify the tag is still free
+      - name: Verify nothing landed while the tests ran
         run: |
           set -euo pipefail
+          # The version bump at the end of this run commits onto the tested
+          # commit, so a branch that has moved turns that push into a
+          # non-fast-forward and the release fails after publishing. Fail here
+          # instead, before anything has been tagged or deployed, with a
+          # message that says what happened. This is not the only guard: that
+          # push is plain and never forced, so git still rejects it if the
+          # branch moves between this check and the bump.
+          tip="$(git ls-remote origin "refs/heads/${RELEASE_BRANCH}" | cut -f1)"
+          if [ "${tip}" != "${RELEASE_SHA}" ]; then
+            echo "::error::${RELEASE_BRANCH} moved from ${RELEASE_SHA} to ${tip} while the build and test jobs ran. Nothing has been tagged or published; re-run the release so the new commits get built and tested too."
+            exit 1
+          fi
           if git ls-remote --exit-code origin "refs/tags/${RELEASE_TAG}" > /dev/null 2>&1; then
             echo "::error::Tag ${RELEASE_TAG} appeared while this run was in flight."
             exit 1
@@ -233,8 +245,9 @@ jobs:
       - name: Build release
         # Tests are skipped here because the `verify` job already ran the
         # whole suite on every supported JDK against this exact commit; this
-        # build only needs to compile, sign and package.
-        run: mvn -B -e -T 3 -DskipTests -Drevision="${RELEASE_VERSION}" install -P release
+        # build only needs to compile, sign and package. It is also the last
+        # gate before the tag push, so a failure here costs nothing.
+        run: mvn -B -e -T 4 -DskipTests -Drevision="${RELEASE_VERSION}" install -P release
         env:
           MAVEN_OPTS: -XX:MaxRAMPercentage=90.0
 
@@ -259,7 +272,7 @@ jobs:
             echo "Checked, without touching the remote:"
             echo
             echo "- ${RELEASE_BRANCH} pinned at ${RELEASE_SHA}, green on every supported JDK"
-            echo "- ${RELEASE_TAG} does not exist yet"
+            echo "- ${RELEASE_BRANCH} has not moved since, and ${RELEASE_TAG} does not exist yet"
             echo "- the release build with -Drevision=${RELEASE_VERSION} succeeded and every pom resolved"
             echo "- the next development version would be ${DEVELOPMENT_VERSION}"
             echo
@@ -282,15 +295,23 @@ jobs:
           fi
 
       - name: Deploy release
-        # No -T here: central-publishing-maven-plugin (extensions=true, from the
+        # `clean` matters. `Build release` above already ran the whole
+        # lifecycle in this workspace, so target/ holds that run's output:
+        # jars maven-shade-plugin rewrote in place, and the signatures
+        # maven-gpg-plugin wrote beside them. Re-entering the lifecycle over
+        # that state lets plugins act on their own previous output -- shade
+        # re-shading an already-shaded jar, for one -- so what gets published
+        # is not a clean build of the tagged commit. release:perform used to
+        # avoid this by building in a fresh target/checkout; `clean` is the
+        # equivalent now that the deploy shares a workspace with the build.
+        #
+        # No -T: central-publishing-maven-plugin (extensions=true, from the
         # org.finos:finos parent) defers every module's artifacts and uploads
         # one bundle for the whole reactor at the end. Under Maven's parallel
         # builder that aggregation deadlocks -- every thread ends up stuck on
-        # "Waiting for other projects build to finish..." indefinitely. The
-        # build is already done and installed by the step above; deploy only
-        # signs what is missing and uploads, so parallelism buys nothing.
+        # "Waiting for other projects build to finish..." indefinitely.
         if: ${{ !inputs.dryRun }}
-        run: mvn -B -e -DskipTests -Drevision="${RELEASE_VERSION}" deploy -P release
+        run: mvn -B -e -DskipTests -Drevision="${RELEASE_VERSION}" clean deploy -P release
         env:
           MAVEN_OPTS: -XX:MaxRAMPercentage=90.0
 
@@ -298,12 +319,18 @@ jobs:
         if: ${{ !inputs.dryRun }}
         run: |
           set -euo pipefail
-          # On the branch's current tip, not the tested commit: anything that
-          # landed during the release stays. The change is one property, so
-          # there is nothing to conflict with.
-          git fetch origin "${RELEASE_BRANCH}"
-          git checkout -B "${RELEASE_BRANCH}" "origin/${RELEASE_BRANCH}"
+          # Committed onto the tested commit, never onto whatever the remote
+          # tip has become, so the push below is a plain fast-forward: if
+          # anything landed on the branch after the check above, git rejects it
+          # rather than reverting a <revision> somebody else changed. The
+          # release is already published by then, which is why the recovery
+          # summary covers setting <revision> by hand.
+          git checkout -B "${RELEASE_BRANCH}" "${RELEASE_SHA}"
           sed -i "s|<revision>.*</revision>|<revision>${DEVELOPMENT_VERSION}</revision>|" pom.xml
+          if git diff --quiet -- pom.xml; then
+            echo "::error::sed left pom.xml unchanged; set <revision> to ${DEVELOPMENT_VERSION} by hand on ${RELEASE_BRANCH}."
+            exit 1
+          fi
           git add pom.xml
           git commit -m "Bump version to ${DEVELOPMENT_VERSION}"
           git push origin "${RELEASE_BRANCH}"
@@ -314,20 +341,40 @@ jobs:
         # the tag survives is a human decision. What this can do is remove the
         # guesswork -- `Clean repo after failed release` infers "the latest
         # tag", where the exact ref is known here.
-        if: failure()
+        # Cancellation as well as failure: a run killed between the tag push
+        # and the deploy is exactly the case the concurrency comment above
+        # says needs manual recovery, and `failure()` alone does not fire for
+        # it.
+        if: ${{ failure() || cancelled() }}
         run: |
           set -euo pipefail
-          remote_tag="$(git ls-remote origin "refs/tags/${RELEASE_TAG}" 2> /dev/null | awk -v ref="refs/tags/${RELEASE_TAG}" '$2 == ref { print $1 }')" || true
+          # Never claim "nothing was pushed" on a guess. A remote that cannot
+          # be reached is not a remote without the tag, and that summary tells
+          # the reader to stop looking.
+          if tag_refs="$(git ls-remote origin "refs/tags/${RELEASE_TAG}")"; then
+            remote_tag="$(awk -v ref="refs/tags/${RELEASE_TAG}" '$2 == ref { print $1 }' <<< "${tag_refs}")"
+          else
+            remote_tag=unknown
+          fi
           {
-            echo "## Release ${RELEASE_VERSION} failed"
+            echo "## Release ${RELEASE_VERSION} did not finish"
             echo
             if [ -z "${remote_tag}" ]; then
               echo "**Nothing was pushed.** The tag ${RELEASE_TAG} does not exist on the remote"
-              echo "and ${RELEASE_BRANCH} was not touched. Nothing needs cleaning up:"
-              echo "fix the cause and dispatch the release again."
+              echo "and ${RELEASE_BRANCH} was not touched. Nothing needs cleaning up: deal with"
+              echo "whatever stopped this run and dispatch the release again."
             else
-              echo "**The tag is already pushed**, so this failed during deploy or the"
-              echo "version bump. Recover by hand, in this order:"
+              if [ "${remote_tag}" = unknown ]; then
+                echo "**The remote could not be reached** to check whether ${RELEASE_TAG} was"
+                echo "pushed, so confirm it by hand first:"
+                echo
+                echo "       git ls-remote origin refs/tags/${RELEASE_TAG}"
+                echo
+                echo "The steps below assume the tag is there."
+              else
+                echo "**The tag is already pushed**, so this stopped at or after the tag push."
+              fi
+              echo "Recover by hand, in this order:"
               echo
               echo "1. Work out whether anything reached Maven Central. This project publishes"
               echo "   with autoPublish enabled and publishing cannot be undone:"
@@ -337,12 +384,15 @@ jobs:
               echo "   Check the Central portal too, for a deployment stuck in validation."
               echo "2. If ${RELEASE_VERSION} **was** published, leave the tag alone. If the bump"
               echo "   commit is missing, set <revision> in pom.xml to ${DEVELOPMENT_VERSION} by hand"
-              echo "   on ${RELEASE_BRANCH}."
+              echo "   on ${RELEASE_BRANCH} -- but look at what is on the branch first. That bump"
+              echo "   is pushed as a fast-forward from ${RELEASE_SHA}, so it is rejected when"
+              echo "   somebody else pushed while this ran; if their commit set <revision>"
+              echo "   deliberately, keep their value rather than overwriting it."
               echo "3. Only if nothing was published, delete the tag and dispatch again:"
               echo
               echo "       git push --delete origin ${RELEASE_TAG}"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
           if [ -n "${remote_tag}" ]; then
-            echo "::error::Release ${RELEASE_VERSION} failed after pushing ${RELEASE_TAG}. See the job summary for recovery steps."
+            echo "::error::Release ${RELEASE_VERSION} did not finish and may need manual cleanup. See the job summary for recovery steps."
           fi

--- a/docs/guides/build-and-ci.md
+++ b/docs/guides/build-and-ci.md
@@ -133,8 +133,9 @@ The pipeline is defined in [`.github/workflows/build.yml`](../../.github/workflo
 
 ### Trigger
 
-Runs on every `push` and `pull_request` event.
-The post-release version-bump commit (message starting `Bump version to`) is skipped.
+Runs on every branch `push` and `pull_request` event. Tag pushes are ignored,
+and the post-release version-bump commit (message starting `Bump version to`)
+is skipped.
 
 ### Environment
 
@@ -174,9 +175,11 @@ workflow. The project uses Maven CI-friendly versions: every pom's version is
 `${revision}`, defined once in the root pom, and `flatten-maven-plugin` writes
 the resolved version into the published poms. A release builds and deploys the
 tested commit with `-Drevision=<version>`, pushes the tag `legend-pure-<version>`
-onto that commit, and then commits the next `-SNAPSHOT` to the branch. There are
-no release commits and nothing is rebuilt from the tag. Do not trigger releases
-manually unless you are the designated release engineer.
+onto that commit, and then commits the next `-SNAPSHOT` to the branch. There is
+no release commit — the tag lands on the tested commit itself — and the deploy
+runs `clean deploy`, so what is published is a fresh build of that commit rather
+than the output the preceding `install` left behind in `target/`. Do not trigger
+releases manually unless you are the designated release engineer.
 
 ---
 


### PR DESCRIPTION
#1333 replaced `maven-release-plugin` with a direct `-Drevision` build, and #1334 dropped `-T` from the deploy after the 5.99.1 release deadlocked. This reviews the rest of what changed, and the two workflows that inherited the same patterns.

### Deploy with `clean deploy`

`Build release` already runs the whole lifecycle in the release job's workspace, so `target/` holds that run's output — jars `maven-shade-plugin` rewrote in place, and the signatures `maven-gpg-plugin` wrote beside them. Re-entering the lifecycle over that state lets plugins act on their own previous output rather than on a clean build of the tagged commit. `release:perform` avoided this by building in a fresh `target/checkout`; `clean` is the equivalent now that the build and the deploy share a workspace.

This also corrects #1334's comment, which said the deploy "only signs what is missing and uploads" — Maven re-runs the whole lifecycle either way.

### Build the release with `-T 4`

Matches the CI build in `build-and-test.yml`.

### Restore the check that nothing landed on the release branch

#1333 removed it on the grounds that nothing is committed before the tag, but the version bump still commits to the branch — and it was rewritten to `checkout -B <branch> origin/<branch>` plus a blind `sed`, which always succeeds. A `<revision>` somebody else changed while the release ran would be silently reverted.

The pre-build check is back, and the bump is based on the tested commit again, so its push is a plain fast-forward that git rejects on a race rather than clobbering.

`legend-stack-release.yml` lost the same protection implicitly — `release:prepare`'s branch push was non-forced — and gets the same treatment.

### Stop rebuilding on tag pushes

The `Build CI` skip filter moved from `[maven-release-plugin]` to `Bump version to`. The release tag used to point at a release-plugin commit and so was skipped; it now points at an ordinary commit, so every release spends a second full matrix rebuilding a commit already built, and hands `Publish Test Results` a duplicate set of results for it. Fixed with `tags-ignore`.

### Fix the recovery summary

Three problems in `Explain how to recover`:

- It advised setting `<revision>` by hand without noting that a rejected bump usually means somebody else changed it deliberately — following it literally would undo their change.
- `if: failure()` does not fire on cancellation, which is precisely the case the workflow's own concurrency comment singles out as needing manual recovery.
- A remote it could not reach was reported as a remote without the tag ("**Nothing was pushed.** … Nothing needs cleaning up"), with the git error hidden by `2> /dev/null`. It now distinguishes "no tag" from "could not check" and falls through to the conservative advice.

### Not addressed here

A release still compiles the reactor three times: in `verify`, in `Build release`, and in `Deploy release`. `Build release` is not redundant — it is the only build that exercises `-Drevision` and `-P release` (gpg, javadoc and source jars) — but its output is discarded by the `clean`. Collapsing it into the deploy would mean tagging after publishing, a bigger change to the point of no return; better left until the new flow has a few releases behind it.

### Verification

- All 8 workflows parse as YAML; all 17 `run:` blocks pass `bash -n`.
- The version-bump `sed` and its no-op guard exercised against the real `pom.xml` in a scratch repo: it changes exactly the one `<revision>` line, and the guard fires correctly in both directions under `set -euo pipefail`.
- `Explain how to recover` exercised in all three states — tag absent, tag present, remote unreachable — with a stubbed `git ls-remote`.

`docs/guides/build-and-ci.md` updated to match.