### PR TITLE
Add Pure tests for time zone handling, and report executeInDb failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 
 **/.DS_Store
 **/pure-duckDB-test-Db*
+**/pure-duckdb-test-db*

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/tests/duckdb_round_trip.pure
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/tests/duckdb_round_trip.pure
@@ -1,0 +1,146 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pure-native round trip tests for the DuckDB backend, covering how a
+// value of a date or time type survives being written and read back.
+// Companion to `h2_round_trip.pure`, which asks the same questions of H2:
+// two drivers reaching different answers is the whole reason these
+// readings are worth pinning down. `execute_in_db.pure` holds the DuckDB
+// basics, and `temp_tables.pure` the temp-table lifecycle.
+//
+// The DuckDB test database is a single file-backed connection shared by
+// the whole run, with its session time zone set to UTC, so each test
+// creates its table with CREATE OR REPLACE and drops it at the end.
+
+import meta::external::store::relational::runtime::*;
+import meta::relational::runtime::*;
+import meta::relational::metamodel::execute::*;
+
+// --- Time zones -------------------------------------------------------
+//
+// A connection's `timeZone` names the zone the database keeps its wall
+// clocks in. It settles how a TIMESTAMP is read, and must not reach a
+// DATE or a TIMESTAMPTZ, neither of which is a wall clock waiting for a
+// zone. Every name here is resolved by
+// `org.finos.legend.pure.m4.tools.time.TimeZones`.
+
+function <<access.private>> meta::relational::tests::readDuckDbColumnInZone(sql: String[1], timeZone: String[1]): Any[*]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.DuckDB, timeZone = $timeZone);
+   executeInDb($sql, $db, 0, 1000).rows->map(row | $row.values->at(0));
+}
+
+// A DATE column carries a day and no zone, as a Pure StrictDate does, so
+// the zone the connection names has no bearing on it. Reading one as an
+// instant does give it a bearing, since a day only comes back out of an
+// instant once a zone is chosen to read it in, and the day that comes
+// back is a different one either side of midnight.
+function <<test.Test>>
+meta::relational::tests::testExecuteInDuckDbDateIgnoresTheConnectionTimeZone(): Boolean[1]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.DuckDB);
+   executeInDb('CREATE OR REPLACE TABLE duckdb_tz_day (recorded_on DATE)', $db, 0, 1000);
+   executeInDb('INSERT INTO duckdb_tz_day VALUES (DATE \'1753-12-31\'), (DATE \'2014-03-10\')', $db, 0, 1000);
+
+   let ok = ['GMT', 'UTC', 'America/New_York', 'Asia/Tokyo', 'EST', '+0530']->forAll(tz |
+      assertEquals(
+         [%1753-12-31, %2014-03-10],
+         meta::relational::tests::readDuckDbColumnInZone('SELECT recorded_on FROM duckdb_tz_day ORDER BY recorded_on', $tz),
+         'connection time zone %s', $tz));
+
+   executeInDb('DROP TABLE duckdb_tz_day', $db, 0, 1000);
+   $ok;
+}
+
+// A TIMESTAMP column carries a wall clock the database keeps in the zone
+// the connection names, and a Pure DateTime is a moment, so reading one
+// shifts it out of that zone. The shift is done here rather than by
+// handing the driver a calendar, which not every driver honours: DuckDB
+// 1.0.0 ignored one entirely and answered as though the connection named
+// UTC, leaving every timestamp short by the connection's offset.
+function <<test.Test>>
+meta::relational::tests::testExecuteInDuckDbTimestampIsShiftedOutOfTheConnectionTimeZone(): Boolean[1]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.DuckDB);
+   executeInDb('CREATE OR REPLACE TABLE duckdb_tz_moment (recorded_at TIMESTAMP)', $db, 0, 1000);
+   executeInDb('INSERT INTO duckdb_tz_moment VALUES (TIMESTAMP \'2014-03-10 12:00:00\')', $db, 0, 1000);
+   let sql = 'SELECT recorded_at FROM duckdb_tz_moment';
+
+   // 2014-03-10 is inside daylight saving time in New York, so -04:00 rather than -05:00.
+   // EST keeps no daylight saving time and is -05:00 whichever zone the running JDK reads it
+   // as: it stood for the fixed offset through Java 21 and for America/Panama from Java 25.
+   let ok = [
+      assertEquals(%2014-03-10T12:00:00.000000000+0000, meta::relational::tests::readDuckDbColumnInZone($sql, 'GMT')->toOne(), 'connection time zone %s', 'GMT'),
+      assertEquals(%2014-03-10T16:00:00.000000000+0000, meta::relational::tests::readDuckDbColumnInZone($sql, 'America/New_York')->toOne(), 'connection time zone %s', 'America/New_York'),
+      assertEquals(%2014-03-10T03:00:00.000000000+0000, meta::relational::tests::readDuckDbColumnInZone($sql, 'Asia/Tokyo')->toOne(), 'connection time zone %s', 'Asia/Tokyo'),
+      assertEquals(%2014-03-10T17:00:00.000000000+0000, meta::relational::tests::readDuckDbColumnInZone($sql, 'EST')->toOne(), 'connection time zone %s', 'EST'),
+      assertEquals(%2014-03-10T06:30:00.000000000+0000, meta::relational::tests::readDuckDbColumnInZone($sql, '+0530')->toOne(), 'connection time zone %s', '+0530')
+   ]->forAll(assertion | $assertion);
+
+   executeInDb('DROP TABLE duckdb_tz_moment', $db, 0, 1000);
+   $ok;
+}
+
+// A moment from before its zone kept standard time. java.util holds only
+// the standard offset a zone later adopted, where java.time holds the
+// mean solar offset the zone actually kept: New York is -05:00:00 by one
+// and -04:56:02 by the other in 1753. Those four minutes are what turned
+// a stored 1753-12-31 into 1753-12-30 when a date was read as an instant,
+// so the reading has to be the java.time one.
+function <<test.Test>>
+meta::relational::tests::testExecuteInDuckDbTimestampBeforeStandardTime(): Boolean[1]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.DuckDB);
+   executeInDb('CREATE OR REPLACE TABLE duckdb_tz_old_moment (recorded_at TIMESTAMP)', $db, 0, 1000);
+   executeInDb('INSERT INTO duckdb_tz_old_moment VALUES (TIMESTAMP \'1753-12-31 00:00:00\')', $db, 0, 1000);
+
+   let ok = assertEquals(
+      %1753-12-31T04:56:02.000000000+0000,
+      meta::relational::tests::readDuckDbColumnInZone('SELECT recorded_at FROM duckdb_tz_old_moment', 'America/New_York')->toOne());
+
+   executeInDb('DROP TABLE duckdb_tz_old_moment', $db, 0, 1000);
+   $ok;
+}
+
+// A TIMESTAMPTZ column carries a moment already, so there is no wall
+// clock to place and nothing to shift into or out of. The zone the
+// connection names says where the database keeps its wall clocks, and
+// this column holds none.
+function <<test.Test>>
+meta::relational::tests::testExecuteInDuckDbTimestampTzIgnoresTheConnectionTimeZone(): Boolean[1]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.DuckDB);
+   executeInDb('CREATE OR REPLACE TABLE duckdb_tz_zoned (recorded_at TIMESTAMPTZ)', $db, 0, 1000);
+   executeInDb('INSERT INTO duckdb_tz_zoned VALUES (TIMESTAMPTZ \'2014-03-10 12:00:00+02\')', $db, 0, 1000);
+   let sql = 'SELECT recorded_at FROM duckdb_tz_zoned';
+
+   let ok = ['GMT', 'America/New_York', 'Asia/Tokyo', '+0530']->forAll(tz |
+      assertEquals(
+         %2014-03-10T10:00:00.000000000+0000,
+         meta::relational::tests::readDuckDbColumnInZone($sql, $tz)->toOne(),
+         'connection time zone %s', $tz));
+
+   executeInDb('DROP TABLE duckdb_tz_zoned', $db, 0, 1000);
+   $ok;
+}
+
+// A name that stands for no zone is a mistake worth reporting. It used to
+// be answered with GMT, which is what kept a whole class of time zone
+// bugs out of sight: a result read in the wrong zone looks like a result.
+function <<test.Test>>
+meta::relational::tests::testExecuteInDuckDbRejectsAnUnknownTimeZone(): Boolean[1]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.DuckDB, timeZone = 'Not/AZone');
+   assertError(| executeInDb('SELECT 1', $db, 0, 1000), 'Error in executeInDb: Unknown time zone: Not/AZone');
+}

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/tests/h2_round_trip.pure
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/tests/h2_round_trip.pure
@@ -86,3 +86,125 @@ meta::relational::tests::testCreateTempTableInH2(): Boolean[1]
    dropTempTable('tt_h2', $db);
    $ok;
 }
