### PR TITLE
Fix the push trigger so branch builds run again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,16 @@ name: Build CI
 
 on:
   push:
-    # Branch pushes only. A release tag lands on a commit this workflow already
-    # built when it went onto the branch, so building it again on the tag push
-    # spends a second full matrix on it and hands `Publish Test Results` a
-    # duplicate set of results for the same commit.
-    tags-ignore:
+    # Branch pushes only -- and `branches` rather than `tags-ignore` on
+    # purpose. A push filter that names only tags stops the workflow running
+    # for branch pushes as well, because branches are then the undefined ref;
+    # naming every branch here leaves *tags* undefined instead, which is what
+    # actually skips them.
+    # A release tag lands on a commit this workflow already built when it went
+    # onto the branch, so building it again on the tag push spends a second
+    # full matrix on it and hands `Publish Test Results` a duplicate set of
+    # results for the same commit.
+    branches:
       - '**'
   pull_request:
 


### PR DESCRIPTION
`tags-ignore` was meant to read "run on branches, skip tags", but a push filter that names only tags stops the workflow running for branch pushes too: branches become the undefined ref, and GitHub does not run the workflow for an undefined ref. With every tag ignored and branches undefined, `push` stopped firing at all, so only `pull_request` still triggered a build and a plain branch push did nothing.

Name every branch instead. That leaves tags as the undefined ref, which is what actually skips them, and restores branch builds.