+
+// --- Time zones -------------------------------------------------------
+//
+// A connection's `timeZone` names the zone the database keeps its wall
+// clocks in. It settles how a TIMESTAMP is read, and must not reach a
+// DATE or a TIMESTAMP WITH TIME ZONE, neither of which is a wall clock
+// waiting for a zone. Every name here is resolved by
+// `org.finos.legend.pure.m4.tools.time.TimeZones`.
+
+function <<access.private>> meta::relational::tests::readH2ColumnInZone(sql: String[1], timeZone: String[1]): Any[*]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.H2, timeZone = $timeZone);
+   executeInDb($sql, $db, 0, 1000).rows->map(row | $row.values->at(0));
+}
+
+// A DATE column carries a day and no zone, as a Pure StrictDate does, so
+// the zone the connection names has no bearing on it. Reading one as an
+// instant does give it a bearing, since a day only comes back out of an
+// instant once a zone is chosen to read it in, and the day that comes
+// back is a different one either side of midnight.
+function <<test.Test>>
+meta::relational::tests::testExecuteInH2DateIgnoresTheConnectionTimeZone(): Boolean[1]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.H2);
+   executeInDb('DROP TABLE IF EXISTS h2_tz_day', $db, 0, 1000);
+   executeInDb('CREATE LOCAL TEMPORARY TABLE h2_tz_day (recorded_on DATE)', $db, 0, 1000);
+   executeInDb('INSERT INTO h2_tz_day VALUES (DATE \'1753-12-31\'), (DATE \'2014-03-10\')', $db, 0, 1000);
+
+   let ok = ['GMT', 'UTC', 'America/New_York', 'Asia/Tokyo', 'EST', '+0530']->forAll(tz |
+      assertEquals(
+         [%1753-12-31, %2014-03-10],
+         meta::relational::tests::readH2ColumnInZone('SELECT recorded_on FROM h2_tz_day ORDER BY recorded_on', $tz),
+         'connection time zone %s', $tz));
+
+   executeInDb('DROP TABLE h2_tz_day', $db, 0, 1000);
+   $ok;
+}
+
+// A TIMESTAMP column carries a wall clock the database keeps in the zone
+// the connection names, and a Pure DateTime is a moment, so reading one
+// shifts it out of that zone. `+0530` is the case that used to go wrong
+// quietly: java.util takes an offset only with a GMT prefix and answers
+// every other name it does not know with GMT, so the shift was skipped
+// and nothing about the result said so.
+function <<test.Test>>
+meta::relational::tests::testExecuteInH2TimestampIsShiftedOutOfTheConnectionTimeZone(): Boolean[1]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.H2);
+   executeInDb('DROP TABLE IF EXISTS h2_tz_moment', $db, 0, 1000);
+   executeInDb('CREATE LOCAL TEMPORARY TABLE h2_tz_moment (recorded_at TIMESTAMP)', $db, 0, 1000);
+   executeInDb('INSERT INTO h2_tz_moment VALUES (TIMESTAMP \'2014-03-10 12:00:00\')', $db, 0, 1000);
+   let sql = 'SELECT recorded_at FROM h2_tz_moment';
+
+   // 2014-03-10 is inside daylight saving time in New York, so -04:00 rather than -05:00.
+   // EST keeps no daylight saving time and is -05:00 whichever zone the running JDK reads it
+   // as: it stood for the fixed offset through Java 21 and for America/Panama from Java 25.
+   let ok = [
+      assertEquals(%2014-03-10T12:00:00.000000000+0000, meta::relational::tests::readH2ColumnInZone($sql, 'GMT')->toOne(), 'connection time zone %s', 'GMT'),
+      assertEquals(%2014-03-10T16:00:00.000000000+0000, meta::relational::tests::readH2ColumnInZone($sql, 'America/New_York')->toOne(), 'connection time zone %s', 'America/New_York'),
+      assertEquals(%2014-03-10T03:00:00.000000000+0000, meta::relational::tests::readH2ColumnInZone($sql, 'Asia/Tokyo')->toOne(), 'connection time zone %s', 'Asia/Tokyo'),
+      assertEquals(%2014-03-10T17:00:00.000000000+0000, meta::relational::tests::readH2ColumnInZone($sql, 'EST')->toOne(), 'connection time zone %s', 'EST'),
+      assertEquals(%2014-03-10T06:30:00.000000000+0000, meta::relational::tests::readH2ColumnInZone($sql, '+0530')->toOne(), 'connection time zone %s', '+0530')
+   ]->forAll(assertion | $assertion);
+
+   executeInDb('DROP TABLE h2_tz_moment', $db, 0, 1000);
+   $ok;
+}
+
+// A moment from before its zone kept standard time. java.util holds only
+// the standard offset a zone later adopted, where java.time holds the
+// mean solar offset the zone actually kept: New York is -05:00:00 by one
+// and -04:56:02 by the other in 1753. Those four minutes are what turned
+// a stored 1753-12-31 into 1753-12-30 when a date was read as an instant,
+// so the reading has to be the java.time one.
+function <<test.Test>>
+meta::relational::tests::testExecuteInH2TimestampBeforeStandardTime(): Boolean[1]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.H2);
+   executeInDb('DROP TABLE IF EXISTS h2_tz_old_moment', $db, 0, 1000);
+   executeInDb('CREATE LOCAL TEMPORARY TABLE h2_tz_old_moment (recorded_at TIMESTAMP)', $db, 0, 1000);
+   executeInDb('INSERT INTO h2_tz_old_moment VALUES (TIMESTAMP \'1753-12-31 00:00:00\')', $db, 0, 1000);
+
+   let ok = assertEquals(
+      %1753-12-31T04:56:02.000000000+0000,
+      meta::relational::tests::readH2ColumnInZone('SELECT recorded_at FROM h2_tz_old_moment', 'America/New_York')->toOne());
+
+   executeInDb('DROP TABLE h2_tz_old_moment', $db, 0, 1000);
+   $ok;
+}
+
+// A TIMESTAMP WITH TIME ZONE column carries a moment already, so there is
+// no wall clock to place and nothing to shift into or out of. The zone
+// the connection names says where the database keeps its wall clocks,
+// and this column holds none.
+function <<test.Test>>
+meta::relational::tests::testExecuteInH2TimestampWithTimeZoneIgnoresTheConnectionTimeZone(): Boolean[1]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.H2);
+   executeInDb('DROP TABLE IF EXISTS h2_tz_zoned', $db, 0, 1000);
+   executeInDb('CREATE LOCAL TEMPORARY TABLE h2_tz_zoned (recorded_at TIMESTAMP WITH TIME ZONE)', $db, 0, 1000);
+   executeInDb('INSERT INTO h2_tz_zoned VALUES (TIMESTAMP WITH TIME ZONE \'2014-03-10 12:00:00+02\')', $db, 0, 1000);
+   let sql = 'SELECT recorded_at FROM h2_tz_zoned';
+
+   let ok = ['GMT', 'America/New_York', 'Asia/Tokyo', '+0530']->forAll(tz |
+      assertEquals(
+         %2014-03-10T10:00:00.000000000+0000,
+         meta::relational::tests::readH2ColumnInZone($sql, $tz)->toOne(),
+         'connection time zone %s', $tz));
+
+   executeInDb('DROP TABLE h2_tz_zoned', $db, 0, 1000);
+   $ok;
+}
+
+// A name that stands for no zone is a mistake worth reporting. It used to
+// be answered with GMT, which is what kept a whole class of time zone
+// bugs out of sight: a result read in the wrong zone looks like a result.
+function <<test.Test>>
+meta::relational::tests::testExecuteInH2RejectsAnUnknownTimeZone(): Boolean[1]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.H2, timeZone = 'Not/AZone');
+   assertError(| executeInDb('SELECT 1', $db, 0, 1000), 'Error in executeInDb: Unknown time zone: Not/AZone');
+}

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/tests/load_values.pure
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-m2-store-relational-pure/src/main/resources/platform_store_relational/tests/load_values.pure
@@ -15,8 +15,15 @@
 // Pure-native tests for loadValuesToDbTable.
 //
 // Uses the ###Relational DSL to declare a real Database/Schema/Table
-// chain — the populated heap rows are what the native consumes when
+// chain -- the populated heap rows are what the native consumes when
 // it reads `Table.name`.
+//
+// The values are shaped like `TestDatabaseConnection.testDataSetupCsv`,
+// which the loader was written for: three header rows -- schema name,
+// table name, column names -- and then a row per record. The loader
+// drops the first three rows, so a call that hands it bare data rows
+// loses three of them, silently and without an error. That is what left
+// these tests unable to insert anything.
 
 ###Pure
 import meta::external::store::relational::runtime::*;
@@ -37,6 +44,12 @@ function <<access.private>> meta::relational::tests::loadValues::table():Table[1
 }
 
 // Insert two rows via loadValuesToDbTable and verify the count.
+//
+// ToFix on DuckDB only, and not for anything to do with the loader.
+// bulkInsertInDb calls Connection.commit() on a connection left in
+// auto-commit mode, which H2 tolerates and DuckDB reports as "cannot
+// commit - no transaction is active". The H2 half below is the same
+// test, and runs.
 function <<test.ToFix>>
 meta::relational::tests::loadValues::testLoadValuesToDbTableInsertsRows_duckDb(): Boolean[1]
 {
@@ -44,11 +57,11 @@ meta::relational::tests::loadValues::testLoadValuesToDbTableInsertsRows_duckDb()
    $db->meta::relational::tests::loadValues::testLoadValuesToDbTableInsertsRows();
 }
 
-function <<test.ToFix>>
+function <<test.Test>>
 meta::relational::tests::loadValues::testLoadValuesToDbTableInsertsRows_h2(): Boolean[1]
 {
    let db = ^TestDatabaseConnection(type = DatabaseType.H2);
-   executeInDb('CREATE SCHEMA MAIN', $db, 0, 1000);
+   executeInDb('CREATE SCHEMA IF NOT EXISTS MAIN', $db, 0, 1000);
    $db->meta::relational::tests::loadValues::testLoadValuesToDbTableInsertsRows();
 }
 
@@ -61,7 +74,7 @@ meta::relational::tests::loadValues::afterLoad_duckdb(): Boolean[1]
 }
 
 
-function <<test.AfterPackage, test.ToFix>>
+function <<test.AfterPackage>>
 meta::relational::tests::loadValues::afterLoad_h2(): Boolean[1]
 {
    let db = ^TestDatabaseConnection(type = DatabaseType.H2);
@@ -73,12 +86,42 @@ function <<access.private>> meta::relational::tests::loadValues::testLoadValuesT
 {
    executeInDb('CREATE TABLE main.lv(a INTEGER, b VARCHAR)', $db, 0, 1000);
 
+   let header = [^List<Any>(values = ['main']), ^List<Any>(values = ['lv']), ^List<Any>(values = ['a', 'b'])];
    let row1 = ^List<Any>(values = [1, 'foo']);
    let row2 = ^List<Any>(values = [2, 'bar']);
-   let outer = ^List<List<Any>>(values = [$row1, $row2]);
+   let outer = ^List<List<Any>>(values = $header->concatenate([$row1, $row2]));
    let tbl = meta::relational::tests::loadValues::table();
    loadValuesToDbTable($outer, $tbl, $db);
 
    let rs = executeInDb('SELECT count(*) FROM main.lv', $db, 0, 1000);
    assertEquals(2, $rs.rows->at(0).values->at(0));
+}
+
+// A day written through loadValuesToDbTable and read back is the same day.
+//
+// Nothing chooses a zone on the way in: the loader hands a date column the
+// string the Pure date names itself with and lets the driver parse it, which
+// is what the comment in LoadCsvToDbTable means by keeping dates as strings.
+// Nothing chooses a zone on the way out either, since a date column carries a
+// day and no zone. So the day survives whatever zone the connection names, and
+// this is the write side of testExecuteInH2DateIgnoresTheConnectionTimeZone.
+function <<test.Test>>
+meta::relational::tests::loadValues::testLoadValuesToDbTableRoundTripsADay_h2(): Boolean[1]
+{
+   let db = ^TestDatabaseConnection(type = DatabaseType.H2);
+   executeInDb('CREATE SCHEMA IF NOT EXISTS MAIN', $db, 0, 1000);
+   executeInDb('CREATE TABLE main.lv_day(recorded_on DATE)', $db, 0, 1000);
+
+   let header = [^List<Any>(values = ['main']), ^List<Any>(values = ['lv_day']), ^List<Any>(values = ['recorded_on'])];
+   let rows = [^List<Any>(values = [%1753-12-31]), ^List<Any>(values = [%2014-03-10])];
+   loadValuesToDbTable(
+      ^List<List<Any>>(values = $header->concatenate($rows)),
+      ^Table(schema = ^Schema(database = ^Database(name = 'db'), name = 'main'), name = 'lv_day', columns = [^Column(name = 'recorded_on', type = ^meta::relational::metamodel::datatype::Date())]),
+      $db);
+
+   ['GMT', 'America/New_York', 'Asia/Tokyo', '+0530']->forAll(tz |
+      assertEquals(
+         [%1753-12-31, %2014-03-10],
+         executeInDb('SELECT recorded_on FROM main.lv_day ORDER BY recorded_on', ^TestDatabaseConnection(type = DatabaseType.H2, timeZone = $tz), 0, 1000).rows->map(row | $row.values->at(0)),
+         'connection time zone %s', $tz));
 }

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-compiled-store-relational/src/main/resources/org/finos/legend/pure/runtime/java/extension/store/relational/compiled/RelationalGen.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-compiled-store-relational/src/main/resources/org/finos/legend/pure/runtime/java/extension/store/relational/compiled/RelationalGen.java
@@ -203,12 +203,11 @@ public class RelationalGen
         Root_meta_relational_metamodel_execute_ResultSet pureResult = new Root_meta_relational_metamodel_execute_ResultSet_Impl("OK");
 
         Connection connection = null;
-        ConnectionWithDataSourceInfo connectionWithDataSourceInfo = null;
         try
         {
 
             long startRequestConnection = System.nanoTime();
-            connectionWithDataSourceInfo = connectionManagerHandler.getConnectionWithDataSourceInfo(pureConnection, ((CompiledExecutionSupport) es).getProcessorSupport());
+            ConnectionWithDataSourceInfo connectionWithDataSourceInfo = connectionManagerHandler.getConnectionWithDataSourceInfo(pureConnection, ((CompiledExecutionSupport) es).getProcessorSupport());
             connection = connectionWithDataSourceInfo.getConnection();
             if (!PureConnectionUtils.isPureConnectionType(pureConnection, "Hive"))
             {
@@ -252,6 +251,15 @@ public class RelationalGen
         catch (SQLException e)
         {
             throw new PureExecutionException(si, SQLExceptionHandler.buildExceptionString(e, connection), e);
+        }
+        catch (PureExecutionException e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            String message = e.getMessage();
+            throw new PureExecutionException(si, (message == null) ? "Error in executeInDb" : "Error in executeInDb: " + message, e);
         }
     }
 

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-compiled-store-relational/src/main/resources/org/finos/legend/pure/runtime/java/extension/store/relational/compiled/RelationalGen.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-compiled-store-relational/src/main/resources/org/finos/legend/pure/runtime/java/extension/store/relational/compiled/RelationalGen.java
@@ -17,7 +17,6 @@ package org.finos.legend.pure.generated;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.function.Function;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.factory.Stacks;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.ImmutableMap;
@@ -153,13 +152,9 @@ public class RelationalGen
                     rowValues.add(function.valueOf(rowValues));
                 }
                 rows.add((new Root_meta_relational_metamodel_execute_Row_Impl("Anonymous_NoCounter"))._valuesAddAll(rowValues)._parent(pureResult));
-                if (RelationalExecutionProperties.shouldThrowIfMaxRowsExceeded() && rowLimit > 0)
+                if (RelationalExecutionProperties.shouldThrowIfMaxRowsExceeded() && (rowLimit > 0) && (rowCount > rowLimit))
                 {
-                    if (rowCount > rowLimit)
-                    {
-                        throw new PureExecutionException("Too many rows returned. PURE currently supports results with up to " + rowLimit + " rows. Please add a filter or use the take or limit function to limit the rows returned", Stacks.mutable.<org.finos.legend.pure.m4.coreinstance.CoreInstance>empty());
-                    }
-                    ;
+                    throw new PureExecutionException("Too many rows returned. PURE currently supports results with up to " + rowLimit + " rows. Please add a filter or use the take or limit function to limit the rows returned");
                 }
             }
 
@@ -199,7 +194,7 @@ public class RelationalGen
                 {
                 }
             }
-            throw new PureExecutionException(SQLExceptionHandler.buildExceptionString(e, connection), e, Stacks.mutable.<org.finos.legend.pure.m4.coreinstance.CoreInstance>empty());
+            throw new PureExecutionException(SQLExceptionHandler.buildExceptionString(e, connection), e);
         }
     }
 
@@ -256,7 +251,7 @@ public class RelationalGen
         }
         catch (SQLException e)
         {
-            throw new PureExecutionException(si, SQLExceptionHandler.buildExceptionString(e, connection), e, Stacks.mutable.<org.finos.legend.pure.m4.coreinstance.CoreInstance>empty());
+            throw new PureExecutionException(si, SQLExceptionHandler.buildExceptionString(e, connection), e);
         }
     }
 
@@ -316,7 +311,7 @@ public class RelationalGen
     {
         Integer rowLimit = numberOfRows == null ? null : numberOfRows.intValue();
         ListIterable<String> columnTypes = getColumnTypes(table, ((CompiledExecutionSupport) es).getProcessorSupport());
-        Iterable<ListIterable<?>> values = LoadToDbTableHelper.collectIterable(LazyIterate.drop(CsvReader.readCsv(((CompiledExecutionSupport) es).getCodeStorage(), null, filePath, 500, rowLimit, Stacks.mutable.<org.finos.legend.pure.m4.coreinstance.CoreInstance>empty()), 1), columnTypes, filePath, table._name());
+        Iterable<ListIterable<?>> values = LoadToDbTableHelper.collectIterable(LazyIterate.drop(CsvReader.readCsv(((CompiledExecutionSupport) es).getCodeStorage(), null, filePath, 500, rowLimit, null), 1), columnTypes, filePath, table._name());
         bulkInsertInDb(pureConnection, table, values, rowLimit, es);
         return Lists.mutable.empty();
     }
@@ -353,7 +348,7 @@ public class RelationalGen
     {
         if (!(pureConnection instanceof Root_meta_external_store_relational_runtime_TestDatabaseConnection))
         {
-            throw new PureExecutionException("Bulk insert is only supported for the TestDatabaseConnection", Stacks.mutable.<org.finos.legend.pure.m4.coreinstance.CoreInstance>empty());
+            throw new PureExecutionException("Bulk insert is only supported for the TestDatabaseConnection");
         }
 
         String schemaName = table._schema()._name();
@@ -407,7 +402,7 @@ public class RelationalGen
         }
         catch (SQLException e)
         {
-            throw new PureExecutionException(SQLExceptionHandler.buildExceptionString(e, connection), e, Stacks.mutable.<org.finos.legend.pure.m4.coreinstance.CoreInstance>empty());
+            throw new PureExecutionException(SQLExceptionHandler.buildExceptionString(e, connection), e);
         }
     }
 }

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-compiled-store-relational/src/test/java/org/finos/legend/pure/runtime/java/extension/store/relational/compiled/natives/TestResultSetValueHandlers.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-compiled-store-relational/src/test/java/org/finos/legend/pure/runtime/java/extension/store/relational/compiled/natives/TestResultSetValueHandlers.java
@@ -57,8 +57,12 @@ public class TestResultSetValueHandlers
      * through java.time in the zone of the calendar it is given, DuckDB through java.util in the
      * JVM default zone whatever calendar it is given. No one choice of zone reads both. So the
      * day is asked for directly, and a java.sql.Date is only the way back for a driver that will
-     * not give one -- which DuckDB 1.0.0, the version resolved here, will not. Both paths are
-     * therefore covered: H2 takes the first, DuckDB the second.
+     * not give one.
+     *
+     * <p>Both drivers resolved here answer {@link ResultSet#getObject(int, Class)} for a
+     * {@link java.time.LocalDate}, so both take the first path and the way back is not exercised.
+     * DuckDB 1.0.0 was the driver that refused, and the reason the way back is there at all; it
+     * has answered since 1.3.0.0.
      */
     @Test
     public void testDateColumnIsIndependentOfTheDefaultTimeZone() throws SQLException
@@ -131,9 +135,10 @@ public class TestResultSetValueHandlers
      * A timestamp column carries a wall clock the database keeps in the zone the connection
      * names, and a Pure date is that moment in UTC, so reading one shifts it out of that zone.
      * Asking the driver to do the shifting, by handing it a calendar, does not do that for every
-     * driver: DuckDB 1.0.0 ignores the calendar and answers as though the connection named UTC,
+     * driver: DuckDB 1.0.0 ignored the calendar and answered as though the connection named UTC,
      * so every timestamp came back short by the connection zone. Reading the wall clock and
-     * shifting it here leaves nothing for a driver to differ over.
+     * shifting it here leaves nothing for a driver to differ over, whether or not the driver
+     * resolved today is one that would have got it right.
      */
     @Test
     public void testTimestampColumnIsShiftedOutOfTheConnectionZone() throws SQLException

--- a/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-interpreted-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/interpreted/natives/ExecuteInDb.java
+++ b/legend-pure-store/legend-pure-store-relational/legend-pure-runtime-java-extension-interpreted-store-relational/src/main/java/org/finos/legend/pure/runtime/java/extension/store/relational/interpreted/natives/ExecuteInDb.java
@@ -150,7 +150,6 @@ public class ExecuteInDb extends NativeFunction
         CoreInstance pureResult = this.repository.newAnonymousCoreInstance(functionExpression.getSourceInformation(), resultSetClassifier);
 
         Connection connection = null;
-        ConnectionWithDataSourceInfo connectionWithDataSourceInfo = null;
         Statement statement = null;
         try
         {
@@ -163,7 +162,7 @@ public class ExecuteInDb extends NativeFunction
                 String tz = dbTimeZone == null ? "GMT" : dbTimeZone.getName();
 
                 long startRequestConnection = System.nanoTime();
-                connectionWithDataSourceInfo = connectionManagerHandler.getConnectionWithDataSourceInfo(connectionInformation, processorSupport);
+                ConnectionWithDataSourceInfo connectionWithDataSourceInfo = connectionManagerHandler.getConnectionWithDataSourceInfo(connectionInformation, processorSupport);
                 Instance.addValueToProperty(pureResult, "connectionAcquisitionTimeInNanoSecond", this.repository.newIntegerCoreInstance(System.nanoTime() - startRequestConnection), processorSupport);
 
                 connection = connectionWithDataSourceInfo.getConnection();
@@ -181,9 +180,7 @@ public class ExecuteInDb extends NativeFunction
                 if (!PureConnectionUtils.isPureConnectionType(connectionInformation, "Hive"))
                 {
                     statement.setQueryTimeout(timeOutInSeconds);
-
                 }
-
 
                 connectionManagerHandler.addPotentialDebug(connectionInformation, statement);
                 this.message.setMessage("Executing SQL...");
@@ -243,6 +240,15 @@ public class ExecuteInDb extends NativeFunction
         catch (SQLException e)
         {
             throw new PureExecutionException(functionExpression.getSourceInformation(), SQLExceptionHandler.buildExceptionString(e, connection), e, functionExpressionCallStack);
+        }
+        catch (PureExecutionException e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            String message = e.getMessage();
+            throw new PureExecutionException(functionExpression.getSourceInformation(), (message == null) ? "Error in executeInDb" : "Error in executeInDb: " + message, e, functionExpressionCallStack);
         }
 
         this.message.setMessage("Executing SQL...[DONE]");

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <guava.version>33.4.6-jre</guava.version>
         <vavr.version>1.0.1</vavr.version>
         <h2.version>2.1.214</h2.version>
-        <duckdb.version>1.0.0</duckdb.version>
+        <duckdb.version>1.4.5.0</duckdb.version>
         <jackson.version>2.10.5</jackson.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>


### PR DESCRIPTION
A follow-up to finos/legend-pure#1332, which changed how a time zone name is resolved and how a date or timestamp column is read. That change was covered by Java tests reading a `ResultSet` directly. These cover it from Pure, through `executeInDb`, on both the interpreted and the compiled engine — the two of which turned out not to agree about what a failure is.

### Ten tests, five per database

`h2_round_trip.pure` gains five, and `duckdb_round_trip.pure` is new and asks the same five of DuckDB. A connection's `timeZone` names the zone the database keeps its wall clocks in, and each test pins one part of what that does and does not settle:

- **A DATE ignores it.** A date column carries a day and no zone, so `GMT`, `America/New_York`, `Asia/Tokyo`, `EST`, and `+0530` all read the same day.
- **A TIMESTAMP is shifted out of it.** One stored wall clock read under five zones gives five different moments. `+0530` is the case that used to go wrong quietly, since java.util takes an offset only with a `GMT` prefix and answers every other name it does not know with GMT — so the shift was skipped and nothing about the result said so.
- **A TIMESTAMP from before its zone kept standard time** comes back on the mean solar offset java.time holds rather than the standard offset java.util holds. New York is `-04:56:02` in 1753 by one and `-05:00:00` by the other, and those four minutes are what turned a stored `1753-12-31` into `1753-12-30`.
- **A column carrying a zone is not shifted at all**, since it holds a moment already: `TIMESTAMP WITH TIME ZONE` on H2, `TIMESTAMPTZ` on DuckDB.
- **A name that stands for no zone is reported**, rather than answered with GMT.

Two databases rather than one because the drivers disagree, and the disagreement is the whole reason these readings are worth pinning down. Each test was checked against a reverted fix: reverting the reading to a `java.sql.Date` fails the date test on H2 and the 1753 timestamp on DuckDB, neither driver catching both; reverting the resolution to `TimeZone.getTimeZone` fails the shift and the rejection on both.

### executeInDb reports its failures as Pure errors

The rejection test is what turned this up. `TimeZones` reports an unresolvable name by throwing `IllegalArgumentException`. `executeInDb` turned a `SQLException` into a `PureExecutionException` and let every other failure through as itself, so that one reached the caller as a bare Java exception with no source information, and Pure code could not catch it. The interpreted engine wrapped it on the way out, since it wraps any runtime exception it sees; the compiled engine did not. The same query failed two different ways depending on which engine ran it, and only one of them was a failure Pure could say anything about.

Both engines now wrap what they did not throw themselves, naming the function and keeping the original message and cause. A `PureExecutionException` is rethrown as it stands, so a failure that already carries source information keeps it.

### loadValuesToDbTable, and a day written as well as read

Its tests were `ToFix` because they could not insert anything. The loader takes values shaped like `TestDatabaseConnection.testDataSetupCsv`, which that class documents: three header rows — schema name, table name, column names — and then a row per record, of which it drops the first three. The tests handed it two bare data rows, so both were dropped and the count came back 0 where the test wanted 2. With the header rows in place the H2 test runs.

`testLoadValuesToDbTableRoundTripsADay_h2` is new, and covers the writing side of what the reading tests cover. Nothing picks a zone on the way in either: a date column is handed the string the Pure date names itself with and the driver parses it, which is what `LoadCsvToDbTable` means by keeping dates as strings.

The DuckDB half stays `ToFix`, for a reason of its own and nothing to do with the loader: `bulkInsertInDb` calls `Connection.commit()` on a connection left in auto-commit mode, which H2 tolerates and DuckDB reports as "cannot commit - no transaction is active". The stereotype now says so. Left for a separate change, since the fix is a choice between dropping the commit and running the insert in a transaction, and the connection it would run in is shared.

### DuckDB 1.4.5.0

The upgrade brought two things worth following up on. The test database file is created under a lower case name now, where 1.0.0 used the mixed case name the connection URL asks for, so the ignore rule naming the mixed case form stopped matching and a test run left two untracked files in each relational runtime module. And `TestResultSetValueHandlers` explained that a `java.sql.Date` is the way back for a driver that will not answer `getObject` for a `LocalDate`, "which DuckDB 1.0.0, the version resolved here, will not" — 1.4.5.0 does, as DuckDB has since 1.3.0.0, so both drivers there now take the first path and the way back is not exercised at all. The test says that instead.

`RelationalGen` also loses the `Stacks.mutable.empty()` arguments that were being passed only to satisfy a signature.

### Verification

22 Pure tests on each engine, 25 in the compiled relational module, no failures and no checkstyle violations. Six commits, each self-contained.